### PR TITLE
Fix links to TUTORIAL.md and edit CLI.md

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -57,10 +57,10 @@ Note: Support for directories will be added in the near future.
 
 ## Verbosity ##
 
-Modify the verbosity of the logger.  Logger messages are saved to `tuf.log` in
-the current working directory.
+Set the verbosity of the logger (2, by default).  Logger messages are saved to
+`tuf.log` in the current working directory.
 ```Bash
-$ repo.py --verbose
+$ repo.py --verbose <0-5>
 ```
 
 ## Clean ##

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -45,8 +45,9 @@ $ repo.py --init --consistent_snapshot
 
 
 
+## Add a target file. ##
 
-## Add a target file.  More than one target file may be specified. ##
+More than one target file may be specified.
 ```Bash
 $ repo.py --add <foo.tar.gz> <bar.tar.gz>
 ```
@@ -54,7 +55,10 @@ Note: Support for directories will be added in the near future.
 `$ repo.py --add </path/to/dir> [--recursive]`
 
 
-## Remove the files created via `repo.py --init`.
+
+## Clean ##
+
+Remove the files created via `repo.py --init`.
 ```Bash
 $ repo.py --clean
 ```

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -45,7 +45,7 @@ $ repo.py --init --consistent_snapshot
 
 
 
-## Add a target file. ##
+## Add a target file ##
 
 More than one target file may be specified.
 ```Bash
@@ -55,6 +55,13 @@ Note: Support for directories will be added in the near future.
 `$ repo.py --add </path/to/dir> [--recursive]`
 
 
+## Verbosity ##
+
+Modify the verbosity of the logger.  Logger messages are saved to `tuf.log` in
+the current working directory.
+```Bash
+$ repo.py --verbose
+```
 
 ## Clean ##
 

--- a/docs/GETTING_STARTED.rst
+++ b/docs/GETTING_STARTED.rst
@@ -4,4 +4,4 @@ Getting Started
 - `Installation <INSTALLATION.rst>`_
 - `Contributors <CONTRIBUTORS.rst>`_
 - `Quickstart <QUICKSTART.md>`_ (Work in Progress)
-- `Tutorial <https://github.com/theupdateframework/tuf/tree/develop/tuf/README.md>`_
+- `Tutorial <TUTORIAL.md>`_

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -30,6 +30,6 @@ $ client.py --repo http://localhost:8001 foo.tar.gz
 ```
 
 
-See [CLI.md](CLI.md) for more examples.  A [tutorial](../tuf/README.md) is also
+See [CLI.md](CLI.md) for more examples.  A [tutorial](TUTORIAL.md) is also
 available, and intended for users that want more control over the creation
 process.


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request fixes links to the tutorial doc.  `QUICKSTART.md` and `GETTING_STARTED.rst` incorrectly link to the README.

`CLI.md` is also modified to cover the `--verbose` command-line option, and to edit a couple subtitles.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz>