### PR TITLE
CLI: Implement --trust option

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,4 +1,4 @@
-# CLI examples #
+# CLI #
 
 Note: This is a work in progress and subject to change.
 
@@ -45,6 +45,7 @@ $ repo.py --init --consistent_snapshot
 
 
 
+
 ## Add a target file ##
 
 Copy a target file to the repo and add it to the Targets metadata (or the
@@ -81,7 +82,7 @@ Remove all target files, that match `foo*.tgz,` from the Targets metadata.
 $ repo.py --remove "foo*.tgz"
 ```
 
-Remove all target files from the `my_role` Targets metadata.
+Remove all target files from the `my_role` metadata.
 ```Bash
 $ repo.py --remove "*" --role my_role --sign tufkeystore/my_role_key
 ```
@@ -94,24 +95,46 @@ specific metadata with `--sign`.  The supported key types are: `ecdsa`,
 ```Bash
 $ repo.py --key
 $ repo.py --key <keytype>
-$ repo.py --key <keytype> --path </path/to/repo_dir> --pw [my_password], --filename <key_filename>
+$ repo.py --key <keytype> [--path </path/to/repo_dir> --pw [my_password], --filename <key_filename>]
 ```
 
 Instead of using some default password, the user can enter one on the command
 line or be prompted for it via password masking.
 ```Bash
-$ repo.py --key ... --pw my_password
+$ repo.py --key ed25519 --pw my_password
 ```
 
 ```Bash
-$ repo.py --key ... --pw
+$ repo.py --key rsa --pw
 Enter a password for the top-level role keys:
 Confirm:
 ```
 
 
+
+## Trust keys ##
+
+The Root role specifies the trusted keys of the top-level roles, including
+itself.  The --trust command-line option, in conjunction with --pubkeys and
+--role, can be used to indicate the trusted keys of a role.
+
+```Bash
+$ repo.py --trust --pubkeys --role
+```
+
+For example:
+```Bash
+$ repo.py --init --bare
+$ repo.py --trust --pubkeys keystore/my_key.pub keystore/my_key_too.pub --role root
+```
+
+Note: This action replaces any previously trusted keys that might have been
+specified for --role.
+
+
+
 ## Sign metadata ##
-Sign, using the specified key, the metadata of the role indicated by --role
+Sign, using the specified key, the metadata of the role indicated in --role
 (must be Targets or a delegated role).  If no key argument or --role is given,
 the Targets role or its key is used.  The Snapshot and Timestamp role are also
 automatically signed, if possible.
@@ -120,7 +143,7 @@ $ repo.py --sign
 $ repo.py --sign </path/to/key> [--role <rolename>, --path </path/to/repo>]
 ```
 
-For example, to sign new Timestamp metadata:
+For example, to sign the delegated `foo` metadata:
 ```Bash
 $ repo.py --sign /path/to/foo_key --role foo
 ```
@@ -130,14 +153,15 @@ signing of Snapshot and Timestamp metadata.
 
 
 
-## Delegate trust ##
+## Delegation ##
 
-Delegate trust of target files from the targets role (or the one specified
+Delegate trust of target files from the Targets role (or the one specified
 in --role) to some other role (--delegatee).  --delegatee is trusted to
 sign for target files that match the delegated glob patterns.
+
 ```Bash
 $ repo.py --delegate <glob pattern> ... --delegatee <rolename> --pubkeys
-</path/to/pubkey.pub>... [--role <rolename> --terminating --threshold <X>
+</path/to/pubkey.pub> ... [--role <rolename> --terminating --threshold <X>
 --sign </path/to/role_privkey>]
 ```
 
@@ -149,7 +173,7 @@ $ repo.py --delegate "/foo*.tgz" --delegatee foo --pubkeys ./keystore/foo.pub
 
 
 
-## Revoke trust ##
+## Revocation ##
 
 Revoke trust of target files from a delegated role (--delegatee).  The
 "targets" role performs the revocation if --role is not specified.


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request implements the --trust command-line option, which can be used to specify the trusted keys of the top-level roles in Root metadata.

Example:

```Bash
(env) $ repo.py --init --bare
(env) $ cat tufrepo/metadata/root.json
{
 "signatures": [],
 "signed": {
  "_type": "root",
  "consistent_snapshot": false,
  "expires": "2019-03-20T02:45:03Z",
  "keys": {},
  "roles": {
   "root": {
    "keyids": [],
    "threshold": 1
   },
   "snapshot": {
    "keyids": [],
    "threshold": 1
   },
   "targets": {
    "keyids": [],
    "threshold": 1
   },
   "timestamp": {
    "keyids": [],
    "threshold": 1
   }
  },
  "spec_version": "1.0",
  "version": 1
 }
}

(env) $ repo.py --key ed25519 --filename root_key
(env) $ repo.py --trust --pubkeys tufkeystore/root_key.pub --role root
(env) $ cat tufrepo/metadata/root.json
{
 "signatures": [],
 "signed": {
  "_type": "root",
  "consistent_snapshot": false,
  "expires": "2019-03-20T02:45:03Z",
  "keys": {
   "d1eb39da485919fbf7738e5f5c45e315a1f439c77f9e054d4ad5e07371179eb6": {
    "keyid_hash_algorithms": [
     "sha256",
     "sha512"
    ],
    "keytype": "ed25519",
    "keyval": {
     "public": "ff1f11b6d961f5cfedee662d704385228aa3d2d907e6213f34ddffec44298306"
    },
    "scheme": "ed25519"
   }
  },
  "roles": {
   "root": {
    "keyids": [
     "d1eb39da485919fbf7738e5f5c45e315a1f439c77f9e054d4ad5e07371179eb6"
    ],
    "threshold": 1
   },
   "snapshot": {
    "keyids": [],
    "threshold": 1
   },
   "targets": {
    "keyids": [],
    "threshold": 1
   },
   "timestamp": {
    "keyids": [],
    "threshold": 1
   }
  },
  "spec_version": "1.0",
  "version": 1
 }
}(env) $
```


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>