### PR TITLE
CLI: Add --distrust command-line option

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -128,8 +128,14 @@ $ repo.py --init --bare
 $ repo.py --trust --pubkeys keystore/my_key.pub keystore/my_key_too.pub --role root
 ```
 
-Note: This action replaces any previously trusted keys that might have been
-specified for --role.
+### Distrust keys ###
+
+Conversely, the Root role can discontinue trust of specified key(s).
+
+Example of how to discontinue trust of a key:
+```Bash
+$ repo.py --distrust --pubkeys keystore/my_key_too.pub --role root
+```
 
 
 

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -449,7 +449,7 @@ def remove_verification_key(parsed_arguments):
         raise tuf.exception.Error('The given --role is not a top-level role.')
 
     except securesystemslib.exceptions.Error:
-      print(repr(keypath) + ' is not trusted key.  Skipping.')
+      print(repr(keypath) + ' is not a trusted key.  Skipping.')
 
   repository.write('root', increment_version_number=False)
 


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request implements the `--distrust` command-line option.

```Bash
(env) $ cat tufrepo/metadata/root.json
{
 "signatures": [],
 "signed": {
  "_type": "root",
  "consistent_snapshot": false,
  "expires": "2019-03-24T00:04:32Z",
  "keys": {
   "6c71374ebac51cb20955cf711d7d2263a709be70841cf46ab445b2f9eb59f07e": {
    "keyid_hash_algorithms": [
     "sha256",
     "sha512"
    ],
    "keytype": "ed25519",
    "keyval": {
     "public": "f7e35f9a944e00ba7e014ade19347111c3160d0a9b4b021074ca14018c375eb1"
    },
    "scheme": "ed25519"
   }
  },
  "roles": {
   "root": {
    "keyids": [],
    "threshold": 1
   },
   "snapshot": {
    "keyids": [],
    "threshold": 1
   },
   "targets": {
    "keyids": [
     "6c71374ebac51cb20955cf711d7d2263a709be70841cf46ab445b2f9eb59f07e"
    ],
    "threshold": 1
   },
   "timestamp": {
    "keyids": [],
    "threshold": 1
   }
  },
  "spec_version": "1.0",
  "version": 1
 }
}

(env) $ repo.py --distrust --pubkeys tufkeystore/my_key.pub
(env) $ cat tufrepo/metadata/root.json
{
 "signatures": [],
 "signed": {
  "_type": "root",
  "consistent_snapshot": false,
  "expires": "2019-03-24T00:04:32Z",
  "keys": {},
  "roles": {
   "root": {
    "keyids": [],
    "threshold": 1
   },
   "snapshot": {
    "keyids": [],
    "threshold": 1
   },
   "targets": {
    "keyids": [],
    "threshold": 1
   },
   "timestamp": {
    "keyids": [],
    "threshold": 1
   }
  },
  "spec_version": "1.0",
  "version": 1
 }
}

(env) $repo.py --distrust --pubkeys tufkeystore/my_key.pub
'tufkeystore/my_key.pub' is not trusted key.  Skipping.
```