### PR TITLE
Update formats.py and repository_tool.py.

### DIFF
--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -158,8 +158,9 @@ ROLENAME_SCHEMA = SCHEMA.AnyString()
 # http://www.emc.com/emc-plus/rsa-labs/historical/twirl-and-rsa-key-size.htm#table1
 RSAKEYBITS_SCHEMA = SCHEMA.Integer(lo=2048)
 
-# The number of bins used to delegate to hashed roles.
-NUMBINS_SCHEMA = SCHEMA.Integer(lo=16)
+# The number of bins, or the requested number of delegated hashed roles.
+# Expected to be a power of 2.
+NUMBINS_SCHEMA = SCHEMA.Integer(lo=1)
 
 # A PyCrypto signature.
 PYCRYPTOSIGNATURE_SCHEMA = SCHEMA.AnyString()


### PR DESCRIPTION
repository_tool.targets.delegate_hashed_bins():

Edit comments, add logging information, and rename 'max_number_of_bins' (now 'total_hash_prefixes') for clarity.
Fix expected value of 'number_of_bins' (power of 2 instead of multiple of 16.)
Remove the 'self' argument in get_filepaths_in_directory() (now a staticmethod.)

formats.py:
NUMBINS_SCHEMA may now start from 1 (allow the creation of 1 delegated hashed bin.)
