### PR TITLE
Bump the pylint and bandit dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -27,4 +27,5 @@ securesystemslib==0.10.8
 tox==2.9.1
 
 # Linting requirements.
-pylint==1.7.5
+pylint==1.8.1
+bandit==1.4.0


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

Bump dev dependencies: pylint to `1.8.1` and bandit to `1.4.0`.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz <vladimir.v.diaz@gmail.com>