### PR TITLE
Add MIT and Apache license classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,8 @@ setup(
   classifiers = [
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',
-    'License :: Freely Distributable',
+    'License :: OSI Approved :: MIT License',
+    'License :: OSI Approved :: Apache Software License',
     'Natural Language :: English',
     'Operating System :: POSIX',
     'Operating System :: POSIX :: Linux',


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

Fix the license trove classifier in `setup.py`.  Since TUF is dual-licensed, the license trove classifiers should instead specify the MIT and Apache licenses.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz <vladimir.v.diaz@gmail.com>