### PR TITLE
Disable the 'iso8601' logger.

### DIFF
--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -129,7 +129,13 @@ import tuf.util
 import tuf._vendor.iso8601 as iso8601
 import tuf._vendor.six as six
 
+# See 'log.py' to learn how logging is handled in TUF.
 logger = logging.getLogger('tuf.client.updater')
+
+# Disable 'iso8601' logger messages to prevent 'iso8601' from clogging the
+# log file.
+iso8601_logger = logging.getLogger('tuf._vendor.iso8601.iso8601')
+iso8601_logger.disabled = True
 
 
 class Updater(object):

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -57,6 +57,11 @@ import tuf._vendor.six as six
 # See 'log.py' to learn how logging is handled in TUF.
 logger = logging.getLogger('tuf.repository_lib')
 
+# Disable 'iso8601' logger messages to prevent 'iso8601' from clogging the
+# log file.
+iso8601_logger = logging.getLogger('tuf._vendor.iso8601.iso8601')
+iso8601_logger.disabled = True
+
 # Recommended RSA key sizes:
 # http://www.emc.com/emc-plus/rsa-labs/historical/twirl-and-rsa-key-size.htm#table1
 # According to the document above, revised May 6, 2003, RSA keys of


### PR DESCRIPTION
Disable 'iso8601' log messages so that the log file contain only TUF messages.
