### PR TITLE
Speed up update procedure

### DIFF
--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -111,25 +111,26 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
 
   # Test: Incorrect lengths.
   def test_download_url_to_tempfileobj_and_lengths(self):
-    # We do *not* catch 'securesystemslib.exceptions.DownloadLengthMismatchError' in the following two
-    # calls because the file at 'self.url' contains enough bytes to satisfy the
-    # smaller number of required bytes requested. safe_download() and
-    # unsafe_download() will only log a warning when the the server-reported
-    # length of the file does not match the required_length.  'updater.py'
-    # *does* verify the hashes of downloaded content.
+    # We do *not* catch
+    # 'securesystemslib.exceptions.DownloadLengthMismatchError' in the
+    # following two calls because the file at 'self.url' contains enough bytes
+    # to satisfy the smaller number of required bytes requested.
+    # safe_download() and unsafe_download() will only log a warning when the
+    # the server-reported length of the file does not match the
+    # required_length.  'updater.py' *does* verify the hashes of downloaded
+    # content.
     download.safe_download(self.url, self.target_data_length - 4)
     download.unsafe_download(self.url, self.target_data_length - 4)
 
-    # We catch 'tuf.exceptions.SlowRetrievalError' for both safe_download() and
-    # unsafe_download() because they will not download more bytes than
-    # requested and the connection eventually hits a slow retrieval error when
-    # the server can't satisfy the request (in this case, a length greater
-    # than the size of the target file).
-    self.assertRaises(tuf.exceptions.SlowRetrievalError, download.safe_download,
-                      self.url, self.target_data_length + 1)
+    # We catch 'tuf.exceptions.DownloadLengthMismatchError' for safe_download()
+    # because it will not download more bytes than requested (in this case, a
+    # length greater than the size of the target file).
+    self.assertRaises(tuf.exceptions.DownloadLengthMismatchError,
+        download.safe_download, self.url, self.target_data_length + 1)
 
-    self.assertRaises(tuf.exceptions.SlowRetrievalError, download.unsafe_download,
-                      self.url, self.target_data_length + 1)
+    # Calling unsafe_download() with a mismatched length should not raise an
+    # exception.
+    download.unsafe_download(self.url, self.target_data_length + 1)
 
 
 

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -313,10 +313,11 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
                 'successfully. Now sleeping until snapshot metadata expires.')
 
     # Sleep until expiry_time ('repository.snapshot.expiration')
-    time.sleep(max(0, expiry_time - time.time()))
+    time.sleep(max(0, expiry_time - time.time() + 1))
 
     logger.info('Test: Refreshing #2 - Now trying to refresh again after local'
       ' snapshot expiry.')
+
     try:
       self.repository_updater.refresh() # We expect this to fail!
 
@@ -329,6 +330,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # NoWorkingMirrorError indicates something else in this case - unavailable
     # repo, for example.
     else:
+
       self.fail('TUF failed to detect expired stale snapshot metadata. Freeze'
         ' attack successful.')
 
@@ -377,7 +379,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
     # Wait just long enough for the timestamp metadata (which is now both on
     # the repository and on the client) to expire.
-    time.sleep(max(0, expiry_time - time.time()))
+    time.sleep(max(0, expiry_time - time.time() + 1))
 
     # Try to refresh top-level metadata on the client. Since we're already past
     # 'repository.timestamp.expiration', the TUF client is expected to detect

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -166,7 +166,7 @@ class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
     file1_filepath = os.path.join(self.repository_directory, 'targets',
                                   'file1.txt')
     with open(file1_filepath, 'wb') as file_object:
-      data = 'a' * total_bytes
+      data = 'a' * int(round(total_bytes))
       file_object.write(data.encode('utf-8'))
 
     key_file = os.path.join(self.keystore_directory, 'timestamp_key')

--- a/tuf/download.py
+++ b/tuf/download.py
@@ -339,13 +339,15 @@ def _download_fixed_amount_of_data(connection, temp_file, required_length):
     while True:
       # We download a fixed chunk of data in every round. This is so that we
       # can defend against slow retrieval attacks. Furthermore, we do not wish
-      # to download an extremely large file in one shot.  Before beginning the
-      # round, sleep for a short amount of time so that the CPU is not hogged
-      # in the while loop.
-      time.sleep(0.05)
+      # to download an extremely large file in one shot.
+      # Before beginning the round, sleep (if set) for a short amount of time
+      # so that the CPU is not hogged in the while loop.
+      if tuf.settings.SLEEP_BEFORE_ROUND:
+        time.sleep(tuf.settings.SLEEP_BEFORE_ROUND)
+
       data = b''
       read_amount = min(tuf.settings.CHUNK_SIZE,
-                        required_length - number_of_bytes_received)
+          required_length - number_of_bytes_received)
 
       try:
         data = connection.read(read_amount)

--- a/tuf/settings.py
+++ b/tuf/settings.py
@@ -82,14 +82,15 @@ DEFAULT_TARGETS_REQUIRED_LENGTH = 5000000 #bytes
 SOCKET_TIMEOUT = 2 #seconds
 
 # The maximum chunk of data, in bytes, we would download in every round.
-CHUNK_SIZE = 8192 #bytes
+#CHUNK_SIZE = 8192 #bytes
+CHUNK_SIZE = 100000 #bytes
 
 # The minimum average download speed (bytes/second) that must be met to
 # avoid being considered as a slow retrieval attack.
 MIN_AVERAGE_DOWNLOAD_SPEED = 100 #bytes/second
 
 # The time (in seconds) we ignore a server with a slow initial retrieval speed.
-SLOW_START_GRACE_PERIOD = 3 #seconds
+SLOW_START_GRACE_PERIOD = 0.01 #seconds
 
 # Software updaters that integrate the framework are required to specify
 # the URL prefix for the mirrors that clients can contact to download updates.
@@ -114,3 +115,9 @@ CONSISTENT_METHOD = 'copy'
 # bin delegations.  The other instances (e.g., digest of files) that require a
 # hashing algorithm rely on settings in the securesystemslib external library.
 DEFAULT_HASH_ALGORITHM = 'sha256'
+
+# The client's update procedure (contained within a while-loop) can potentially
+# hog the CPU.  The following setting can be used to force the update sequence
+# to suspend execution for a specified amount of time.  See
+# theupdateframework/tuf/issue#338.
+SLEEP_BEFORE_ROUND = None


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request tweaks a couple settings (SLOW_START_GRACE_PERIOD and CHUNK_SIZE) and implements an optional setting (SLEEP_BEFORE_ROUND) to significantly speed up the client's update procedure.  The execution time of the example update is reduced from **6.388** to **0.324** seconds.  The unit tests run faster, as well (from ~10 mins to ~2 mins). The example update procedure (1) refreshes top-level metadata (2) downloads one delegated file and (3) downloads a target file.

A profile of the client code following the tweaks:
```Bash
$ python profile_client_update.py
Tue Mar 27 14:55:28 2018    output.txt

         177238 function calls (173530 primitive calls) in 0.324 seconds
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
4624/4618    0.013    0.000    0.021    0.000 /usr/local/Cellar/python/2.7.12_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py:340(read)
        6    0.013    0.002    0.050    0.008 download.py:291(_download_fixed_amount_of_data)
   348/61    0.009    0.000    0.027    0.000 env/bin/../lib/python2.7/sre_parse.py:395(_parse)
...
```

Script used to profile the client code:
```Python
"""
Execute the following command to generate profile data.
$ python -m cProfile -o output.txt ../../tuf/scripts/client.py --repo http://localhost:8001 /simple/index.html
"""
import pstats
p = pstats.Stats('output.txt')
#p.sort_stats('cumulative').print_stats(10)
p.sort_stats('tottime').print_stats(10)
```

The number of socket.read() calls can be further reduced, but the tweaks implemented in this pull request are good enough at the moment.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>