### PR TITLE
fix of mix-and-match attack and indefinite-freeze-attack

### DIFF
--- a/tests/integration/test_indefinite_freeze_attack.py
+++ b/tests/integration/test_indefinite_freeze_attack.py
@@ -130,11 +130,11 @@ def test_indefinite_freeze_attack(TUF=False):
 
       # Try downloading again, this should raise an error.
       try:
-	_download(url=url_to_repo, filename=downloaded_file, using_tuf=TUF)
+        _download(url=url_to_repo, filename=downloaded_file, using_tuf=TUF)
       except tuf.ExpiredMetadataError, error:
-	print('Caught an expiration error!')
+        print('Caught an expiration error!')
       else:
-	raise IndefiniteFreezeAttackAlert(ERROR_MSG)
+        raise IndefiniteFreezeAttackAlert(ERROR_MSG)
   finally:
     util_test_tools.cleanup(root_repo, server_proc)
 

--- a/tests/integration/test_mix_and_match_attack.py
+++ b/tests/integration/test_mix_and_match_attack.py
@@ -38,6 +38,7 @@ import os
 import shutil
 import urllib
 import tempfile
+import time
 
 import tuf
 import tuf.interposition
@@ -125,6 +126,8 @@ def test_mix_and_match_attack(TUF=False):
       url_to_file = 'http://localhost:9999/'+file_basename
 
 
+    # Wait for some time to let program set up local http server
+    time.sleep(1)
     # Client's initial download.
     _download(url=url_to_file, filename=downloaded_file, using_tuf=TUF)
 


### PR DESCRIPTION
This patch fix the error type in these two tests, it should show the correct error type now.
