### PR TITLE
CLI --sign: Support non-ECDSA keys

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -80,10 +80,10 @@ $ repo.py --key <keytype> --path </path/to/repo_dir> --pw [my_password], --filen
 
 
 ## Sign metadata ##
-Sign, using the specified key argument, the metadata of the role indicated by
---role.  If no key argument or --role is given, the Targets role or its key is
-used.  The Snapshot and Timestamp role are also automatically signed, if
-possible.
+Sign, using the specified key, the metadata of the role indicated by --role
+(must be Targets or a delegated role).  If no key argument or --role is given,
+the Targets role or its key is used.  The Snapshot and Timestamp role are also
+automatically signed, if possible.
 ```Bash
 $ repo.py --sign
 $ repo.py --sign </path/to/key>
@@ -97,8 +97,7 @@ $ repo.py --sign /path/to/timestamp_key --role timestamp
 ```
 
 Note: In the future, the user might have the option of disabling automatic
-signing of Snapshot and Timestamp metadata.  Only ECDSA keys are
-presently supported with `--sign`, but other key types will be added.
+signing of Snapshot and Timestamp metadata.
 
 
 


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request adds support for any key type (from those supported: ed25519, rsa, and ecdsa) in the --sign command-line option.  It previously supported only ECDSA keys.

```Bash
(env) $ repo.py --init
(env) $ cat tufrepo/metadata/targets.json
{
 "signatures": [
  {
   "keyid": "d35049c1622c3331c1808369f071ebb51dedb3934c62c8f4de46d5cd520571fd",
   "sig": "304402200fc281b6ebf04d07a4a6c6bcb03d330f983e2d3ebc5fae25864ffdb4f30b205502203e7fc96285bacc89ee924c91243b31f09b7cbcdf0cce089a255453267e53a759"
  }
 ],
 "signed": {
  "_type": "targets",
  "delegations": {
   "keys": {},
   "roles": []
  },
  "expires": "2018-06-02T04:44:49Z",
  "spec_version": "1.0",
  "targets": {},
  "version": 1
 }
}
(env) $ repo.py --key ed25519 --filename my_key
(env) $ repo.py --sign tufkeystore/my_key --role targets
Enter a password for the encrypted key (tufkeystore/my_key):
(env) $ cat tufrepo/metadata/targets.json
{
 "signatures": [
  {
   "keyid": "d54d813682b0ebcd20e07b166180602ca4e0360a155542f599df447036e9965c",
   "sig": "cbda98bcf62b2650c60b5cb140e4e2e6790464550d265775d2a2f0d2b804dd8d76a5c75f20359d68245593f549c35ad21217054214ac4ce360240062f1538308"
  }
 ],
 "signed": {
  "_type": "targets",
  "delegations": {
   "keys": {},
   "roles": []
  },
  "expires": "2018-06-02T04:44:49Z",
  "spec_version": "1.0",
  "targets": {},
  "version": 2
 }
}
(env) $
```

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz>