### PR TITLE
Fix link to MAINTAINERS.txt in GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,7 +6,7 @@ project consists of the TUF
 
 ## Maintainership and Consensus Builder
 The project is maintained by the people indicated in
-[MAINTAINERS.md](MAINTAINERS.md).  A maintainer is expected to (1) submit and
+[MAINTAINERS.txt](MAINTAINERS.txt).  A maintainer is expected to (1) submit and
 review GitHub pull requests and (2) open issues or [submit vulnerability
 reports](https://github.com/theupdateframework/tuf#security-issues-and-bugs).
 A maintainer has the authority to approve or reject pull requests submitted by


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**:
No issue

**Description of the changes being introduced by the pull request**:
Correct file suffix `.md` to `.txt`

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


