### PR TITLE
Fix repository_tool.py issues reported.

### DIFF
--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -444,7 +444,7 @@ class Repository(object):
       shutil.rmtree(temp_repository_directory, ignore_errors=True)
 
 
-
+  @staticmethod
   def get_filepaths_in_directory(self, files_directory, recursive_walk=False,
                                  followlinks=True):
     """
@@ -488,7 +488,7 @@ class Repository(object):
       message = repr(files_directory)+' is not a directory.'
       raise tuf.Error(message)
    
-    # A list of the target filepaths found in 'file_directory'.
+    # A list of the target filepaths found in 'files_directory'.
     targets = []
 
     # FIXME: We need a way to tell Python 2, but not Python 3, to return
@@ -1779,7 +1779,6 @@ class Targets(Metadata):
 
     # Update the tuf.roledb entry.
     targets_directory_length = len(self._targets_directory) 
-    absolute_list_of_targets = []
     relative_list_of_targets = []
    
     # Ensure the paths in 'list_of_targets' are valid and fall under the
@@ -1797,7 +1796,6 @@ class Targets(Metadata):
         raise tuf.Error(message)
       
       if os.path.isfile(filepath):
-        absolute_list_of_targets.append(filepath)
         relative_list_of_targets.append(filepath[targets_directory_length:])
       else:
         message = repr(filepath)+' is not a valid file.'
@@ -2595,15 +2593,15 @@ def _get_password(prompt='Password: ', confirm=False):
 
 
 
-def _check_if_partial_loaded(rolename, signable, roleinfo):
+def _metadata_is_partially_loaded(rolename, signable, roleinfo):
   """
   Non-public function that determines whether 'rolename' is loaded with
-  at least 1 good signatures, but an insufficient threshold (which means
+  at least 1 good signature, but an insufficient threshold (which means
   'rolename' was written to disk with repository.write_partial().  If 'rolename'
   is found to be partially loaded, mark it as partially loaded in its
   'tuf.roledb' roleinfo.  This function exists to assist in deciding whether
   a role's version number should be incremented when write() or write_parital()
-  is called.
+  is called.  Return True if 'rolename' was partially loaded, False otherwise. 
   """
 
   # The signature status lists the number of good signatures, including
@@ -2611,8 +2609,11 @@ def _check_if_partial_loaded(rolename, signable, roleinfo):
   status = tuf.sig.get_signature_status(signable, rolename)
   
   if len(status['good_sigs']) < status['threshold'] and \
-                              len(status['good_sigs']) >= 1:
-    roleinfo['partial_loaded'] = True
+                                                  len(status['good_sigs']) >= 1:
+    return True
+  
+  else:
+    return False
 
 
 
@@ -3055,8 +3056,12 @@ def load_repository(repository_directory):
 
         if os.path.exists(metadata_path+'.gz'):
           roleinfo['compressions'].append('gz')
+       
+        # The roleinfo of 'metadata_name' should have been initialized with
+        # defaults when it was loaded from its parent role.
+        if _metadata_is_partially_loaded(metadata_name, signable, roleinfo):
+          roleinfo['partial_loaded'] = True
         
-        _check_if_partial_loaded(metadata_name, signable, roleinfo)
         tuf.roledb.update_roleinfo(metadata_name, roleinfo)
         loaded_metadata.append(metadata_name)
 
@@ -3138,8 +3143,13 @@ def _load_top_level_metadata(repository, top_level_filenames):
 
     if os.path.exists(root_filename+'.gz'):
       roleinfo['compressions'].append('gz')
+   
+    # By default, roleinfo['partial_loaded'] of top-level roles should be set to
+    # False in 'create_roledb_from_root_metadata()'.  Update this field, if
+    # necessary, now that we have its signable object.
+    if _metadata_is_partially_loaded('root', signable, roleinfo):
+      roleinfo['partial_loaded'] = True
     
-    _check_if_partial_loaded('root', signable, roleinfo)
     tuf.roledb.update_roleinfo('root', roleinfo)
 
     # Ensure the 'consistent_snapshot' field is extracted.
@@ -3164,7 +3174,9 @@ def _load_top_level_metadata(repository, top_level_filenames):
     if os.path.exists(timestamp_filename+'.gz'):
       roleinfo['compressions'].append('gz')
     
-    _check_if_partial_loaded('timestamp', signable, roleinfo)
+    if _metadata_is_partially_loaded('timestamp', signable, roleinfo):
+      roleinfo['partial_loaded'] = True
+    
     tuf.roledb.update_roleinfo('timestamp', roleinfo)
   
   else:
@@ -3192,7 +3204,9 @@ def _load_top_level_metadata(repository, top_level_filenames):
     if os.path.exists(snapshot_filename+'.gz'):
       roleinfo['compressions'].append('gz')
     
-    _check_if_partial_loaded('snapshot', signable, roleinfo)
+    if _metadata_is_partially_loaded('snapshot', signable, roleinfo):
+      roleinfo['partial_loaded'] = True
+    
     tuf.roledb.update_roleinfo('snapshot', roleinfo)
   
   else:
@@ -3222,8 +3236,10 @@ def _load_top_level_metadata(repository, top_level_filenames):
     roleinfo['delegations'] = targets_metadata['delegations']
     if os.path.exists(targets_filename+'.gz'):
       roleinfo['compressions'].append('gz')
+   
+    if _metadata_is_partially_loaded('targets', signable, roleinfo):
+      roleinfo['partial_loaded'] = True
     
-    _check_if_partial_loaded('targets', signable, roleinfo)
     tuf.roledb.update_roleinfo('targets', roleinfo)
 
     # Add the keys specified in the delegations field of the Targets role.
@@ -3246,9 +3262,9 @@ def _load_top_level_metadata(repository, top_level_filenames):
       rolename = role['name'] 
       roleinfo = {'name': role['name'], 'keyids': role['keyids'],
                   'threshold': role['threshold'], 'compressions': [''],
-                  'signing_keyids': [], 'signatures': [],
-                  'delegations': {'keys': {},
-                                  'roles': []}}
+                  'signing_keyids': [], 'partial_loaded': False,
+                  'signatures': [], 'delegations': {'keys': {},
+                                                    'roles': []}}
       tuf.roledb.add_role(rolename, roleinfo)
   
   else:


### PR DESCRIPTION
Reported Issues:
Fix 'files_directory' variable name typo in comment.  Convert get_filepaths_in_directory() to a static method.

add_targets() declares 'absolute_list_of_targets' but only appends files to it.  Get rid of this variable.

The roleinfo dict of delegated roles was not fully set by load_repository().  Writing new metadata after it had loaded been tried to access a non-existent 'partial_loaded' dict key.  Non-public function that decided whether a metadata file was partially loaded renamed to _metadata_is_partially_loaded(), and now returns a Boolean.

Minor edits to comments related to the fixes above.
