### PR TITLE
Convert coverage's badge to SVG from PNG

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ A Framework for Securing Software Update Systems
 .. image:: https://travis-ci.org/theupdateframework/tuf.svg?branch=develop
    :target: https://travis-ci.org/theupdateframework/tuf
 
-.. image:: https://coveralls.io/repos/theupdateframework/tuf/badge.png?branch=develop
+.. image:: https://coveralls.io/repos/theupdateframework/tuf/badge.svg?branch=develop
    :target: https://coveralls.io/r/theupdateframework/tuf?branch=develop
 
 .. image:: https://pyup.io/repos/github/theupdateframework/tuf/shield.svg


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

Convert the coverage badge to SVG.  The PNG image isn't as sharp, and clashes with the other SVG badges.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


