### PR TITLE
Add copyright and license identifiers to source files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
+
+# Copyright 2013 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
 
 """
 <Program Name>
@@ -11,7 +14,7 @@
   March 2013.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   BUILD SOURCE DISTRIBUTION

--- a/tests/aggregate_tests.py
+++ b/tests/aggregate_tests.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2013 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   aggregate_tests.py
@@ -16,7 +19,7 @@
   unit tests. -Zane Fisher
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Run all the unit tests from every .py file beginning with "test_" in

--- a/tests/repository_data/generate.py
+++ b/tests/repository_data/generate.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2014 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   generate.py
@@ -11,7 +14,7 @@
   February 26, 2014.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Provide a set of pre-generated key files and a basic repository that unit

--- a/tests/repository_data/generate_project_data.py
+++ b/tests/repository_data/generate_project_data.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2014 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   generate_project_data.py
@@ -7,8 +10,11 @@
 <Author>
   Santiago Torres <torresariass@gmail.com>
 
+<Started>
+  January 22, 2014.
+
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Generate a pre-fabricated set of metadata files for 'test_developer_tool.py'

--- a/tests/simple_https_server.py
+++ b/tests/simple_https_server.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 
+# Copyright 2014 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program>
   simple_https_server.py
- 
+
 <Author>
   Vladimir Diaz.
 
@@ -11,17 +14,17 @@
   June 17, 2014
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Provide a simple https server that can be used by the unit tests.  For
   example, 'download.py' can connect to the https server started by this module
   to verify that https downloads are permitted.
-  
+
 <Reference>
   ssl.wrap_socket:
     https://docs.python.org/2/library/ssl.html#functions-constants-and-exceptions
-  
+
   SimpleHTTPServer:
     http://docs.python.org/library/simplehttpserver.html#module-SimpleHTTPServer
 """
@@ -50,7 +53,7 @@ if len(sys.argv) > 1:
     PORT = int(sys.argv[1])
     if PORT < 30000 or PORT > 45000:
       raise ValueError
-  
+
   except ValueError:
     PORT = _generate_random_port()
 

--- a/tests/simple_server.py
+++ b/tests/simple_server.py
@@ -1,21 +1,24 @@
 #!/usr/bin/env python
 
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program>
   simple_server.py
- 
+
 <Author>
   Konstantin Andrianov.
 
 <Started>
   February 15, 2012.
-  
+
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt or LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
-  This is a basic server that was designed to be used in conjunction with 
-  test_download.py to test download.py module. 
+  This is a basic server that was designed to be used in conjunction with
+  test_download.py to test download.py module.
 
 <Reference>
   SimpleHTTPServer:
@@ -45,7 +48,7 @@ if len(sys.argv) > 1:
     PORT = int(sys.argv[1])
     if PORT < 30000 or PORT > 45000:
       raise ValueError
-  
+
   except ValueError:
     PORT = _port_gen()
 

--- a/tests/slow_retrieval_server.py
+++ b/tests/slow_retrieval_server.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   slow_retrieval_server.py
@@ -11,7 +14,7 @@
   March 13, 2012.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Server that throttles data by sending one byte at a time (specified time
@@ -54,19 +57,19 @@ class Handler(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):
       data = None
       with open(filepath, 'r') as fileobj:
         data = fileobj.read()
-      
+
       self.send_response(200)
       self.send_header('Content-length', str(len(data)))
       self.end_headers()
-      
+
       if self.server.test_mode == 'mode_1':
         # Before sending any data, the server does nothing for a long time.
-        DELAY = 40 
+        DELAY = 40
         time.sleep(DELAY)
         self.wfile.write(data)
 
         return
-      
+
       # 'mode_2'
       else:
         DELAY = 1
@@ -78,7 +81,7 @@ class Handler(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):
         for i in range(len(data)):
           self.wfile.write(data[i].encode('utf-8'))
           time.sleep(DELAY)
-        
+
         return
 
     except IOError as e:

--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_arbitrary_package_attack.py
@@ -16,7 +19,7 @@
     discontinue use of the old repository tools. -vladimir.v.diaz
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Simulate an arbitrary package attack, where an updater client attempts to

--- a/tests/test_developer_tool.py
+++ b/tests/test_developer_tool.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2014 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_developer_tool.py.
@@ -8,8 +11,11 @@
   Santiago Torres Arias <torresariass@gmail.com>
   Zane Fisher <zanefisher@gmail.com>
 
+<Started>
+  January 22, 2014.
+
 <Copyright>
-  See LICENSE for licensing inforation.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing inforation.
 
 <Purpose>
   Unit test for the 'developer_tool.py' module.

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2014 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program>
   test_download.py
@@ -11,7 +14,7 @@
   March 26, 2012.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Unit test for 'download.py'.

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_endless_data_attack.py
@@ -17,7 +20,7 @@
     -vladimir.v.diaz
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Simulate an endless data attack, where an updater client tries to download a

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2014 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_exceptions.py
@@ -11,7 +14,7 @@
   July 13, 2017.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Test cases for exceptions.py (mainly the exceptions defined there).

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2013 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_extraneous_dependencies_attack.py
@@ -15,10 +18,11 @@
     than verifying text output), use pre-generated repository files, and
     discontinue use of the old repository tools.  Modify the previous scenario
     simulated for the mix-and-match attack.  The metadata that specified the
-    dependencies of a project modified (previously a text file.) -vladimir.v.diaz
+    dependencies of a project modified (previously a text file.)
+    -vladimir.v.diaz
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Simulate an extraneous dependencies attack.  The client attempts to download

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_formats.py
@@ -11,7 +14,7 @@
   October 2012.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Unit test for 'formats.py'

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_indefinite_freeze_attack.py
@@ -25,7 +28,7 @@
     -sebastien.awwad
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Simulate an indefinite freeze attack.  In an indefinite freeze attack,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2015 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_init.py
@@ -11,7 +14,7 @@
   March 30, 2015.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Test cases for __init__.py (mainly the exceptions defined there).

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2016 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_key_revocation_integration.py
@@ -11,7 +14,7 @@
   April 28, 2016.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Integration test that verifies top-level roles are updated after all of their

--- a/tests/test_keydb.py
+++ b/tests/test_keydb.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_keydb.py
@@ -11,7 +14,7 @@
   October 2012.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Unit test for 'keydb.py'.

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2014 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_log.py
@@ -11,7 +14,7 @@
   May 1, 2014.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Unit test for 'log.py'.

--- a/tests/test_mirrors.py
+++ b/tests/test_mirrors.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program>
   test_mirrors.py
@@ -11,7 +14,7 @@
   March 26, 2012.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Unit test for 'mirrors.py'.

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_mix_and_match_attack.py
@@ -17,7 +20,7 @@
     simulated for the mix-and-match attack.  -vladimir.v.diaz
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Simulate a mix-and-match attack.  In a mix-and-match attack, an attacker is

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_multiple_repositories_integration.py
@@ -11,7 +14,7 @@
   February 2, 2017
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Verify that clients are able to keep track of multiple repositories and

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_replay_attack.py
@@ -17,10 +20,10 @@
     -vladimir.v.diaz
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
-  Simulate a replay, or rollback,  attack.  In a replay attack, a client is
+  Simulate a replay, or rollback, attack.  In a replay attack, a client is
   tricked into installing software that is older than that which the client
   previously knew to be available.
 

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2014 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_repository_lib.py
@@ -11,7 +14,7 @@
   June 1, 2014.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Unit test for 'repository_lib.py'.

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2014 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_repository_tool.py
@@ -11,7 +14,7 @@
   April 7, 2014.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Unit test for 'repository_tool.py'.

--- a/tests/test_roledb.py
+++ b/tests/test_roledb.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_roledb.py
@@ -11,7 +14,7 @@
   October 2012.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Unit test for 'roledb.py'.

--- a/tests/test_root_versioning_integration.py
+++ b/tests/test_root_versioning_integration.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2016 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_root_versioning_integration.py
@@ -11,7 +14,7 @@
   July 21, 2016.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Test root versioning for efficient root key rotation.

--- a/tests/test_sig.py
+++ b/tests/test_sig.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_sig.py
@@ -12,7 +15,7 @@
   February 28, 2012.  Based on a previous version of this module.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Test cases for for sig.py.

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_slow_retrieval_attack.py
@@ -17,7 +20,7 @@
     previous setup. -vladimir.v.diaz
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Simulate a slow retrieval attack, where an attacker is able to prevent clients

--- a/tests/test_unittest_toolbox.py
+++ b/tests/test_unittest_toolbox.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_unittest_toolbox.py
@@ -11,7 +14,7 @@
   July 14, 2017.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Test cases for unittest_toolbox.py.

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_updater.py
@@ -15,7 +18,7 @@
     exact repositories, and add realistic retrieval of files. -vladimir.v.diaz
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   'test_updater.py' provides a collection of methods that test the public /

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2016 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   test_updater_root_rotation_integration.py
@@ -11,7 +14,7 @@
   August 8, 2016.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   'test_updater_root_rotation.py' provides a collection of methods that test

--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -1,2 +1,0 @@
-import os
-os.environ['SIMPLE_SETTINGS'] = "tuf.settings"

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   updater.py
@@ -10,7 +15,7 @@
   July 2012.  Based on a previous version of this module. (VLAD)
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   'updater.py' is intended to be the only TUF module that software update

--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2014 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   developer_tool.py
@@ -14,7 +17,7 @@
   January 22, 2014.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENCE-MIT.txt OR LICENCE-APACHE.txt for licensing information.
 
 <Purpose>
   See 'tuf/README-developer-tools.md' for a complete guide on using

--- a/tuf/download.py
+++ b/tuf/download.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   download.py
@@ -10,7 +15,7 @@
   Vladimir Diaz <vladimir.v.diaz@gmail.com>
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Download metadata and target files and check their validity.  The hash and

--- a/tuf/exceptions.py
+++ b/tuf/exceptions.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+
+# Copyright 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   exceptions.py
@@ -9,7 +14,7 @@
   January 10, 2017
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Define TUF Exceptions.

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   formats.py
@@ -12,7 +15,7 @@
   Refactored April 30, 2012. -vladimir.v.diaz
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   A central location for all format-related checking of TUF objects.

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   keydb.py
@@ -9,7 +14,7 @@
   March 21, 2012.  Based on a previous version of this module by Geremy Condra.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Represent a collection of keys and their organization.  This module ensures

--- a/tuf/log.py
+++ b/tuf/log.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   log.py
@@ -9,7 +14,7 @@
   April 4, 2012.  Based on a previous version of this module by Geremy Condra.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   A central location for all logging-related configuration.  This module should

--- a/tuf/mirrors.py
+++ b/tuf/mirrors.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   mirrors.py
@@ -10,7 +15,7 @@
   March 12, 2012.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Extract a list of mirror urls corresponding to the file type and the location

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2014 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   repository_lib.py
@@ -11,7 +14,7 @@
   June 1, 2014.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Provide a library for the repository tool that can create a TUF repository.

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2013 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   repository_tool.py
@@ -11,7 +14,7 @@
   October 19, 2013
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Provide a tool that can create a TUF repository.  It can be used with the

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   roledb.py
@@ -9,7 +14,7 @@
   March 21, 2012.  Based on a previous version of this module by Geremy Condra.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Represent a collection of roles and their organization.  The caller may

--- a/tuf/scripts/basic_client.py
+++ b/tuf/scripts/basic_client.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   basic_client.py
@@ -11,7 +14,7 @@
   September 2012
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Provide a basic TUF client that can update all of the metatada and target

--- a/tuf/settings.py
+++ b/tuf/settings.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+# Copyright 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   settings.py
@@ -11,7 +14,7 @@
   January 11, 2017
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
  A central location for TUF configuration settings.  Example options include

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program Name>
   sig.py
@@ -9,7 +14,7 @@
   February 28, 2012.   Based on a previous version by Geremy Condra.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Survivable key compromise is one feature of a secure update system

--- a/tuf/unittest_toolbox.py
+++ b/tuf/unittest_toolbox.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
 """
 <Program>
   unittest_toolbox.py
@@ -9,7 +14,7 @@
   March 26, 2012.
 
 <Copyright>
-  See LICENSE for licensing information.
+  See LICENSE-MIT.txt OR LICENSE-APACHE.txt for licensing information.
 
 <Purpose>
   Provides an array of various methods for unit testing.  Use it instead of


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request adds a copyright and license identifiers to all of the source files.  The LICENSE file
referenced in docstrings is also updated to point to the MIT and APACHE license files.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>