### PR TITLE
Allow roles to be written without needing target files to exist on the repository

### DIFF
--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1901,7 +1901,7 @@ def write_metadata_file(metadata, filename, version_number,
     if it exists.
 
   <Returns>
-    None. 
+    The filename of the written file. 
   """
 
   # Do the arguments have the correct format?
@@ -2052,7 +2052,7 @@ def _write_compressed_metadata(file_object, compressed_filename,
       digest_object.update(compressed_content)
       new_digests.append(digest_object.hexdigest())
    
-    # Attach each version nu to the compressed consistent snapshot filename.
+    # Attach each version number to the compressed consistent snapshot filename.
     for new_digest in new_digests:
       dirname, basename = os.path.split(compressed_filename)
       for compression_extension in SUPPORTED_COMPRESSION_EXTENSIONS:

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -420,6 +420,35 @@ class Repository(object):
       shutil.rmtree(temp_repository_directory, ignore_errors=True)
 
 
+
+  def dirty_roles(self):
+    """
+    <Purpose>
+      Print/log the roles that have been modified.  For example,
+      if some role's version number is changed (repository.timestamp.version = 2),
+      it is considered dirty and will be included in the list of dirty
+      roles printed/logged here.  Unlike status(), signatures, public keys,
+      targets, etc. are not verified.  status() should be called instead if
+      the caller would like to verify if a valid role file is generated
+      if write() were to be called.
+      
+    <Arguments>
+      None.
+
+    <Exceptions>
+      None.
+    
+    <Side Effects>
+      None.
+
+    <Returns>
+      None.
+    """
+
+    logger.info('Dirty roles: ' + str(tuf.roledb.get_dirty_roles()))
+   
+
+
   @staticmethod
   def get_filepaths_in_directory(files_directory, recursive_walk=False,
                                  followlinks=True):

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -230,19 +230,20 @@ class Repository(object):
     # populated, otherwise write() throws a 'tuf.UnsignedMetadataError'
     # exception if any of the top-level roles are missing signatures, keys, etc.
 
-    # Write the metadata files of all the delegated roles that are dirty (i.e.,
+    # Write the metadata files of all the Targets roles that are dirty (i.e.,
     # have been modified via roledb.update_roleinfo()).
     dirty_roles = tuf.roledb.get_dirty_roles()
-    for delegated_rolename in tuf.roledb.get_dirty_roles():
+    
+    for dirty_rolename in tuf.roledb.get_dirty_roles():
       
       # Ignore top-level roles, they will be generated later in this method. 
-      if delegated_rolename in ['root', 'targets', 'snapshot', 'timestamp']:
+      if dirty_rolename in ['root', 'targets', 'snapshot', 'timestamp']:
         continue
     
-      delegated_filename = os.path.join(self._metadata_directory,
-                                        delegated_rolename + METADATA_EXTENSION)
-      repo_lib._generate_and_write_metadata(delegated_rolename,
-                                            delegated_filename,
+      dirty_filename = os.path.join(self._metadata_directory,
+                                        dirty_rolename + METADATA_EXTENSION)
+      repo_lib._generate_and_write_metadata(dirty_rolename,
+                                            dirty_filename,
                                             write_partial,
                                             self._targets_directory,
                                             self._metadata_directory,
@@ -297,8 +298,8 @@ class Repository(object):
      
     # Delete the metadata of roles no longer in 'tuf.roledb'.  Obsolete roles
     # may have been revoked and should no longer have their metadata files
-    # available on disk, otherwise loading a repository may unintentionally load
-    # them.
+    # available on disk, otherwise loading a repository may unintentionally
+    # load them.
     repo_lib._delete_obsolete_metadata(self._metadata_directory,
                                        snapshot_signable['signed'],
                                        consistent_snapshot)


### PR DESCRIPTION
Feature requested and outlined here: https://groups.google.com/forum/#!topic/theupdateframework/k0WmDb5HQCY

Note: repository.dirty_roles() implemented to only print roles that have been modified.  In contrast, repository.status() verifies that metadata to be written is valid.  For dirty roles that require target files to exist on the repository (e.g., targets.json), an exception is raised, as expected.

```Bash
(tuf2.7)$ rm repository/targets/*
(tuf2.7)$ python modify_timestamp.py 
Enter a password for the encrypted ED25519 key: 
(tuf2.7)$ git status
On branch update_roles_without_needing_targets
Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   repository/metadata.staged/timestamp.json
	modified:   repository/metadata.staged/timestamp.json.gz
	deleted:    repository/targets/file1.txt
	deleted:    repository/targets/file2.txt
	deleted:    repository/targets/file3.txt
	modified:   ../../tox.ini
```

modify_timestamp.py:
```Python
from tuf.repository_tool import *                                               
                                                                                   
repository = load_repository('repository')                                      
repository.timestamp.version = 2                                                
timestamp_private_key = import_ed25519_privatekey_from_file('keystore/timestamp_key')
repository.timestamp.load_signing_key(timestamp_private_key)                    
#repository.status()                                                            
repository.write()        
