### PR TITLE
Import `tuf.log` in `test_init.py` and fix logger name.  Issue #303.

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -29,8 +29,9 @@ import unittest
 import logging
 
 import tuf
+import tuf.log
 
-logger = logging.getLogger('tuf.test_keys')
+logger = logging.getLogger('tuf.test_init')
 
 class TestInit(unittest.TestCase):
   def setUp(self):


### PR DESCRIPTION
In PR #307, `tuf.log` is no longer imported by `__init__.py`.  Add an import statement for `tuf.log` to fix missing handler warning in `test_init.py`.  The logger name specified is also incorrect.