### PR TITLE
CLI: Implement --remove command-line option

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -51,10 +51,10 @@ $ repo.py --init --consistent_snapshot
 
 ## Add a target file ##
 
-Copy a target file to the repo and add it to Targets metadata.  More than one
-target file, or directory, may be specified with --add.  The --recursive option
-may be selected to also include files in subdirectories of a specified
-directory.
+Copy a target file to the repo and add it to the Targets metadata (or the
+Targets role specified in --role).  More than one target file, or directory,
+may be specified in --add.  The --recursive option may be toggled to also
+include files in subdirectories of a specified directory.
 ```Bash
 $ repo.py --add <foo.tar.gz> <bar.tar.gz>
 $ repo.py --add </path/to/dir> [--recursive]
@@ -65,6 +65,30 @@ Similar to the --init case, the repository location can be chosen.
 $ repo.py --add <foo.tar.gz> --path </path/to/my_repo>
 ```
 
+
+
+
+## Remove a target file ##
+
+Remove a target file from the Targets metadata (or the Targets role specified
+in --role).  More than one target file or glob pattern may be specified in
+--remove.
+
+```Bash
+$ repo.py --remove <glob_pattern> ...
+```
+
+Examples:
+
+Remove all target files, that match `foo*.tgz,` from the Targets metadata.
+```Bash
+$ repo.py --remove "foo*.tgz"
+```
+
+Remove all target files from the `my_role` Targets metadata.
+```Bash
+$ repo.py --remove "*" --role my_role --sign tufkeystore/my_role_key
+```
 
 
 ## Generate key ##
@@ -105,7 +129,7 @@ Delegate trust of target files from the targets role (or the one specified
 in --role) to some other role (--delegatee).  --delegatee is trusted to
 sign for target files that match the delegated glob patterns.
 ```Bash
-$ repo.py --delegate <glob pattern>... --delegatee <rolename> --pubkeys
+$ repo.py --delegate <glob pattern> ... --delegatee <rolename> --pubkeys
 </path/to/pubkey.pub>... [--role <rolename> --terminating --threshold <X>
 --sign </path/to/role_privkey>]
 ```


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request implements the --remove command-line option, which can be used to remove target files from Targets or delegated metadata.

**Example of removing a single target file (`/foo.tar.gz`) from Targets metadata that matches a given glob pattern (`/foo*.gz`):**
```Bash
(env) $ repo.py --init
(env) $ repo.py --add foo.tar.gz
(env) $ cat tufrepo/metadata/targets.json
{
 "signatures": [
  {
   "keyid": "327e606945f908c5be4d9c6c230a00f7765e208204efbcdccbea6a0a6e53e947",
   "sig": "3046022100801ca13feaaf1a277a63419a811cd05f4b26fc3a09c2c9228aaa5a54ffb7bdb502210085516c1bcb80668ef17c6c4409b95e81de7ee6d7c14433a11cb2f7aa3a645562"
  }
 ],
 "signed": {
  "_type": "targets",
  "delegations": {
   "keys": {},
   "roles": []
  },
  "expires": "2018-06-08T00:04:03Z",
  "spec_version": "1.0",
  "targets": {
   "/foo.tar.gz": {
    "hashes": {
     "sha256": "853ff93762a06ddbf722c4ebe9ddd66d8f63ddaea97f521c3ecc20da7c976020",
     "sha512": "f65f341b35981fda842b09b2c8af9bcdb7602a4c2e6fa1f7d41f0974d3e3122f268fc79d5a4af66358f5133885cd1c165c916f80ab25e5d8d95db46f803c782c"
    },
    "length": 13
   }
  },
  "version": 2
 }
}

(env) $repo.py --remove "/foo*.gz"
(env) $ cat tufrepo/metadata/targets.json
{
 "signatures": [
  {
   "keyid": "327e606945f908c5be4d9c6c230a00f7765e208204efbcdccbea6a0a6e53e947",
   "sig": "3046022100c68c992f77d327e246089a029cb4a3be32fa202a9e2d23e62d52f6b70c6b3438022100a75fb4727e40d4221840b38c770bd7e5c99845a3e11ba7f32aaee18ec2f1a570"
  }
 ],
 "signed": {
  "_type": "targets",
  "delegations": {
   "keys": {},
   "roles": []
  },
  "expires": "2018-06-08T00:04:03Z",
  "spec_version": "1.0",
  "targets": {},
  "version": 4
 }
}(env) $
```


**Here is an example of removing all target files specified in the Targets metadata.**

```Bash
(env) $ repo.py --init
(env) $ repo.py --add foo.tar.gz bar.tar.gz
(env) $ cat tufrepo/metadata/targets.json
{
 "signatures": [
  {
   "keyid": "a16ba2e460a98a92bcd402c2c0b786083879cbb2439bdeebee2fdbe8b785d2e3",
   "sig": "3046022100faa1cdb34044e51d2332b2a72e32f73b0d090e3d2210db1a4a1e840473a362e3022100d5ccef3dac0194c870bbc59401c4fcdfc562576241b5c770cb3bfe4b432e7466"
  }
 ],
 "signed": {
  "_type": "targets",
  "delegations": {
   "keys": {},
   "roles": []
  },
  "expires": "2018-06-08T00:11:03Z",
  "spec_version": "1.0",
  "targets": {
   "/bar.tar.gz": {
    "hashes": {
     "sha256": "263fd4162288c8bfe7f5cc62f4d760bbea5ca7f182fd0a9102fd6269e1589b11",
     "sha512": "3c6f05d97d0ee9444e60b0721d2cbd940382b30c18164f9739a71adcaf16a6584a8c20c7415a29eb5cc9f05915e835c7b85e5dcde034a81c20b7813ad5b307c9"
    },
    "length": 15
   },
   "/foo.tar.gz": {
    "hashes": {
     "sha256": "853ff93762a06ddbf722c4ebe9ddd66d8f63ddaea97f521c3ecc20da7c976020",
     "sha512": "f65f341b35981fda842b09b2c8af9bcdb7602a4c2e6fa1f7d41f0974d3e3122f268fc79d5a4af66358f5133885cd1c165c916f80ab25e5d8d95db46f803c782c"
    },
    "length": 13
   }
  },
  "version": 2
 }
}

(env) $ repo.py --remove "*"
(env) $ cat tufrepo/metadata/targets.json
{
 "signatures": [
  {
   "keyid": "a16ba2e460a98a92bcd402c2c0b786083879cbb2439bdeebee2fdbe8b785d2e3",
   "sig": "304502204993785f68814e678429cacb97ac491d8e45af9192bb936f88a9f4d3160963fb022100c2bb9952e2af3f5a79d82784e8eb02690d2447b672743df29bd35ffc4d7c3a22"
  }
 ],
 "signed": {
  "_type": "targets",
  "delegations": {
   "keys": {},
   "roles": []
  },
  "expires": "2018-06-08T00:11:03Z",
  "spec_version": "1.0",
  "targets": {},
  "version": 3
 }
}(env) $
```


- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


