### PR TITLE
Fix consensus builder pgp fingerprint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,7 +182,7 @@ At a minimum, the report must contain the following:
 * Steps to reproduce the issue.
 
 Optionally, reports that are emailed can be encrypted with PGP.  You should use
-PGP key fingerprint E9C0 59EC 0D32 64FA B35F  94AD 465B F9F6 F8EB 475.
+PGP key fingerprint E9C0 59EC 0D32 64FA B35F  94AD 465B F9F6 F8EB 475A.
 
 Please do not use the GitHub issue tracker to submit vulnerability reports.
 The issue tracker is intended for bug reports and to make feature requests.


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:
Appends missing trailing `A` to Justin's PGP fingerprint
The (supposedly) correct fingerprint can be queried at:
https://pgp.mit.edu/pks/lookup?search=justin+cappos&fingerprint=on
https://github.com/theupdateframework/tuf/blob/develop/MAINTAINERS.txt#L9

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature