### PR TITLE
Install importlib under py26

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,5 +24,6 @@ install_command = pip install --pre {opts} {packages}
 deps =
     -r{toxinidir}/requirements.txt 
     unittest2
+    importlib
 
 install_command = pip install --pre {opts} {packages}


### PR DESCRIPTION
After reorganizing the code base in PR #401 (where `simple_settings` was also added as a new dependency), CI fails with an import error under py26.  This pull request installs the backport of `importlib` under py26.  `importlib` is needed by `simple_settings`.