### PR TITLE
CLI: Support directories with the --add command-line option

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -51,9 +51,13 @@ $ repo.py --init --consistent_snapshot
 
 ## Add a target file ##
 
-More than one target file may be specified.
+Copy a target file to the repo and add it to Targets metadata.  More than one
+target file, or directory, may be specified with --add.  The --recursive option
+may be selected to also include files in subdirectories of a specified
+directory.
 ```Bash
 $ repo.py --add <foo.tar.gz> <bar.tar.gz>
+$ repo.py --add </path/to/dir> [--recursive]
 ```
 
 Similar to the --init case, the repository location can be specified.
@@ -61,8 +65,6 @@ Similar to the --init case, the repository location can be specified.
 $ repo.py --add <foo.tar.gz> --path </path/to/my_repo>
 ```
 
-Note: Support for directories will be added in the near future.
-`$ repo.py --add </path/to/dir> [--recursive]`
 
 
 ## Verbosity ##


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request adds support for `$ repo.py --add </path/to/dir> [--recursive]`.  Files in directories, and subdirectories if --recursive is set, are copied to the repo and added to Targets metadata.

The pull request also documents the new feature in `CLI.md`.

For example:
```Bash
$ tree packages/
packages/
├── foo.tar.gz
└── latest
    └── bar.tar.gz

1 directory, 2 files
$ repo.py --add packages/ --recursive
$ tree tufrepo/targets/
tufrepo/targets/
└── packages
    ├── foo.tar.gz
    └── latest
        └── bar.tar.gz

2 directories, 2 files
$ cat tufrepo/metadata/targets.json
{
 "signatures": [
  {
   "keyid": "46b8a692688a6eb79f198b30f7fa66695d465b9628bca5074c37dd46939c19f1",
   "sig": "3045022049a2606b4636db1bee3aa540ad2e1a33d3fbe7652939d92adb3360c86c919075022100a98b0edf3f4236684d3c53588088c192261774e175412f54478c8f575308ddf6"
  }
 ],
 "signed": {
  "_type": "targets",
  "delegations": {
   "keys": {},
   "roles": []
  },
  "expires": "2018-05-05T04:14:07Z",
  "spec_version": "1.0",
  "targets": {
   "/packages/foo.tar.gz": {
    "hashes": {
     "sha256": "853ff93762a06ddbf722c4ebe9ddd66d8f63ddaea97f521c3ecc20da7c976020",
     "sha512": "f65f341b35981fda842b09b2c8af9bcdb7602a4c2e6fa1f7d41f0974d3e3122f268fc79d5a4af66358f5133885cd1c165c916f80ab25e5d8d95db46f803c782c"
    },
    "length": 13
   },
   "/packages/latest/bar.tar.gz": {
    "hashes": {
     "sha256": "263fd4162288c8bfe7f5cc62f4d760bbea5ca7f182fd0a9102fd6269e1589b11",
     "sha512": "3c6f05d97d0ee9444e60b0721d2cbd940382b30c18164f9739a71adcaf16a6584a8c20c7415a29eb5cc9f05915e835c7b85e5dcde034a81c20b7813ad5b307c9"
    },
    "length": 15
   }
  },
  "version": 2
 }
}
```

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>