### PR TITLE
Edit link for recommended RSA key lengths

### DIFF
--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -63,9 +63,9 @@ tuf.log.add_console_handler()
 tuf.log.set_console_log_level(logging.INFO)
 
 # Recommended RSA key sizes:
-# http://www.emc.com/emc-plus/rsa-labs/historical/twirl-and-rsa-key-size.htm#table1
-# According to the document above, revised May 6, 2003, RSA keys of
-# size 3072 provide security through 2031 and beyond.
+# https://en.wikipedia.org/wiki/Key_size#Asymmetric_algorithm_key_lengths
+# Based on the above, RSA keys of size 3072 are expected to provide security
+# through 2031 and beyond.
 DEFAULT_RSA_KEY_BITS=3072
 
 # The algorithm used by the repository to generate the path hash prefixes


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

Edit the link that explains why 3072-bit keys are recommended.  The previous link no longer worked.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-of-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>
