### PR TITLE
Properly load the paths of nested delegations.

### DIFF
--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2807,6 +2807,7 @@ def load_repository(repository_directory):
                       'threshold': role['threshold'],
                       'compressions': [''], 'signing_keyids': [],
                       'signatures': [],
+                      'paths': {},
                       'partial_loaded': False,
                       'delegations': {'keys': {},
                                       'roles': []}}


### PR DESCRIPTION
Fix issue reported by Andrew: load_repository() fails to load the paths of nested delegations.
