### PR TITLE
Revise behavior and documentation on delegating paths.  Fix for issue #570.

### DIFF
--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1208,10 +1208,10 @@ class TestTargets(unittest.TestCase):
                       path_hash_prefixes=path_hash_prefixes)
 
     # Test for targets that do not exist under the targets directory.
-    self.assertRaises(securesystemslib.exceptions.Error, self.targets_object.delegate, rolename,
-                      public_keys, list_of_targets, threshold,
-                      terminating=False, restricted_paths=['non-existent.txt'],
-                      path_hash_prefixes=path_hash_prefixes)
+    # An exception should be raised for non-existent delegated paths.
+    self.targets_object.delegate(rolename, public_keys, list_of_targets,
+        threshold, terminating=False, restricted_paths=['non-existent.txt'],
+        path_hash_prefixes=path_hash_prefixes)
 
 
     # Test improperly formatted arguments.
@@ -1494,14 +1494,14 @@ class TestTargets(unittest.TestCase):
         self.targets_object.add_restricted_paths, restricted_paths,
         'non_delegated_rolename')
 
-    # Non-existent 'restricted_paths'.
-    self.assertRaises(securesystemslib.exceptions.Error,
-        self.targets_object.add_restricted_paths, ['/non-existent'], 'tuf')
+    # add_restricted_paths() should not raise an exception for non-existent
+    # paths, which is previously did.
+    self.targets_object.add_restricted_paths(['/non-existent'], 'tuf')
 
-    # Directory not under the repository's targets directory.
+    # add_restricted_paths() should not raise an exception for directories that
+    # do not fall under the repository's targets directory.
     repository_directory = os.path.join('repository_data', 'repository')
-    self.assertRaises(securesystemslib.exceptions.Error,
-        self.targets_object.add_restricted_paths, [repository_directory], 'tuf')
+    self.targets_object.add_restricted_paths([repository_directory], 'tuf')
 
 
 

--- a/tuf/README.md
+++ b/tuf/README.md
@@ -357,10 +357,12 @@ the target filepaths to metadata.
 ['repository/targets/file2.txt', 'repository/targets/file1.txt', 'repository/targets/file3.txt']
 
 # Add the list of target paths to the metadata of the top-level Targets role.
-# Any target file paths that might already exist are NOT replaced.
+# Any target file paths that might already exist are NOT replaced, and
 # add_targets() does not create or move target files on the file system.  Any
 # target paths added to a role must fall under the expected targets directory,
-# otherwise an exception is raised.
+# otherwise an exception is raised. The targets added to a role should actually
+# exist once writeall() or write() is called, so that the hash and size of
+# these targets can be included in Targets metadata.
 >>> repository.targets.add_targets(list_of_targets)
 
 # Individual target files may also be added to roles, including custom data


### PR DESCRIPTION
**Fixes issue #**:

This fixes #570.

**Description of the changes being introduced by the pull request**:

This pull request modifies the behavior when delegating paths to a role.  The code incorrectly raises an exception when delegating a non-existent path or glob pattern, and requires each of them to fall under the repository's targets directory.  Instead, the logger should print a debug message in these cases.

Furthermore, the documentation is updated to make it clear that added targets, via add_target(), must actually exist at the specified path once writeall() or write() is called.  If these targets do not exist, the
hash and file size of these targets cannot be added to their respective targets metadata. 

Note: Instances of `restricted paths` will be renamed in a separate pull request, as recommended in issue #567.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
