### PR TITLE
Raise exception if --pubkeys not given while delegating

### DIFF
--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -145,11 +145,16 @@ def process_arguments(parsed_arguments):
 def delegate(parsed_arguments):
 
   if not parsed_arguments.delegatee:
-    raise tuf.exceptions.Error('--delegatee must be set to perform a delegation.')
+    raise tuf.exceptions.Error(
+        '--delegatee must be set to perform the delegation.')
 
   if parsed_arguments.delegatee in ['root', 'snapshot', 'timestamp', 'targets']:
     raise tuf.exceptions.Error(
         'Cannot delegate to the top-level role: ' + repr(parsed_arguments.delegatee))
+
+  if not parsed_arguments.pubkeys:
+    raise tuf.exceptions.Error(
+        '--pubkeys must be set to perform the delegation.')
 
   public_keys = []
   for public_key in parsed_arguments.pubkeys:


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request ensures that an exception is raised if the `--pubkeys` command-line option is not given while delegating to another role.

For example:

```Bash
(env) $ repo.py --delegate "foo*.tar.gz" --delegatee foo
Error: --pubkeys must be set to perform the delegation.
(env) $
```

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>