### PR TITLE
CLI --sign: Support signing of delegated metadata and ability to import any public key type

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -86,14 +86,12 @@ the Targets role or its key is used.  The Snapshot and Timestamp role are also
 automatically signed, if possible.
 ```Bash
 $ repo.py --sign
-$ repo.py --sign </path/to/key>
-$ repo.py --sign </path/to/key> [--role <rolename>]
 $ repo.py --sign </path/to/key> [--role <rolename>, --path </path/to/repo>]
 ```
 
 For example, to sign new Timestamp metadata:
 ```Bash
-$ repo.py --sign /path/to/timestamp_key --role timestamp
+$ repo.py --sign /path/to/foo_key --role foo
 ```
 
 Note: In the future, the user might have the option of disabling automatic
@@ -112,7 +110,8 @@ $ repo.py --delegate <glob pattern>... --delegatee <rolename> --pubkeys
 --sign </path/to/role_privkey>]
 ```
 
-Example:
+For example, to delegate trust of `/foo*.gz` packages to the `foo` role:
+
 ```
 $ repo.py --delegate "/foo*.tgz" --delegatee foo --pubkeys ./keystore/foo.pub
 ```

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1189,12 +1189,6 @@ class TestTargets(unittest.TestCase):
     self.assertEqual(self.targets_object.get_delegated_rolenames(),
                      ['tuf'])
 
-    # Try to delegate to a role that has already been delegated.
-    self.assertRaises(securesystemslib.exceptions.Error,
-        self.targets_object.delegate, rolename, public_keys, paths, threshold,
-        terminating=False, list_of_targets=list_of_targets,
-        path_hash_prefixes=path_hash_prefixes)
-
     # Test for targets that do not exist under the targets directory.
     self.targets_object.revoke(rolename)
     self.assertRaises(securesystemslib.exceptions.Error,

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2233,11 +2233,6 @@ class Targets(Metadata):
     if path_hash_prefixes is not None:
       securesystemslib.formats.PATH_HASH_PREFIXES_SCHEMA.check_match(path_hash_prefixes)
 
-    # Check if 'rolename' is not already a delegation.
-    if tuf.roledb.role_exists(rolename, self._repository_name):
-      raise securesystemslib.exceptions.Error(repr(rolename) + ' already'
-          ' delegated.')
-
     # Keep track of the valid keyids (added to the new Targets object) and
     # their keydicts (added to this Targets delegations).
     keyids = []

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -373,18 +373,16 @@ def sign_role(parsed_arguments):
 
       # Load the private key keydb and set the roleinfo in roledb so that
       # metadata can be written with repository.write().
-      try:
-        tuf.keydb.add_key(
-            role_privatekey, repository_name = repository._repository_name)
-
-      except securesystemslib.exceptions.KeyAlreadyExistsError:
-        pass
+      tuf.keydb.remove_key(role_privatekey['keyid'],
+          repository_name = repository._repository_name)
+      tuf.keydb.add_key(
+          role_privatekey, repository_name = repository._repository_name)
 
       expiration = tuf.formats.unix_timestamp_to_datetime(
           int(time.time() + 7889230))
       expiration = expiration.isoformat() + 'Z'
 
-      roleinfo = {'name': parsed_arguments.role, 'keyids': [],
+      roleinfo = {'name': parsed_arguments.role, 'keyids': [role_privatekey['keyid']],
           'signing_keyids': [role_privatekey['keyid']], 'partial_loaded': False, 'paths': {},
           'signatures': [], 'version': 1, 'expires': expiration,
           'delegations': {'keys': {}, 'roles': []}}


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request allows any delegated role to be signed with the --sign option (it previously only supported signing of the Targets role).  Public keys of any key type can now be imported, as well.

Unrelated: Allow 2+ roles to delegate to the same role.  Although pending pull request #590 implements it, it is implemented here to get everything working.

```Bash
(env) $ repo.py --init
(env) $ repo.py --key ed25519 --filename foo_key
(env) $ repo.py --delegate "foo*.tgz" --delegatee foo --pubkeys tufkeystore/foo_key.pub
(env) $ repo.py --sign tufkeystore/foo_key --role foo
Enter a password for the encrypted key (tufkeystore/foo_key):
(env) $ cat tufrepo/metadata/foo.json
{
 "signatures": [
  {
   "keyid": "93d511347a13c2c3bec4537bbe5b642c7860c4f2590dfec6470182628404699f",
   "sig": "7f78b552560b589814cd7a7fc49047a855660d576c22fc9e6b83b55cf733d0516a07bd664993ef48908e7bff6770395940cc07b5f3529cbc97f2253face07b0f"
  }
 ],
 "signed": {
  "_type": "targets",
  "delegations": {
   "keys": {},
   "roles": []
  },
  "expires": "2018-06-05T05:53:53Z",
  "spec_version": "1.0",
  "targets": {},
  "version": 1
 }
}(env) $
```

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>