### PR TITLE
Add --revoke option in `repo.py`

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -67,7 +67,7 @@ $ repo.py --add <foo.tar.gz> --path </path/to/my_repo>
 
 
 
-# Generate key ##
+## Generate key ##
 Generate a cryptographic key.  The generated key can later be used to sign
 specific metadata with `--sign`.  The supported key types are: `ecdsa`,
 `ed25519`, and `rsa`.  If a keytype is not given, an ECDSA key is generated.
@@ -108,9 +108,20 @@ Delegate trust of target files from the targets role (or the one specified
 in --role) to some other role (--delegatee).  --delegatee is trusted to
 sign for target files that match the delegated glob patterns.
 ```Bash
-$ repo.py --delegate <glob pattern> ... --role <rolename>
-    --delegatee <rolename> --terminating --threshold <X>
-    --keys </path/to/pubkey> --sign </path/to/role_privkey>
+$ repo.py --delegate <glob pattern>... --delegatee <rolename> --pubkeys
+</path/to/pubkey.pub>... [--role <rolename> --terminating --threshold <X>
+--sign </path/to/role_privkey>]
+```
+
+
+
+## Revoke trust ##
+
+Revoke trust of target files from a delegated role (--delegatee).  The
+"targets" role performs the revocation if --role is not specified.
+```Bash
+$ repo.py --revoke --delegatee <rolename> [--role <rolename>
+--sign </path/to/role_privkey>]
 ```
 
 

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2392,7 +2392,7 @@ class Targets(Metadata):
       del self._delegated_roles[rolename]
       self._parent_targets_object.remove_delegated_role(rolename)
 
-    except tuf.exceptions.UnknownRoleError, KeyError:
+    except (tuf.exceptions.UnknownRoleError, KeyError):
       pass
 
 

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2385,14 +2385,15 @@ class Targets(Metadata):
         repository_name=self._repository_name)
 
     # Remove 'rolename' from 'tuf.roledb.py'.
-    tuf.roledb.remove_role(rolename, self._repository_name)
+    try:
+      tuf.roledb.remove_role(rolename, self._repository_name)
+      # Remove the rolename delegation from the current role.  For example, the
+      # 'django' role is removed from repository.targets('django').
+      del self._delegated_roles[rolename]
+      self._parent_targets_object.remove_delegated_role(rolename)
 
-    # Remove the rolename delegation from the current role.  For example, the
-    # 'django' role is removed from repository.targets('django').
-    del self._delegated_roles[rolename]
-    self._parent_targets_object.remove_delegated_role(rolename)
-
-
+    except tuf.exceptions.UnknownRoleError, KeyError:
+      pass
 
 
 


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request implements the `--revoke` command-line option in `repo.py`.  It also adds the option to `CLI.md` and revises the `--delegate` text.


```Bash
$ repo.py --revoke --delegatee <rolename>
    [--role <rolename> --sign </path/to/role_privkey>]
```


Example:
```Bash
(env) $ repo.py --init
(env) $ repo.py --delegate "foo*.tar.gz" --delegatee foo --pubkeys tufkeystore/targets_key.pub
(env) $ cat tufrepo/metadata/targets.json
{
 "signatures": [
  {
   "keyid": "d42886b1cffb9a8cc1f4cfa5fba9d4274ce1053c5b7a7e1e97303d190650b593",
   "sig": "3045022100b6724055e95b85642bc46a19cce754a7b246572ab64eae864421e83fe310b50d022075ed6950f1ffc723a9839c45fda010a3873c0b609061bb08c3823833599197b4"
  }
 ],
 "signed": {
  "_type": "targets",
  "delegations": {
   "keys": {
    "d42886b1cffb9a8cc1f4cfa5fba9d4274ce1053c5b7a7e1e97303d190650b593": {
     "keyid_hash_algorithms": [
      "sha256",
      "sha512"
     ],
     "keytype": "ecdsa-sha2-nistp256",
     "keyval": {
      "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6NvbCodu17KOXKW3zLifp38FV68N\n/ExYJcJUMwp9xhQ/xocFQi2yAivXZBYPXvacCRE2grInzpDlSPyFQL456g==\n-----END PUBLIC KEY-----\n"
     },
     "scheme": "ecdsa-sha2-nistp256"
    }
   },
   "roles": [
    {
     "keyids": [
      "d42886b1cffb9a8cc1f4cfa5fba9d4274ce1053c5b7a7e1e97303d190650b593"
     ],
     "name": "foo",
     "paths": [
      "foo*.tar.gz"
     ],
     "terminating": false,
     "threshold": 1
    }
   ]
  },
  "expires": "2018-05-16T02:46:09Z",
  "spec_version": "1.0",
  "targets": {},
  "version": 2
 }
}(env) $ repo.py --revoke --delegatee foo
(env) $ cat tufrepo/metadata/targets.json
{
 "signatures": [
  {
   "keyid": "d42886b1cffb9a8cc1f4cfa5fba9d4274ce1053c5b7a7e1e97303d190650b593",
   "sig": "3045022100de8977ddb88a7a10f98525ab8f4dd79dc504245c373bc23e953cf4b92c2d24010220794e9324c0736e9bcc72a0ec5f15479233de1d6ec1ace5a6cbdcac2bc0298359"
  }
 ],
 "signed": {
  "_type": "targets",
  "delegations": {
   "keys": {
    "d42886b1cffb9a8cc1f4cfa5fba9d4274ce1053c5b7a7e1e97303d190650b593": {
     "keyid_hash_algorithms": [
      "sha256",
      "sha512"
     ],
     "keytype": "ecdsa-sha2-nistp256",
     "keyval": {
      "public": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6NvbCodu17KOXKW3zLifp38FV68N\n/ExYJcJUMwp9xhQ/xocFQi2yAivXZBYPXvacCRE2grInzpDlSPyFQL456g==\n-----END PUBLIC KEY-----\n"
     },
     "scheme": "ecdsa-sha2-nistp256"
    }
   },
   "roles": []
  },
  "expires": "2018-05-16T02:46:09Z",
  "spec_version": "1.0",
  "targets": {},
  "version": 3
 }
}(env) $
```


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz>