### PR TITLE
Add BadSignatureError cases to test_arbitrary_package_attack and test_extraneous_dependencies_attack.

### DIFF
--- a/tests/integration/test_arbitrary_package_attack.py
+++ b/tests/integration/test_arbitrary_package_attack.py
@@ -109,35 +109,20 @@ def test_arbitrary_package_attack(using_tuf=False, modify_metadata=False):
         # Modify targets metadata to reflect the change to the target file.
         targets_metadata_filepath = os.path.join(tuf_repo, 'metadata',
                                                               'targets.txt')
-
-        targets_metadata_key_list = ['signed', 'targets', file_basename]
-
-        util_test_tools.update_signed_file_in_metadata(
-                                                  target_filepath,
-                                                  targets_metadata_filepath,
-                                                  targets_metadata_key_list)
+        util_test_tools.update_target_in_metadata(target_filepath,
+                                                  targets_metadata_filepath)
 
         # Modify release metadata to reflect the change to targets metadata.
         release_metadata_filepath = os.path.join(tuf_repo, 'metadata',
                                                               'release.txt')
-
-        release_metadata_key_list = ['signed', 'meta', 'targets.txt']
-
-        util_test_tools.update_signed_file_in_metadata(
-                                                  targets_metadata_filepath,
-                                                  release_metadata_filepath,
-                                                  release_metadata_key_list)
+        util_test_tools.update_role_in_metadata(targets_metadata_filepath,
+                                                release_metadata_filepath)
 
         # Modify timestamp metadata to reflect the change to release metadata.
         timestamp_metadata_filepath = os.path.join(tuf_repo, 'metadata',
                                                               'timestamp.txt')
-
-        timestamp_metadata_key_list = ['signed', 'meta', 'release.txt']
-        
-        util_test_tools.update_signed_file_in_metadata(
-                                                  release_metadata_filepath,
-                                                  timestamp_metadata_filepath,
-                                                  timestamp_metadata_key_list)
+        util_test_tools.update_role_in_metadata(release_metadata_filepath,
+                                                timestamp_metadata_filepath)
 
     # Attacker modifies the file at the regular repository.
     util_test_tools.modify_file_at_repository(filepath, 'Evil A')

--- a/tests/integration/test_extraneous_dependencies_attack.py
+++ b/tests/integration/test_extraneous_dependencies_attack.py
@@ -144,38 +144,23 @@ def test_extraneous_dependency_attack(using_tuf=False, modify_metadata=False):
 
       if modify_metadata:
 
-        # Modify targets metadata to reflect the change to the dependent file.
+        # Modify targets metadata to reflect the change to the target file.
         targets_metadata_filepath = os.path.join(tuf_repo, 'metadata',
                                                               'targets.txt')
-
-        targets_metadata_key_list = ['signed', 'targets', dependent_basename]
-
-        util_test_tools.update_signed_file_in_metadata(
-                                                  dependent_target_filepath,
-                                                  targets_metadata_filepath,
-                                                  targets_metadata_key_list)
+        util_test_tools.update_target_in_metadata(dependent_target_filepath,
+                                                  targets_metadata_filepath)
 
         # Modify release metadata to reflect the change to targets metadata.
         release_metadata_filepath = os.path.join(tuf_repo, 'metadata',
                                                               'release.txt')
-
-        release_metadata_key_list = ['signed', 'meta', 'targets.txt']
-
-        util_test_tools.update_signed_file_in_metadata(
-                                                  targets_metadata_filepath,
-                                                  release_metadata_filepath,
-                                                  release_metadata_key_list)
+        util_test_tools.update_role_in_metadata(targets_metadata_filepath,
+                                                release_metadata_filepath)
 
         # Modify timestamp metadata to reflect the change to release metadata.
         timestamp_metadata_filepath = os.path.join(tuf_repo, 'metadata',
                                                               'timestamp.txt')
-
-        timestamp_metadata_key_list = ['signed', 'meta', 'release.txt']
-
-        util_test_tools.update_signed_file_in_metadata(
-                                                  release_metadata_filepath,
-                                                  timestamp_metadata_filepath,
-                                                  timestamp_metadata_key_list)
+        util_test_tools.update_role_in_metadata(release_metadata_filepath,
+                                                timestamp_metadata_filepath)
               
 
         

--- a/tuf/tests/util_test_tools.py
+++ b/tuf/tests/util_test_tools.py
@@ -616,21 +616,19 @@ def create_delegation(tuf_repo, delegated_targets_path, keyid, keyid_password,
   signercli._get_metadata_directory = original_get_metadata_directory
 
 
-def update_signed_file_in_metadata(signee_filepath, signer_filepath,
-                                    lookup_keys):
+def update_target_in_metadata(signee_filepath, signer_filepath):
   """
   <Purpose>
-    Update metadata to reflect a modified file's new hash and length, WITHOUT
-    signing it. This is meant to simulate something a clever attacker might do.
+    Update targets metadata to reflect a modified target's new hash and length,
+    WITHOUT signing it. This is meant to simulate something a clever attacker
+    might do.
 
   <Arguments>
     signee_filepath:
-      filepath of the file that has been modified since the metadata was
+      filepath of the target file that has been modified since the metadata was
       generated
     signer_filepath:
-      filepath of the metadata that signs the modified file
-    lookup_keys:
-      a list of the DICTIONARY keys used to look up signee's file info in signer
+      filepath of the targets role that signs the modified file
   """
 
   signer_file = open(signer_filepath, 'r+')
@@ -639,14 +637,43 @@ def update_signed_file_in_metadata(signee_filepath, signer_filepath,
   modified_file_length, modified_file_hash =\
                                 tuf.util.get_file_details(signee_filepath)
 
-  # use lookup_keys to look up signee's file data in the metadata
-  metadata_dict = metadata
-  for key in lookup_keys:
-    metadata_dict = metadata_dict[key]
+  # Modify the metadata to reflect signee's new hash and length.
+  signee_basename = os.path.basename(signee_filepath)
+  metadata['signed']['targets'][signee_basename]['hashes'] = modified_file_hash
+  metadata['signed']['targets'][signee_basename]['length'] =\
+                                                          modified_file_length
+
+  # Rewrite signer using the modified metadata.
+  signer_file.seek(0)
+  json.dump(metadata, signer_file, indent=1, sort_keys=True)
+  signer_file.close()
+
+
+def update_role_in_metadata(signee_filepath, signer_filepath):
+  """
+  <Purpose>
+    Update metadata to reflect another metadata file's new hash and length,
+    WITHOUT signing it. This is meant to simulate something a clever attacker
+    might do.
+
+  <Arguments>
+    signee_filepath:
+      filepath of the role metadata that has been modified since the metadata
+      was generated
+    signer_filepath:
+      filepath of the role that signs the modified file
+  """
+
+  signer_file = open(signer_filepath, 'r+')
+  metadata = json.load(signer_file)
+
+  modified_file_length, modified_file_hash =\
+                                tuf.util.get_file_details(signee_filepath)
 
   # Modify the metadata to reflect signee's new hash and length.
-  metadata_dict['hashes'] = modified_file_hash
-  metadata_dict['length'] = modified_file_length
+  signee_basename = os.path.basename(signee_filepath)
+  metadata['signed']['meta'][signee_basename]['hashes'] = modified_file_hash
+  metadata['signed']['meta'][signee_basename]['length'] = modified_file_length
 
   # Rewrite signer using the modified metadata.
   signer_file.seek(0)


### PR DESCRIPTION
Expands the tests to simulate an attack in which a BadHashError is avoided by modifying the metadata to reflect the attacker's changes to a target file. In this case, the tests expect a BadSignatureError.
