### PR TITLE
WIP: Fixes #589. Allows 2+ roles to delegate to same role

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -140,6 +140,11 @@ For example, to delegate trust of `/foo*.gz` packages to the `foo` role:
 $ repo.py --delegate "/foo*.tgz" --delegatee foo --pubkeys ./keystore/foo.pub
 ```
 
+Note that multiple roles can delegate to the same role; the delegation graph
+does not have to be a tree. Roles A and B might independently delegate paths to
+the same role, C.
+Cycles are detected and cut short in the depth first traversal the updater
+performs to search for metadata about a target.
 
 
 ## Revoke trust ##

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -463,7 +463,7 @@ specification and [METADATA.md](METADATA.md) for a detailed example.
 All of the target files available on the software repository created so far
 have been added to one role (the top-level Targets role).  However, what if
 multiple developers are responsible for the files of a project?  What if
-responsiblity separation is desired?  Performing a delegation, where one role
+responsibility separation is desired?  Performing a delegation, where one role
 delegates trust of some paths to another role, is an option for integrators
 that require additional roles on top of the top-level roles available by
 default.
@@ -508,6 +508,13 @@ Dirty roles: ['timestamp', 'snapshot', 'targets', 'unclaimed']
 # and "timestamp".
 >>> repository.writeall()
 ```
+
+Note that multiple roles can delegate to the same role; the delegation graph
+does not have to be a tree. Roles A and B might independently delegate paths to
+the same role, C.
+Cycles are detected and cut short in the depth first traversal the updater
+performs to search for metadata about a target.
+
 
 #### Revoke Delegated Role ####
 ```python

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1189,6 +1189,11 @@ class TestTargets(unittest.TestCase):
     self.assertEqual(self.targets_object.get_delegated_rolenames(),
                      ['tuf'])
 
+    # Try to delegate to a role that has already been delegated. Expect success.
+    self.targets_object.delegate(rolename, public_keys, paths, threshold,
+        terminating=False, list_of_targets=list_of_targets,
+        path_hash_prefixes=path_hash_prefixes)
+
     # Test for targets that do not exist under the targets directory.
     self.targets_object.revoke(rolename)
     self.assertRaises(securesystemslib.exceptions.Error,

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1147,9 +1147,9 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     targets_directory = os.path.join(self.repository_directory, 'targets')
 
     # Patterns for delegating the directories
-    foo_pattern = '/foo/*'
-    bar_pattern = '/foo/bar/*'
-    baz_pattern = '/foo/baz/*'
+    foo_pattern = 'foo/*'
+    bar_pattern = 'foo/bar/*'
+    baz_pattern = 'foo/baz/*'
 
     os.makedirs(os.path.join(targets_directory, 'foo', 'bar'))
     os.makedirs(os.path.join(targets_directory, 'foo', 'baz'))
@@ -1242,12 +1242,12 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
       # there is a BadSignatureError('roleC') in it.
 
     with self.assertRaises(tuf.exceptions.NoWorkingMirrorError):
-      self.repository_updater.get_one_valid_targetinfo('/' + bar_target_fname)
+      self.repository_updater.get_one_valid_targetinfo(bar_target_fname)
       # TODO: Consider checking inside NoWorkingMirrorError to make sure that
       # there is a BadSignatureError('roleC') in it.
 
     self.repository_updater.get_one_valid_targetinfo(baz_target_fname)
-    self.repository_updater.get_one_valid_targetinfo('/' + baz_target_fname)
+    self.repository_updater.get_one_valid_targetinfo(baz_target_fname)
 
 
 

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1371,7 +1371,7 @@ class Updater(object):
         In case the repository is somehow inconsistent; e.g. a parent has not
         delegated to a child (contrary to expectations).
 
-      tuf.SignatureError:
+      securesystemslib.exceptions.BadSignatureError:
         In case the metadata file does not have a valid signature.
 
     <Side Effects>


### PR DESCRIPTION
Removes an incorrect check that prevents delegating to a role if any role has previously delegated to that role. (Previously, if X delegated to A, then Y was prevented from delegating to A.)

Adds a few tests.

See #589 for more details. (Note that the central fix, a removal of a few lines, has been merged already in #638, and so has been removed from this commit history.)

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature
