### PR TITLE
Fix ssl build failure

### DIFF
--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -66,7 +66,7 @@ class TestFormats(unittest.TestCase):
       'KEYIDS_SCHEMA': (securesystemslib.formats.KEYIDS_SCHEMA,
                         ['123456789abcdef', '123456789abcdef']),
 
-      'SIG_SCHEME_SCHEMA': (securesystemslib.formats.SIG_SCHEME_SCHEMA, 'rsassa-pss-sha256'),
+      'SCHEME_SCHEMA': (securesystemslib.formats.SCHEME_SCHEMA, 'rsassa-pss-sha256'),
 
       'RELPATH_SCHEMA': (securesystemslib.formats.RELPATH_SCHEMA, 'metadata/root/'),
 

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -316,34 +316,33 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     with open(invalid_keyfile, 'wb') as file_object:
       file_object.write(b'bad keyfile')
 
-    self.assertRaises(securesystemslib.exceptions.Error, repo_lib.import_ed25519_privatekey_from_file,
-                      invalid_keyfile, 'pw')
+    self.assertRaises(securesystemslib.exceptions.Error,
+        repo_lib.import_ed25519_privatekey_from_file, invalid_keyfile, 'pw')
 
     # Invalid private key imported (contains unexpected keytype.)
     imported_ed25519_key['keytype'] = 'invalid_keytype'
 
-    # Use 'pycrypto_keys.py' to bypass the key format validation performed by
+    # Use 'pyca_crypto_keys.py' to bypass the key format validation performed by
     # 'keys.py'.
     salt, iterations, derived_key = \
-      securesystemslib.pycrypto_keys._generate_derived_key('pw')
+      securesystemslib.pyca_crypto_keys._generate_derived_key('pw')
 
     # Store the derived key info in a dictionary, the object expected
     # by the non-public _encrypt() routine.
     derived_key_information = {'salt': salt, 'iterations': iterations,
-                               'derived_key': derived_key}
+        'derived_key': derived_key}
 
     # Convert the key object to json string format and encrypt it with the
     # derived key.
     encrypted_key = \
-      securesystemslib.pycrypto_keys._encrypt(json.dumps(imported_ed25519_key),
-                                 derived_key_information)
+      securesystemslib.pyca_crypto_keys._encrypt(
+          json.dumps(imported_ed25519_key), derived_key_information)
 
     with open(ed25519_keypath, 'wb') as file_object:
-      file_object.write(encrypted_key.encode('utf-8'))
+        file_object.write(encrypted_key.encode('utf-8'))
 
     self.assertRaises(securesystemslib.exceptions.FormatError,
-                      repo_lib.import_ed25519_privatekey_from_file,
-                      ed25519_keypath, 'pw')
+        repo_lib.import_ed25519_privatekey_from_file, ed25519_keypath, 'pw')
 
 
 

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -98,14 +98,6 @@ SNAPSHOT_EXPIRATION = 604800
 # Initial 'timestamp.json' expiration time of 1 day.
 TIMESTAMP_EXPIRATION = 86400
 
-try:
-  securesystemslib.keys.check_crypto_libraries(['rsa', 'ed25519', 'general'])
-
-except securesystemslib.exceptions.UnsupportedLibraryError: #pragma: no cover
-  logger.warn('Warning: The repository and developer tools require'
-    ' additional libraries, which can be installed as follows:'
-    '\n $ pip install tuf[tools]')
-
 
 class Repository(object):
   """


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

`securesystemslib` (SSL) [v0.10.8 introduced](https://github.com/secure-systems-lab/securesystemslib/blob/3db6a951d175e0d98468e86a2949292e765780a8/CHANGELOG.md#securesystemslib-v0108) backwards-incompatible changes.  This pull request updates affected modules so that they no longer reference obsolete SSL functions and schemata.  Version 0.10.8 of SSL dropped PyCrypto and multiple-library support.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz <vladimir.v.diaz@gmail.com>