### PR TITLE
Clarify procedure for updating to new root.json

### DIFF
--- a/docs/tuf-spec.txt
+++ b/docs/tuf-spec.txt
@@ -1014,9 +1014,9 @@ Version 1.0 (Draft)
    root keys in the previous version of root.json, up to the threshold listed
    for root in the previous version of root.json. If this is not the case,
    clients will (correctly) not validate the new root.json file.  For example,
-   if there is 1.root.json that has threshold 2 and 2.root.json that has
+   if there is a 1.root.json that has threshold 2 and a 2.root.json that has
    threshold 3, 2.root.json MUST be signed by at least 2 keys defined in
-   1.root.json and at least 3 keys defined in 3.root.json.
+   1.root.json and at least 3 keys defined in 2.root.json.
    
    To replace a delegated developer key, the role that delegated to that key
    just replaces that key with another in the signed metadata where the

--- a/docs/tuf-spec.txt
+++ b/docs/tuf-spec.txt
@@ -1010,8 +1010,8 @@ Version 1.0 (Draft)
    metadata.
    
    In the event that the keys being updated are root keys, it is important to
-	 note that the new root.json must at least be signed by the keys listed as
-	 root keys in the previous version of root.json, up to the threshold listed
+   note that the new root.json must at least be signed by the keys listed as
+   root keys in the previous version of root.json, up to the threshold listed
    for root in the previous version of root.json. If this is not the case,
    clients will (correctly) not validate the new root.json file.  For example,
    if there is 1.root.json that has threshold 2 and 2.root.json that has

--- a/docs/tuf-spec.txt
+++ b/docs/tuf-spec.txt
@@ -1007,10 +1007,17 @@ Version 1.0 (Draft)
    found that has been signed by a threshold of keys that the client already
    trusts. This is to ensure that outdated clients remain able to update,
    without requiring all previous root keys to be kept to sign new root.json
-   metadata.  Before a new version of root (e.g., 2.root.json) can be trusted,
-   the client must validate it against the trusted keys and threshold set by
-   its previous version (i.e., 1.root.json).
-
+   metadata.
+   
+   In the event that the keys being updated are root keys, it is important to
+	 note that the new root.json must at least be signed by the keys listed as
+	 root keys in the previous version of root.json, up to the threshold listed
+   for root in the previous version of root.json. If this is not the case,
+   clients will (correctly) not validate the new root.json file.  For example,
+   if there is 1.root.json that has threshold 2 and 2.root.json that has
+   threshold 3, 2.root.json MUST be signed by at least 2 keys defined in
+   1.root.json and at least 3 keys defined in 3.root.json.
+   
    To replace a delegated developer key, the role that delegated to that key
    just replaces that key with another in the signed metadata where the
    delegation is done.

--- a/docs/tuf-spec.txt
+++ b/docs/tuf-spec.txt
@@ -1002,12 +1002,14 @@ Version 1.0 (Draft)
    role.  When replacing root keys, an application will sign the new root.json
    file with both the new and old root keys. Any time such a change is
    required, the root.json file is versioned and accessible by version number,
-   e.g. 3.root.json. Clients update the set of trusted root keys by requesting
+   e.g., 3.root.json. Clients update the set of trusted root keys by requesting
    the current root.json and all previous root.json versions, until one is
-   found that has been signed by keys the client already trusts. This is to 
-   ensure that outdated clients remain able to update, without requiring all 
-   previous root keys to be kept to sign new root.json metadata.
-
+   found that has been signed by a threshold of keys that the client already
+   trusts. This is to ensure that outdated clients remain able to update,
+   without requiring all previous root keys to be kept to sign new root.json
+   metadata.  Before a new version of root (e.g., 2.root.json) can be trusted,
+   the client must validate it against the trusted keys and threshold set by
+   its previous version (i.e., 1.root.json).
 
    To replace a delegated developer key, the role that delegated to that key
    just replaces that key with another in the signed metadata where the


### PR DESCRIPTION
Clients should validate new root.json according to the threshold and keys set by its previous version.

See @heartsucker's comment [here](https://github.com/heartsucker/rust-tuf/issues/42#issuecomment-302436972).