### PR TITLE
Add --sign option to repo.py

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -67,6 +67,29 @@ $ repo.py --add <foo.tar.gz> --path </path/to/my_repo>
 
 
 
+## Sign metadata ##
+Sign, using the specified key argument, the metadata of the role indicated by
+--role.  If no key argument or --role is given, the Targets role or its key is
+used.  The Snapshot and Timestamp role are also automatically signed, if
+possible.
+```Bash
+$ repo.py --sign
+$ repo.py --sign </path/to/key>
+$ repo.py --sign </path/to/key> [--role <rolename>]
+$ repo.py --sign </path/to/key> [--role <rolename>, --path </path/to/repo>]
+```
+
+For example, to sign a new Timestamp:
+```Bash
+$ repo.py --sign /path/to/timestamp_key --role timestamp
+```
+
+Note: In the future, the user might be given the option of disabling automatic
+signing of Snapshot and Timestamp metadata.  Also, only ECDSA keys are
+presently supported, but other key types will be added.
+
+
+
 ## Verbosity ##
 
 Set the verbosity of the logger (2, by default).  Logger messages are saved to
@@ -74,6 +97,8 @@ Set the verbosity of the logger (2, by default).  Logger messages are saved to
 ```Bash
 $ repo.py --verbose <0-5>
 ```
+
+
 
 ## Clean ##
 


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request adds the `--sign` command-line option to `repo.py`.  Users can use this option to sign for specific metadata in the repo.  For convenience, the `Snapshot` and `Timestamp` are automatically signed, if possible.

```Bash
(env) $ cat tufrepo/metadata/timestamp.json
{
 "signatures": [
  {
   "keyid": "794104c6cd8e018bcf65e1accf208470ec7ea1cc07b8fa7a3384d05e71cf8544",
   "sig": "3046022100cdda4308fbc2c6a41ab1b4a5c0ec375c0c93d4f0c869a86544e5852b837bfd87022100e9602bc15289bf29f1ae1d8ec4ccf968f8437ce3b8f4e7f8fecf8e3b8a331a62"
  }
 ],
 "signed": {
  "_type": "timestamp",
  "expires": "2018-02-06T22:24:16Z",
  "meta": {
   "snapshot.json": {
    "hashes": {
     "sha256": "f5b17893d8190eb40a4d7c494964d1fc04d5b3f805d7a19cb5ba57d7696fa240"
    },
    "length": 484,
    "version": 1
   }
  },
  "spec_version": "1.0",
  "version": 1
 }
}(env) $ repo.py --sign tufkeystore/timestamp_key --role timestamp
Enter a password for the encrypted ECDSA key (tufkeystore/timestamp_key):
(env) $ cat tufrepo/metadata/timestamp.json
{
 "signatures": [
  {
   "keyid": "794104c6cd8e018bcf65e1accf208470ec7ea1cc07b8fa7a3384d05e71cf8544",
   "sig": "3045022100983d22e6dbc7c632bedcb7d321932788a102dda7e2312a73de0e2a95aed18df9022058c9c683b008f4689ff96a1841ce125fc0f83a63f653a0a4c8514c73a80b8f1f"
  }
 ],
 "signed": {
  "_type": "timestamp",
  "expires": "2018-02-06T22:24:16Z",
  "meta": {
   "snapshot.json": {
    "hashes": {
     "sha256": "d23a15d9f8f4654d9a941c4cf6b4c7fde655f60aa7ce5f38de77784d6c45042a"
    },
    "length": 482,
    "version": 2
   }
  },
  "spec_version": "1.0",
  "version": 2
 }
}
```

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>