### PR TITLE
Link to CLI.md from getting started and readme docs

### DIFF
--- a/docs/GETTING_STARTED.rst
+++ b/docs/GETTING_STARTED.rst
@@ -4,4 +4,5 @@ Getting Started
 - `Installation <INSTALLATION.rst>`_
 - `Contributors <CONTRIBUTORS.rst>`_
 - `Quickstart <QUICKSTART.md>`_ (Work in Progress)
+- `CLI <CLI.md>`_ (Work in Progress)
 - `Tutorial <TUTORIAL.md>`_

--- a/tuf/README.md
+++ b/tuf/README.md
@@ -1,3 +1,5 @@
 [Quickstart](../docs/QUICKSTART.md)
 
+[CLI](../docs/CLI.md)
+
 [Tutorial](../docs/TUTORIAL.md)


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request adds a link to `CLI.md` from the `GETTING_STARTED.md` and `tuf/README.rst` docs.

If a user wants to visit the CLI doc from the landing page, they have to currently click through the following links from the README's  `Documentation` section: Getting Started -> Quickstart -> CLI.md (at the bottom of the page).

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>