### PR TITLE
Remove duplicate pip upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ env:
   - TOXENV=py36
 
 before_script:
-  - pip install -U pip wheel
-  - pip wheel pylint bandit tox
+  - pip install pylint bandit tox
 
 script:
   - pylint tuf

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ env:
   - TOXENV=py36
 
 before_script:
-  - pip install -U pip wheel pylint
-  - pip install -U pip wheel bandit
-  - pip install -U pip wheel tox
+  - pip install -U pip wheel
+  - pip wheel pylint bandit tox
 
 script:
   - pylint tuf


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request edit the Travis CI configuration to remove duplicate upgrade commands.  It should only install pylint, bandit, and tox.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz <vladimir.v.diaz@gmail.com>