### PR TITLE
Ignore virtualenv and pyenv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # root level directories
 dist/*
 build/*
+env/*
 
 # global file patterns
 *.log
@@ -13,3 +14,4 @@ build/*
 .tox/*
 tests/htmlcov/*
 .DS_Store
+.python-version


### PR DESCRIPTION
**Fixes issue #**:
The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:
Edit `.gitignore` so that virtualenv and pyenv files are ignored by git.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature