### PR TITLE
Read and write keys from memory: Fix issue#571

### DIFF
--- a/tuf/README.md
+++ b/tuf/README.md
@@ -172,6 +172,14 @@ Confirm:
 Enter a password for the encrypted Ed25519 key:
 ```
 
+Note: Methods are also available to generate and write keys from memory.
+* generate_ed25519_key()
+* generate_ecdsa_key()
+* generate_rsa_key()
+
+* import_ecdsakey_from_pem(pem)
+* import_rsakey_from_pem(pem)
+
 ### Create Top-level Metadata ###
 The [metadata document](../METADATA.md) outlines the JSON files that must exist
 on a TUF repository.  The following sub-sections demonstrate the

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -746,16 +746,12 @@ def _log_warning_if_expires_soon(rolename, expires_iso8601_timestamp,
 
 
 def generate_and_write_rsa_keypair(filepath, bits=DEFAULT_RSA_KEY_BITS,
-                                   password=None):
+    password=None):
   """
   <Purpose>
     Generate an RSA key file, create an encrypted PEM string (using 'password'
     as the pass phrase), and store it in 'filepath'.  The public key portion of
-    the generated RSA key is stored in <'filepath'>.pub.  Which cryptography
-    library performs the cryptographic decryption is determined by the string
-    set in 'settings.RSA_CRYPTO_LIBRARY'.  PyCrypto currently supported.  The
-    PEM private key is encrypted with 3DES and CBC the mode of operation.  The
-    password is strengthened with PBKDF1-MD5.
+    the generated RSA key is stored in <'filepath'>.pub.
 
   <Arguments>
     filepath:
@@ -790,13 +786,6 @@ def import_rsa_privatekey_from_file(filepath, password=None):
   <Purpose>
     Import the encrypted PEM file in 'filepath', decrypt it, and return the key
     object in 'securesystemslib.RSAKEY_SCHEMA' format.
-
-    Which cryptography library performs the cryptographic decryption is
-    determined by the string set in 'settings.RSA_CRYPTO_LIBRARY'.  PyCrypto
-    currently supported.
-
-    The PEM private key is encrypted with 3DES and CBC the mode of operation.
-    The password is strengthened with PBKDF1-MD5.
 
   <Arguments>
     filepath:
@@ -834,11 +823,6 @@ def import_rsa_publickey_from_file(filepath):
     key, specifically 'securesystemslib.RSAKEY_SCHEMA'.  If the RSA PEM
     in 'filepath' contains a private key, it is discarded.
 
-    Which cryptography library performs the cryptographic decryption is
-    determined by the string set in 'settings.RSA_CRYPTO_LIBRARY'.  PyCrypto
-    currently supported.  If the RSA PEM in 'filepath' contains a private key,
-    it is discarded.
-
   <Arguments>
     filepath:
       <filepath>.pub file, an RSA PEM file.
@@ -871,9 +855,8 @@ def generate_and_write_ed25519_keypair(filepath, password=None):
     library performs the cryptographic decryption is determined by the string
     set in 'settings.ED25519_CRYPTO_LIBRARY'.
 
-    PyCrypto currently supported.  The Ed25519 private key is encrypted with
-    AES-256 and CTR the mode of operation.  The password is strengthened with
-    PBKDF2-HMAC-SHA256.
+    The Ed25519 private key is encrypted with AES-256 and CTR the mode of
+    operation.  The password is strengthened with PBKDF2-HMAC-SHA256.
 
   <Arguments>
     filepath:
@@ -946,12 +929,8 @@ def import_ed25519_privatekey_from_file(filepath, password=None):
     Import the encrypted ed25519 TUF key file in 'filepath', decrypt it, and
     return the key object in 'securesystemslib.ED25519KEY_SCHEMA' format.
 
-    Which cryptography library performs the cryptographic decryption is
-    determined by the string set in 'settings.ED25519_CRYPTO_LIBRARY'.  PyCrypto
-    currently supported.
-
-    The TUF private key (may also contain the public part) is encrypted with AES
-    256 and CTR the mode of operation.  The password is strengthened with
+    The TUF private key (may also contain the public part) is encrypted with
+    AES 256 and CTR the mode of operation.  The password is strengthened with
     PBKDF2-HMAC-SHA256.
 
   <Arguments>
@@ -983,7 +962,6 @@ def import_ed25519_privatekey_from_file(filepath, password=None):
 
   return securesystemslib.interface.import_ed25519_privatekey_from_file(
       filepath, password)
-
 
 
 
@@ -1101,8 +1079,8 @@ def get_metadata_fileinfo(filename, custom=None):
   # dictionary that a client might define to include additional
   # file information, such as the file's author, version/revision
   # numbers, etc.
-  filesize, filehashes = \
-    securesystemslib.util.get_file_details(filename, securesystemslib.settings.HASH_ALGORITHMS)
+  filesize, filehashes = securesystemslib.util.get_file_details(filename,
+      securesystemslib.settings.HASH_ALGORITHMS)
 
   return tuf.formats.make_fileinfo(filesize, filehashes, custom=custom)
 
@@ -1310,8 +1288,7 @@ def generate_root_metadata(version, expiration_date, consistent_snapshot,
 
 
 def generate_targets_metadata(targets_directory, target_files, version,
-                              expiration_date, delegations=None,
-                              write_consistent_targets=False):
+    expiration_date, delegations=None, write_consistent_targets=False):
   """
   <Purpose>
     Generate the targets metadata object. The targets in 'target_files' must
@@ -1351,7 +1328,8 @@ def generate_targets_metadata(targets_directory, target_files, version,
     securesystemslib.exceptions.FormatError, if an error occurred trying to
     generate the targets metadata object.
 
-    securesystemslib.exceptions.Error, if any of the target files cannot be read.
+    securesystemslib.exceptions.Error, if any of the target files cannot be
+    read.
 
   <Side Effects>
     The target files are read and file information generated about them.  If
@@ -1426,9 +1404,7 @@ def generate_targets_metadata(targets_directory, target_files, version,
 
   # Generate the targets metadata object.
   targets_metadata = tuf.formats.TargetsFile.make_metadata(version,
-                                                           expiration_date,
-                                                           filedict,
-                                                           delegations)
+      expiration_date, filedict, delegations)
 
   return targets_metadata
 
@@ -1549,8 +1525,7 @@ def generate_snapshot_metadata(metadata_directory, version, expiration_date,
 
   # Generate the Snapshot metadata object.
   snapshot_metadata = tuf.formats.SnapshotFile.make_metadata(version,
-                                                             expiration_date,
-                                                             fileinfodict)
+      expiration_date, fileinfodict)
 
   return snapshot_metadata
 
@@ -1618,8 +1593,7 @@ def generate_timestamp_metadata(snapshot_filename, version, expiration_date,
 
   # Generate the timestamp metadata object.
   timestamp_metadata = tuf.formats.TimestampFile.make_metadata(version,
-                                                               expiration_date,
-                                                               snapshot_fileinfo)
+      expiration_date, snapshot_fileinfo)
 
   return timestamp_metadata
 
@@ -1783,10 +1757,10 @@ def write_metadata_file(metadata, filename, version_number, consistent_snapshot)
   # location (i.e., 'file_object') and then moved to 'filename'.
   file_object = securesystemslib.util.TempFile()
 
-  # Serialize 'metadata' to the file-like object and then write
-  # 'file_object' to disk.  The dictionary keys of 'metadata' are sorted
-  # and indentation is used.  The 'securesystemslib.util.TempFile' file-like object is
-  # automically closed after the final move.
+  # Serialize 'metadata' to the file-like object and then write 'file_object'
+  # to disk.  The dictionary keys of 'metadata' are sorted and indentation is
+  # used.  The 'securesystemslib.util.TempFile' file-like object is automically
+  # closed after the final move.
   file_object.write(file_content)
 
   if consistent_snapshot:
@@ -1897,8 +1871,9 @@ def _log_status_of_top_level_roles(targets_directory, metadata_directory,
           metadata_directory, repository_name=repository_name)
     _log_status('root', signable, repository_name)
 
-  # 'tuf.exceptions.UnsignedMetadataError' raised if metadata contains an invalid threshold
-  # of signatures.  log the valid/threshold message, where valid < threshold.
+  # 'tuf.exceptions.UnsignedMetadataError' raised if metadata contains an
+  # invalid threshold of signatures.  log the valid/threshold message, where
+  # valid < threshold.
   except tuf.exceptions.UnsignedMetadataError as e:
     _log_status('root', e.signable, repository_name)
     return
@@ -2028,10 +2003,11 @@ def create_tuf_client_directory(repository_directory, client_directory):
       and target files downloaded from a TUF repository.
 
   <Exceptions>
-    securesystemslib.exceptions.FormatError, if the arguments are improperly formatted.
+    securesystemslib.exceptions.FormatError, if the arguments are improperly
+    formatted.
 
-    securesystemslib.exceptions.RepositoryError, if the metadata directory in 'client_directory'
-    already exists.
+    securesystemslib.exceptions.RepositoryError, if the metadata directory in
+    'client_directory' already exists.
 
   <Side Effects>
     Copies metadata files and directories from 'repository_directory' to
@@ -2053,13 +2029,13 @@ def create_tuf_client_directory(repository_directory, client_directory):
   # the repository's root file must be copied.
   repository_directory = os.path.abspath(repository_directory)
   metadata_directory = os.path.join(repository_directory,
-                                    METADATA_DIRECTORY_NAME)
+      METADATA_DIRECTORY_NAME)
 
   # Set the client's metadata directory, which will store the metadata copied
   # from the repository directory set above.
   client_directory = os.path.abspath(client_directory)
   client_metadata_directory = os.path.join(client_directory,
-                                           METADATA_DIRECTORY_NAME)
+      METADATA_DIRECTORY_NAME)
 
   # If the client's metadata directory does not already exist, create it and
   # any of its parent directories, otherwise raise an exception.  An exception

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -3174,6 +3174,8 @@ def import_ed25519_publickey_from_file(filepath):
 def import_ed25519_privatekey_from_file(filepath, password):
   return repo_lib.import_ed25519_privatekey_from_file(filepath, password)
 
+# NOTE: securesystemslib cannot presently import an Ed25519 key from PEM.
+
 def generate_and_write_rsa_keypair(filepath, bits, password):
   return repo_lib.generate_and_write_rsa_keypair(filepath, bits, password)
 
@@ -3185,6 +3187,9 @@ def import_rsa_publickey_from_file(filepath):
 
 def import_rsa_privatekey_from_file(filepath, password):
   return repo_lib.import_rsa_privatekey_from_file(filepath, password)
+
+def import_rsakey_from_pem(pem):
+  return securesystemslib.keys.import_rsakey_from_pem(pem)
 
 def generate_and_write_ecdsa_keypair(filepath, password=None):
   return securesystemslib.interface.generate_and_write_ecdsa_keypair(
@@ -3199,6 +3204,9 @@ def import_ecdsa_privatekey_from_file(filepath, password):
 
 def import_ecdsa_publickey_from_file(filepath):
   return securesystemslib.interface.import_ecdsa_privatekey_from_file(filepath)
+
+def import_ecdsakey_from_pem(pem):
+  return securesystems.keys.import_ecdsakey_from_pem(pem)
 
 def create_tuf_client_directory(repository_directory, client_directory):
   return repo_lib.create_tuf_client_directory(

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -3167,51 +3167,53 @@ def append_signature(signature, metadata_filepath):
 # Users are expected to call functions provided by repository_tool.py.  We opt
 # for wrapper functions, instead of using the import statements to achieve the
 # equivalent, to avoid linter warnings for unused imports.
-def generate_and_write_ed25519_keypair(filepath, password):
+def generate_and_write_ed25519_keypair(filepath, password=None):
   return repo_lib.generate_and_write_ed25519_keypair(filepath, password)
 
-def generate_ed25519_key():
-  return securesystemslib.keys.generate_ed25519_key()
+def generate_ed25519_key(scheme='ed25519'):
+  return securesystemslib.keys.generate_ed25519_key(scheme)
 
 def import_ed25519_publickey_from_file(filepath):
   return repo_lib.import_ed25519_publickey_from_file(filepath)
 
-def import_ed25519_privatekey_from_file(filepath, password):
+def import_ed25519_privatekey_from_file(filepath, password=None):
   return repo_lib.import_ed25519_privatekey_from_file(filepath, password)
 
 # NOTE: securesystemslib cannot presently import an Ed25519 key from PEM.
 
-def generate_and_write_rsa_keypair(filepath, bits, password):
+def generate_and_write_rsa_keypair(filepath,
+    bits=repo_lib.DEFAULT_RSA_KEY_BITS, password=None):
   return repo_lib.generate_and_write_rsa_keypair(filepath, bits, password)
 
-def generate_rsa_key():
-  return securesystemslib.keys.generate_rsa_key()
+def generate_rsa_key(bits=securesystemslib.keys._DEFAULT_RSA_KEY_BITS,
+    scheme='rsassa-pss-sha256'):
+  return securesystemslib.keys.generate_rsa_key(bits, scheme)
 
 def import_rsa_publickey_from_file(filepath):
   return repo_lib.import_rsa_publickey_from_file(filepath)
 
-def import_rsa_privatekey_from_file(filepath, password):
+def import_rsa_privatekey_from_file(filepath, password=None):
   return repo_lib.import_rsa_privatekey_from_file(filepath, password)
 
-def import_rsakey_from_pem(pem):
-  return securesystemslib.keys.import_rsakey_from_pem(pem)
+def import_rsakey_from_pem(pem, scheme='rsassa-pss-sha256'):
+  return securesystemslib.keys.import_rsakey_from_pem(pem, scheme)
 
-def generate_and_write_ecdsa_keypair(filepath, password=None):
+def generate_and_write_ecdsa_keypair(filepath=None, password=None):
   return securesystemslib.interface.generate_and_write_ecdsa_keypair(
       filepath, password)
 
-def generate_ecdsa_key():
-  return securesystemslib.keys.generate_ecdsa_key()
+def generate_ecdsa_key(scheme='ecdsa-sha2-nistp256'):
+  return securesystemslib.keys.generate_ecdsa_key(scheme)
 
-def import_ecdsa_privatekey_from_file(filepath, password):
+def import_ecdsa_privatekey_from_file(filepath, password=None):
   return securesystemslib.interface.import_ecdsa_privatekey_from_file(
       filepath, password)
 
 def import_ecdsa_publickey_from_file(filepath):
   return securesystemslib.interface.import_ecdsa_privatekey_from_file(filepath)
 
-def import_ecdsakey_from_pem(pem):
-  return securesystemslib.keys.import_ecdsakey_from_pem(pem)
+def import_ecdsakey_from_pem(pem, scheme='ecdsa-sha2-nistp256'):
+  return securesystemslib.keys.import_ecdsakey_from_pem(pem, scheme)
 
 def create_tuf_client_directory(repository_directory, client_directory):
   return repo_lib.create_tuf_client_directory(

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -50,7 +50,7 @@ import tuf.repository_lib as repo_lib
 
 import securesystemslib.keys
 import securesystemslib.formats
-import securesystemslib.interface
+import securesystemslib.keys
 import iso8601
 import six
 
@@ -3158,35 +3158,40 @@ def append_signature(signature, metadata_filepath):
   file_object.move(metadata_filepath)
 
 
-# Wrapper functions that we wish to make available here from repository_lib.py
-# and securesystemslib.interface.
+# Wrapper functions that we wish to make available here from securesystemslib.
 # Users are expected to call functions provided by repository_tool.py.  We opt
 # for this approach, instead of using the import statements to achieve the
 # equivalent, to avoid linter warnings for unused imports.
-def generate_and_write_rsa_keypair(filepath, bits, password):
-  return repo_lib.generate_and_write_rsa_keypair(filepath, bits, password)
-
 def generate_and_write_ed25519_keypair(filepath, password):
   return repo_lib.generate_and_write_ed25519_keypair(filepath, password)
 
-def import_rsa_publickey_from_file(filepath):
-  return repo_lib.import_rsa_publickey_from_file(filepath)
+def generate_ed25519_key():
+  return securesystemslib.keys.generate_ed25519_key()
 
 def import_ed25519_publickey_from_file(filepath):
   return repo_lib.import_ed25519_publickey_from_file(filepath)
 
-def import_rsa_privatekey_from_file(filepath, password):
-  return repo_lib.import_rsa_privatekey_from_file(filepath, password)
-
 def import_ed25519_privatekey_from_file(filepath, password):
   return repo_lib.import_ed25519_privatekey_from_file(filepath, password)
 
-def create_tuf_client_directory(repository_directory, client_directory):
-  return repo_lib.create_tuf_client_directory(repository_directory, client_directory)
+def generate_and_write_rsa_keypair(filepath, bits, password):
+  return repo_lib.generate_and_write_rsa_keypair(filepath, bits, password)
 
-def disable_console_log_messages():
-  return repo_lib.disable_console_log_messages()
+def generate_rsa_key():
+  return securesystemslib.keys.generate_rsa_key()
 
+def import_rsa_publickey_from_file(filepath):
+  return repo_lib.import_rsa_publickey_from_file(filepath)
+
+def import_rsa_privatekey_from_file(filepath, password):
+  return repo_lib.import_rsa_privatekey_from_file(filepath, password)
+
+def generate_and_write_ecdsa_keypair(filepath, password=None):
+  return securesystemslib.interface.generate_and_write_ecdsa_keypair(
+      filepath, password)
+
+def generate_ecdsa_key():
+  return securesystemslib.keys.generate_ecdsa_key()
 
 def import_ecdsa_privatekey_from_file(filepath, password):
   return securesystemslib.interface.import_ecdsa_privatekey_from_file(
@@ -3195,9 +3200,12 @@ def import_ecdsa_privatekey_from_file(filepath, password):
 def import_ecdsa_publickey_from_file(filepath):
   return securesystemslib.interface.import_ecdsa_privatekey_from_file(filepath)
 
-def generate_and_write_ecdsa_keypair(filepath, password=None):
-  return securesystemslib.interface.generate_and_write_ecdsa_keypair(
-      filepath, password)
+def create_tuf_client_directory(repository_directory, client_directory):
+  return repo_lib.create_tuf_client_directory(
+      repository_directory, client_directory)
+
+def disable_console_log_messages():
+  return repo_lib.disable_console_log_messages()
 
 
 

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -62,6 +62,12 @@ logger = logging.getLogger('tuf.repository_tool')
 tuf.log.add_console_handler()
 tuf.log.set_console_log_level(logging.INFO)
 
+# Recommended RSA key sizes:
+# http://www.emc.com/emc-plus/rsa-labs/historical/twirl-and-rsa-key-size.htm#table1
+# According to the document above, revised May 6, 2003, RSA keys of
+# size 3072 provide security through 2031 and beyond.
+DEFAULT_RSA_KEY_BITS=3072
+
 # The algorithm used by the repository to generate the path hash prefixes
 # of hashed bin delegations.  Please see delegate_hashed_bins()
 HASH_FUNCTION = tuf.settings.DEFAULT_HASH_ALGORITHM
@@ -3185,8 +3191,7 @@ def generate_and_write_rsa_keypair(filepath,
     bits=repo_lib.DEFAULT_RSA_KEY_BITS, password=None):
   return repo_lib.generate_and_write_rsa_keypair(filepath, bits, password)
 
-def generate_rsa_key(bits=securesystemslib.keys._DEFAULT_RSA_KEY_BITS,
-    scheme='rsassa-pss-sha256'):
+def generate_rsa_key(bits=DEFAULT_RSA_KEY_BITS, scheme='rsassa-pss-sha256'):
   return securesystemslib.keys.generate_rsa_key(bits, scheme)
 
 def import_rsa_publickey_from_file(filepath):

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -50,6 +50,7 @@ import tuf.repository_lib as repo_lib
 
 import securesystemslib.keys
 import securesystemslib.formats
+import securesystemslib.interface
 import iso8601
 import six
 
@@ -3157,9 +3158,10 @@ def append_signature(signature, metadata_filepath):
   file_object.move(metadata_filepath)
 
 
-# Wrapper functions that we wish to make available here from repository_lib.py.
+# Wrapper functions that we wish to make available here from repository_lib.py
+# and securesystemslib.interface.
 # Users are expected to call functions provided by repository_tool.py.  We opt
-# for this approach, as opposed to using import statements to achieve the
+# for this approach, instead of using the import statements to achieve the
 # equivalent, to avoid linter warnings for unused imports.
 def generate_and_write_rsa_keypair(filepath, bits, password):
   return repo_lib.generate_and_write_rsa_keypair(filepath, bits, password)
@@ -3184,6 +3186,19 @@ def create_tuf_client_directory(repository_directory, client_directory):
 
 def disable_console_log_messages():
   return repo_lib.disable_console_log_messages()
+
+
+def import_ecdsa_privatekey_from_file(filepath, password):
+  return securesystemslib.interface.import_ecdsa_privatekey_from_file(
+      filepath, password)
+
+def import_ecdsa_publickey_from_file(filepath):
+  return securesystemslib.interface.import_ecdsa_privatekey_from_file(filepath)
+
+def generate_and_write_ecdsa_keypair(filepath, password=None):
+  return securesystemslib.interface.generate_and_write_ecdsa_keypair(
+      filepath, password)
+
 
 
 if __name__ == '__main__':

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -50,7 +50,6 @@ import tuf.repository_lib as repo_lib
 
 import securesystemslib.keys
 import securesystemslib.formats
-import securesystemslib.keys
 import iso8601
 import six
 
@@ -3160,7 +3159,7 @@ def append_signature(signature, metadata_filepath):
 
 # Wrapper functions that we wish to make available here from securesystemslib.
 # Users are expected to call functions provided by repository_tool.py.  We opt
-# for this approach, instead of using the import statements to achieve the
+# for wrapper functions, instead of using the import statements to achieve the
 # equivalent, to avoid linter warnings for unused imports.
 def generate_and_write_ed25519_keypair(filepath, password):
   return repo_lib.generate_and_write_ed25519_keypair(filepath, password)
@@ -3206,7 +3205,7 @@ def import_ecdsa_publickey_from_file(filepath):
   return securesystemslib.interface.import_ecdsa_privatekey_from_file(filepath)
 
 def import_ecdsakey_from_pem(pem):
-  return securesystems.keys.import_ecdsakey_from_pem(pem)
+  return securesystemslib.keys.import_ecdsakey_from_pem(pem)
 
 def create_tuf_client_directory(repository_directory, client_directory):
   return repo_lib.create_tuf_client_directory(


### PR DESCRIPTION
**Fixes issue #**:

Closes #571.

**Description of the changes being introduced by the pull request**:

This pull request adds wrapper functions to [securesystemslib](https://github.com/secure-systems-lab/securesystemslib) routines that can write and read keys from memory.  The repository tool only provided wrapper functions to read and write from disk.  For example, `import_ed25519_privatekey_from_file(filepath, password)` and `generate_and_write_ed25519_keypair(filepath, password=None)`

Wrapper functions that are being added to the repository tool....

```Python
from tuf.repository_tool import *

generate_ed25519_key()
generate_ecdsa_key()
generate_rsa_key()

import_ecdsakey_from_pem(pem)
import_rsakey_from_pem(pem)
```

This pull request also adds wrapper functions for missing ECDSA functions.
```Python
generate_and_write_ecdsa_keypair(filepath, password=None)
import_ecdsa_privatekey_from_file(filepath, password)
import_ecdsa_publickey_from_file(filepath)
```

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>
