### PR TITLE
Remove extension '.json.gz' from the list of supported extensions

### DIFF
--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -94,7 +94,7 @@ TIMESTAMP_EXPIRES_WARN_SECONDS = 86400
 SUPPORTED_KEY_TYPES = ['rsa', 'ed25519']
 
 # The full list of supported TUF metadata extensions.
-METADATA_EXTENSIONS = ['.json.gz', '.json']
+METADATA_EXTENSIONS = ['.json']
 
 # The supported extensions of roles listed in Snapshot metadata.
 SNAPSHOT_ROLE_EXTENSIONS = ['.json']


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request removes `.json.gz` from the list of supported metadata file extensions.  The code was incorrectly logging that `.json.gz` is a supported metadata extension.

Note: Compressed metadata was previously supported.

Thanks is given to @trishankatdatadog for reporting the issue.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz <vladimir.v.diaz@gmail.com>

