### PR TITLE
Review and update Pull Request #238.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,7 +166,7 @@ Installing extras does not work if minimal install was a wheel (pip <= 1.5.6.)
 
 ::
 
-    $ pip install -no-use-wheel tuf
+    $ pip install --no-use-wheel tuf
     $ pip install tuf[tools]
 
 Instructions for Contributors

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -98,6 +98,31 @@ class TestKeys(unittest.TestCase):
     self.assertRaises(tuf.FormatError, KEYS.format_keyval_to_metadata,
                       keytype, keyvalue)
     keyvalue['public'] = public
+  
+  
+  
+  def test_format_rsakey_from_pem(self):
+    pem = self.rsakey_dict['keyval']['public']
+    rsa_key = KEYS.format_rsakey_from_pem(pem)
+    
+    # Check if the format of the object returned by this function corresponds
+    # to 'tuf.formats.RSAKEY_SCHEMA' format.
+    self.assertTrue(tuf.formats.RSAKEY_SCHEMA.matches(rsa_key)) 
+    
+    # Verify whitespace is stripped.
+    self.assertEqual(rsa_key, KEYS.format_rsakey_from_pem(pem + '\n'))
+
+    # Supplying a 'bad_pem' argument.
+    self.assertRaises(tuf.FormatError, KEYS.format_rsakey_from_pem, 'bad_pem')
+
+    # Supplying an improperly formatted PEM.
+    # Strip the PEM header and footer.
+    pem_header = '-----BEGIN PUBLIC KEY-----'
+    pem_footer= '-----END PUBLIC KEY-----'
+    self.assertRaises(tuf.FormatError, KEYS.format_rsakey_from_pem,
+                      pem[:len(pem_footer)])
+    self.assertRaises(tuf.FormatError, KEYS.format_rsakey_from_pem,
+                      pem[len(pem_header):])
 
 
 


### PR DESCRIPTION
- Add test_formats_rsakey_from_pem() test case and test condition for improperly formatted PEM.
- Add test condition to verify trailing white space is removed and matches the expected PEM format generated
  internally.  Public PEMs generated externally (with the expected trailing newline) was not previously considered.
- re.sub() with the 'flags' keyword argument caused type error in Python 2.6.  Converted PEM validation to use index() to address issue above.
- Raise specific exception for missing header or missing footer.
- Check footer follows header.

Thanks @meskio for the pull request, and for supplying the scripts / PEM files to test.
