### PR TITLE
Revise API for delegating paths

### DIFF
--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1437,15 +1437,15 @@ class TestTargets(unittest.TestCase):
                       self.targets_object.remove_target_from_bin, 3)
 
     # Invalid target file path argument.
-    self.assertRaises(securesystemslib.exceptions.Error, self.targets_object.remove_target_from_bin,
-                      '/non-existent')
+    self.assertRaises(securesystemslib.exceptions.Error,
+        self.targets_object.remove_target_from_bin, '/non-existent')
 
 
 
-  def test_add_restricted_paths(self):
+  def test_add_paths(self):
     # Test normal case.
-    # Perform a delegation so that add_restricted_paths() has a child role
-    # to restrict.
+    # Perform a delegation so that add_paths() has a child role to delegate a
+    # path to.
     keystore_directory = os.path.join('repository_data', 'keystore')
     public_keypath = os.path.join(keystore_directory, 'snapshot_key.pub')
     public_key = repo_tool.import_ed25519_publickey_from_file(public_keypath)
@@ -1464,8 +1464,8 @@ class TestTargets(unittest.TestCase):
 
     restricted_path = os.path.join(self.targets_directory, 'tuf_files')
     os.mkdir(restricted_path)
-    restricted_paths = [restricted_path + '/*']
-    self.targets_object.add_restricted_paths(restricted_paths, 'tuf')
+    paths = [restricted_path + '/*']
+    self.targets_object.add_paths(paths, 'tuf')
 
     # Retrieve 'targets_object' roleinfo, and verify the roleinfo contains
     # the expected restricted paths of the delegated role.  Only
@@ -1475,31 +1475,30 @@ class TestTargets(unittest.TestCase):
     delegated_role = targets_object_roleinfo['delegations']['roles'][0]
     self.assertEqual(['/tuf_files/*'], delegated_role['paths'])
 
-    # Try to add a restricted path that has already been set.
-    # add_restricted_paths() should simply log a message in this case.
-    self.targets_object.add_restricted_paths(restricted_paths, 'tuf')
+    # Try to add a delegated path that has already been set.
+    # add_paths() should simply log a message in this case.
+    self.targets_object.add_paths(paths, 'tuf')
 
     # Test improperly formatted arguments.
     self.assertRaises(securesystemslib.exceptions.FormatError,
-        self.targets_object.add_restricted_paths, 3, 'tuf')
+        self.targets_object.add_paths, 3, 'tuf')
     self.assertRaises(securesystemslib.exceptions.FormatError,
-        self.targets_object.add_restricted_paths, restricted_paths, 3)
+        self.targets_object.add_paths, paths, 3)
 
 
     # Test invalid arguments.
     # A non-delegated child role.
     self.assertRaises(securesystemslib.exceptions.Error,
-        self.targets_object.add_restricted_paths, restricted_paths,
-        'non_delegated_rolename')
+        self.targets_object.add_paths, paths, 'non_delegated_rolename')
 
-    # add_restricted_paths() should not raise an exception for non-existent
+    # add_paths() should not raise an exception for non-existent
     # paths, which is previously did.
-    self.targets_object.add_restricted_paths(['/non-existent'], 'tuf')
+    self.targets_object.add_paths(['/non-existent'], 'tuf')
 
-    # add_restricted_paths() should not raise an exception for directories that
+    # add_paths() should not raise an exception for directories that
     # do not fall under the repository's targets directory.
     repository_directory = os.path.join('repository_data', 'repository')
-    self.targets_object.add_restricted_paths([repository_directory], 'tuf')
+    self.targets_object.add_paths([repository_directory], 'tuf')
 
 
 

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1183,70 +1183,73 @@ class TestTargets(unittest.TestCase):
     rolename = 'tuf'
     list_of_targets = [target1_filepath, target2_filepath]
     threshold = 1
-    restricted_paths = [self.targets_directory + '/*']
+    paths = [self.targets_directory + '/*']
     path_hash_prefixes = ['e3a3', '8fae', 'd543']
 
-    self.targets_object.delegate(rolename, public_keys, list_of_targets,
-                                 threshold, terminating=False,
-                                 restricted_paths=restricted_paths,
-                                 path_hash_prefixes=path_hash_prefixes)
+    self.targets_object.delegate(rolename, public_keys, paths,
+        threshold, terminating=False, list_of_targets=list_of_targets,
+        path_hash_prefixes=path_hash_prefixes)
 
     self.assertEqual(self.targets_object.get_delegated_rolenames(),
                      ['tuf'])
 
     # Try to delegate to a role that has already been delegated.
-    self.assertRaises(securesystemslib.exceptions.Error, self.targets_object.delegate, rolename,
-                      public_keys, list_of_targets, threshold, terminating=False,
-                      restricted_paths=restricted_paths,
-                      path_hash_prefixes=path_hash_prefixes)
+    self.assertRaises(securesystemslib.exceptions.Error,
+        self.targets_object.delegate, rolename, public_keys, paths, threshold,
+        terminating=False, list_of_targets=list_of_targets,
+        path_hash_prefixes=path_hash_prefixes)
 
     # Test for targets that do not exist under the targets directory.
     self.targets_object.revoke(rolename)
-    self.assertRaises(securesystemslib.exceptions.Error, self.targets_object.delegate, rolename,
-                      public_keys, ['non-existent.txt'], threshold,
-                      terminating=False, restricted_paths=restricted_paths,
-                      path_hash_prefixes=path_hash_prefixes)
+    self.assertRaises(securesystemslib.exceptions.Error,
+        self.targets_object.delegate, rolename, public_keys, paths, threshold,
+        terminating=False, list_of_targets=['non-existent.txt'],
+        path_hash_prefixes=path_hash_prefixes)
 
     # Test for targets that do not exist under the targets directory.
-    # An exception should be raised for non-existent delegated paths.
-    self.targets_object.delegate(rolename, public_keys, list_of_targets,
-        threshold, terminating=False, restricted_paths=['non-existent.txt'],
+    # An exception should not be raised for non-existent delegated paths.
+    self.targets_object.delegate(rolename, public_keys, ['non-existent.txt'],
+        threshold, terminating=False, list_of_targets=list_of_targets,
         path_hash_prefixes=path_hash_prefixes)
 
 
     # Test improperly formatted arguments.
-    self.assertRaises(securesystemslib.exceptions.FormatError, self.targets_object.delegate,
-                      3, public_keys, list_of_targets, threshold,
-                      restricted_paths, path_hash_prefixes)
-    self.assertRaises(securesystemslib.exceptions.FormatError, self.targets_object.delegate,
-                      rolename, 3, list_of_targets, threshold,
-                      restricted_paths, path_hash_prefixes)
-    self.assertRaises(securesystemslib.exceptions.FormatError, self.targets_object.delegate,
-                      rolename, public_keys, 3, threshold,
-                      restricted_paths, path_hash_prefixes)
-    self.assertRaises(securesystemslib.exceptions.FormatError, self.targets_object.delegate,
-                      rolename, public_keys, list_of_targets, '3',
-                      restricted_paths, path_hash_prefixes)
-    self.assertRaises(securesystemslib.exceptions.FormatError, self.targets_object.delegate,
-                      rolename, public_keys, list_of_targets, threshold,
-                      3, path_hash_prefixes)
-    self.assertRaises(securesystemslib.exceptions.FormatError, self.targets_object.delegate,
-                      rolename, public_keys, list_of_targets, threshold,
-                      restricted_paths, 3)
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+        self.targets_object.delegate, 3, public_keys, paths, threshold,
+        list_of_targets, path_hash_prefixes)
 
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+        self.targets_object.delegate, rolename, 3, paths, threshold,
+        list_of_targets, path_hash_prefixes)
+
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+        self.targets_object.delegate, rolename, public_keys, 3, threshold,
+        list_of_targets, path_hash_prefixes)
+
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+        self.targets_object.delegate, rolename, public_keys, paths, '3',
+        list_of_targets, path_hash_prefixes)
+
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+        self.targets_object.delegate, rolename, public_keys, paths, threshold,
+        3, path_hash_prefixes)
+
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+        self.targets_object.delegate, rolename, public_keys, paths, threshold,
+        list_of_targets, 3)
 
     # Test invalid arguments (e.g., already delegated 'rolename', non-existent
     # files, etc.).
     # Test duplicate 'rolename' delegation, which should have been delegated
     # in the normal case above.
-    self.assertRaises(securesystemslib.exceptions.Error, self.targets_object.delegate,
-                      rolename, public_keys, list_of_targets, threshold,
-                      restricted_paths, path_hash_prefixes)
+    self.assertRaises(securesystemslib.exceptions.Error,
+        self.targets_object.delegate, rolename, public_keys, paths, threshold,
+        list_of_targets, path_hash_prefixes)
 
     # Test non-existent target paths.
-    self.assertRaises(securesystemslib.exceptions.Error, self.targets_object.delegate,
-                      rolename, public_keys, ['/non-existent'], threshold,
-                      restricted_paths, path_hash_prefixes)
+    self.assertRaises(securesystemslib.exceptions.Error,
+        self.targets_object.delegate, rolename, public_keys, [], threshold,
+        ['/non-existent'], path_hash_prefixes)
 
 
 
@@ -1319,7 +1322,7 @@ class TestTargets(unittest.TestCase):
     # to contain a hash prefix of 'e', and should be available at:
     # repository.targets('e').
     self.targets_object.delegate_hashed_bins(list_of_targets, public_keys,
-                                             number_of_bins=16)
+        number_of_bins=16)
 
     # Ensure each hashed bin initially contains zero targets.
     for delegation in self.targets_object.delegations:
@@ -1456,9 +1459,8 @@ class TestTargets(unittest.TestCase):
     rolename = 'tuf'
     threshold = 1
 
-    self.targets_object.delegate(rolename, public_keys, [],
-                                 threshold, restricted_paths=None,
-                                 path_hash_prefixes=None)
+    self.targets_object.delegate(rolename, public_keys, [], threshold,
+        list_of_targets=None, path_hash_prefixes=None)
 
     # Delegate an extra role for test coverage (i.e., check that restricted
     # paths are not added to a child role not requested.)

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -961,12 +961,11 @@ class TestTargets(unittest.TestCase):
     public_keys = [public_key]
     threshold = 1
 
-    self.targets_object.delegate('tuf', public_keys, [target1_filepath],
-                                 threshold, restricted_paths=None,
-                                 path_hash_prefixes=None)
-    self.targets_object.delegate('warehouse', public_keys, [target2_filepath],
-                                 threshold, restricted_paths=None,
-                                 path_hash_prefixes=None)
+    self.targets_object.delegate('tuf', public_keys, [], threshold, False,
+        [target1_filepath], path_hash_prefixes=None)
+
+    self.targets_object.delegate('warehouse', public_keys, [], threshold, False,
+        [target2_filepath], path_hash_prefixes=None)
 
     # Test that get_delegated_rolenames returns the expected delegations.
     expected_delegated_rolenames = ['targets/tuf/', 'targets/warehouse']
@@ -1000,13 +999,11 @@ class TestTargets(unittest.TestCase):
     # Set needed arguments by delegate().
     public_keys = [public_key]
     rolename = 'tuf'
-    list_of_targets = [target1_filepath]
+    paths = [target1_filepath]
     threshold = 1
 
-    self.targets_object.delegate(rolename, public_keys, list_of_targets,
-                                 threshold, terminating=False,
-                                 restricted_paths=None,
-                                 path_hash_prefixes=None)
+    self.targets_object.delegate(rolename, public_keys, paths, threshold,
+        terminating=False, list_of_targets=None, path_hash_prefixes=None)
 
     # Test that a valid Targets() object is returned by delegations().
     for delegated_object in self.targets_object.delegations:
@@ -1021,8 +1018,7 @@ class TestTargets(unittest.TestCase):
   def test_add_delegated_role(self):
     # Test for invalid targets object.
     self.assertRaises(securesystemslib.exceptions.FormatError,
-                      self.targets_object.add_delegated_role, 'targets',
-                                                             'bad_object')
+        self.targets_object.add_delegated_role, 'targets', 'bad_object')
 
 
 
@@ -1518,12 +1514,11 @@ class TestTargets(unittest.TestCase):
     # Set needed arguments by delegate().
     public_keys = [public_key]
     rolename = 'tuf'
-    list_of_targets = [target1_filepath]
+    paths = [target1_filepath]
     threshold = 1
 
-    self.targets_object.delegate(rolename, public_keys, list_of_targets,
-                                 threshold, restricted_paths=None,
-                                 path_hash_prefixes=None)
+    self.targets_object.delegate(rolename, public_keys, [], threshold, False,
+        paths, path_hash_prefixes=None)
 
     # Test revoke()
     self.targets_object.revoke('tuf')

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1077,10 +1077,10 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
 
     repository.targets.delegate('role3', [self.role_keys['targets']['public']],
-                                [], restricted_paths=[foo_pattern])
+        [foo_pattern])
 
     repository.targets.delegate('role4', [self.role_keys['targets']['public']],
-                                [foo_package], restricted_paths=[foo_pattern])
+        [foo_pattern], list_of_targets=[foo_package])
 
     repository.targets.load_signing_key(self.role_keys['targets']['private'])
     repository.targets('role3').load_signing_key(self.role_keys['targets']['private'])
@@ -1112,9 +1112,10 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # Ensure we delegate in trusted order (i.e., 'role2' has higher priority.)
     repository.targets.delegate('role3', [self.role_keys['targets']['public']],
-                                [], terminating=True, restricted_paths=[foo_pattern])
+        [foo_pattern], terminating=True, list_of_targets=[])
+
     repository.targets.delegate('role4', [self.role_keys['targets']['public']],
-                                [foo_package], restricted_paths=[foo_pattern])
+        [foo_pattern], list_of_targets=[foo_package])
 
     repository.targets('role3').load_signing_key(self.role_keys['targets']['private'])
     repository.targets('role4').load_signing_key(self.role_keys['targets']['private'])

--- a/tuf/README.md
+++ b/tuf/README.md
@@ -476,8 +476,8 @@ targets and generate signed metadata.
 
 # Make a delegation from "targets" to "unclaimed", initially containing zero
 # targets.
-# delegate(rolename, list_of_public_keys, list_of_file_paths, threshold,
-#          restricted_paths, path_hash_prefixes)
+# delegate(rolename, list_of_public_keys, paths, threshold=1,
+#     list_of_targets=None, path_hash_prefixes=None)
 >>> repository.targets.delegate("unclaimed", [public_unclaimed_key], [])
 
 # Load the private key of "unclaimed" so that unclaimed's metadata can be

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2239,14 +2239,15 @@ class Targets(Metadata):
     relative_targetpaths = {}
     targets_directory_length = len(self._targets_directory)
 
-    for target in list_of_targets:
-      target = os.path.abspath(target)
-      if not target.startswith(self._targets_directory + os.sep):
-        raise securesystemslib.exceptions.Error(repr(target) + ' is not under'
-          ' the repository\'s targets'
-          ' directory: ' + repr(self._targets_directory))
+    if list_of_targets:
+      for target in list_of_targets:
+        target = os.path.abspath(target)
+        if not target.startswith(self._targets_directory + os.sep):
+          raise securesystemslib.exceptions.Error(repr(target) + ' is not under'
+            ' the repository\'s targets'
+            ' directory: ' + repr(self._targets_directory))
 
-      relative_targetpaths.update({target[targets_directory_length:]: {}})
+        relative_targetpaths.update({target[targets_directory_length:]: {}})
 
     # Verify whether each path in 'paths' falls under the repository's targets
     # directory.
@@ -2548,9 +2549,9 @@ class Targets(Metadata):
 
       # Delegate from the "unclaimed" targets role to each 'bin_rolename'
       # (i.e., outer_bin_index).
-      self.delegate(bin_rolename, keys_of_hashed_bins,
-                    list_of_targets=bin_rolename_targets,
-                    path_hash_prefixes=path_hash_prefixes)
+      self.delegate(bin_rolename, keys_of_hashed_bins, [],
+          list_of_targets=bin_rolename_targets,
+          path_hash_prefixes=path_hash_prefixes)
       logger.debug('Delegated from ' + repr(self.rolename) + ' to ' + repr(bin_rolename))
 
 

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -1758,32 +1758,33 @@ class Targets(Metadata):
 
 
 
-  def add_restricted_paths(self, restricted_paths, child_rolename):
+  def add_paths(self, paths, child_rolename):
     """
     <Purpose>
-      Add 'restricted_paths' to the restricted paths of 'child_rolename'.
-      The updater client verifies the target paths specified by child roles, and
-      searches for targets by visiting these restricted paths.  A child role may
-      only provide targets specifically listed in the delegations field of the
-      parent, or a target that matches a restricted path.
+      Add 'paths' to the delegated paths for 'child_rolename'.  'paths' can be
+      a list of either file paths or glob patterns.  The updater client
+      verifies the target paths specified by child roles, and searches for
+      targets by visiting these delegated paths.  A child role may only provide
+      targets specifically listed in the delegations field of the parent role,
+      or a target that matches a delegated path.
 
       >>>
       >>>
       >>>
 
     <Arguments>
-      restricted_paths:
-        A list of paths that 'child_rolename' should be restricted to.
+      paths:
+        A list of glob patterns, or file paths, that 'child_rolename' is
+        trusted to provide.
 
       child_rolename:
-        The child delegation that requires an update to its restricted paths,
-        as listed in the parent role's delegations (e.g., 'Django' in
-        'unclaimed').
+        The child delegation that requires an update to its delegated or
+        trusted paths, as listed in the parent role's delegations (e.g.,
+        'Django' in 'unclaimed').
 
     <Exceptions>
-      securesystemslib.exceptions.Error, if a restricted path in
-      'restricted_paths' is not a string path, or if 'child_rolename' has not
-      been delegated yet.
+      securesystemslib.exceptions.Error, if a delegated path in 'paths' is not
+      a string path, or if 'child_rolename' has not been delegated yet.
 
     <Side Effects>
       Modifies this Targets' delegations field.
@@ -1796,11 +1797,11 @@ class Targets(Metadata):
     # Ensure the arguments have the appropriate number of objects and object
     # types, and that all dict keys are properly named.
     # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
-    securesystemslib.formats.PATHS_SCHEMA.check_match(restricted_paths)
+    securesystemslib.formats.PATHS_SCHEMA.check_match(paths)
     tuf.formats.ROLENAME_SCHEMA.check_match(child_rolename)
 
     # A list of relative and verified paths to be added to the child role's
-    # entry in the parent's delegations.
+    # entry in the parent's delegations field.
     relative_paths = []
 
     # Ensure that 'child_rolename' exists, otherwise it will not have an entry
@@ -1809,32 +1810,32 @@ class Targets(Metadata):
       raise securesystemslib.exceptions.Error(repr(child_rolename) + ' does'
         ' not exist.')
 
-    for restricted_path in restricted_paths:
-      # Do the restricted paths fall under the repository's targets directory?
+    for path in paths:
+      # Do the delegated paths fall under the repository's targets directory?
       # Append a trailing path separator with os.path.join(path, '').
       targets_directory = os.path.join(self._targets_directory, '')
-      if not restricted_path.startswith(targets_directory):
-        logger.debug(repr(restricted_path) + ' does not live under the'
+      if not path.startswith(targets_directory):
+        logger.debug(repr(path) + ' does not live under the'
             ' repository\'s targets'
           ' directory: ' + repr(self._targets_directory))
 
-      relative_paths.append(restricted_path[len(self._targets_directory):])
+      relative_paths.append(path[len(self._targets_directory):])
 
     # Get the current role's roleinfo, so that its delegations field can be
     # updated.
     roleinfo = tuf.roledb.get_roleinfo(self._rolename, self._repository_name)
 
-    # Update the restricted paths of 'child_rolename' to add relative paths.
+    # Update the delegated paths of 'child_rolename' to add relative paths.
     for role in roleinfo['delegations']['roles']:
       if role['name'] == child_rolename:
-        restricted_paths = role['paths']
+        delegated_paths = role['paths']
 
     for relative_path in relative_paths:
-      if relative_path not in restricted_paths:
-        restricted_paths.append(relative_path)
+      if relative_path not in delegated_paths:
+        delegated_paths.append(relative_path)
 
       else:
-        logger.debug(repr(relative_path) + ' is already a restricted path.')
+        logger.debug(repr(relative_path) + ' is already a delegated path.')
 
     tuf.roledb.update_roleinfo(self._rolename, roleinfo,
         repository_name=self._repository_name)


### PR DESCRIPTION
**Fixes issue #**:

Closes #567.

**Description of the changes being introduced by the pull request**:

This pull request revises the API for the delegate() and add_paths() methods of the repository tool.  The documentation on the repo tool is also updated to reflect the changes made to these methods.

The API is revised because the current interface makes the delegated paths of the delegated role an optional argument.  It also uses a name, `restricted_paths`, that is not used in the specification.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>

