### PR TITLE
Fix issue#572 (non-default repo names cause an exception)

### DIFF
--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1604,10 +1604,14 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     self.assertTrue(os.path.exists(metadata_directory))
     self.assertTrue(os.path.exists(targets_directory))
 
+    # Test for a repository name that doesn't exist yet.  Note:
+    # The 'test_repository' repository name is created in setup() before this
+    # test case is run.
+    repository = repo_tool.create_new_repository(repository_directory, 'my-repo')
 
     # Test improperly formatted arguments.
     self.assertRaises(securesystemslib.exceptions.FormatError,
-                      repo_tool.create_new_repository, 3, repository_name)
+        repo_tool.create_new_repository, 3, repository_name)
 
     # For testing purposes, try to create a repository directory that
     # fails due to a non-errno.EEXIST exception raised.  create_new_repository()
@@ -1656,7 +1660,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     # Test normal case.
     temporary_directory = tempfile.mkdtemp(dir=self.temporary_directory)
     original_repository_directory = os.path.join('repository_data',
-                                                 'repository')
+        'repository')
 
     repository_directory = os.path.join(temporary_directory, 'repository')
     metadata_directory = os.path.join(repository_directory, 'metadata.staged')
@@ -1694,25 +1698,28 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     self.assertTrue('/file2.txt' in repository.targets.target_files)
     self.assertTrue('/file3.txt' in repository.targets('role1').target_files)
 
+    # Test for a non-default repository name.
+    repository = repo_tool.load_repository(repository_directory, 'my-repo')
+
     # Test improperly formatted arguments.
-    self.assertRaises(securesystemslib.exceptions.FormatError, repo_tool.load_repository, 3)
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+        repo_tool.load_repository, 3)
 
 
     # Test for invalid 'repository_directory' (i.e., does not contain the
     # minimum required metadata.
-    root_filepath = \
-      os.path.join(repository_directory,
-                   repo_tool.METADATA_STAGED_DIRECTORY_NAME, 'root.json')
+    root_filepath = os.path.join(repository_directory,
+        repo_tool.METADATA_STAGED_DIRECTORY_NAME, 'root.json')
     os.remove(root_filepath)
-    self.assertRaises(securesystemslib.exceptions.RepositoryError, repo_tool.load_repository,
-                      repository_directory)
+    self.assertRaises(securesystemslib.exceptions.RepositoryError,
+        repo_tool.load_repository, repository_directory)
 
 
 
   def test_dirty_roles(self):
     repository_name = 'test_repository'
     original_repository_directory = os.path.join('repository_data',
-                                                 'repository')
+        'repository')
     repository = repo_tool.load_repository(original_repository_directory,
         repository_name)
 

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -162,6 +162,14 @@ class Repository(object):
     self._targets_directory = targets_directory
     self._repository_name = repository_name
 
+    try:
+      tuf.roledb.create_roledb(repository_name)
+      tuf.keydb.create_keydb(repository_name)
+
+    except securesystemslib.exceptions.InvalidNameError:
+      logger.debug(repr(repository_name) + ' already exists.  Overwriting'
+          ' its contents.')
+
     # Set the top-level role objects.
     self.root = Root(self._repository_name)
     self.snapshot = Snapshot(self._repository_name)
@@ -2869,7 +2877,7 @@ def create_new_repository(repository_directory, repository_name='default'):
   # have been set and contain default values (e.g., Root roles has a threshold
   # of 1, expires 1 year into the future, etc.)
   repository = Repository(repository_directory, metadata_directory,
-                          targets_directory, repository_name)
+      targets_directory, repository_name)
 
   return repository
 
@@ -2889,8 +2897,8 @@ def load_repository(repository_directory, repository_name='default'):
       sub-directories.
 
     repository_name:
-      The name of the repository.  If not supplied, 'rolename' is added to the
-      'default' repository.
+      The name of the repository.  If not supplied, 'default' is used as the
+      repository name.
 
   <Exceptions>
     securesystemslib.exceptions.FormatError, if 'repository_directory' or any of
@@ -2912,7 +2920,6 @@ def load_repository(repository_directory, repository_name='default'):
   securesystemslib.formats.PATH_SCHEMA.check_match(repository_directory)
   securesystemslib.formats.NAME_SCHEMA.check_match(repository_name)
 
-  # Load top-level metadata.
   repository_directory = os.path.abspath(repository_directory)
   metadata_directory = os.path.join(repository_directory,
     METADATA_STAGED_DIRECTORY_NAME)
@@ -2921,7 +2928,7 @@ def load_repository(repository_directory, repository_name='default'):
   # The Repository() object loaded (i.e., containing all the metadata roles
   # found) and returned.
   repository = Repository(repository_directory, metadata_directory,
-                          targets_directory, repository_name)
+      targets_directory, repository_name)
 
   filenames = repo_lib.get_metadata_filenames(metadata_directory)
 


### PR DESCRIPTION
**Fixes issue #**:

Closes #572. 

**Description of the changes being introduced by the pull request**:

This pull request ensures that a non-default repository name exists in roledb and keydb before creating or loading a repository.  `load_repository('repo_dir', 'my-repo-name')` and `create_new_repository('repo_dir', 'my-repo-name')` incorrectly throw an exception if `my-repo-name` doesn't exist.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>
