### PR TITLE
Correctly set version dependency for 'six' and 'iso8601'

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,8 +16,8 @@
 # signatures.  The minimal install can only verify ed25519 signatures.  Pinned
 # packages: http://nvie.com/posts/pin-your-packages/
 cffi==1.11.2
-six=1.11.0
-iso8601=0.1.12
+six==1.11.0
+iso8601==0.1.12
 pynacl==1.2.1
 cryptography==2.1.4
 securesystemslib==0.10.8


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request correctly specifies, in `dev-requirements.txt`, the dependency version of `six` and `iso8601`.

`dev-requirements` incorrectly uses a `=` instead of the expected `==`.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz <vladimir.v.diaz@gmail.com>