### PR TITLE
Load latest consistent metadata from disk

### DIFF
--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1491,7 +1491,7 @@ def generate_snapshot_metadata(metadata_directory, version, expiration_date,
   # files found there.  This information is stored in the 'meta' field of
   # 'snapshot.json'.
 
-  for metadata_filename in os.listdir(metadata_directory):
+  for metadata_filename in sorted(os.listdir(metadata_directory), reverse=True):
     # Strip the version number if 'consistent_snapshot' is True.
     # Example:  '10.django.json'  --> 'django.json'
     metadata_name, junk = _strip_version_number(metadata_filename,

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2952,7 +2952,7 @@ def load_repository(repository_directory, repository_name='default'):
   loaded_metadata = []
   targets_objects['targets'] = repository.targets
 
-  for metadata_role in os.listdir(metadata_directory):
+  for metadata_role in sorted(os.listdir(metadata_directory), reverse=True):
 
     metadata_path = os.path.join(metadata_directory, metadata_role)
     metadata_name = \


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request ensures that `repository_tool.load_repository()` loads the latest consistent metadata from disk.  The latest consistent metadata for some role X should be loaded from disk even if a different, lower version of X is listed in Snapshot.  This behavior is needed because roles may independently add/edit metadata without updating Snapshot.

For example, suppose we have a collaborative repo where the Root or some delegated file is modified.  The person responsible for the metadata file signs it with keys that only they control.  The written metadata file now differs from what is specified in the "stale" Snapshot file.  To refresh the repo (new versions of Timestamp and Snapshot must be written), the repository maintainers must load the latest consistent metadata on disk and not what's in the current Snapshot, otherwise the newly updated Root or delegated file is ignored.  Once the latest consistent metadata is loaded, the stale Snapshot file can be re-signed with the latest versions of metadata available on disk.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>