### PR TITLE
Fix #322 freeze attack by detecting expiry of stale metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build/*
 .coverage
 .tox/*
 tests/htmlcov/*
+.DS_Store

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -181,18 +181,18 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
   def test_without_tuf(self):
     # Two tests are conducted here.
-    # Test 1: If an expired timestamp is downloaded, is it recognized as such?
-    # Test 2: If we find that the timestamp acquired from a mirror indicates
+    # Test 1: If we find that the timestamp acquired from a mirror indicates
     #         that there is no new snapshot file, and our current snapshot
     #         file is expired, is it recognized as such?
+    # Test 2: If an expired timestamp is downloaded, is it recognized as such?
 
-    # Test 2 Begin:
+    # Test 1 Begin:
     #
     # See description of scenario in Test 2 in the test_with_tuf method.
     # Without TUF, Test 2 is tantamount to Test 1, and so we skip this test.
 
 
-    # Test 1 Begin:
+    # Test 2 Begin:
     #
     # 'timestamp.json' specifies the latest version of the repository files.
     # A client should only accept the same version of this file up to a certain
@@ -241,13 +241,13 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
   def test_with_tuf(self):
     # Two tests are conducted here.
-    # Test 1: If an expired timestamp is downloaded, is it recognized as such?
-    # Test 2: If we find that the timestamp acquired from a mirror indicates
+    # Test 1: If we find that the timestamp acquired from a mirror indicates
     #         that there is no new snapshot file, and our current snapshot
     #         file is expired, is it recognized as such?
+    # Test 2: If an expired timestamp is downloaded, is it recognized as such?
 
 
-    # Test 2 Begin:
+    # Test 1 Begin:
     #
     # Addresses this issue: https://github.com/theupdateframework/tuf/issues/322
     #
@@ -337,7 +337,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
 
 
-    # Test 1 Begin:
+    # Test 2 Begin:
     #
     # 'timestamp.json' specifies the latest version of the repository files.
     # A client should only accept the same version of this file up to a certain
@@ -349,16 +349,13 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # TUF client. The TUF client performs a refresh of top-level metadata, which
     # includes 'timestamp.json'.
     
-    timestamp_path = os.path.join(self.repository_directory, 'metadata',
-                                  'timestamp.json')
-    
     # Modify the timestamp file on the remote repository.  'timestamp.json'
     # must be properly updated and signed with 'repository_tool.py', otherwise
     # the client will reject it as invalid metadata.  The resulting
     # 'timestamp.json' should be valid metadata, but expired (as intended).
     repository = repo_tool.load_repository(self.repository_directory)
  
-    key_file = os.path.join(self.keystore_directory, 'timestamp_key') 
+    key_file = os.path.join(self.keystore_directory, 'timestamp_key')
     timestamp_private = repo_tool.import_rsa_privatekey_from_file(key_file,
                                                                   'password')
 

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -180,13 +180,26 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
 
   def test_without_tuf(self):
-    # Test 1:
-    # Scenario:
+    # Two tests are conducted here.
+    # Test 1: If an expired timestamp is downloaded, is it recognized as such?
+    # Test 2: If we find that the timestamp acquired from a mirror indicates
+    #         that there is no new snapshot file, and our current snapshot
+    #         file is expired, is it recognized as such?
+
+    # Test 2 Begin:
+    #
+    # See description of scenario in Test 2 in the test_with_tuf method.
+    # Without TUF, Test 2 is tantamount to Test 1, and so we skip this test.
+
+
+    # Test 1 Begin:
+    #
     # 'timestamp.json' specifies the latest version of the repository files.
     # A client should only accept the same version of this file up to a certain
     # point, or else it cannot detect that new files are available for download.
     # Modify the repository's timestamp.json' so that it expires soon, copy it
     # over the to client, and attempt to re-fetch the same expired version. 
+    #
     # A non-TUF client (without a way to detect when metadata has expired) is
     # expected to download the same version, and thus the same outdated files.
     # Verify that the same file size and hash of 'timestamp.json' is downloaded.
@@ -225,11 +238,6 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # Verify 'download_fileinfo' is equal to the current local file.
     self.assertEqual(download_fileinfo, fileinfo)
 
-    # Test 2:
-    # See description of scenario in Test 2 in the test_with_tuf method.
-    # Without TUF, Test 2 is tantamount to Test 1, and so it is not tested
-    # again here.
-
 
   def test_with_tuf(self):
     # Two tests are conducted here.
@@ -237,9 +245,11 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # Test 2: If we find that the timestamp acquired from a mirror indicates
     #         that there is no new snapshot file, and our current snapshot
     #         file is expired, is it recognized as such?
+
+
+    # Test 2 Begin:
     #
-    # Test 2 addresses this issue:
-    #   https://github.com/theupdateframework/tuf/issues/322
+    # Addresses this issue: https://github.com/theupdateframework/tuf/issues/322
     #
     # If time has passed and our snapshot (or any targets role) is expired, and
     # the mirror whose timestamp we fetched doesn't indicate the existence of a
@@ -247,13 +257,14 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # the software update system / application / user. This test creates that
     # scenario. The correct behavior is to raise an exception.
     #
-    # Background: Expiration checks were previously conducted
-    # (ensure_not_expired) when the metadata file was downloaded. If no new
-    # metadata file was downloaded, no expiry check would occurs. (Exception:
-    # root was checked for expiration at the beginning of each refresh() cycle,
-    # and timestamp was always checked because it was always fetched.) Snapshot
-    # and targets were never checked if the user does not have evidence that
-    # they have changed.
+    # Background: Expiration checks (updater._ensure_not_expired) were
+    # previously conducted when the metadata file was downloaded. If no new
+    # metadata file was downloaded, no expiry check would occur. In particular, 
+    # while root was checked for expiration at the beginning of each
+    # updater.refresh() cycle, and timestamp was always checked because it was
+    # always fetched, snapshot and targets were never checked if the user did 
+    # not receive evidence that they had changed.
+    # That bug was fixed and this test tests that fix going forward.
 
     timestamp_path = os.path.join(self.repository_directory, 'metadata',
                                   'timestamp.json')
@@ -325,11 +336,17 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
 
 
-    # Part 1:
+    # Test 1 Begin:
+    #
+    # 'timestamp.json' specifies the latest version of the repository files.
+    # A client should only accept the same version of this file up to a certain
+    # point, or else it cannot detect that new files are available for download.
+    # Modify the repository's timestamp.json' so that it expires soon, copy it
+    # over the to client, and attempt to re-fetch the same expired version.
 
-    # The same scenario outlined in test_without_tuf() is followed here, except
-    # with a TUF client.  The TUF client performs a refresh of top-level
-    # metadata, which also includes 'timestamp.json'.
+    # The same scenario as in test_without_tuf() is followed here, except with a
+    # TUF client. The TUF client performs a refresh of top-level metadata, which
+    # includes 'timestamp.json'.
     
     timestamp_path = os.path.join(self.repository_directory, 'metadata',
                                   'timestamp.json')

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -295,9 +295,9 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
     time.sleep(0.1)
 
-    # Expire snapshot in 3s
+    # Expire snapshot in 0s
     datetime_object = tuf.formats.unix_timestamp_to_datetime(int(time.time() +
-                                                                 3))
+                                                                 0))
     repository.snapshot.expiration = datetime_object
 
     # Now write to the repository
@@ -313,11 +313,11 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     logger.info('Test: Refreshing #1 - Initial metadata refresh occurring.')
     self.repository_updater.refresh()
     logger.info("Test: Refreshed #1 - Initial metadata refresh completed "
-                "successfully. Now sleeping 3s so snapshot metadata expires.")
+                "successfully. Now sleeping 6s so snapshot metadata expires.")
 
-    # Sleep for at least 7 seconds to ensure 'repository.snapshot.expiration'
+    # Sleep for at least 2 seconds to ensure 'repository.snapshot.expiration'
     # is reached.
-    time.sleep(3)
+    time.sleep(2)
     logger.info("Test: Refreshing #2 - Now trying to refresh again after local "
       "snapshot expiry.")
     try:
@@ -361,8 +361,8 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
     repository.timestamp.load_signing_key(timestamp_private)
     
-    # expire in 3 seconds.
-    datetime_object = tuf.formats.unix_timestamp_to_datetime(int(time.time() + 3))
+    # expire in 2 seconds.
+    datetime_object = tuf.formats.unix_timestamp_to_datetime(int(time.time() + 2))
     repository.timestamp.expiration = datetime_object
     repository.write()
     
@@ -374,7 +374,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # Verify that the TUF client detects outdated metadata and refuses to
     # continue the update process.  Sleep for at least 3 seconds to ensure
     # 'repository.timestamp.expiration' is reached.
-    time.sleep(3)
+    time.sleep(2)
     try:
       self.repository_updater.refresh()
     

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -269,15 +269,16 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # Modify the timestamp file on the remote repository.  'timestamp.json'
     # must be properly updated and signed with 'repository_tool.py', otherwise
     # the client will reject it as invalid metadata.
+
+    # Load the repository
     repository = repo_tool.load_repository(self.repository_directory)
- 
+
+    # Load the timestamp and snapshot keys, since we will be signing a new
+    # timestamp and a new snapshot file.
     key_file = os.path.join(self.keystore_directory, 'timestamp_key') 
     timestamp_private = repo_tool.import_rsa_privatekey_from_file(key_file,
                                                                   'password')
-
     repository.timestamp.load_signing_key(timestamp_private)
-
-    # Load snapshot keys.
     key_file = os.path.join(self.keystore_directory, 'snapshot_key') 
     snapshot_private = repo_tool.import_rsa_privatekey_from_file(key_file,
                                                                   'password')

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -283,12 +283,6 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
                                                                   'password')
     repository.snapshot.load_signing_key(snapshot_private)
 
-    # Load root keys.
-    key_file = os.path.join(self.keystore_directory, 'root_key')
-    root_private = repo_tool.import_rsa_privatekey_from_file(key_file,
-                                                                  'password')
-    repository.root.load_signing_key(root_private)
-
     # Expire snapshot in 8s. This should be far enough into the future that we
     # haven't reached it before the first refresh validates timestamp expiry. We
     # want a successful refresh before expiry, then a second refresh after

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -295,9 +295,9 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
     time.sleep(0.1)
 
-    # Expire snapshot in 7s
+    # Expire snapshot in 3s
     datetime_object = tuf.formats.unix_timestamp_to_datetime(int(time.time() +
-                                                                 7))
+                                                                 3))
     repository.snapshot.expiration = datetime_object
 
     # Now write to the repository
@@ -313,11 +313,11 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     logger.info('Test: Refreshing #1 - Initial metadata refresh occurring.')
     self.repository_updater.refresh()
     logger.info("Test: Refreshed #1 - Initial metadata refresh completed "
-                "successfully. Now sleeping 7s so snapshot metadata expires.")
+                "successfully. Now sleeping 3s so snapshot metadata expires.")
 
     # Sleep for at least 7 seconds to ensure 'repository.snapshot.expiration'
     # is reached.
-    time.sleep(7)
+    time.sleep(3)
     logger.info("Test: Refreshing #2 - Now trying to refresh again after local "
       "snapshot expiry.")
     try:
@@ -361,8 +361,8 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
     repository.timestamp.load_signing_key(timestamp_private)
     
-    # expire in 4 seconds.
-    datetime_object = tuf.formats.unix_timestamp_to_datetime(int(time.time() + 4))
+    # expire in 3 seconds.
+    datetime_object = tuf.formats.unix_timestamp_to_datetime(int(time.time() + 3))
     repository.timestamp.expiration = datetime_object
     repository.write()
     
@@ -372,9 +372,9 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
                     os.path.join(self.repository_directory, 'metadata'))
     
     # Verify that the TUF client detects outdated metadata and refuses to
-    # continue the update process.  Sleep for at least 4 seconds to ensure
+    # continue the update process.  Sleep for at least 3 seconds to ensure
     # 'repository.timestamp.expiration' is reached.
-    time.sleep(4)
+    time.sleep(3)
     try:
       self.repository_updater.refresh()
     

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -302,13 +302,11 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # Now write to the repository
     repository.write()
     # And move the staged metadata to the "live" metadata.
-    time.sleep(0.1) # superstitious move to allow write to finish?
     shutil.rmtree(os.path.join(self.repository_directory, 'metadata'))
     shutil.copytree(os.path.join(self.repository_directory, 'metadata.staged'),
                     os.path.join(self.repository_directory, 'metadata'))
 
     # Refresh metadata on the client. For this refresh, all data is not expired.
-    time.sleep(0.1) # superstitious move to allow copy to finish?
     logger.info('Test: Refreshing #1 - Initial metadata refresh occurring.')
     self.repository_updater.refresh()
     logger.info("Test: Refreshed #1 - Initial metadata refresh completed "

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -18,9 +18,10 @@
   March 9, 2016.
     Additional test added relating to issue:
     https://github.com/theupdateframework/tuf/issues/322
-    If a metadata file is not downloaded (no indication of a new version
-    available), its expiration must still be detected. This add'l test
-    complains if such does not occur, and accompanies code to detect it.
+    If a metadata file is not updated (no indication of a new version
+    available), the expiration of the pre-existing, locally trusted metadata
+    must still be detected. This additional test complains if such does not
+    occur, and accompanies code in tuf.client.updater:refresh() to detect it.
     -sebastien.awwad
 
 <Copyright>

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -312,26 +312,27 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     time.sleep(0.1)
     logger.info('Test: Refreshing #1 - Initial metadata refresh occurring.')
     self.repository_updater.refresh()
-    logger.info("Test: Refreshed #1 - Initial metadata refresh occurred. Now "
-                "sleeping 6s.")
+    logger.info("Test: Refreshed #1 - Initial metadata refresh completed "
+                "successfully. Now sleeping 7s so snapshot metadata expires.")
 
     # Sleep for at least 7 seconds to ensure 'repository.snapshot.expiration'
     # is reached.
     time.sleep(7)
-    logger.info("Test: Refreshing #2 - Now trying to refresh again after "
-      " snapshot expiry.")
+    logger.info("Test: Refreshing #2 - Now trying to refresh again after local "
+      "snapshot expiry.")
     try:
       self.repository_updater.refresh() # We expect this to fail!
 
     except tuf.ExpiredMetadataError as e:
-      logger.info("Test: Refresh #2 - failed as expected. Stale-expired "
+      logger.info("Test: Refresh #2 - failed as expected. Expired local "
                   "snapshot case generated a tuf.ExpiredMetadataError exception"
-                  ". Test pass.")
-    #I think that I only expect tuf.ExpiredMetadata error here. A
+                  " as expected. Test pass.")
+    # I think that I only expect tuf.ExpiredMetadata error here. A
     # NoWorkingMirrorError indicates something else in this case - unavailable
     # repo, for example.
     else:
-      self.fail("TUF failed to detect expired stale snapshot metadata. Freeze.")
+      self.fail("TUF failed to detect expired stale snapshot metadata. Freeze "
+        "attack successful.")
 
 
 

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -180,18 +180,13 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
 
   def test_without_tuf(self):
-    # Two tests are conducted here.
+    # Without TUF, Test 1 and Test 2 are functionally equivalent, so we skip
+    # Test 1 and only perform Test 2.
     #
     # Test 1: If we find that the timestamp acquired from a mirror indicates
     #         that there is no new snapshot file, and our current snapshot
     #         file is expired, is it recognized as such?
     # Test 2: If an expired timestamp is downloaded, is it recognized as such?
-
-    # Test 1 Begin:
-    #
-    # See description of scenario in Test 2 in the test_with_tuf method.
-    # Without TUF, Test 2 and Test 1 are functionally equivalent, and so we skip
-    # Test 1.
 
 
     # Test 2 Begin:

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -15,6 +15,14 @@
     than verifying text output), use pre-generated repository files, and
     discontinue use of the old repository tools. -vladimir.v.diaz
 
+  March 9, 2016.
+    Additional test added relating to issue:
+    https://github.com/theupdateframework/tuf/issues/322
+    If a metadata file is not downloaded (no indication of a new version
+    available), its expiration must still be detected. This add'l test
+    complains if such does not occur, and accompanies code to detect it.
+    -sebastien.awwad
+
 <Copyright>
   See LICENSE for licensing information.
 
@@ -171,6 +179,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
 
   def test_without_tuf(self):
+    # Test 1:
     # Scenario:
     # 'timestamp.json' specifies the latest version of the repository files.
     # A client should only accept the same version of this file up to a certain
@@ -215,9 +224,108 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # Verify 'download_fileinfo' is equal to the current local file.
     self.assertEqual(download_fileinfo, fileinfo)
 
+    # Test 2:
+    # See description of scenario in Test 2 in the test_with_tuf method.
+    # Without TUF, Test 2 is tantamount to Test 1, and so it is not tested
+    # again here.
 
 
   def test_with_tuf(self):
+    # Two tests are conducted here.
+    # Test 1: If an expired timestamp is downloaded, is it recognized as such?
+    # Test 2: If we find that the timestamp acquired from a mirror indicates
+    #         that there is no new snapshot file, and our current snapshot
+    #         file is expired, is it recognized as such?
+    #
+    # Test 2 addresses this issue:
+    #   https://github.com/theupdateframework/tuf/issues/322
+    #
+    # If time has passed and our snapshot (or any targets role) is expired, and
+    # the mirror whose timestamp we fetched doesn't indicate the existence of a
+    # new snapshot version, we still need to check that it's expired and notify
+    # the software update system / application / user. This test creates that
+    # scenario. The correct behavior is to raise an exception.
+    #
+    # Background: Expiration checks were previously conducted
+    # (ensure_not_expired) when the metadata file was downloaded. If no new
+    # metadata file was downloaded, no expiry check would occurs. (Exception:
+    # root was checked for expiration at the beginning of each refresh() cycle,
+    # and timestamp was always checked because it was always fetched.) Snapshot
+    # and targets were never checked if the user does not have evidence that
+    # they have changed.
+
+    timestamp_path = os.path.join(self.repository_directory, 'metadata',
+                                  'timestamp.json')
+    
+    # Modify the timestamp file on the remote repository.  'timestamp.json'
+    # must be properly updated and signed with 'repository_tool.py', otherwise
+    # the client will reject it as invalid metadata.  The resulting
+    # 'timestamp.json' should be valid metadata, but expired (as intended).
+    repository = repo_tool.load_repository(self.repository_directory)
+ 
+    key_file = os.path.join(self.keystore_directory, 'timestamp_key') 
+    timestamp_private = repo_tool.import_rsa_privatekey_from_file(key_file,
+                                                                  'password')
+
+    repository.timestamp.load_signing_key(timestamp_private)
+
+    # Load snapshot keys.
+    key_file = os.path.join(self.keystore_directory, 'snapshot_key') 
+    snapshot_private = repo_tool.import_rsa_privatekey_from_file(key_file,
+                                                                  'password')
+    repository.snapshot.load_signing_key(snapshot_private)
+
+    # Load root keys.
+    key_file = os.path.join(self.keystore_directory, 'root_key')
+    root_private = repo_tool.import_rsa_privatekey_from_file(key_file,
+                                                                  'password')
+    repository.root.load_signing_key(root_private)
+
+    time.sleep(0.1)
+
+    # Expire snapshot in 7s
+    datetime_object = tuf.formats.unix_timestamp_to_datetime(int(time.time() +
+                                                                 7))
+    repository.snapshot.expiration = datetime_object
+
+    # Now write to the repository
+    repository.write()
+    # And move the staged metadata to the "live" metadata.
+    time.sleep(0.1)
+    shutil.rmtree(os.path.join(self.repository_directory, 'metadata'))
+    shutil.copytree(os.path.join(self.repository_directory, 'metadata.staged'),
+                    os.path.join(self.repository_directory, 'metadata'))
+
+    # Refresh metadata on the client. For this refresh, all data is not expired.
+    time.sleep(0.1)
+    logger.info('Test: Refreshing #1 - Initial metadata refresh occurring.')
+    self.repository_updater.refresh()
+    logger.info("Test: Refreshed #1 - Initial metadata refresh occurred. Now "
+                "sleeping 6s.")
+
+    # Sleep for at least 7 seconds to ensure 'repository.snapshot.expiration'
+    # is reached.
+    time.sleep(7)
+    logger.info("Test: Refreshing #2 - Now trying to refresh again after "
+      " snapshot expiry.")
+    try:
+      self.repository_updater.refresh() # We expect this to fail!
+
+    except tuf.ExpiredMetadataError as e:
+      logger.info("Test: Refresh #2 - failed as expected. Stale-expired "
+                  "snapshot case generated a tuf.ExpiredMetadataError exception"
+                  ". Test pass.")
+    #I think that I only expect tuf.ExpiredMetadata error here. A
+    # NoWorkingMirrorError indicates something else in this case - unavailable
+    # repo, for example.
+    else:
+      self.fail("TUF failed to detect expired stale snapshot metadata. Freeze.")
+
+
+
+
+    # Part 1:
+
     # The same scenario outlined in test_without_tuf() is followed here, except
     # with a TUF client.  The TUF client performs a refresh of top-level
     # metadata, which also includes 'timestamp.json'.
@@ -237,8 +345,8 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
     repository.timestamp.load_signing_key(timestamp_private)
     
-    # expire in 1 second.
-    datetime_object = tuf.formats.unix_timestamp_to_datetime(int(time.time() + 1))
+    # expire in 4 seconds.
+    datetime_object = tuf.formats.unix_timestamp_to_datetime(int(time.time() + 4))
     repository.timestamp.expiration = datetime_object
     repository.write()
     
@@ -248,15 +356,19 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
                     os.path.join(self.repository_directory, 'metadata'))
     
     # Verify that the TUF client detects outdated metadata and refuses to
-    # continue the update process.  Sleep for at least 2 seconds to ensure
+    # continue the update process.  Sleep for at least 4 seconds to ensure
     # 'repository.timestamp.expiration' is reached.
-    time.sleep(2)
+    time.sleep(4)
     try:
       self.repository_updater.refresh()
     
     except tuf.NoWorkingMirrorError as e:
       for mirror_url, mirror_error in six.iteritems(e.mirror_errors):
         self.assertTrue(isinstance(mirror_error, tuf.ExpiredMetadataError))
+    
+    else:
+      self.fail("TUF failed to detect expired stale timestamp metadata. Freeze "
+        "attack successful.")
 
 
 if __name__ == '__main__':

--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -332,13 +332,13 @@ class NoWorkingMirrorError(Error):
   def __str__(self):
     all_errors = 'No working mirror was found:'
 
-    for mirror_url, mirror_error in self.mirror_errors.iteritems():
+    for mirror_url, mirror_error in six.iteritems(self.mirror_errors):
       try:
         # http://docs.python.org/2/library/urlparse.html#urlparse.urlparse
         mirror_url_tokens = six.moves.urllib.parse.urlparse(mirror_url)
       
       except:
-        logging.exception('Failed to parse mirror URL: ' + repr(mirror_url))
+        #logging.exception('Failed to parse mirror URL: ' + repr(mirror_url))
         mirror_netloc = mirror_url
       
       else:

--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -30,6 +30,9 @@ from __future__ import unicode_literals
 
 import six
 
+import logging
+logger = logging.getLogger('tuf.__init__')
+
 # Import 'tuf.formats' if a module tries to import the
 # entire tuf package (i.e., from tuf import *). 
 __all__ = ['formats']
@@ -338,7 +341,7 @@ class NoWorkingMirrorError(Error):
         mirror_url_tokens = six.moves.urllib.parse.urlparse(mirror_url)
       
       except:
-        #logging.exception('Failed to parse mirror URL: ' + repr(mirror_url))
+        logger.exception('Failed to parse mirror URL: ' + repr(mirror_url))
         mirror_netloc = mirror_url
       
       else:

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -658,7 +658,7 @@ class Updater(object):
     # to avoid further recursion. We use this bool and pull the recursion out
     # of the except block so as to avoid unprintable nested NoWorkingMirrorError
     # exceptions.
-    retry_once = False
+#    retry_once = False
 
     # Use default but sane information for timestamp metadata, and do not
     # require strict checks on its required length.
@@ -691,7 +691,9 @@ class Updater(object):
       if unsafely_update_root_if_necessary:
         logger.info('Valid top-level metadata cannot be downloaded.  Unsafely '
           'update the Root metadata.')
-        retry_once = True
+#        retry_once = True
+        self._update_metadata('root', DEFAULT_ROOT_UPPERLENGTH)
+        self.refresh(unsafely_update_root_if_necessary=False)
 
       else:
         raise
@@ -701,7 +703,10 @@ class Updater(object):
         logger.info('No changes were detected from the mirrors for a given role'
           ', and that metadata that is available on disk has been found to be '
           'expired. Trying to update root in case of foul play.')
-        retry_once = True
+#        retry_once = True
+        self._update_metadata('root', DEFAULT_ROOT_UPPERLENGTH)
+        self.refresh(unsafely_update_root_if_necessary=False)
+
       
       # The caller explicitly requested not to unsafely fetch an expired Root.
       else:
@@ -712,9 +717,9 @@ class Updater(object):
 
     # Update failed and we aren't already in a retry. Try once more after
     # updating root.
-    if retry_once:
-        self._update_metadata('root', DEFAULT_ROOT_UPPERLENGTH)
-        self.refresh(unsafely_update_root_if_necessary=False)
+#    if retry_once:
+#        self._update_metadata('root', DEFAULT_ROOT_UPPERLENGTH)
+#        self.refresh(unsafely_update_root_if_necessary=False)
       
 
 

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1206,7 +1206,7 @@ class Updater(object):
       return file_object
     
     else:
-      logger.exception('Failed to update {0} from all mirrors: {1}'.format(
+      logger.error('Failed to update {0} from all mirrors: {1}'.format(
                        remote_filename, file_mirror_errors))
       raise tuf.NoWorkingMirrorError(file_mirror_errors)
 

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -577,9 +577,10 @@ class Updater(object):
 
       The expiration time for downloaded metadata is also verified.
 
-      If the refresh fails for any reason, it will be retried once after first
-      attempting to update the root metadata file. Only then will the exceptions
-      listed here potentially be raised.
+      If the refresh fails for any reason, then unless
+      unsafely_update_root_if_necessary is set, refresh will be retried once
+      after first attempting to update the root metadata file. Only after this
+      check will the exceptions listed here potentially be raised.
 
     <Arguments>
       unsafely_update_root_if_necessary:
@@ -655,10 +656,7 @@ class Updater(object):
 
     # If an exception is raised during the metadata update attempts, we will
     # attempt to update root metadata once by recursing with a special argument
-    # to avoid further recursion. We use this bool and pull the recursion out
-    # of the except block so as to avoid unprintable nested NoWorkingMirrorError
-    # exceptions.
-#    retry_once = False
+    # to avoid further recursion.
 
     # Use default but sane information for timestamp metadata, and do not
     # require strict checks on its required length.
@@ -691,7 +689,6 @@ class Updater(object):
       if unsafely_update_root_if_necessary:
         logger.info('Valid top-level metadata cannot be downloaded.  Unsafely '
           'update the Root metadata.')
-#        retry_once = True
         self._update_metadata('root', DEFAULT_ROOT_UPPERLENGTH)
         self.refresh(unsafely_update_root_if_necessary=False)
 
@@ -703,7 +700,6 @@ class Updater(object):
         logger.info('No changes were detected from the mirrors for a given role'
           ', and that metadata that is available on disk has been found to be '
           'expired. Trying to update root in case of foul play.')
-#        retry_once = True
         self._update_metadata('root', DEFAULT_ROOT_UPPERLENGTH)
         self.refresh(unsafely_update_root_if_necessary=False)
 
@@ -714,13 +710,6 @@ class Updater(object):
           ', and that metadata that is available on disk has been found to be '
           'expired. Your metadata is out of date.')
         raise
-
-    # Update failed and we aren't already in a retry. Try once more after
-    # updating root.
-#    if retry_once:
-#        self._update_metadata('root', DEFAULT_ROOT_UPPERLENGTH)
-#        self.refresh(unsafely_update_root_if_necessary=False)
-      
 
 
 


### PR DESCRIPTION
This fixes Issue #322. Please see that issue!
It replaces PR #323, which got too messy.

**Update:
This PR also:**
- :bug::bug: Fixes [two additional bugs issues identified below](https://github.com/theupdateframework/tuf/pull/324#issuecomment-197543256), both causing unprintable NoWorkingMirrorError exceptions - one in python 3 only and the other in either 2 or 3 with certain mirror name issues.
- adds .DS_Store to .gitignore

This started as a manual squash commit of detect_expiry_322, to avoid merge conflicts.

Comment lines from the individual commits include:
1. Fix #322 by detecting expiry of stale files. initial attempt
2. temp commit of files from Soma
3. removing freeze_attack_stale_expiry and leaving the test added to indefinite freeze attack
4. fixing indefinite freeze attack test: now incorporates old reject-freshly-downloaded-but-expired-timestamp test as well as reject-stale-already-present-but-expired-snapshot test
5. small refinements to indefinite freeze attack test
6. Pulled the recursion out of the except block in refresh() to avoid unprintable nested exceptions.
7. Added comments to the last commit (retry_once)
8. Merge pull request #1 from awwad/detect_expiry_322_temp (removing cruft in another branch)