### PR TITLE
Fix link to APACHE license

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -283,7 +283,7 @@ and distributed under the (1) MIT License and (2) Apache License, Version 2.0.
 Please see `LICENSE-MIT.txt
 <https://github.com/theupdateframework/tuf/tree/develop/tuf/LICENSE-MIT.txt>`_
 and `LICENSE-APACHE.txt
-<https://github.com/theupdateframework/tuf/tree/develop/tuf/LICENSE-MIT.txt>`_.
+<https://github.com/theupdateframework/tuf/tree/develop/tuf/LICENSE-APACHE.txt>`_.
 
 
 Acknowledgements


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

Fix the README's link to LICENSE-APACHE.txt, which incorrectly points to the MIT license.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


