### PR TITLE
Remove '/' from target filepath

### DIFF
--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -2617,7 +2617,7 @@ class Updater(object):
       # We will compare targets against this file.
       filepath = target['filepath']
       if filepath[0] == '/':
-          filepath = filepath[1:]
+        filepath = filepath[1:]
       target_filepath = os.path.join(destination_directory, filepath)
       
       if target_filepath in updated_targetpaths:


### PR DESCRIPTION
os.path.join ignore previous parameters if one starts with '/'. All
targets start with '/', making updated_targets to try to open a file in
the root folder in case of a unix system.
