### PR TITLE
Add --delegate option to `repo.py` CLI (WIP)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -5,8 +5,8 @@ Note: This is a work in progress and subject to change.
 ## Create a repository ##
 
 Create a TUF repository in the current working directory.  A cryptographic key
-is created and set for each top-level role.  The Targets role does not sign for
-any targets nor does it delegate trust to any roles.
+is created and set for each top-level role.  The written Targets metadata does
+not sign for any targets, nor does it delegate trust to any roles.
 
 ```Bash
 $ repo.py --init
@@ -14,10 +14,10 @@ $ repo.py --init
 
 Optionally, the repository can be written to a specified location.
 ```Bash
-$ repo.py --init --path </path/to/repo>
+$ repo.py --init --path </path/to/repo_dir>
 ```
 
-Note:  The default top-level key files created with --init are saved to disk
+Note:  The default top-level key files created with `--init` are saved to disk
 encrypted, with a default password of 'pw'.  Instead of using the default
 password, the user can enter one on the command line or be prompted
 for it via password masking.
@@ -42,7 +42,7 @@ $ repo.py --init --bare
 
 Create a TUF repository with [consistent
 snapshots](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#7-consistent-snapshots)
-enabled.  If enabled, all target filenames have their hash prepended.
+enabled, where all target files have their hash prepended to the filename.
 ```Bash
 $ repo.py --init --consistent_snapshot
 ```
@@ -60,7 +60,7 @@ $ repo.py --add <foo.tar.gz> <bar.tar.gz>
 $ repo.py --add </path/to/dir> [--recursive]
 ```
 
-Similar to the --init case, the repository location can be specified.
+Similar to the --init case, the repository location can be chosen.
 ```Bash
 $ repo.py --add <foo.tar.gz> --path </path/to/my_repo>
 ```
@@ -68,13 +68,13 @@ $ repo.py --add <foo.tar.gz> --path </path/to/my_repo>
 
 
 # Generate key ##
-Generate a cryptographic key.  The generated key can later be used with --sign
-to sign specific metadata.  Key types supported: `ecdsa`, `ed25519`, and
-`rsa`.
+Generate a cryptographic key.  The generated key can later be used to sign
+specific metadata with `--sign`.  The supported key types are: `ecdsa`,
+`ed25519`, and `rsa`.  If a keytype is not given, an ECDSA key is generated.
 ```Bash
 $ repo.py --key
 $ repo.py --key <keytype>
-$ repo.py --key <keytype> --path </path/to/repo> --pw [my_password], --filename
+$ repo.py --key <keytype> --path </path/to/repo_dir> --pw [my_password], --filename <key_filename>
 ```
 
 
@@ -91,21 +91,22 @@ $ repo.py --sign </path/to/key> [--role <rolename>]
 $ repo.py --sign </path/to/key> [--role <rolename>, --path </path/to/repo>]
 ```
 
-For example, to sign a new Timestamp:
+For example, to sign new Timestamp metadata:
 ```Bash
 $ repo.py --sign /path/to/timestamp_key --role timestamp
 ```
 
-Note: In the future, the user might be given the option of disabling automatic
-signing of Snapshot and Timestamp metadata.  Also, only ECDSA keys are
-presently supported, but other key types will be added.
+Note: In the future, the user might have the option of disabling automatic
+signing of Snapshot and Timestamp metadata.  Only ECDSA keys are
+presently supported with `--sign`, but other key types will be added.
 
 
 
 ## Verbosity ##
 
-Set the verbosity of the logger (2, by default).  Logger messages are saved to
-`tuf.log` in the current working directory.
+Set the verbosity of the logger (2, by default).  The lower the number, the
+greater the verbosity.  Logger messages are saved to `tuf.log` in the current
+working directory.
 ```Bash
 $ repo.py --verbose <0-5>
 ```

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -102,6 +102,19 @@ presently supported with `--sign`, but other key types will be added.
 
 
 
+## Delegate trust ##
+
+Delegate trust of target files from the targets role (or the one specified
+in --role) to some other role (--delegatee).  --delegatee is trusted to
+sign for target files that match the delegated glob patterns.
+```Bash
+$ repo.py --delegate <glob pattern> ... --role <rolename>
+    --delegatee <rolename> --terminating --threshold <X>
+    --keys </path/to/pubkey> --sign </path/to/role_privkey>
+```
+
+
+
 ## Verbosity ##
 
 Set the verbosity of the logger (2, by default).  The lower the number, the

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1464,9 +1464,7 @@ class TestTargets(unittest.TestCase):
     # delegated paths are not added to a child role that was not requested).
     self.targets_object.delegate('junk_role', public_keys, [])
 
-    delegated_path = os.path.join(self.targets_directory, 'tuf_files')
-    os.mkdir(delegated_path)
-    paths = [delegated_path + '/*']
+    paths = ['/tuf_files/*']
     self.targets_object.add_paths(paths, 'tuf')
 
     # Retrieve 'targets_object' roleinfo, and verify the roleinfo contains the

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1051,7 +1051,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # default.)
     targets_directory = os.path.join(self.repository_directory, 'targets')
     foo_directory = os.path.join(targets_directory, 'foo')
-    foo_pattern = os.path.join(foo_directory, 'foo*.tar.gz')
+    foo_pattern = '/foo/foo*.tar.gz'
     os.makedirs(foo_directory)
 
     foo_package = os.path.join(foo_directory, 'foo1.1.tar.gz')

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -944,7 +944,7 @@ class Updater(object):
 
     # Iterate the keys of the delegated roles of 'parent_role' and load them.
     for keyid, keyinfo in six.iteritems(keys_info):
-      if keyinfo['keytype'] in ['rsa', 'ed25519']:
+      if keyinfo['keytype'] in ['rsa', 'ed25519', 'ecdsa-sha2-nistp256']:
 
         # We specify the keyid to ensure that it's the correct keyid
         # for the key.

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -1814,10 +1814,6 @@ class Targets(Metadata):
     securesystemslib.formats.PATHS_SCHEMA.check_match(paths)
     tuf.formats.ROLENAME_SCHEMA.check_match(child_rolename)
 
-    # A list of relative and verified paths or glob patterns to be added to the
-    # child role's entry in the parent's delegations field.
-    relative_paths = []
-
     # Ensure that 'child_rolename' exists, otherwise it will not have an entry
     # in the parent role's delegations field.
     if not tuf.roledb.role_exists(child_rolename, self._repository_name):
@@ -1834,8 +1830,6 @@ class Targets(Metadata):
         logger.debug(repr(path) + ' is not located in the'
             ' repository\'s targets'
             ' directory: ' + repr(self._targets_directory))
-
-      relative_paths.append(path[len(self._targets_directory):])
 
     # Get the current role's roleinfo, so that its delegations field can be
     # updated.
@@ -2269,17 +2263,10 @@ class Targets(Metadata):
 
         relative_targetpaths.update({target[targets_directory_length:]: {}})
 
-    # Verify whether each path in 'paths' is located in the repository's
-    # targets directory.
-    relative_paths = []
-
     for path in paths:
       if not path.startswith(self._targets_directory + os.sep):
         logger.debug(repr(path) + ' is not loated in the repository\'s'
           ' targets directory: ' + repr(self._targets_directory))
-
-      # Append a trailing path separator with os.path.join(path, '').
-      relative_paths.append(path[targets_directory_length:])
 
     # Create a new Targets object for the 'rolename' delegation.  An initial
     # expiration is set (3 months from the current time).
@@ -2311,7 +2298,7 @@ class Targets(Metadata):
                 'paths': list(roleinfo['paths'].keys())}
 
     if paths:
-      roleinfo['paths'] = relative_paths
+      roleinfo['paths'] = paths
 
     if path_hash_prefixes:
       roleinfo['path_hash_prefixes'] = path_hash_prefixes

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -1814,6 +1814,10 @@ class Targets(Metadata):
     securesystemslib.formats.PATHS_SCHEMA.check_match(paths)
     tuf.formats.ROLENAME_SCHEMA.check_match(child_rolename)
 
+    # A list of relative and verified paths or glob patterns to be added to the
+    # child role's entry in the parent's delegations field.
+    relative_paths = []
+
     # Ensure that 'child_rolename' exists, otherwise it will not have an entry
     # in the parent role's delegations field.
     if not tuf.roledb.role_exists(child_rolename, self._repository_name):
@@ -1830,6 +1834,8 @@ class Targets(Metadata):
         logger.debug(repr(path) + ' is not located in the'
             ' repository\'s targets'
             ' directory: ' + repr(self._targets_directory))
+
+      relative_paths.append(path)
 
     # Get the current role's roleinfo, so that its delegations field can be
     # updated.

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -137,7 +137,8 @@ def delegate(parsed_arguments):
     raise tuf.exceptions.Error('--delegatee must be set to perform a delegation.')
 
   if parsed_arguments.delegatee in ['root', 'snapshot', 'timestamp', 'targets']:
-    raise tuf.exceptions.Error('Cannot delegate to a top-level role.')
+    raise tuf.exceptions.Error(
+        'Cannot delegate to the top-level role: ' + repr(parsed_arguments.delegatee))
 
   public_keys = []
   for public_key in parsed_arguments.pubkeys:
@@ -162,6 +163,7 @@ def delegate(parsed_arguments):
     repository.targets.load_signing_key(targets_private)
 
 
+  # A non-top-level role.
   else:
     repository.targets(parsed_arguments.role).delegate(
         parsed_arguments.delegatee, public_keys,
@@ -306,7 +308,7 @@ def add_target_to_repo(target_path, repo_targets_path, repository):
   """
 
   if not os.path.exists(target_path):
-    print(repr(target_path) + ' does not exist.  Skipping.')
+    logger.debug(repr(target_path) + ' does not exist.  Skipping.')
 
   else:
     securesystemslib.util.ensure_parent_dir(

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -435,60 +435,66 @@ def parse_arguments():
   parser = argparse.ArgumentParser(
       description='Create or modify a TUF repository.')
 
-  # Add the parser arguments supported by PROG_NAME.
-  parser.add_argument('-v', '--verbose', type=int, default=2,
-      choices=range(0, 6), help='Set the verbosity level of logging messages.'
-      ' The lower the setting, the greater the verbosity.  Supported logging'
-      ' levels: 0=UNSET, 1=DEBUG, 2=INFO, 3=WARNING, 4=ERROR,'
-      ' 5=CRITICAL')
-
   parser.add_argument('-i', '--init', action='store_true',
-      help='Create a repository.  The current working directory is'
-      ' used by default.')
+      help='Create a repository.  The repository is created in the current'
+      ' working directory unless --path is specified.')
 
   parser.add_argument('-p', '--path', nargs='?', default='.',
       metavar='</path/to/repo_dir>', help='Specify a repository path.  If used'
-      ' with --init, the initialized repository is saved to the specified'
-      ' path.  The current working directory is used by default.')
+      ' with --init, the initialized repository is saved to the given'
+      ' path.')
 
   parser.add_argument('-b', '--bare', action='store_true',
       help='If initializing a repository, neither create nor set keys'
       ' for any of the top-level roles.  False, by default.')
 
   parser.add_argument('--consistent_snapshot', action='store_true',
-      help='Enable consistent snapshots.  Consistent snapshot is False by'
-      ' default.')
+      help='Set consistent snapshots for an initialized repository.'
+      '  Consistent snapshot is False by default.')
 
   parser.add_argument('-c', '--clean', type=str, nargs='?', const='.',
-      metavar='</path/to/dir', help='Delete repo files from the'
-      ' specified directory.')
+      metavar='</path/to/repo_dir', help='Delete the repo files from the'
+      ' specified directory.  If a directory is not specified, the current'
+      ' working directory is cleaned.')
 
   parser.add_argument('-a', '--add', type=str, nargs='+',
-      metavar='</path/to/file>', help='Add one or more target files.'
-      '  If a directory is given, all files in the directory are added.')
-
-  parser.add_argument('-r', '--recursive', action='store_true',
-      help='Any directory specified with --add is processed recursively.'
-      '  False, by default.')
-
-  parser.add_argument('--sign', nargs='?', type=str, const='.',
-      default=None, metavar='</path/to/privkey>', help='Sign a role file'
-      '  with the specified key.')
-
-  parser.add_argument('-k', '--key', type=str, nargs='?', const='ecdsa',
-      default=None, choices=['ecdsa', 'ed25519', 'rsa'],
-      help='Generate an ECDSA, Ed25519, or RSA key.  An "ecdsa" key is'
-      ' created by default.')
+      metavar='</path/to/file>', help='Add one or more target files to the'
+      ' "targets" role (or the role specified in --role).  If a directory'
+      ' is given, all files in the directory are added.')
 
   parser.add_argument('--role', nargs='?', type=str, const='targets',
       default='targets', metavar='<rolename>', help='Specify a rolename.'
       ' The rolename "targets" is used by default.')
 
-  parser.add_argument('--pw', nargs='?', default='pw', metavar='<password>',
-      help='Specify a password. "pw" is used by default.')
+  parser.add_argument('-r', '--recursive', action='store_true',
+      help='By setting -r, any directory specified with --add is processed'
+      ' recursively.  If unset, the default behavior is to not add target'
+      ' files in subdirectories.')
+
+  parser.add_argument('-k', '--key', type=str, nargs='?', const='ecdsa',
+      default=None, choices=['ecdsa', 'ed25519', 'rsa'],
+      help='Generate an ECDSA, Ed25519, or RSA key.  An ECDSA key is'
+      ' created if the key type is unspecified.')
 
   parser.add_argument('--filename', nargs='?', default=None, const=None,
-      metavar='<filename>', help='Specify a filename.')
+      metavar='<filename>', help='Specify a filename.  This option can'
+      ' be used to name a generated key file.')
+
+  parser.add_argument('--sign', nargs='?', type=str, const='.',
+      default=None, metavar='</path/to/privkey>', help='Sign the "targets"'
+      ' metadata (or the one for --role) with the specified key.')
+
+  parser.add_argument('--pw', nargs='?', default='pw', metavar='<password>',
+      help='Specify a password. "pw" is used if --pw is unset, or a'
+      ' password can be entered via a prompt by specifying --pw by itself.'
+      '  This option can be used with --sign and --key.')
+
+  # Add the parser arguments supported by PROG_NAME.
+  parser.add_argument('-v', '--verbose', type=int, default=2,
+      choices=range(0, 6), help='Set the verbosity level of logging messages.'
+      ' The lower the setting, the greater the verbosity.  Supported logging'
+      ' levels: 0=UNSET, 1=DEBUG, 2=INFO, 3=WARNING, 4=ERROR,'
+      ' 5=CRITICAL')
 
 
   parsed_args = parser.parse_args()


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request implements (albeit roughly, for now) the `--delegate` option, and its supporting command-line options (e.g., --terminating, --threshold, etc.)

An example delegation from Targets to `foo`:
```Bash
$ repo.py --delegate "packages/foo/*.tar.gz" --delegatee foo --pubkeys </path/to/pubkey.pub>
```

An example delegation from a non-Targets role (with optional arguments):
```Bash
$ repo.py --delegate <glob pattern> --role <rolename> --delegatee <rolename>
    --terminating --threshold <X> --pubkeys </path/to/pubkey.pub>
    --sign </path/to/role_key>
```
Note: The glob pattern should be enclosed in quotes to prevent the possibility of a wild-card character expansion on the command line.

Unrelated: This pull request also (1) reorders the list of add_arguments() so that the help output lists the command-line options in order of importance (2) updates `CLI.md` to document the `--delegate`
option (3) revises some of the help descriptions, and (4) recognizes `ecdsa-sha2-nistp256` key type while visiting delegations.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>