### PR TITLE
Edit pull request #643

### DIFF
--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -318,32 +318,32 @@ class TestRepository(unittest.TestCase):
 
     # Verify that a writeall() fails if a repository is loaded and a change
     # is made to a role.
-    repository = repo_tool.load_repository(repository_directory, repository_name)
+    repo_tool.load_repository(repository_directory, repository_name)
 
     repository.timestamp.expiration = datetime.datetime(2030, 1, 1, 12, 0)
     self.assertRaises(tuf.exceptions.UnsignedMetadataError, repository.writeall)
 
-    # Next, perform a writeall() with consistent snapshots enabled.
-    # Since the timestamp was modified, load its private key.
+    # Load the required Timestamp key so that a valid repository can be written.
     repository.timestamp.load_signing_key(timestamp_privkey)
+    repository.writeall()
 
     # Test creation of a consistent snapshot repository.  Writing a consistent
     # snapshot modifies the Root metadata, which specifies whether a repository
-    # supports consistent snapshots.  Verify that an exception is raised due to
-    # the missing signatures of Root and Snapshot.
-    self.assertRaises(tuf.exceptions.UnsignedMetadataError, repository.writeall, consistent_snapshot=True)
+    # supports consistent snapshot.  Verify that an exception is raised due to
+    # the missing signature of Root.
+    self.assertRaises(tuf.exceptions.UnsignedMetadataError, repository.writeall, True)
 
-    # Load the private keys of Root and Snapshot (new version required since
-    # Root will change to enable consistent snapshots.
+    # Make sure the private keys of Root (new version required since Root will
+    # change to enable consistent snapshot), Snapshot, role1, and timestamp
+    # loaded before writing consistent snapshot.
     repository.root.load_signing_key(root_privkey)
-    repository.targets.load_signing_key(targets_privkey)
     repository.snapshot.load_signing_key(snapshot_privkey)
     repository.targets('role1').load_signing_key(role1_privkey)
 
-    # Verify that a consistent snapshot can be written and loaded.  The
-    # 'targets' and 'role1' roles must be marked as dirty, otherwise writeall()
-    # will not create consistent snapshots for them.
-    repository.mark_dirty(['targets', 'role1'])
+    # Verify that a consistent snapshot can be written and loaded.  The roles
+    # above must be marked as dirty, otherwise writeall() will not create a
+    # consistent snapshot for them.
+    repository.mark_dirty(['role1', 'root', 'snapshot', 'timestamp'])
     repository.writeall(consistent_snapshot=True)
 
     # Verify that the newly written consistent snapshot can be loaded

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -549,6 +549,7 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
 
     # Load Root's roleinfo and update 'tuf.roledb'.
     roleinfo = tuf.roledb.get_roleinfo('root', repository_name)
+    roleinfo['consistent_snapshot'] = root_metadata['consistent_snapshot']
     roleinfo['signatures'] = []
     for signature in signable['signatures']:
       if signature not in roleinfo['signatures']:

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -252,7 +252,9 @@ class Repository(object):
     # metadata file.  _generate_and_write_metadata() raises a
     # 'securesystemslib.exceptions.Error' exception if the metadata cannot be
     # written.
-    if 'root' in dirty_rolenames:
+    root_roleinfo = tuf.roledb.get_roleinfo('root', self._repository_name)
+    old_consistent_snapshot = root_roleinfo['consistent_snapshot']
+    if 'root' in dirty_rolenames or consistent_snapshot != old_consistent_snapshot:
       repo_lib._generate_and_write_metadata('root', filenames['root'],
           self._targets_directory, self._metadata_directory,
           consistent_snapshot, filenames,


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request edits #643 (Do not refresh root metadata unless dirty when consistent_snapshot is enabled).  It modifies the approach used there, by loading the previous consistent snapshot setting when reading the Root file.  Before attempting to write a new Root file, the old consistent snapshot setting (specified in the currently trusted Root file) is compared to the new consistent snapshot setting and written if the settings differ.

This pull request also edits the unit/test conditions for writing a consistent snapshot.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>