### PR TITLE
Fix default console log level so that status() prints INFO-level messages

### DIFF
--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1913,7 +1913,7 @@ def write_metadata_file(metadata, filename, compressions, consistent_snapshot):
     # and indentation is used.  The 'tuf.util.TempFile' file-like object is
     # automically closed after the final move.
     file_object.write(file_content)
-    logger.info('Saving ' + repr(written_filename))
+    logger.debug('Saving ' + repr(written_filename))
     file_object.move(written_filename)
     
     for consistent_filename in consistent_filenames:

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -66,7 +66,7 @@ logger = logging.getLogger('tuf.repository_tool')
 # Add a console handler so that users are aware of potentially unintended
 # states, such as multiple roles that share keys.
 tuf.log.add_console_handler()
-tuf.log.set_console_log_level(logging.WARNING)
+tuf.log.set_console_log_level(logging.INFO)
 
 # The algorithm used by the repository to generate the digests of the
 # target filepaths, which are included in metadata files and may be prepended


### PR DESCRIPTION
The default log level was switched to WARNING but prevents status() from printing messages as expected.
Modify the log level of 'Saving <role>.json' message so that it doesn't clog status().
Thank you @hrdarji for testing the documentation and reporting the non-printing behavior of status().
