### PR TITLE
Make sure the keystore directory exists before writing default key

### DIFF
--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -296,10 +296,16 @@ def gen_key(parsed_arguments):
   # working directory.  By default, the filenames are written to <KEYID>.pub
   # and <KEYID> (private key).  Move them from the CWD to the repo's keystore.
   if not parsed_arguments.filename:
-    shutil.move(keypath, os.path.join(parsed_arguments.path,
-        KEYSTORE_DIR, os.path.basename(keypath)))
-    shutil.move(keypath + '.pub', os.path.join(parsed_arguments.path,
-        KEYSTORE_DIR, os.path.basename(keypath + '.pub')))
+    privkey_repo_path =  os.path.join(parsed_arguments.path,
+        KEYSTORE_DIR, os.path.basename(keypath))
+    pubkey_repo_path =  os.path.join(parsed_arguments.path,
+        KEYSTORE_DIR, os.path.basename(keypath + '.pub'))
+
+    securesystemslib.util.ensure_parent_dir(privkey_repo_path)
+    securesystemslib.util.ensure_parent_dir(pubkey_repo_path)
+
+    shutil.move(keypath, privkey_repo_path)
+    shutil.move(keypath + '.pub', pubkey_repo_path)
 
 
 


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request ensures that a generated key with no filename specified (so the KEYID is used as its filename) can always be written to the repo's tufkeystore directory.  The keystore directory might not exist for any reason, but it can happen if the user creates a bare repo via `repo.py --init --bare`.

```Bash
(env) $ repo.py --init --bare
(env) $ ls tufkeystore
ls: tufkeystore: No such file or directory
(env) $ repo.py --key ed25519
(env) $ ls tufkeystore/
9004c8f1537baa7312fe26e6952fc427ed0cc00de2ad4675920fc294889b46a1
9004c8f1537baa7312fe26e6952fc427ed0cc00de2ad4675920fc294889b46a1.pub
```

Example where a repo path is given:

```Bash
(env) $ repo.py --init --bare --path myrepo
(env) $ repo.py --key ed25519 --path myrepo
(env) $ ls myrepo/tufkeystore/
5290a244e18af39efd842a244269fec01eb3bc3035edbc5f72c04acde5aa8617
5290a244e18af39efd842a244269fec01eb3bc3035edbc5f72c04acde5aa8617.pub
```

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>