### PR TITLE
Fix typo in exception message: 'The given target path ...'

### DIFF
--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -2867,7 +2867,7 @@ class Updater(object):
           return child_role_name
 
         else:
-          logger.debug('The given target path' + repr(target_filepath) + ' is'
+          logger.debug('The given target path ' + repr(target_filepath) + ' is'
               ' not an allowed trusted path of ' + repr(child_role_path))
 
           continue


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.  Issue reported by @trishankatdatadog.

**Description of the changes being introduced by the pull request**:

This pull request fixes a typo in an exception message.  Example:
```
"The given target pathu'/simple/X/index.html' is not an allowed trusted path of u'/simple/index.html'"
```

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>