### PR TITLE
Edit travis py versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
-
+dist: trusty
 sudo: false
-
 cache: pip
+python: 3.6
 
-python:
-  - "3.5"
+env:
+  - TOXENV=py27
+  - TOXENV=py34
+  - TOXENV=py36
 
 before_script:
   - pip install -U pip wheel tox
@@ -13,7 +15,7 @@ before_script:
 script: tox
 
 after_success:
-  - cd tests 
+  - cd tests
   - coveralls
   - cd -
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -18,7 +18,7 @@
 cffi==1.7.0
 pycrypto==2.6.1
 pynacl==1.0.1
-cryptography==1.4.0
+cryptography==2.0.3
 securesystemslib==0.10.7
 
 # Testing requirements.  The rest of the testing dependencies available in

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: Security',
     'Topic :: Software Development'

--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -266,7 +266,8 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
     tuf.formats.check_signable_object_format(metadata)
 
     with open(metadata_path, 'wb') as file_object:
-      json.dumps(metadata, file_object, indent=1, sort_keys=True).encode('utf-8')
+      file_object.write(json.dumps(metadata, indent=1,
+          separators=(',', ': '), sort_keys=True).encode('utf-8'))
 
     # Verify that the malicious 'targets.json' is not downloaded.  Perform
     # a refresh of top-level metadata to demonstrate that the malicious

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -56,17 +56,10 @@ import random
 import subprocess
 import sys
 import errno
-
-# 'unittest2' required for testing under Python < 2.7.
-if sys.version_info >= (2, 7):
-  import unittest
-
-else:
-  import unittest2 as unittest
+import unittest
 
 import tuf
 import tuf.exceptions
-
 import tuf.log
 import tuf.formats
 import tuf.keydb
@@ -317,8 +310,8 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # Verify that _load_metadata_from_file() doesn't raise an exception for
     # improperly formatted metadata, and doesn't load the bad file.
-    with open(role1_filepath, 'a') as file_object:
-      file_object.write('bad JSON data')
+    with open(role1_filepath, 'ab') as file_object:
+      file_object.write(b'bad JSON data')
 
     self.repository_updater._load_metadata_from_file('current', 'role1')
     self.assertEqual(len(self.repository_updater.metadata['current']), 5)
@@ -416,7 +409,8 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # Verify that the versioninfo specified in Timestamp is used if the Snapshot
     # role hasn't been downloaded yet.
     del self.repository_updater.metadata['current']['snapshot']
-    self.assertRaises(self.repository_updater._update_versioninfo('snapshot.json'))
+    #self.assertRaises(self.repository_updater._update_versioninfo('snapshot.json'))
+    self.repository_updater._update_versioninfo('snapshot.json')
     self.assertEqual(versioninfo_dict['snapshot.json']['version'], 1)
 
 
@@ -1325,8 +1319,8 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     repository.targets.load_signing_key(self.role_keys['targets']['private'])
     repository.snapshot.load_signing_key(self.role_keys['snapshot']['private'])
 
-    with open(target1, 'a') as file_object:
-      file_object.write('append extra text')
+    with open(target1, 'ab') as file_object:
+      file_object.write(b'append extra text')
 
     length, hashes = securesystemslib.util.get_file_details(target1)
 
@@ -1511,21 +1505,21 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     targets_path = os.path.join(self.client_metadata_current, 'targets.json')
     targets_metadata = securesystemslib.util.load_json_file(targets_path)
     targets_metadata['signed']['delegations']['roles'][0]['paths'] = ['/file8.txt']
-    with open(targets_path, 'w') as file_object:
+    with open(targets_path, 'wb') as file_object:
       file_object.write(repo_lib._get_written_metadata(targets_metadata))
 
     role1_path = os.path.join(self.client_metadata_current, 'role1.json')
     role1_metadata = securesystemslib.util.load_json_file(role1_path)
     role1_metadata['signed']['delegations']['roles'][0]['name'] = 'targets'
     role1_metadata['signed']['delegations']['roles'][0]['paths'] = ['/file8.txt']
-    with open(role1_path, 'w') as file_object:
+    with open(role1_path, 'wb') as file_object:
       file_object.write(repo_lib._get_written_metadata(role1_metadata))
 
     role2_path = os.path.join(self.client_metadata_current, 'role2.json')
     role2_metadata = securesystemslib.util.load_json_file(role2_path)
     role2_metadata['signed']['delegations']['roles'] = role1_metadata['signed']['delegations']['roles']
     role2_metadata['signed']['delegations']['roles'][0]['paths'] = ['/file8.txt']
-    with open(role2_path, 'w') as file_object:
+    with open(role2_path, 'wb') as file_object:
       file_object.write(repo_lib._get_written_metadata(role2_metadata))
 
     logger.debug('attempting circular delegation')
@@ -1547,7 +1541,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     role1_path = os.path.join(self.client_metadata_current, 'role1.json')
     role1_metadata = securesystemslib.util.load_json_file(role1_path)
     role1_metadata['signed']['delegations']['roles'][0]['paths'] = ['/*.exe']
-    with open(role1_path, 'w') as file_object:
+    with open(role1_path, 'wb') as file_object:
       file_object.write(repo_lib._get_written_metadata(role1_metadata))
 
     self.assertEqual(self.repository_updater._visit_child_role(child_role,

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35
+envlist = py27, py33, py34, py35, py36
 
 [testenv]
 changedir = tests


### PR DESCRIPTION
* Support Python versions 2.7, 3.3, 3.4, 3.5, 3.6.
* Test only Python versions 2.7, 3.4, 3.6 under Travis (for reasons listed at https://github.com/secure-systems-lab/securesystemslib/pull/59)
* Fix unit test failures under Python 3.