### PR TITLE
Update test_download.py comments and test case.

### DIFF
--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -105,29 +105,29 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
 
   # Test: Incorrect lengths.
   def test_download_url_to_tempfileobj_and_lengths(self):
+    # We do *not* catch 'tuf.DownloadLengthMismatchError' in the following two
+    # calls because the file at 'self.url' contains enough bytes to satisfy the
+    # smaller number of required bytes requested. safe_download() and
+    # unsafe_download() will only log a warning when the the server-reported
+    # length of the file does not match the required_length.  'updater.py'
+    # *does* verify the hashes of downloaded content.
+    download.safe_download(self.url, self.target_data_length - 4)
+    download.unsafe_download(self.url, self.target_data_length - 4)
 
-    # NOTE: We catch tuf.BadHashError here because the file, shorter by a byte,
-    # would not match the expected hashes. We log a warning when we find that
-    # the server-reported length of the file does not match our
-    # required_length. We also see that STRICT_REQUIRED_LENGTH does not change
-    # the outcome of the previous test.
-    download.safe_download(self.url, self.target_data_length - 1)
-    download.unsafe_download(self.url, self.target_data_length - 1)
-
-    # NOTE: We catch tuf.DownloadLengthMismatchError here because the
-    # STRICT_REQUIRED_LENGTH, which is True by default, mandates that we must
-    # download exactly what is required.
+    # We catch 'tuf.DownloadLengthMismatchError' here because safe_download()
+    # will not download more bytes than requested.
     self.assertRaises(tuf.DownloadLengthMismatchError, download.safe_download,
                       self.url, self.target_data_length + 1)
 
-    # NOTE: However, we do not catch a tuf.DownloadLengthMismatchError here for
-    # the same test as the previous one because we have disabled
-    # STRICT_REQUIRED_LENGTH.
+    # However, we do *not* catch 'tuf.DownloadLengthMismatchError' next because 
+    # unsafe_download() does the enforce the upper limit.  The length reported
+    # and the length downloaded are still logged.
     temp_fileobj = download.unsafe_download(self.url,
                                             self.target_data_length + 1)
     self.assertEqual(self.target_data, temp_fileobj.read().decode('utf-8'))
     self.assertEqual(self.target_data_length, len(temp_fileobj.read()))
     temp_fileobj.close_temp_file()
+
 
 
   def test_download_url_to_tempfileobj_and_performance(self):
@@ -223,8 +223,8 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     message = 'Downloading target file from https server: ' + https_url  
     logger.info(message)
     try: 
-      download.safe_download(https_url, target_data_length - 1)
-      download.unsafe_download(https_url, target_data_length - 1)
+      download.safe_download(https_url, target_data_length)
+      download.unsafe_download(https_url, target_data_length)
     
     finally:
       https_server_process 

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -110,7 +110,7 @@ class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
 
     # NOTE: Following error is raised if a delay is not applied:
     # <urlopen error [Errno 111] Connection refused>
-    time.sleep(.5)
+    time.sleep(1)
 
     return server_process
    


### PR DESCRIPTION
Fix and expand comments for the test case dealing with incorrect file lengths.
Download the actual file length of the target file downloaded in the https test case.
