### PR TITLE
Revise maintainers.txt to list add'l info

### DIFF
--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -1,8 +1,26 @@
-The TUF project is managed by Justin Cappos at NYU (jcappos@nyu.edu).
+The project is currently managed by Justin Cappos at New York University.
+Please see GOVERNANCE.md for the project's governance and maintainership.
+
+Consensus Builder:
+
+  Justin Cappos
+    Email: jcappos@nyu.edu
+    GitHub username: @JustinCappos
+    PGP fingerprint: E9C0 59EC 0D32 64FA B35F  94AD 465B F9F6 F8EB 475A
 
 Maintainers:
 
-Vladimir Diaz (vladimir.diaz@nyu.edu)
-Sebastien Awwad (sebastien.awwad@nyu.edu)
-Lukas Puehringer (lukas.puehringer@nyu.edu)
+  Vladimir Diaz
+    Email: vladimir.diaz@nyu.edu
+    GitHub username: @vladimir-v-diaz
+    PGP fingerprint: 3E87 BB33 9378 BC7B 3DD0  E5B2 5DEE 9B97 B0E2 289A
 
+  Sebastien Awwad
+    Email: sebastien.awwad@nyu.edu
+    GitHub username: @awwad
+    PGP fingerprint: C2FB 9C91 0758 B682 7BC4  3233 BC0C 6DED D5E5 CC03
+
+  Lukas Puehringer
+    Email: lukas.puehringer@nyu.edu
+    GitHub username: @lukpueh
+    PGP fingerprint: 8BA6 9B87 D43B E294 F23E  8120 89A2 AD3C 07D9 62E8


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request revises `MAINTAINERS.txt` to list additional information for each role member.  That is,
it adds the email, GitHub username, and PGP fingerprint fields.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz <vladimir.v.diaz@gmail.com>