### PR TITLE
Edit crypto key information for maintainers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ list.
 Security Issues and Bugs
 ------------------------
 
-Security issues can be reported by emailing justincappos@gmail.com.
+Security issues can be reported by emailing jcappos@nyu.edu.
 
 At a minimum, the report must contain the following:
 
@@ -77,7 +77,7 @@ At a minimum, the report must contain the following:
 * Steps to reproduce the issue.
 
 Optionally, reports that are emailed can be encrypted with PGP.  You should use
-PGP key fingerprint E9C0 59EC 0D32 64FA B35F  94AD 465B F9F6 F8EB 475A.
+PGP key fingerprint **E9C0 59EC 0D32 64FA B35F  94AD 465B F9F6 F8EB 475A**.
 
 Please do not use the GitHub issue tracker to submit vulnerability reports.
 The issue tracker is intended for bug reports and to make feature requests.

--- a/docs/INSTALLATION.rst
+++ b/docs/INSTALLATION.rst
@@ -1,11 +1,15 @@
 Installation
 ------------
 
-pip is the recommended installer.  The project can be installed either locally
-or from the Python Package Index.  All `TUF releases
+*pip* is the recommended installer.  The project can be installed either
+locally or from the Python Package Index.  All `TUF releases
 <https://github.com/theupdateframework/tuf/releases>`_ are cryptographically
 signed, with GPG signatures available on both GitHub and `PyPI
-<https://pypi.python.org/pypi/tuf/>`_.
+<https://pypi.python.org/pypi/tuf/>`_.  PGP key information for our maintainers
+is available on our `website
+<https://theupdateframework.github.io/people.html>`_, on major keyservers,
+and on the `maintainers page
+<https://github.com/theupdateframework/tuf/blob/develop/docs/MAINTAINERS.txt>`_.
 
 The latest release and its packaging information, such as who signed the
 release and their PGP fingerprint, can also be found on our 1-year `roadmap


### PR DESCRIPTION
**Fixes issue #**:

Addresses issue #555.

**Description of the changes being introduced by the pull request**:

This pull request:

  * replaces Justin's listed email addresses (justincappos@gmail.com -> jcappos@nyu.edu).
  * Justin's PGP fingerprint is bolded.
  * Provides links to pages (website and maintainers doc) that contain info on maintainer keys.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>