### PR TITLE
Update README.md

### DIFF
--- a/tuf/client/README.md
+++ b/tuf/client/README.md
@@ -3,7 +3,7 @@
 systems need to utilize for a low-level integration.  It provides a single
 class representing an updater that includes methods to download, install, and
 verify metadata or target files in a secure manner.  Importing
-**tuf.client.updater.py** and instantiating its main class is all that is
+**tuf.client.updater** and instantiating its main class is all that is
 required by the client prior to a TUF update request.  The importation and
 instantiation steps allow TUF to load all of the required metadata files
 and set the repository mirror information.


### PR DESCRIPTION
Are users supposed to run 
```

>>> import tuf.client.updater.py

``` 
or 

```

>>> import tuf.client.updater

``` 

The way it's written is a bit confusing. The first one returns an error.