### PR TITLE
Fix slash sensitivity: Issue #630

### DIFF
--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1085,7 +1085,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # backtracking to 'role3'.  'role2' allows backtracking.
     self.repository_updater.refresh()
     self.repository_updater.get_one_valid_targetinfo('foo/foo1.1.tar.gz')
-
+    self.repository_updater.get_one_valid_targetinfo('/foo/foo1.1.tar.gz')
 
     # Test when 'role2' does *not* allow backtracking.  If 'foo/foo1.1.tar.gz'
     # is not provided by the authoritative 'role2',


### PR DESCRIPTION
**Fixes issue #**:

Close #630.

**Description of the changes being introduced by the pull request**:

This pull request makes sure that a leading path separator is disregarded when comparing a requested target file with a delegated glob pattern (e.g., "/foo*.tgz).

For instance: client request `foo-1.0.tgz` should match with trusted glob pattern `/foo*.tgz`.


```Python
for rolename in ['r1', 'r2']:
  repo.targets.delegate(rolename, [pubkey], ['/a*'])
```

```Bash
(env) $ client.py --repo http://localhost:8001 /a1.txt
(env) $ rm -rf tuftargets/
(env) $ client.py --repo http://localhost:8001 a1.txt
```

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>