### PR TITLE
Continue if the keyid is not in keydb while checking signatures

### DIFF
--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -374,6 +374,7 @@ def _remove_invalid_and_duplicate_signatures(signable):
     
     except tuf.UnknownKeyError as e:
       signable['signatures'].remove(signature)
+      continue
     
     # Remove 'signature' from 'signable' if it is an invalid signature.
     if not tuf.keys.verify_signature(key, signature, signed):


### PR DESCRIPTION
After the tuf.UnknownError tuf.keys.verify_signature will throw:
'tuf.FormatError: Wanted a u'ANYKEY_SCHEMA'.'
