### PR TITLE
Support pyca/Cryptography

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,6 +17,7 @@
 # http://nvie.com/posts/pin-your-packages/
 pycrypto==2.6.1
 pynacl==0.2.3
+cryptography==0.9
 
 # Testing requirements.  The rest of the testing dependencies available in
 # 'tox.ini'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,7 +17,7 @@
 # http://nvie.com/posts/pin-your-packages/
 pycrypto==2.6.1
 pynacl==0.2.3
-cryptography==0.9
+cryptography==1.0
 
 # Testing requirements.  The rest of the testing dependencies available in
 # 'tox.ini'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cryptography
 pynacl
 pycrypto
 six

--- a/tests/test_pyca_crypto_keys.py
+++ b/tests/test_pyca_crypto_keys.py
@@ -84,9 +84,10 @@ class TestPyca_crypto_keys(unittest.TestCase):
                       crypto_keys.create_rsa_signature, '', data)
    
     # Check for invalid 'data'.
-    #crypto_keys.create_rsa_signature(private_rsa, '')
+    self.assertRaises(TypeError,
+                      crypto_keys.create_rsa_signature, private_rsa, '')
     
-    self.assertRaises(tuf.CryptoError,
+    self.assertRaises(tuf.FormatError,
                       crypto_keys.create_rsa_signature, private_rsa, 123)
 
     # Check for missing private key.
@@ -120,9 +121,9 @@ class TestPyca_crypto_keys(unittest.TestCase):
                                                       'invalid_method',
                                                       public_rsa, data)
     
-    # Check for invalid signature and data.
-    self.assertRaises(AttributeError, crypto_keys.verify_rsa_signature, signature,
-                                       method, public_rsa, 123)
+    # Check for invalid 'signature' and 'data' arguments.
+    self.assertRaises(tuf.FormatError, crypto_keys.verify_rsa_signature,
+                      signature, method, public_rsa, 123)
     
     self.assertEqual(False, crypto_keys.verify_rsa_signature(signature, method,
                             public_rsa, b'mismatched data'))

--- a/tests/test_pyca_crypto_keys.py
+++ b/tests/test_pyca_crypto_keys.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+
+"""
+<Program Name>
+  test_pyca_crypto_keys.py
+
+<Author> 
+  Vladimir Diaz <vladimir.v.diaz@gmail.com>
+
+<Started>
+  June 3, 2015. 
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Test cases for 'pyca_crypto_keys.py'.
+"""
+
+# Help with Python 3 compatibility, where the print statement is a function, an
+# implicit relative import is invalid, and the '/' operator performs true
+# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+
+import unittest
+import logging
+
+import tuf
+import tuf.log
+import tuf.formats
+import tuf.pyca_crypto_keys as crypto_keys
+
+logger = logging.getLogger('tuf.test_pyca_crypto_keys')
+
+public_rsa, private_rsa = crypto_keys.generate_rsa_public_and_private()
+FORMAT_ERROR_MSG = 'tuf.FormatError raised.  Check object\'s format.'
+
+
+class TestPyca_crypto_keys(unittest.TestCase):
+  def setUp(self):
+    pass
+
+
+  def test_generate_rsa_public_and_private(self):
+    pub, priv = crypto_keys.generate_rsa_public_and_private()
+    
+    # Check format of 'pub' and 'priv'.
+    self.assertEqual(None, tuf.formats.PEMRSA_SCHEMA.check_match(pub),
+                     FORMAT_ERROR_MSG)
+    self.assertEqual(None, tuf.formats.PEMRSA_SCHEMA.check_match(priv),
+                     FORMAT_ERROR_MSG)
+
+    # Check for invalid bits argument.  bit >= 2048 and a multiple of 256.
+    self.assertRaises(tuf.FormatError,
+                      crypto_keys.generate_rsa_public_and_private, 1024)
+   
+    crypto_keys.generate_rsa_public_and_private(2050)
+
+    self.assertRaises(tuf.FormatError,
+                      crypto_keys.generate_rsa_public_and_private, '2048')
+  
+  
+  
+  def test_create_rsa_signature(self):
+    global private_rsa
+    global public_rsa
+    data = 'The quick brown fox jumps over the lazy dog'.encode('utf-8')
+    signature, method = crypto_keys.create_rsa_signature(private_rsa, data)
+
+    # Verify format of returned values.
+    self.assertNotEqual(None, signature)
+    self.assertEqual(None, tuf.formats.NAME_SCHEMA.check_match(method),
+                     FORMAT_ERROR_MSG)
+    self.assertEqual('RSASSA-PSS', method)
+
+    # Check for improperly formatted arguments.
+    self.assertRaises(tuf.FormatError,
+                      crypto_keys.create_rsa_signature, 123, data)
+    
+    self.assertRaises(TypeError,
+                      crypto_keys.create_rsa_signature, '', data)
+   
+    # Check for invalid 'data'.
+    #crypto_keys.create_rsa_signature(private_rsa, '')
+    
+    self.assertRaises(tuf.CryptoError,
+                      crypto_keys.create_rsa_signature, private_rsa, 123)
+
+    # Check for missing private key.
+    self.assertRaises(tuf.CryptoError,
+                      crypto_keys.create_rsa_signature, public_rsa, data)
+
+
+
+  def test_verify_rsa_signature(self):
+    global public_rsa
+    global private_rsa
+    data = 'The quick brown fox jumps over the lazy dog'.encode('utf-8')
+    signature, method = crypto_keys.create_rsa_signature(private_rsa, data)
+
+    valid_signature = crypto_keys.verify_rsa_signature(signature, method, public_rsa,
+                                                data)
+    self.assertEqual(True, valid_signature)
+
+    # Check for improperly formatted arguments.
+    self.assertRaises(tuf.FormatError, crypto_keys.verify_rsa_signature, signature,
+                                       123, public_rsa, data)
+    
+    self.assertRaises(tuf.FormatError, crypto_keys.verify_rsa_signature, signature,
+                                       method, 123, data)
+    
+    self.assertRaises(tuf.FormatError, crypto_keys.verify_rsa_signature, 123, method,
+                                       public_rsa, data)
+    
+    self.assertRaises(tuf.UnknownMethodError, crypto_keys.verify_rsa_signature,
+                                                      signature,
+                                                      'invalid_method',
+                                                      public_rsa, data)
+    
+    # Check for invalid signature and data.
+    self.assertRaises(tuf.CryptoError, crypto_keys.verify_rsa_signature, signature,
+                                       method, public_rsa, 123)
+    
+    self.assertEqual(False, crypto_keys.verify_rsa_signature(signature, method,
+                            public_rsa, b'mismatched data'))
+
+    mismatched_signature, method = crypto_keys.create_rsa_signature(private_rsa,
+                                                             b'mismatched data')
+    
+    self.assertEqual(False, crypto_keys.verify_rsa_signature(mismatched_signature,
+                            method, public_rsa, data))
+
+
+# Run the unit tests.
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/test_pyca_crypto_keys.py
+++ b/tests/test_pyca_crypto_keys.py
@@ -121,7 +121,7 @@ class TestPyca_crypto_keys(unittest.TestCase):
                                                       public_rsa, data)
     
     # Check for invalid signature and data.
-    self.assertRaises(tuf.CryptoError, crypto_keys.verify_rsa_signature, signature,
+    self.assertRaises(AttributeError, crypto_keys.verify_rsa_signature, signature,
                                        method, public_rsa, 123)
     
     self.assertEqual(False, crypto_keys.verify_rsa_signature(signature, method,

--- a/tests/test_pycrypto_keys.py
+++ b/tests/test_pycrypto_keys.py
@@ -85,9 +85,10 @@ class TestPycrypto_keys(unittest.TestCase):
    
     # Check for invalid 'data'.
     pycrypto.create_rsa_signature(private_rsa, '')
-    
-    self.assertRaises(tuf.CryptoError,
-                      pycrypto.create_rsa_signature, private_rsa, 123)
+   
+    # TODO: create_rsa_signature should reject non-string data.
+    #self.assertRaises(tuf.CryptoError,
+    #                  pycrypto.create_rsa_signature, private_rsa, 123)
 
     # Check for missing private key.
     self.assertRaises(tuf.CryptoError,
@@ -120,8 +121,9 @@ class TestPycrypto_keys(unittest.TestCase):
                                                       public_rsa, data)
     
     # Check for invalid signature and data.
-    self.assertRaises(tuf.CryptoError, pycrypto.verify_rsa_signature, signature,
-                                       method, public_rsa, 123)
+    # TODO: verify_rsa_signature should reject non-string data.
+    #self.assertRaises(tuf.CryptoError, pycrypto.verify_rsa_signature, signature,
+    #                                   method, public_rsa, 123)
     
     self.assertEqual(False, pycrypto.verify_rsa_signature(signature, method,
                             public_rsa, b'mismatched data'))

--- a/tests/test_pycrypto_keys.py
+++ b/tests/test_pycrypto_keys.py
@@ -86,9 +86,9 @@ class TestPycrypto_keys(unittest.TestCase):
     # Check for invalid 'data'.
     pycrypto.create_rsa_signature(private_rsa, '')
    
-    # TODO: create_rsa_signature should reject non-string data.
-    #self.assertRaises(tuf.CryptoError,
-    #                  pycrypto.create_rsa_signature, private_rsa, 123)
+    # create_rsa_signature should reject non-string data.
+    self.assertRaises(tuf.FormatError,
+                      pycrypto.create_rsa_signature, private_rsa, 123)
 
     # Check for missing private key.
     self.assertRaises(tuf.CryptoError,
@@ -121,10 +121,10 @@ class TestPycrypto_keys(unittest.TestCase):
                                                       public_rsa, data)
     
     # Check for invalid signature and data.
-    # TODO: verify_rsa_signature should reject non-string data.
-    #self.assertRaises(tuf.CryptoError, pycrypto.verify_rsa_signature, signature,
-    #                                   method, public_rsa, 123)
-    
+    # Verify_rsa_signature should reject non-string data.
+    self.assertRaises(tuf.FormatError, pycrypto.verify_rsa_signature, signature,
+                                       method, public_rsa, 123)
+   
     self.assertEqual(False, pycrypto.verify_rsa_signature(signature, method,
                             public_rsa, b'mismatched data'))
 

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -55,6 +55,7 @@ logger = logging.getLogger('tuf.test_repository_tool')
 
 repo_tool.disable_console_log_messages()
 
+
 class TestRepository(unittest.TestCase):
   @classmethod
   def setUpClass(cls):

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -53,8 +53,7 @@ import six
 
 logger = logging.getLogger('tuf.test_repository_tool')
 
-#repo_tool.disable_console_log_messages()
-
+repo_tool.disable_console_log_messages()
 
 class TestRepository(unittest.TestCase):
   @classmethod
@@ -219,9 +218,6 @@ class TestRepository(unittest.TestCase):
     
     # (6) Write repository.
     repository.targets.compressions = ['gz']
-    print('start') 
-    repository.status()
-    print('end')
     repository.write()
 
     

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -53,7 +53,7 @@ import six
 
 logger = logging.getLogger('tuf.test_repository_tool')
 
-repo_tool.disable_console_log_messages()
+#repo_tool.disable_console_log_messages()
 
 
 class TestRepository(unittest.TestCase):
@@ -219,6 +219,9 @@ class TestRepository(unittest.TestCase):
     
     # (6) Write repository.
     repository.targets.compressions = ['gz']
+    print('start') 
+    repository.status()
+    print('end')
     repository.write()
 
     

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1046,7 +1046,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
       # The repository must be rewritten with consistent snapshots set.
       repository = repo_tool.load_repository(self.repository_directory)
      
-      repository.root.load_signing_key(self.role_keys['snapshot']['private'])
+      repository.root.load_signing_key(self.role_keys['root']['private'])
       repository.snapshot.load_signing_key(self.role_keys['snapshot']['private'])
       repository.timestamp.load_signing_key(self.role_keys['timestamp']['private'])
       repository.write(consistent_snapshot=True)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -73,7 +73,7 @@ import tuf.roledb
 import tuf.repository_tool as repo_tool
 import tuf.unittest_toolbox as unittest_toolbox
 import tuf.client.updater as updater
-import tuf._vendor.six as six
+import six
 
 logger = logging.getLogger('tuf.test_updater')
 repo_tool.disable_console_log_messages()

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34
-
+#envlist = py26, py27, py32, py33, py34
+envlist = py27
 
 [testenv]
 changedir = tests

--- a/tuf/conf.py
+++ b/tuf/conf.py
@@ -96,7 +96,7 @@ ED25519_CRYPTO_LIBRARY = 'ed25519'
 # RSA_CRYPTO_LIBRARY and ED25519_CRYPTO_LIBRARY are needed on the client side
 # of the software updater.
 # Supported RSA cryptography libraries:  ['pycrypto', 'pyca-cryptography']
-GENERAL_CRYPTO_LIBRARY = 'pycrypto'
+GENERAL_CRYPTO_LIBRARY = 'pyca-cryptography'
 
 # The algorithm(s) in REPOSITORY_HASH_ALGORITHMS are chosen by the repository
 # tool to generate the digests listed in metadata and prepended to the

--- a/tuf/conf.py
+++ b/tuf/conf.py
@@ -84,6 +84,7 @@ PBKDF2_ITERATIONS = 100000
 # The user client may set the specific cryptography library used by The Update
 # Framework updater, or the software updater integrating TUF.  
 # Supported RSA cryptography libraries:  ['pycrypto', 'pyca-cryptography']
+
 RSA_CRYPTO_LIBRARY = 'pyca-cryptography'
 
 # Supported ed25519 cryptography libraries: ['pynacl', 'ed25519']
@@ -96,6 +97,7 @@ ED25519_CRYPTO_LIBRARY = 'ed25519'
 # RSA_CRYPTO_LIBRARY and ED25519_CRYPTO_LIBRARY are needed on the client side
 # of the software updater.
 # Supported RSA cryptography libraries:  ['pycrypto', 'pyca-cryptography']
+
 GENERAL_CRYPTO_LIBRARY = 'pyca-cryptography'
 
 # The algorithm(s) in REPOSITORY_HASH_ALGORITHMS are chosen by the repository

--- a/tuf/conf.py
+++ b/tuf/conf.py
@@ -83,23 +83,24 @@ PBKDF2_ITERATIONS = 100000
 
 # The user client may set the specific cryptography library used by The Update
 # Framework updater, or the software updater integrating TUF.  
-# Supported RSA cryptography libraries:  ['pycrypto']
-RSA_CRYPTO_LIBRARY = 'pycrypto'
+# Supported RSA cryptography libraries:  ['pycrypto', 'pyca-cryptography']
+RSA_CRYPTO_LIBRARY = 'pyca-cryptography'
 
 # Supported ed25519 cryptography libraries: ['pynacl', 'ed25519']
 ED25519_CRYPTO_LIBRARY = 'ed25519'
 
-# General purpose cryptography. Algorithms and functions that fall under general
-# purpose include AES, PBKDF2, cryptographically strong random number
+# General purpose cryptography. Algorithms and functions that fall under
+# general purpose include AES, PBKDF2, cryptographically strong random number
 # generators, and cryptographic hash functions.  The majority of the general
 # cryptography is needed by the repository and developer tools.
 # RSA_CRYPTO_LIBRARY and ED25519_CRYPTO_LIBRARY are needed on the client side
 # of the software updater.
+# Supported RSA cryptography libraries:  ['pycrypto', 'pyca-cryptography']
 GENERAL_CRYPTO_LIBRARY = 'pycrypto'
 
-# The algorithm(s) in REPOSITORY_HASH_ALGORITHMS are chosen by the repository tool
-# to generate the digests listed in metadata and prepended to the filenames of
-# consistent snapshots.
+# The algorithm(s) in REPOSITORY_HASH_ALGORITHMS are chosen by the repository
+# tool to generate the digests listed in metadata and prepended to the
+# filenames of consistent snapshots.
 REPOSITORY_HASH_ALGORITHMS = ['sha256']
 
 # Software updaters that integrate the framework are required to specify

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -151,6 +151,9 @@ LOGLEVEL_SCHEMA = SCHEMA.Integer(lo=0, hi=50)
 NAME_SCHEMA = SCHEMA.AnyString()
 NAMES_SCHEMA = SCHEMA.ListOf(NAME_SCHEMA)
 
+# A string representing data.
+DATA_SCHEMA = SCHEMA.AnyString()
+
 # Supported hash algorithms.
 HASHALGORITHMS_SCHEMA = SCHEMA.ListOf(SCHEMA.OneOf(
   [SCHEMA.String('md5'), SCHEMA.String('sha1'),

--- a/tuf/keys.py
+++ b/tuf/keys.py
@@ -971,6 +971,11 @@ def import_rsakey_from_encrypted_pem(encrypted_pem, password):
     public, private = \
       tuf.pycrypto_keys.create_rsa_public_and_private_from_encrypted_pem(encrypted_pem,
                                                                          password)
+  elif _RSA_CRYPTO_LIBRARY == 'pyca-cryptography':
+    public, private = \
+      tuf.pyca_crypto_keys.create_rsa_public_and_private_from_encrypted_pem(encrypted_pem,
+                                                                         password)
+  
   else: #pragma: no cover
     message = 'Invalid crypto library: ' + repr(_RSA_CRYPTO_LIBRARY) + '.'
     raise tuf.UnsupportedLibraryError(message) 
@@ -1363,7 +1368,11 @@ def create_rsa_encrypted_pem(private_key, passphrase):
   if _RSA_CRYPTO_LIBRARY == 'pycrypto':
     encrypted_pem = \
       tuf.pycrypto_keys.create_rsa_encrypted_pem(private_key, passphrase)
- 
+
+  elif _RSA_CRYPTO_LIBRARY == 'pyca-cryptography':
+    encrypted_pem = \
+      tuf.pycrypto_keys.create_rsa_encrypted_pem(private_key, passphrase)
+
   # check_crypto_libraries() should have fully verified _RSA_CRYPTO_LIBRARY.
   else: # pragma: no cover
     message = 'Invalid crypto library: ' + repr(_RSA_CRYPTO_LIBRARY) + '.'

--- a/tuf/pyca_crypto_keys.py
+++ b/tuf/pyca_crypto_keys.py
@@ -847,9 +847,15 @@ def _generate_derived_key(password, salt=None, iterations=None):
   is the number of SHA-256 iterations to perform, otherwise
   '_PBKDF2_ITERATIONS' is used by default.
   """
-  
+ 
+  # Use pyca/cryptography's default backend (e.g., openSSL, CommonCrypto, etc.)
+  # The default backend is not fixed and can be changed by pyca/cryptography
+  # over time.
   backend = default_backend()
-  
+ 
+  # If 'salt' and 'iterations' are unspecified, a new derived key is generated.
+  # If specified, a deterministic key is derived according to the given
+  # 'salt' and 'iterrations' values.
   if salt is None:
     salt = os.urandom(_SALT_SIZE) 
 

--- a/tuf/pyca_crypto_keys.py
+++ b/tuf/pyca_crypto_keys.py
@@ -640,7 +640,7 @@ def create_rsa_public_and_private_from_encrypted_pem(encrypted_pem, passphrase):
   public_pem = public_key.public_bytes(encoding=serialization.Encoding.PEM,
                     format=serialization.PublicFormat.SubjectPublicKeyInfo)
 
-  return public_pem, private_pem
+  return public_pem.decode(), private_pem.decode()
 
 
 

--- a/tuf/pyca_crypto_keys.py
+++ b/tuf/pyca_crypto_keys.py
@@ -465,6 +465,9 @@ def create_rsa_encrypted_pem(private_key, passphrase):
     mode of operation.  Password-Based Key Derivation Function 1 (PBKF1) + MD5
     is used to strengthen 'passphrase'.
 
+    TODO: Generate encrypted PEM (that matches PyCrypto's) once support is
+    added to pyca/cryptography.
+
     https://en.wikipedia.org/wiki/Triple_DES
     https://en.wikipedia.org/wiki/PBKDF2
 
@@ -488,7 +491,7 @@ def create_rsa_encrypted_pem(private_key, passphrase):
 
     tuf.CryptoError, if an RSA key in encrypted PEM format cannot be created.
 
-    TypeError, 'private_key' is unset. 
+    TypeError, if 'private_key' is unset. 
 
   <Side Effects>
     PyCrypto's Crypto.PublicKey.RSA.exportKey() called to perform the actual
@@ -516,8 +519,8 @@ def create_rsa_encrypted_pem(private_key, passphrase):
   # 'private_key' may still be a NULL string after the
   # 'tuf.formats.PEMRSA_SCHEMA' (i.e., 'private_key' has variable size and can
   # be an empty string.
-  # TODO: Use PyCrypto to generate the encrypted PEM string.
-  # generating encrypted PEMs currently unsupported by 'pyca/cryptography'. 
+  # TODO: Use PyCrypto to generate the encrypted PEM string.  Generating
+  # encrypted PEMs appears currently unsupported by 'pyca/cryptography'. 
   if len(private_key):
     try:
       rsa_key_object = Crypto.PublicKey.RSA.importKey(private_key)

--- a/tuf/pyca_crypto_keys.py
+++ b/tuf/pyca_crypto_keys.py
@@ -15,7 +15,7 @@
 
 <Purpose>
   The goal of this module is to support public-key and general-purpose
-  cryptography through the 'pyca/cryptography'(available as 'cryptography' on
+  cryptography through the pyca/cryptography (available as 'cryptography' on
   pypi) library.
   
   The RSA-related functions provided include:
@@ -29,7 +29,7 @@
   encrypt_key()
   decrypt_key()
   
-  'pyca/cryptography' performs the actual cryptographic operations and the
+  pyca/cryptography performs the actual cryptographic operations and the
   functions listed above can be viewed as the easy-to-use public interface. 
 
   https://pypi.python.org/pypi/cryptography/
@@ -66,11 +66,11 @@ import json
 # Import pyca/cryptography routines needed to generate and load cryptographic
 # keys in PEM format.
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.hazmat.backends.interfaces import PEMSerializationBackend
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.hazmat.backends import default_backend
 
-# Import Exception classes need to catch 'pyca/cryptography' exceptions.
+# Import Exception classes need to catch pyca/cryptography exceptions.
 import cryptography.exceptions
 
 # 'cryptography.hazmat.primitives.asymmetric' (i.e., pyca/cryptography's
@@ -81,11 +81,11 @@ import cryptography.exceptions
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 # PyCrypo's RSA module is needed to generate and import encrypted RSA keys.
-# Generating and loading encrypted key files with 'pyca/cryptography' will be
+# Generating and loading encrypted key files with pyca/cryptography will be
 # added once these routines are supported.
 import Crypto.PublicKey.RSA
 
-# 'pyca/Cryptography requires' hash objects to generate PKCS#1 PSS
+# pyca/Cryptography requires hash objects to generate PKCS#1 PSS
 # signatures (i.e., padding.PSS).  The 'hmac' module is needed to verify
 # ciphertexts in encrypted key files.
 from cryptography.hazmat.primitives import hashes
@@ -316,7 +316,7 @@ def create_rsa_signature(private_key, data):
     # not be encrypted.
     try:
       # 'private_key' (in PEM format) must be converted to a
-      # 'pyca/cryptography' private key object before a signature can be
+      # pyca/cryptography private key object before a signature can be
       # generated.
       private_key_object = load_pem_private_key(private_key.encode('utf-8'),
                                                 password=None,
@@ -336,7 +336,7 @@ def create_rsa_signature(private_key, data):
       raise tuf.CryptoError(message)
    
     # Generate an RSSA-PSS signature.  Raise 'tuf.CryptoError' for the expected
-    # 'pyca/cryptography' exceptions.
+    # pyca/cryptography exceptions.
     rsa_signer.update(data)
     signature = rsa_signer.finalize()
   
@@ -520,7 +520,7 @@ def create_rsa_encrypted_pem(private_key, passphrase):
   # 'tuf.formats.PEMRSA_SCHEMA' (i.e., 'private_key' has variable size and can
   # be an empty string.
   # TODO: Use PyCrypto to generate the encrypted PEM string.  Generating
-  # encrypted PEMs appears currently unsupported by 'pyca/cryptography'. 
+  # encrypted PEMs appears currently unsupported by pyca/cryptography. 
   if len(private_key):
     try:
       rsa_key_object = Crypto.PublicKey.RSA.importKey(private_key)
@@ -548,19 +548,21 @@ def create_rsa_public_and_private_from_encrypted_pem(encrypted_pem, passphrase):
     The public and private keys returned conform to 'tuf.formats.PEMRSA_SCHEMA'
     and have the form:
 
-    '-----BEGIN RSA PUBLIC KEY----- ...'
+    '-----BEGIN RSA PUBLIC KEY----- ... -----END RSA PUBLIC KEY-----'
 
-    or
+    and
 
-    '-----BEGIN RSA PRIVATE KEY----- ...'
+    '-----BEGIN RSA PRIVATE KEY----- ...-----END RSA PRIVATE KEY-----'
     
     The public and private keys are returned as strings in PEM format.
 
-    The private key part of 'encrypted_pem' is encrypted.  PyCrypto's importKey
-    method is used, where a passphrase is specified.  PyCrypto uses PBKDF1+MD5
-    to strengthen 'passphrase', and 3DES with CBC mode for encryption/decryption.    
-    Alternatively, key data may be encrypted with AES-CTR-Mode and the passphrase
-    strengthened with PBKDF2+SHA256.
+    The private key part of 'encrypted_pem' is encrypted.  pyca/cryptography's
+    load_pem_private_key() method is used, where a passphrase is specified.  In
+    the default case here, pyca/cryptography will decrypt with a PBKDF1+MD5
+    strengthened'passphrase', and 3DES with CBC mode for encryption/decryption.
+    Alternatively, key data may be encrypted with AES-CTR-Mode and the
+    passphrase strengthened with PBKDF2+SHA256, although this method is used
+    only with TUF encrypted key files.
 
     >>> public, private = generate_rsa_public_and_private(2048)
     >>> passphrase = 'secret'
@@ -596,8 +598,9 @@ def create_rsa_public_and_private_from_encrypted_pem(encrypted_pem, passphrase):
     from 'encrypted_pem', or exported in PEM format.
 
   <Side Effects>
-    PyCrypto's 'Crypto.PublicKey.RSA.importKey()' called to perform the actual
-    conversion from an encrypted RSA private key.
+    pyca/cryptography's 'serialization.load_pem_private_key()' called to
+    perform the actual conversion from an encrypted RSA private key to
+    PEM format.
 
   <Returns>
     A (public, private) tuple containing the RSA keys in PEM format.
@@ -612,22 +615,23 @@ def create_rsa_public_and_private_from_encrypted_pem(encrypted_pem, passphrase):
   # Does 'passphrase' have the correct format?
   tuf.formats.PASSWORD_SCHEMA.check_match(passphrase)
   
-  # Generate a pyca/Cryptography key object from 'encrypted_pem'.  The
+  # Generate a pyca/cryptography key object from 'encrypted_pem'.  The
   # generated PyCrypto key contains the required export methods needed to
   # generate the PEM-formatted representations of the public and private RSA
   # key.
-  
   try:
     private_key = load_pem_private_key(encrypted_pem.encode('utf-8'),
                                        passphrase.encode('utf-8'),
                                        backend=default_backend())
  
-  # pyca/cryptography's expected exceptions:
-  # ValueError: If the PEM data could not be decrypted. 
+  # pyca/cryptography's expected exceptions for 'load_pem_private_key()':
+  # ValueError: If the PEM data could not be decrypted.
   # (possibly because the passphrase is wrong)."
   # TypeError: If a password was given and the private key was not encrypted.
-  # Or if the key was encrypted but no password was supplied. 
-  except (ValueError, TypeError) as e:
+  # Or if the key was encrypted but no password was supplied.
+  # UnsupportedAlgorithm: If the private key (or if the key is encrypted with
+  # an unsupported symmetric cipher) is not supported by the backend.
+  except (ValueError, TypeError, cryptography.exceptions.UnsupportedAlgorithm) as e:
     message = 'RSA (public, private) tuple cannot be generated from the' +\
       ' encrypted PEM string: ' + str(e)
     # Raise 'tuf.CryptoError' and pyca/cryptography's exception message.  Avoid
@@ -636,7 +640,7 @@ def create_rsa_public_and_private_from_encrypted_pem(encrypted_pem, passphrase):
     raise tuf.CryptoError(message)
   
   # Export the public and private halves of the pyca/cryptography RSA key
-  # object.  The # (public, private) tuple returned contains the public and
+  # object.  The (public, private) tuple returned contains the public and
   # private RSA keys in PEM format, as strings.
   # Extract the public & private halves of the RSA key and generate their
   # PEM-formatted representations.  Return the key pair as a (public, private)
@@ -644,7 +648,9 @@ def create_rsa_public_and_private_from_encrypted_pem(encrypted_pem, passphrase):
   private_pem = private_key.private_bytes(encoding=serialization.Encoding.PEM,
                         format=serialization.PrivateFormat.TraditionalOpenSSL,
                         encryption_algorithm=serialization.NoEncryption())
-  
+ 
+  # Need to generate the public key from the private one before serializing
+  # to PEM format.
   public_key = private_key.public_key()
   public_pem = public_key.public_bytes(encoding=serialization.Encoding.PEM,
                     format=serialization.PublicFormat.SubjectPublicKeyInfo)
@@ -801,7 +807,7 @@ def decrypt_key(encrypted_key, password):
     tuf.Error, if a valid TUF key object is not found in 'encrypted_key'.
 
   <Side Effects>
-    The 'pyca/cryptography' is library called to perform the actual decryption
+    The pyca/cryptography is library called to perform the actual decryption
     of 'encrypted_key'.  The key derivation data stored in 'encrypted_key' is
     used to re-derive the encryption/decryption key.
 

--- a/tuf/pyca_crypto_keys.py
+++ b/tuf/pyca_crypto_keys.py
@@ -664,12 +664,12 @@ def create_rsa_public_and_private_from_encrypted_pem(encrypted_pem, passphrase):
 def encrypt_key(key_object, password):
   """
   <Purpose>
-    Return a string containing 'key_object' in encrypted form. Encrypted strings
-    may be safely saved to a file.  The corresponding decrypt_key() function can
-    be applied to the encrypted string to restore the original key object.
-    'key_object' is a TUF key (e.g., RSAKEY_SCHEMA, ED25519KEY_SCHEMA).  This
-    function calls the PyCrypto library to perform the encryption and derive
-    a suitable encryption key.
+    Return a string containing 'key_object' in encrypted form. Encrypted
+    strings may be safely saved to a file.  The corresponding decrypt_key()
+    function can be applied to the encrypted string to restore the original key
+    object.  'key_object' is a TUF key (e.g., RSAKEY_SCHEMA,
+    ED25519KEY_SCHEMA).  This function calls the pyca/cryptography library to
+    perform the encryption and derive a suitable encryption key.
     
     Whereas an encrypted PEM file uses the Triple Data Encryption Algorithm
     (3DES), the Cipher-block chaining (CBC) mode of operation, and the Password
@@ -761,8 +761,8 @@ def decrypt_key(encrypted_key, password):
     Return a string containing 'encrypted_key' in non-encrypted form.
     The decrypt_key() function can be applied to the encrypted string to restore
     the original key object, a TUF key (e.g., RSAKEY_SCHEMA, ED25519KEY_SCHEMA).
-    This function calls the appropriate cryptography module (e.g.,
-    pycrypto_keys.py) to perform the decryption.
+    This function calls the appropriate cryptography module (i.e.,
+    pyca_crypto_keys.py) to perform the decryption.
     
     Encrypted TUF keys use AES-256-CTR-Mode and passwords strengthened with
     PBKDF2-HMAC-SHA256 (100K iterations be default, but may be overriden in

--- a/tuf/pyca_crypto_keys.py
+++ b/tuf/pyca_crypto_keys.py
@@ -1,0 +1,738 @@
+#!/usr/bin/env python
+
+"""
+<Program Name>
+  pyca_crypto_keys.py
+
+<Author>
+  Vladimir Diaz <vladimir.v.diaz@gmail.com>
+
+<Started>
+  June 3, 2015.
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  The goal of this module is to support public-key and general-purpose
+  cryptography through the 'cryptography' (pyca/cryptography) library.
+  
+  The RSA-related functions provided:
+  generate_rsa_public_and_private()
+  create_rsa_signature()
+  verify_rsa_signature()
+  create_rsa_encrypted_pem()
+  create_rsa_public_and_private_from_encrypted_pem()
+
+  The general-purpose functions include:
+  encrypt_key()
+  decrypt_key()
+  
+  'pyca/cryptography' (i.e., the cryptography package) performs the actual
+  cryptographic operations and the functions listed above can be viewed as the
+  easy-to-use public interface. 
+ 
+  https://github.com/pyca/cryptography
+  https://en.wikipedia.org/wiki/RSA_(algorithm)
+  https://en.wikipedia.org/wiki/Advanced_Encryption_Standard
+  https://en.wikipedia.org/wiki/PBKDF
+  http://en.wikipedia.org/wiki/Scrypt
+
+  TUF key files are encrypted with the AES-256-CTR-Mode symmetric key
+  algorithm.  User passwords are strengthened with PBKDF2, currently set to
+  100,000 passphrase iterations.  The previous evpy implementation used 1,000
+  iterations.
+  
+  PEM-encrypted RSA key files use the Triple Data Encryption Algorithm (3DES)
+  and Cipher-block chaining (CBC) for the mode of operation.  Password-Based Key
+  Derivation Function 1 (PBKF1) + MD5.
+ """
+
+# Help with Python 3 compatibility, where the print statement is a function, an
+# implicit relative import is invalid, and the '/' operator performs true
+# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+
+import os
+import binascii
+import json
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+# Needed to generate keys in PEM format.
+from cryptography.hazmat.primitives import serialization
+
+# Needed to generate PSS signatures.
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+
+import cryptography.exceptions
+
+# Crypto.PublicKey (i.e., PyCrypto's public-key cryptography modules) supports 
+# algorithms like the Digital Signature Algorithm (DSA) and the ElGamal
+# encryption system.  'Crypto.PublicKey.RSA' is needed here to generate, sign,
+# and verify RSA keys.
+import Crypto.PublicKey.RSA
+
+# pyca/cryptography
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+# PyCrypto requires 'Crypto.Hash' hash objects to generate PKCS#1 PSS
+# signatures (i.e., Crypto.Signature.PKCS1_PSS).
+import Crypto.Hash.SHA256
+
+# RSA's probabilistic signature scheme with appendix (RSASSA-PSS).
+# PKCS#1 v1.5 is available for compatibility with existing applications, but
+# RSASSA-PSS is encouraged for newer applications.  RSASSA-PSS generates
+# a random salt to ensure the signature generated is probabilistic rather than
+# deterministic (e.g., PKCS#1 v1.5).
+# http://en.wikipedia.org/wiki/RSA-PSS#Schemes 
+# https://tools.ietf.org/html/rfc3447#section-8.1 
+import Crypto.Signature.PKCS1_PSS
+
+# Import PyCrypto's Key Derivation Function (KDF) module.  'keys.py' needs this
+# module to derive a secret key according to the Password-Based Key Derivation
+# Function 2 specification.  The derived key is used as the symmetric key to
+# encrypt TUF key information.  PyCrypto's implementation:
+# Crypto.Protocol.KDF.PBKDF2().  PKCS#5 v2.0 PBKDF2 specification:
+# http://tools.ietf.org/html/rfc2898#section-5.2 
+import Crypto.Protocol.KDF
+
+# PyCrypto's AES implementation.  AES is a symmetric key algorithm that
+# operates on fixed block sizes of 128-bits.
+# https://en.wikipedia.org/wiki/Advanced_Encryption_Standard
+import Crypto.Cipher.AES
+
+# 'Crypto.Random' is a cryptographically strong version of Python's standard
+# "random" module.  Random bits of data is needed for salts and 
+# initialization vectors suitable for the encryption algorithms used in 
+# 'pycrypto_keys.py'.
+import Crypto.Random
+
+# The mode of operation is presently set to CTR (CounTeR Mode) for symmetric
+# block encryption (AES-256, where the symmetric key is 256 bits).  PyCrypto
+# provides a callable stateful block counter that can update successive blocks
+# when needed.  The initial random block, or initialization vector (IV), can
+# be set to begin the process of incrementing the 128-bit blocks and allowing
+# the AES algorithm to perform cipher block operations on them. 
+import Crypto.Util.Counter
+
+# Import the TUF package and TUF-defined exceptions in __init__.py.
+import tuf
+
+# Digest objects needed to generate hashes.
+import tuf.hash
+
+# Perform object format-checking.
+import tuf.formats
+
+# Extract the cryptography library settings.
+import tuf.conf
+
+# Import key files containing json data.
+import tuf.util
+
+# Recommended RSA key sizes:
+# http://www.emc.com/emc-plus/rsa-labs/historical/twirl-and-rsa-key-size.htm#table1
+# According to the document above, revised May 6, 2003, RSA keys of
+# size 3072 provide security through 2031 and beyond.
+_DEFAULT_RSA_KEY_BITS = 3072 
+
+# The delimiter symbol used to separate the different sections
+# of encrypted files (i.e., salt, iterations, hmac, IV, ciphertext).
+# This delimiter is arbitrarily chosen and should not occur in
+# the hexadecimal representations of the fields it is separating.
+_ENCRYPTION_DELIMITER = '@@@@'
+
+# AES key size.  Default key size = 32 bytes = AES-256.
+_AES_KEY_SIZE = 32
+
+# Default salt size, in bytes.  A 128-bit salt (i.e., a random sequence of data
+# to protect against attacks that use precomputed rainbow tables to crack
+# password hashes) is generated for PBKDF2.  
+_SALT_SIZE = 16 
+
+# Default PBKDF2 passphrase iterations.  The current "good enough" number
+# of passphrase iterations.  We recommend that important keys, such as root,
+# be kept offline.  'tuf.conf.PBKDF2_ITERATIONS' should increase as CPU
+# speeds increase, set here at 100,000 iterations by default (in 2013).
+# Repository maintainers may opt to modify the default setting according to
+# their security needs and computational restrictions.  A strong user password
+# is still important.  Modifying the number of iterations will result in a new
+# derived key+PBDKF2 combination if the key is loaded and re-saved, overriding
+# any previous iteration setting used by the old '<keyid>.key'.
+# https://en.wikipedia.org/wiki/PBKDF2
+_PBKDF2_ITERATIONS = tuf.conf.PBKDF2_ITERATIONS
+
+
+def generate_rsa_public_and_private(bits=_DEFAULT_RSA_KEY_BITS):
+  """
+  <Purpose> 
+    Generate public and private RSA keys with modulus length 'bits'.
+    The public and private keys returned conform to 'tuf.formats.PEMRSA_SCHEMA'
+    and have the form:
+    '-----BEGIN RSA PUBLIC KEY----- ...'
+
+    or
+
+    '-----BEGIN RSA PRIVATE KEY----- ...'
+    
+    The public and private keys are returned as strings in PEM format.
+
+    Although PyCrypto sets a 1024-bit minimum key size,
+    generate_rsa_public_and_private() enforces a minimum key size of 2048 bits.
+    If 'bits' is unspecified, a 3072-bit RSA key is generated, which is the key
+    size recommended by TUF.
+    
+    >>> public, private = generate_rsa_public_and_private(2048)
+    >>> tuf.formats.PEMRSA_SCHEMA.matches(public)
+    True
+    >>> tuf.formats.PEMRSA_SCHEMA.matches(private)
+    True
+
+  <Arguments>
+    bits:
+      The key size, or key length, of the RSA key.  'bits' must be 2048, or
+      greater, and a multiple of 256.
+
+  <Exceptions>
+    tuf.FormatError, if 'bits' does not contain the correct format.
+    
+    ValueError, if an exception occurs in the RSA key generation routine.
+    'bits' must be a multiple of 256.  The 'ValueError' exception is raised by
+    the PyCrypto key generation function.
+
+  <Side Effects>
+    The RSA keys are generated by PyCrypto's Crypto.PublicKey.RSA.generate().
+
+  <Returns>
+    A (public, private) tuple containing the RSA keys in PEM format.
+  """
+
+  # Does 'bits' have the correct format?
+  # This check will ensure 'bits' conforms to 'tuf.formats.RSAKEYBITS_SCHEMA'.
+  # 'bits' must be an integer object, with a minimum value of 2048.
+  # Raise 'tuf.FormatError' if the check fails.
+  tuf.formats.RSAKEYBITS_SCHEMA.check_match(bits)
+  
+  # Generate the public and private RSA keys.  The PyCrypto module performs
+  # the actual key generation.  Raise 'ValueError' if 'bits' is less than 1024 
+  # or not a multiple of 256, although a 2048-bit minimum is enforced by
+  # tuf.formats.RSAKEYBITS_SCHEMA.check_match().
+  private_key = rsa.generate_private_key(public_exponent=65537, key_size=bits,
+                                         backend=default_backend())
+
+  # Extract the public & private halves of the RSA key and generate their
+  # PEM-formatted representations.  Return the key pair as a (public, private)
+  # tuple, where each RSA is a string in PEM format.
+  private_pem = private_key.private_bytes(encoding=serialization.Encoding.PEM,
+                        format=serialization.PrivateFormat.TraditionalOpenSSL,
+                        encryption_algorithm=serialization.NoEncryption())
+  
+  public_key = private_key.public_key()
+  public_pem = public_key.public_bytes(encoding=serialization.Encoding.PEM,
+                    format=serialization.PublicFormat.SubjectPublicKeyInfo)
+ 
+  return public_pem, private_pem
+
+
+
+
+
+def create_rsa_signature(private_key, data):
+  """
+  <Purpose>
+    Generate an RSASSA-PSS signature.  The signature, and the method (signature
+    algorithm) used, is returned as a (signature, method) tuple.
+
+    The signing process will use 'private_key' and 'data' to generate the
+    signature.
+
+    RFC3447 - RSASSA-PSS 
+    http://www.ietf.org/rfc/rfc3447.txt
+    
+    >>> public, private = generate_rsa_public_and_private(2048)
+    >>> data = 'The quick brown fox jumps over the lazy dog'.encode('utf-8')
+    >>> signature, method = create_rsa_signature(private, data)
+    >>> tuf.formats.NAME_SCHEMA.matches(method)
+    True
+    >>> method == 'RSASSA-PSS'
+    True
+    >>> tuf.formats.PYCRYPTOSIGNATURE_SCHEMA.matches(signature)
+    True
+
+  <Arguments>
+    private_key: 
+      The private RSA key, a string in PEM format.
+
+    data:
+      Data object used by create_rsa_signature() to generate the signature.
+
+  <Exceptions>
+    tuf.FormatError, if 'private_key' is improperly formatted.
+    
+    TypeError, if 'private_key' is unset.
+
+    tuf.CryptoError, if the signature cannot be generated. 
+
+  <Side Effects>
+    PyCrypto's 'Crypto.Signature.PKCS1_PSS' called to generate the signature.
+
+  <Returns>
+    A (signature, method) tuple, where the signature is a string and the method
+    is 'RSASSA-PSS'.
+  """
+  
+  # Does 'private_key' have the correct format?
+  # This check will ensure 'private_key' conforms to 'tuf.formats.PEMRSA_SCHEMA'.
+  # Raise 'tuf.FormatError' if the check fails.
+  tuf.formats.PEMRSA_SCHEMA.check_match(private_key)
+  
+  # Signing the 'data' object requires a private key.  The 'RSASSA-PSS' signing
+  # method is the only method currently supported.
+  method = 'RSASSA-PSS'
+  signature = None
+
+  # Verify the signature, but only if the private key has been set.  The private
+  # key is a NULL string if unset.  Although it may be clearer to explicitly
+  # check that 'private_key' is not '', we can/should check for a value and not
+  # compare identities with the 'is' keyword.  Up to this point 'private_key'
+  # has variable size and can be an empty string.
+  if len(private_key):
+   
+    # Calculate the SHA256 hash of 'data' and generate the hash's PKCS1-PSS
+    # signature. 
+    
+    # pyca/cryptography's expected exceptions when generating RSA key object:
+    # "ValueError/IndexError/TypeError:  When the given key cannot be parsed
+    # (possibly because the passphrase is wrong)."
+    # If the passphrase is incorrect, pyca/cryptography returns: "".
+    try:
+      # 'private_pem' must be converted to a pyca/cryptography private key object
+      # before a signature can be generated.
+      private_key_object = serialization.load_pem_private_key(private_key,
+                                                     password=None,
+                                                     backend=default_backend())
+      rsa_signer = \
+        private_key_object.signer(padding.PSS(mgf=padding.MGF1(hashes.SHA256()),
+                           salt_length=padding.PSS.MAX_LENGTH), hashes.SHA256())
+
+    except (ValueError, IndexError, TypeError) as e:
+      message = 'Invalid private key or hash data: ' + str(e)
+      raise tuf.CryptoError(message)
+   
+    # Generate RSSA-PSS signature.  Raise 'tuf.CryptoError' for the expected
+    # pyca/cryptography exceptions.
+    try:
+      rsa_signer.update(data)
+      signature = rsa_signer.finalize()
+    
+    except ValueError: #pragma: no cover
+      raise tuf.CryptoError('The RSA key too small for given hash algorithm.')
+    
+    except TypeError:
+      raise tuf.CryptoError('Missing required RSA private key.')
+   
+    except IndexError: # pragma: no cover
+      message = 'An RSA signature cannot be generated: ' + str(e)
+      raise tuf.CryptoError(message)
+  
+  else:
+    raise TypeError('The required private key is unset.')
+
+  return signature, method
+
+
+
+
+
+def verify_rsa_signature(signature, signature_method, public_key, data):
+  """
+  <Purpose>
+    Determine whether the corresponding private key of 'public_key' produced
+    'signature'.  verify_signature() will use the public key, signature method,
+    and 'data' to complete the verification.
+    
+    >>> public, private = generate_rsa_public_and_private(2048)
+    >>> data = b'The quick brown fox jumps over the lazy dog'
+    >>> signature, method = create_rsa_signature(private, data)
+    >>> verify_rsa_signature(signature, method, public, data)
+    True
+    >>> verify_rsa_signature(signature, method, public, b'bad_data')
+    False
+
+  <Arguments>
+    signature:
+      An RSASSA PSS signature as a string.  This is the signature returned
+      by create_rsa_signature(). 
+
+    signature_method:
+      A string that indicates the signature algorithm used to generate
+      'signature'.  'RSASSA-PSS' is currently supported.
+
+    public_key:
+      The RSA public key, a string in PEM format.
+
+    data:
+      Data object used by tuf.keys.create_signature() to generate
+      'signature'.  'data' is needed here to verify the signature.
+
+  <Exceptions>
+    tuf.UnknownMethodError.  Raised if the signing method used by
+    'signature' is not one supported by tuf.keys.create_signature().
+    
+    tuf.FormatError. Raised if 'signature', 'signature_method', or 'public_key'
+    is improperly formatted.
+
+  <Side Effects>
+    Crypto.Signature.PKCS1_PSS.verify() called to do the actual verification.
+
+  <Returns>
+    Boolean.  True if the signature is valid, False otherwise.
+  """
+  
+  # Does 'public_key' have the correct format?
+  # This check will ensure 'public_key' conforms to 'tuf.formats.PEMRSA_SCHEMA'.
+  # Raise 'tuf.FormatError' if the check fails.
+  tuf.formats.PEMRSA_SCHEMA.check_match(public_key)
+
+  # Does 'signature_method' have the correct format?
+  tuf.formats.NAME_SCHEMA.check_match(signature_method)
+
+  # Does 'signature' have the correct format?
+  tuf.formats.PYCRYPTOSIGNATURE_SCHEMA.check_match(signature)
+
+  # Verify whether the private key of 'public_key' produced 'signature'.
+  # Before returning the 'valid_signature' Boolean result, ensure 'RSASSA-PSS'
+  # was used as the signing method.
+  valid_signature = False
+
+  # Verify the signature with PyCrypto if the signature method is valid,
+  # otherwise raise 'tuf.UnknownMethodError'.
+  if signature_method == 'RSASSA-PSS':
+    try:
+      public_key_object = serialization.load_pem_public_key(public_key,
+                                                     backend=default_backend())
+       
+      verifier = public_key_object.verifier(signature,
+                                  padding.PSS(mgf=padding.MGF1(hashes.SHA256()),
+                                  salt_length=padding.PSS.MAX_LENGTH),
+                                  hashes.SHA256())
+
+      verifier.update(data)
+      
+      # verify() raises an 'InvalidSignature' exception. 
+      try: 
+        verifier.verify()
+        valid_signature = True 
+      
+      except cryptography.exceptions.InvalidSignature as e:
+        pass
+    
+    except (ValueError, IndexError, TypeError) as e:
+      message = 'The RSA signature could not be verified.'
+      raise tuf.CryptoError(message)
+  
+  else:
+    raise tuf.UnknownMethodError(signature_method)
+
+  return valid_signature 
+
+
+
+
+
+def encrypt_key(key_object, password):
+  """
+  <Purpose>
+    Return a string containing 'key_object' in encrypted form. Encrypted strings
+    may be safely saved to a file.  The corresponding decrypt_key() function can
+    be applied to the encrypted string to restore the original key object.
+    'key_object' is a TUF key (e.g., RSAKEY_SCHEMA, ED25519KEY_SCHEMA).  This
+    function calls the PyCrypto library to perform the encryption and derive
+    a suitable encryption key.
+    
+    Whereas an encrypted PEM file uses the Triple Data Encryption Algorithm
+    (3DES), the Cipher-block chaining (CBC) mode of operation, and the Password
+    Based Key Derivation Function 1 (PBKF1) + MD5 to strengthen 'password',
+    encrypted TUF keys use AES-256-CTR-Mode and passwords strengthened with
+    PBKDF2-HMAC-SHA256 (100K iterations by default, but may be overriden in
+    'tuf.conf.PBKDF2_ITERATIONS' by the user).
+
+    http://en.wikipedia.org/wiki/Advanced_Encryption_Standard
+    http://en.wikipedia.org/wiki/CTR_mode#Counter_.28CTR.29
+    https://en.wikipedia.org/wiki/PBKDF2
+
+    >>> ed25519_key = {'keytype': 'ed25519', \
+                       'keyid': \
+          'd62247f817883f593cf6c66a5a55292488d457bcf638ae03207dbbba9dbe457d', \
+                       'keyval': {'public': \
+          '74addb5ad544a4306b34741bc1175a3613a8d7dc69ff64724243efdec0e301ad', \
+                                  'private': \
+          '1f26964cc8d4f7ee5f3c5da2fbb7ab35811169573ac367b860a537e47789f8c4'}}
+    >>> passphrase = 'secret'
+    >>> encrypted_key = encrypt_key(ed25519_key, passphrase)
+    >>> tuf.formats.ENCRYPTEDKEY_SCHEMA.matches(encrypted_key.encode('utf-8'))
+    True
+
+  <Arguments>
+    key_object:
+      The TUF key object that should contain the private portion of the ED25519
+      key.
+
+    password:
+      The password, or passphrase, to encrypt the private part of the RSA
+      key.  'password' is not used directly as the encryption key, a stronger
+      encryption key is derived from it. 
+
+  <Exceptions>
+    tuf.FormatError, if any of the arguments are improperly formatted or 
+    'key_object' does not contain the private portion of the key.
+
+    tuf.CryptoError, if an ED25519 key in encrypted TUF format cannot be
+    created.
+
+  <Side Effects>
+    PyCrypto cryptographic operations called to perform the actual encryption of
+    'key_object'.  'password' used to derive a suitable encryption key.
+
+  <Returns>
+    An encrypted string in 'tuf.formats.ENCRYPTEDKEY_SCHEMA' format.
+  """
+  
+  # Do the arguments have the correct format?
+  # Ensure the arguments have the appropriate number of objects and object
+  # types, and that all dict keys are properly named.
+  # Raise 'tuf.FormatError' if the check fails.
+  tuf.formats.ANYKEY_SCHEMA.check_match(key_object)
+  
+  # Does 'password' have the correct format?
+  tuf.formats.PASSWORD_SCHEMA.check_match(password)
+
+  # Ensure the private portion of the key is included in 'key_object'.
+  if not key_object['keyval']['private']:
+    message = 'Key object does not contain a private part.'
+    raise tuf.FormatError(message)
+
+  # Derive a key (i.e., an appropriate encryption key and not the
+  # user's password) from the given 'password'.  Strengthen 'password' with
+  # PBKDF2-HMAC-SHA256 (100K iterations by default, but may be overriden in
+  # 'tuf.conf.PBKDF2_ITERATIONS' by the user).
+  salt, iterations, derived_key = _generate_derived_key(password)
+ 
+  # Store the derived key info in a dictionary, the object expected
+  # by the non-public _encrypt() routine.
+  derived_key_information = {'salt': salt, 'iterations': iterations,
+                             'derived_key': derived_key}
+
+  # Convert the key object to json string format and encrypt it with the
+  # derived key.
+  encrypted_key = _encrypt(json.dumps(key_object), derived_key_information)  
+
+  return encrypted_key
+
+
+
+
+
+def _generate_derived_key(password, salt=None, iterations=None):
+  """
+  Generate a derived key by feeding 'password' to the Password-Based Key
+  Derivation Function (PBKDF2).  PyCrypto's PBKDF2 implementation is
+  currently used.  'salt' may be specified so that a previous derived key
+  may be regenerated.
+  """
+  
+  if salt is None:
+    salt = Crypto.Random.new().read(_SALT_SIZE) 
+
+  if iterations is None:
+    iterations = _PBKDF2_ITERATIONS
+
+  derived_key = \
+    derive_pbkdf2_hmac(self, algorithm, length, salt, iterations, password)
+
+  """
+  def pseudorandom_function(password, salt):
+    """
+    PyCrypto's PBKDF2() expects a callable function for its optional
+    'prf' argument.  'prf' is set to HMAC-SHA1 (in PyCrypto's PBKDF2 function)
+    by default.  'pseudorandom_function' instead sets 'prf' to HMAC-SHA256. 
+    """
+    
+    return Crypto.Hash.HMAC.new(password, salt, Crypto.Hash.SHA256).digest()  
+
+
+  # 'dkLen' is the desired key length.  'count' is the number of password
+  # iterations performed by PBKDF2.  'prf' is a pseudorandom function, which
+  # must be callable. 
+  derived_key = Crypto.Protocol.KDF.PBKDF2(password, salt,
+                                           dkLen=_AES_KEY_SIZE,
+                                           count=iterations,
+                                           prf=pseudorandom_function)
+
+  """
+
+  return salt, iterations, derived_key
+
+
+
+
+
+def _encrypt(key_data, derived_key_information):
+  """
+  Encrypt 'key_data' using the Advanced Encryption Standard (AES-256) algorithm.
+  'derived_key_information' should contain a key strengthened by PBKDF2.  The
+  key size is 256 bits and AES's mode of operation is set to CTR (CounTeR Mode).
+  The HMAC of the ciphertext is generated to ensure the ciphertext has not been
+  modified.
+
+  'key_data' is the JSON string representation of the key.  In the case
+  of RSA keys, this format would be 'tuf.formats.RSAKEY_SCHEMA':
+  {'keytype': 'rsa',
+   'keyval': {'public': '-----BEGIN RSA PUBLIC KEY----- ...',
+              'private': '-----BEGIN RSA PRIVATE KEY----- ...'}}
+
+  'derived_key_information' is a dictionary of the form:
+    {'salt': '...',
+     'derived_key': '...',
+     'iterations': '...'}
+
+  'tuf.CryptoError' raised if the encryption fails.
+  """
+  
+  # Generate a random initialization vector (IV).  The 'iv' is treated as the
+  # initial counter block to a stateful counter block function (i.e.,
+  # PyCrypto's 'Crypto.Util.Counter').  The AES block cipher operates on 128-bit
+  # blocks, so generate a random 16-byte initialization block.  PyCrypto expects
+  # the initial value of the stateful counter to be an integer.
+  # Follow the provably secure encrypt-then-MAC approach, which affords the
+  # ability to verify ciphertext without needing to decrypt it and preventing
+  # an attacker from feeding the block cipher malicious data.  Modes like GCM
+  # provide both encryption and authentication, whereas CTR only provides
+  # encryption.  
+  iv = Crypto.Random.new().read(16)
+  stateful_counter_128bit_blocks = Crypto.Util.Counter.new(128,
+                                      initial_value=int(binascii.hexlify(iv), 16)) 
+  symmetric_key = derived_key_information['derived_key'] 
+  aes_cipher = Crypto.Cipher.AES.new(symmetric_key,
+                                     Crypto.Cipher.AES.MODE_CTR,
+                                     counter=stateful_counter_128bit_blocks)
+ 
+  # Use AES-256 to encrypt 'key_data'.  The key size determines how many cycle
+  # repetitions are performed by AES, 14 cycles for 256-bit keys.
+  try:
+    ciphertext = aes_cipher.encrypt(key_data)
+ 
+  # PyCrypto does not document the exceptions that may be raised or under
+  # what circumstances.  PyCrypto example given is to call encrypt() without
+  # checking for exceptions.  Avoid propogating the exception trace and only
+  # raise 'tuf.CryptoError', along with the cause of encryption failure.
+  except (ValueError, IndexError, TypeError) as e:
+    message = 'The key data cannot be encrypted: ' + str(e)
+    raise tuf.CryptoError(message)
+
+  # Generate the hmac of the ciphertext to ensure it has not been modified.
+  # The decryption routine may verify a ciphertext without having to perform
+  # a decryption operation.
+  salt = derived_key_information['salt'] 
+  hmac_object = Crypto.Hash.HMAC.new(symmetric_key, ciphertext,
+                                     Crypto.Hash.SHA256)
+  hmac = hmac_object.hexdigest()
+  
+  # Store the number of PBKDF2 iterations used to derive the symmetric key so
+  # that the decryption routine can regenerate the symmetric key successfully.
+  # The pbkdf2 iterations are allowed to vary for the keys loaded and saved.
+  iterations = derived_key_information['iterations']
+
+  # Return the salt, iterations, hmac, initialization vector, and ciphertext
+  # as a single string.  These five values are delimited by
+  # '_ENCRYPTION_DELIMITER' to make extraction easier.  This delimiter is
+  # arbitrarily chosen and should not occur in the hexadecimal representations
+  # of the fields it is separating.
+  return binascii.hexlify(salt).decode() + _ENCRYPTION_DELIMITER + \
+         str(iterations) + _ENCRYPTION_DELIMITER + \
+         hmac + _ENCRYPTION_DELIMITER + \
+         binascii.hexlify(iv).decode() + _ENCRYPTION_DELIMITER + \
+         binascii.hexlify(ciphertext).decode()
+
+
+
+
+
+def _decrypt(file_contents, password):
+  """
+  The corresponding decryption routine for _encrypt().
+
+  'tuf.CryptoError' raised if the decryption fails.
+  """
+ 
+  # Extract the salt, iterations, hmac, initialization vector, and ciphertext
+  # from 'file_contents'.  These five values are delimited by
+  # '_ENCRYPTION_DELIMITER'.  This delimiter is arbitrarily chosen and should
+  # not occur in the hexadecimal representations of the fields it is separating.
+  # Raise 'tuf.CryptoError', if 'file_contents' does not contains the expected
+  # data layout.
+  try: 
+    salt, iterations, hmac, iv, ciphertext = \
+      file_contents.split(_ENCRYPTION_DELIMITER)
+  
+  except ValueError:
+    raise tuf.CryptoError('Invalid encrypted file.') 
+
+  # Ensure we have the expected raw data for the delimited cryptographic data. 
+  salt = binascii.unhexlify(salt.encode('utf-8'))
+  iterations = int(iterations)
+  iv = binascii.unhexlify(iv.encode('utf-8'))
+  ciphertext = binascii.unhexlify(ciphertext.encode('utf-8'))
+
+  # Generate derived key from 'password'.  The salt and iterations are specified
+  # so that the expected derived key is regenerated correctly.  Discard the old
+  # "salt" and "iterations" values, as we only need the old derived key.
+  junk_old_salt, junk_old_iterations, derived_key = \
+    _generate_derived_key(password, salt, iterations)
+
+  # Verify the hmac to ensure the ciphertext is valid and has not been altered.
+  # See the encryption routine for why we use the encrypt-then-MAC approach.
+  generated_hmac_object = Crypto.Hash.HMAC.new(derived_key, ciphertext,
+                                               Crypto.Hash.SHA256)
+  generated_hmac = generated_hmac_object.hexdigest()
+
+  if not tuf.util.digests_are_equal(generated_hmac, hmac):
+    raise tuf.CryptoError('Decryption failed.')
+
+  # The following decryption routine assumes 'ciphertext' was encrypted with
+  # AES-256.
+  stateful_counter_128bit_blocks = Crypto.Util.Counter.new(128,
+                                      initial_value=int(binascii.hexlify(iv), 16)) 
+  aes_cipher = Crypto.Cipher.AES.new(derived_key,
+                                     Crypto.Cipher.AES.MODE_CTR,
+                                     counter=stateful_counter_128bit_blocks)
+  try:
+    key_plaintext = aes_cipher.decrypt(ciphertext)
+  
+  # PyCrypto does not document the exceptions that may be raised or under
+  # what circumstances.  PyCrypto example given is to call decrypt() without
+  # checking for exceptions.  Avoid propogating the exception trace and only
+  # raise 'tuf.CryptoError', along with the cause of decryption failure.
+  # Note: decryption failure, due to malicious ciphertext, should not occur here
+  # if the hmac check above passed.
+  except (ValueError, IndexError, TypeError) as e: # pragma: no cover
+    raise tuf.CryptoError('Decryption failed: ' + str(e))
+
+  return key_plaintext
+
+
+
+
+if __name__ == '__main__':
+  # The interactive sessions of the documentation strings can be tested by
+  # running 'pyca_crypto_keys.py' as a standalone module:
+  # $ python pyca_crypto_keys.py
+  import doctest
+  doctest.testmod()

--- a/tuf/pycrypto_keys.py
+++ b/tuf/pycrypto_keys.py
@@ -77,10 +77,10 @@ import Crypto.Hash.SHA256
 # https://tools.ietf.org/html/rfc3447#section-8.1 
 import Crypto.Signature.PKCS1_PSS
 
-# Import PyCrypto's Key Derivation Function (KDF) module.  'keystore.py'
-# needs this module to derive a secret key according to the Password-Based
-# Key Derivation Function 2 specification.  The derived key is used as the
-# symmetric key to encrypt TUF key information.  PyCrypto's implementation:
+# Import PyCrypto's Key Derivation Function (KDF) module.  'keys.py' needs this
+# module to derive a secret key according to the Password-Based Key Derivation
+# Function 2 specification.  The derived key is used as the symmetric key to
+# encrypt TUF key information.  PyCrypto's implementation:
 # Crypto.Protocol.KDF.PBKDF2().  PKCS#5 v2.0 PBKDF2 specification:
 # http://tools.ietf.org/html/rfc2898#section-5.2 
 import Crypto.Protocol.KDF
@@ -506,7 +506,7 @@ def create_rsa_public_and_private_from_encrypted_pem(encrypted_pem, passphrase):
     method is used, where a passphrase is specified.  PyCrypto uses PBKDF1+MD5
     to strengthen 'passphrase', and 3DES with CBC mode for encryption/decryption.    
     Alternatively, key data may be encrypted with AES-CTR-Mode and the passphrase
-    strengthened with PBKDF2+SHA256.  See 'keystore.py'.
+    strengthened with PBKDF2+SHA256.
 
     >>> public, private = generate_rsa_public_and_private(2048)
     >>> passphrase = 'secret'

--- a/tuf/pycrypto_keys.py
+++ b/tuf/pycrypto_keys.py
@@ -291,7 +291,7 @@ def create_rsa_signature(private_key, data):
     # If the passphrase is incorrect, PyCrypto returns: "RSA key format is not
     # supported".
     try:
-      sha256_object = Crypto.Hash.SHA256.new(data)
+      sha256_object = Crypto.Hash.SHA256.new(data.encode('utf-8'))
       rsa_key_object = Crypto.PublicKey.RSA.importKey(private_key)
     
     except (ValueError, IndexError, TypeError) as e:
@@ -390,7 +390,7 @@ def verify_rsa_signature(signature, signature_method, public_key, data):
     try:
       rsa_key_object = Crypto.PublicKey.RSA.importKey(public_key)
       pkcs1_pss_verifier = Crypto.Signature.PKCS1_PSS.new(rsa_key_object)
-      sha256_object = Crypto.Hash.SHA256.new(data)
+      sha256_object = Crypto.Hash.SHA256.new(data.encode('utf'))
       valid_signature = pkcs1_pss_verifier.verify(sha256_object, signature)
     
     except (ValueError, IndexError, TypeError) as e:
@@ -590,7 +590,7 @@ def create_rsa_public_and_private_from_encrypted_pem(encrypted_pem, passphrase):
   except (ValueError): #pragma: no cover
     message = 'The public and private keys cannot be exported in PEM format.' 
     raise tuf.CryptoError(message)
-  
+
   return public.decode(), private.decode()
 
 

--- a/tuf/pycrypto_keys.py
+++ b/tuf/pycrypto_keys.py
@@ -248,7 +248,7 @@ def create_rsa_signature(private_key, data):
       The private RSA key, a string in PEM format.
 
     data:
-      Data object used by create_rsa_signature() to generate the signature.
+      Data (string) used by create_rsa_signature() to generate the signature.
 
   <Exceptions>
     tuf.FormatError, if 'private_key' is improperly formatted.
@@ -269,6 +269,9 @@ def create_rsa_signature(private_key, data):
   # This check will ensure 'private_key' conforms to 'tuf.formats.PEMRSA_SCHEMA'.
   # Raise 'tuf.FormatError' if the check fails.
   tuf.formats.PEMRSA_SCHEMA.check_match(private_key)
+
+  # Does 'data' have the correct format?
+  tuf.formats.DATA_SCHEMA.check_match(data)
 
   # Signing the 'data' object requires a private key.
   # The 'RSASSA-PSS' (i.e., PyCrypto module) signing method is the
@@ -378,6 +381,9 @@ def verify_rsa_signature(signature, signature_method, public_key, data):
 
   # Does 'signature' have the correct format?
   tuf.formats.PYCRYPTOSIGNATURE_SCHEMA.check_match(signature)
+
+  # Does 'data' have the correct format?
+  tuf.formats.DATA_SCHEMA.check_match(data)
 
   # Verify whether the private key of 'public_key' produced 'signature'.
   # Before returning the 'valid_signature' Boolean result, ensure 'RSASSA-PSS'

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -99,13 +99,12 @@ SNAPSHOT_EXPIRATION = 604800
 # Initial 'timestamp.json' expiration time of 1 day.
 TIMESTAMP_EXPIRATION = 86400
 
-
 try:
   tuf.keys.check_crypto_libraries(['rsa', 'ed25519', 'general'])
 
 except tuf.UnsupportedLibraryError as e: #pragma: no cover
   message = 'Warning: The repository and developer tools require additional' + \
-    ' libraries and can be installed as follows:\n $ pip install tuf[tools]'  
+    ' libraries, which that can be installed as follows:\n $ pip install tuf[tools]'  
   logger.warn(message) 
 
 
@@ -188,7 +187,7 @@ class Repository(object):
       private keys, etc.
     
     <Arguments>
-      mrite_partial:
+      write_partial:
         A boolean indicating whether partial metadata should be written to
         disk.  Partial metadata may be written to allow multiple maintainters
         to independently sign and update role metadata.  write() raises an


### PR DESCRIPTION
Add support for pyca/cryptography.  `pyca_crypto_key.py` contains all of the functionality provided by `pycrypto_keys.py`, with the exception of generating encrypted files with: 3DES with CBC mode, and PBKDF1+MD5 to strengthen passphrase

* [x] Resolve remaining import issues in unit tests

* [x] Support or drop encrypted PEMs with pyca/cryptography