### PR TITLE
Refactor test_slow_retrieval_server.py.

### DIFF
--- a/tests/integration/slow_retrieval_server.py
+++ b/tests/integration/slow_retrieval_server.py
@@ -5,19 +5,17 @@
   slow_retrieval_server.py
 
 <Author>
-  Konstantin Andrianov
+  Konstantin Andrianov.
 
 <Started>
-  March 13, 2012
+  March 13, 2012.
 
 <Copyright>
   See LICENSE for licensing information.
 
 <Purpose>
-  Server that throttles data by sending one byte at a time 
-  (specified time interval 'DELAY').  The server is used in
-  test_slow_retrieval_attack.py.
-
+  Server that throttles data by sending one byte at a time (specified time
+  interval 'DELAY').  The server is used in 'test_slow_retrieval_attack.py'.
 """
 
 import os
@@ -28,15 +26,12 @@ from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 
 
 
-
-
-# Modify the HTTPServer class to pass the test_mode argument to do_GET function.
+# Modify the HTTPServer class to pass the 'test_mode' argument to
+# do_GET() function.
 class HTTPServer_Test(HTTPServer):
   def __init__(self, server_address, Handler, test_mode):
     HTTPServer.__init__(self, server_address, Handler)
     self.test_mode = test_mode
-
-
 
 
 
@@ -56,20 +51,22 @@ class Handler(BaseHTTPRequestHandler):
       self.send_header('Content-length', str(len(data)))
       self.end_headers()
       
-      if self.server.test_mode == "mode_1":
-      # before sends any data, the server does nothing during a long time.
-        DELAY = 1000
+      if self.server.test_mode == 'mode_1':
+        # Before sending any data, the server does nothing for a long time.
+        DELAY = 60
         time.sleep(DELAY)
         self.wfile.write(data)
 
         return
-
-      else: # "mode_2"
+      
+      # 'mode_2'
+      else:
         DELAY = 1
         # Throttle the file by sending a character every few seconds.
         for i in range(len(data)):
           self.wfile.write(data[i])
           time.sleep(DELAY)
+        
         return
 
     except IOError, e:
@@ -77,13 +74,9 @@ class Handler(BaseHTTPRequestHandler):
 
 
 
-
-
 def get_random_port():
   port = random.randint(30000, 45000)
   return port
-
-
 
 
 
@@ -94,10 +87,8 @@ def run(port, test_mode):
 
 
 
-
-
 if __name__ == '__main__':
   port = int(sys.argv[1])
   test_mode = sys.argv[2]
-  assert test_mode in ("mode_1", "mode_2")
+  assert test_mode in ('mode_1', 'mode_2')
   run(port, test_mode)

--- a/tests/integration/test_arbitrary_package_attack.py
+++ b/tests/integration/test_arbitrary_package_attack.py
@@ -232,7 +232,9 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
       self.assertTrue(url_file in exception.mirror_errors)
       self.assertTrue(isinstance(exception.mirror_errors[url_file],
                                  tuf.DownloadLengthMismatchError))
-  
+    
+    else:
+      self.fail('TUF did not prevent an arbitrary package attack.')
   
   
   def test_with_tuf_and_metadata_tampering(self):
@@ -281,7 +283,9 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
       self.assertTrue(url_file in exception.mirror_errors)
       self.assertTrue(isinstance(exception.mirror_errors[url_file],
                                  tuf.DownloadLengthMismatchError))
-
+    
+    else:
+      self.fail('TUF did not prevent an arbitrary package attack.')
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_endless_data_attack.py
+++ b/tests/integration/test_endless_data_attack.py
@@ -274,7 +274,9 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
     except tuf.NoWorkingMirrorError, exception:
       for mirror_url, mirror_error in exception.mirror_errors.iteritems():
         self.assertTrue(isinstance(mirror_error, tuf.InvalidMetadataJSONError))
-
+    
+    else:
+      self.fail('TUF did not prevent an endless data attack.')
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_indefinite_freeze_attack.py
+++ b/tests/integration/test_indefinite_freeze_attack.py
@@ -243,6 +243,5 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
                       self.repository_updater.refresh) 
 
 
-
 if __name__ == '__main__':
   unittest.main()

--- a/tests/integration/test_replay_attack.py
+++ b/tests/integration/test_replay_attack.py
@@ -325,6 +325,9 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
         self.assertEqual(url_file, mirror_url)
         self.assertTrue(isinstance(mirror_error, tuf.ReplayedMetadataError))
 
+    else:
+      self.fail('TUF did not prevent a replay attack.')
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Refactored to use the 'unittest' module (test conditions in code, rather than verifying text output), use pre-generated repository files, and discontinue use of the old repository tools. Expanded comments and modified
previous setup.

Minor edits to `slow_retrieval_server.py`.

Add missing else clauses (to detect when TUF fails to prevent an attack) for a couple of the integrations tests.
