### PR TITLE
Add --key command-line option to CLI

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -68,6 +68,9 @@ $ repo.py --add <foo.tar.gz> --path </path/to/my_repo>
 
 
 # Generate key ##
+Generate a cryptographic key.  The generated key can later be used with --sign
+to sign specific metadata.  Key types supported: `ecdsa`, `ed25519`, and
+`rsa`.
 ```Bash
 $ repo.py --key
 $ repo.py --key <keytype>

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -67,6 +67,15 @@ $ repo.py --add <foo.tar.gz> --path </path/to/my_repo>
 
 
 
+# Generate key ##
+```Bash
+$ repo.py --key
+$ repo.py --key <keytype>
+$ repo.py --key <keytype> --path </path/to/repo> --pw [my_password], --filename
+```
+
+
+
 ## Sign metadata ##
 Sign, using the specified key argument, the metadata of the role indicated by
 --role.  If no key argument or --role is given, the Targets role or its key is

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -116,6 +116,33 @@ def process_arguments(parsed_arguments):
   if parsed_arguments.sign:
     sign_role(parsed_arguments)
 
+  if parsed_arguments.key:
+    gen_key(parsed_arguments)
+
+
+
+def gen_key(parsed_arguments):
+
+  if parsed_arguments.key == 'ecdsa':
+    repo_tool.generate_and_write_ecdsa_keypair(
+        os.path.join(parsed_arguments.path, KEYSTORE_DIR,
+        parsed_arguments.filename), password=parsed_arguments.pw)
+
+  elif parsed_arguments.key == 'ed25519':
+    repo_tool.generate_and_write_ed25519_keypair(
+        os.path.join(parsed_arguments.path, KEYSTORE_DIR,
+        parsed_arguments.filename), password=parsed_arguments.pw)
+
+  elif parsed_arguments.key == 'rsa':
+    repo_tool.generate_and_write_rsa_keypair(
+        os.path.join(parsed_arguments.path, KEYSTORE_DIR,
+        parsed_arguments.filename), password=parsed_arguments.pw)
+
+  else:
+    tuf.exceptions.Error(
+        'Invalid key type: ' + repr(parsed_arguments.key) + '.  Supported'
+        ' key types: "ecdsa", "ed25519", "rsa."')
+
 
 
 def sign_role(parsed_arguments):
@@ -426,11 +453,18 @@ def parse_arguments():
       default=None, help='Sign --role <rolename> (Targets role, if'
       ' --role is unset) with the specified key.')
 
+  parser.add_argument('--key', type=str, nargs='?', const='ecdsa',
+      default=None, choices=['ecdsa', 'ed25519', 'rsa'],
+      help='Generate an ECDSA, Ed25519, or RSA key.')
+
   parser.add_argument('--role', nargs='?', type=str, const='targets',
       default='targets', help='Specify a role.')
 
   parser.add_argument('--pw', nargs='?', default='pw',
       help='Specify a password for the top-level key files.')
+
+  parser.add_argument('--filename', nargs='?', default=None, const=None,
+      help='Specify filename of generated key.')
 
   parsed_args = parser.parse_args()
 


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request adds a `--key` command-line option to `repo.py`.  The generated key can later be specified with the --sign option to sign specific metadata.

```Bash
(env) $ repo.py --init
(env) $ repo.py --key ed25519
(env) $ repo.py --key rsa --filename my_rsakey
(env) $ repo.py --key ecdsa --filename my_ecdsakey --pw
Enter a password for the ECDSA key (./tufkeystore/my_ecdsakey):
Confirm:
(env) $ tree tufkeystore/
tufkeystore/
├── b045fd8f6c00f07b89469e69271c3f9bfea1429208bf17cab051d41c87021d69
├── b045fd8f6c00f07b89469e69271c3f9bfea1429208bf17cab051d41c87021d69.pub
├── my_ecdsakey
├── my_ecdsakey.pub
├── my_rsakey
├── my_rsakey.pub
├── root_key
├── root_key.pub
├── snapshot_key
├── snapshot_key.pub
├── targets_key
├── targets_key.pub
├── timestamp_key
└── timestamp_key.pub

0 directories, 14 files
```

Note: `repo.py --key <keytype>` writes keypair files `<KEYID>.pub` and `<KEYID>`. 

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>