### PR TITLE
Add error message for clients that lack a required crypto library.

### DIFF
--- a/tuf/keys.py
+++ b/tuf/keys.py
@@ -778,8 +778,14 @@ def verify_signature(key_dict, signature, data):
   # otherwise raise an exception.
   if keytype == 'rsa':
     if _RSA_CRYPTO_LIBRARY == 'pycrypto':
-      valid_signature = tuf.pycrypto_keys.verify_rsa_signature(sig, method,
-                                                               public, data) 
+      if 'pycrypto' not in _available_crypto_libraries:
+        message = 'Metadata downloaded from the remote repository specified'+\
+          ' an RSA signature.  Verifying RSA signatures requires PyCrypto.' +\
+          '\n$ pip install PyCrypto, or pip install tuf[tools].'
+        raise tuf.UnsupportedLibraryError(message)
+      else:
+        valid_signature = tuf.pycrypto_keys.verify_rsa_signature(sig, method,
+                                                                 public, data) 
     else:
       message = 'Unsupported "tuf.conf.RSA_CRYPTO_LIBRARY": '+\
         repr(_RSA_CRYPTO_LIBRARY)+'.'


### PR DESCRIPTION
Trishank reported:
Better error message when updater expects pycrypto?
NoWorkingMirrorError
TUF could not initialize due to an error: No working mirror was found:
  'module' object has no attribute 'pycrypto_keys'

Fix:
TUF's crypto dependencies was recently changed: ED25519 signatures supported by default, and require PyCrypto or tuf[tools] to verify RSASSA-PSS signatures.
The error returned for clients that tried to verify rsassa-pss signatures without the required library was bad.  Error message returned now . . .

$ basic_client.py --repo http://localhost:8001
Error: No working mirror was found:
  localhost:8001: Metadata downloaded from the remote repository specified an RSA signature.  Verifying RSA signatures requires PyCrypto.
$ pip install PyCrypto, or pip install tuf[tools].
