### PR TITLE
Do not refresh root metadata unless dirty when consistent_snapshot is enabled

### DIFF
--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -318,7 +318,7 @@ class TestRepository(unittest.TestCase):
 
     # Verify that a writeall() fails if a repository is loaded and a change
     # is made to a role.
-    repo_tool.load_repository(repository_directory, repository_name)
+    repository = repo_tool.load_repository(repository_directory, repository_name)
 
     repository.timestamp.expiration = datetime.datetime(2030, 1, 1, 12, 0)
     self.assertRaises(tuf.exceptions.UnsignedMetadataError, repository.writeall)
@@ -331,7 +331,6 @@ class TestRepository(unittest.TestCase):
     # snapshot modifies the Root metadata, which specifies whether a repository
     # supports consistent snapshots.  Verify that an exception is raised due to
     # the missing signatures of Root and Snapshot.
-    repository.root.unload_signing_key(root_privkey)
     self.assertRaises(tuf.exceptions.UnsignedMetadataError, repository.writeall, consistent_snapshot=True)
 
     # Load the private keys of Root and Snapshot (new version required since

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -331,7 +331,8 @@ class TestRepository(unittest.TestCase):
     # snapshot modifies the Root metadata, which specifies whether a repository
     # supports consistent snapshots.  Verify that an exception is raised due to
     # the missing signatures of Root and Snapshot.
-    self.assertRaises(tuf.exceptions.UnsignedMetadataError, repository.writeall, True)
+    repository.root.unload_signing_key(root_privkey)
+    self.assertRaises(tuf.exceptions.UnsignedMetadataError, repository.writeall, consistent_snapshot=True)
 
     # Load the private keys of Root and Snapshot (new version required since
     # Root will change to enable consistent snapshots.

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -252,7 +252,7 @@ class Repository(object):
     # metadata file.  _generate_and_write_metadata() raises a
     # 'securesystemslib.exceptions.Error' exception if the metadata cannot be
     # written.
-    if 'root' in dirty_rolenames or consistent_snapshot:
+    if 'root' in dirty_rolenames:
       repo_lib._generate_and_write_metadata('root', filenames['root'],
           self._targets_directory, self._metadata_directory,
           consistent_snapshot, filenames,


### PR DESCRIPTION
**Fixes issue #**:

When using consistent snapshots, the root metadata was forced to be refreshed even though it was not "dirty."

**Description of the changes being introduced by the pull request**:

Remove a faulty condition, as @vladimir-v-diaz observed. Tested and fixes problem on my end.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


