### PR TITLE
Updates repository_lib to use new securesystemslib interface (fix #412)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 cryptography
 pynacl
 pycrypto
-securesystemslib
+#securesystemslib
+-e git://github.com/lukpueh/securesystemslib.git@update-import-keys#egg=securesystemslib
 six
 iso8601
 coverage

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,9 @@ setup(
     'Topic :: Security',
     'Topic :: Software Development'
   ],
-  install_requires = ['iso8601', 'six', 'securesystemslib>=0.10.2'],
+  # install_requires = ['iso8601', 'six', 'securesystemslib>=0.10.2'],
+  install_requires = ['iso8601', 'six'],
+  dependency_links=['http://github.com/lukpueh/securesystemslib/tarball/update-import-keys#egg=securesystemslib'],
   packages = find_packages(exclude=['tests']),
   scripts = [
     'tuf/scripts/basic_client.py',

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -6,8 +6,6 @@ branch = True
 exclude_lines =
     pragma: no cover
     def check_crypto_libraries
-    def _get_password
-    def _prompt
     def __str__
     if __name__ == .__main__.:
 


### PR DESCRIPTION
Fixes https://github.com/theupdateframework/tuf/issues/412

- `securesystemslib` copies functions to generate and import keys from `repository_lib`.
This PR replaces those function implementations with calls to `securesystemslib.interface`.

- Removes internal `_prompt` and `_get_password` from `repository_lib` because they were only used by the removed function bodies and also exist in `securesystemslib.interface`.

- Updates `requirements.txt` and `setup.py` to point to a `securesystemslib` branch that updates key generate and import functions to return a key object with the optional `keyid_hash_algorithms` field.

**ONLY MERGE AFTER lukpueh/securesystemslib/update-import-keys has merged into securesystemslib/master and above references have been updated!!**

(*@SantiagoTorres secretly dances the we-should-have-used-git-submodules-dance*)