### PR TITLE
CLI --sign: Allow Root+Snapshot+Timestamp to be signed

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -140,10 +140,9 @@ $ repo.py --distrust --pubkeys keystore/my_key_too.pub --role root
 
 
 ## Sign metadata ##
-Sign, using the specified key, the metadata of the role indicated in --role
-(must be Targets or a delegated role).  If no key argument or --role is given,
-the Targets role or its key is used.  The Snapshot and Timestamp role are also
-automatically signed, if possible.
+Sign, with the specified key, the metadata of the role indicated in --role.  If
+no key argument or --role is given, the Targets role or its key is used.  The
+Snapshot and Timestamp role are also automatically signed, if possible.
 ```Bash
 $ repo.py --sign
 $ repo.py --sign </path/to/key> [--role <rolename>, --path </path/to/repo>]

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -475,11 +475,17 @@ def sign_role(parsed_arguments):
         os.path.join(parsed_arguments.path, KEYSTORE_DIR, TARGETS_KEY_NAME),
         parsed_arguments.targets_pw)
 
-  if parsed_arguments.role == 'targets':
+  if parsed_arguments.role in ['targets']:
     repository.targets.load_signing_key(role_privatekey)
 
-  elif parsed_arguments.role in ['snapshot', 'timestamp']:
-    pass
+  elif parsed_arguments.role in ['root']:
+    repository.root.load_signing_key(role_privatekey)
+
+  elif parsed_arguments.role in ['snapshot']:
+    repository.snapshot.load_signing_key(role_privatekey)
+
+  elif parsed_arguments.role in ['timestamp']:
+    repository.timestamp.load_signing_key(role_privatekey)
 
   else:
     # TODO: repository_tool.py will be refactored to clean up the following
@@ -497,8 +503,10 @@ def sign_role(parsed_arguments):
           int(time.time() + 7889230))
       expiration = expiration.isoformat() + 'Z'
 
-      roleinfo = {'name': parsed_arguments.role, 'keyids': [role_privatekey['keyid']],
-          'signing_keyids': [role_privatekey['keyid']], 'partial_loaded': False, 'paths': {},
+      roleinfo = {'name': parsed_arguments.role,
+          'keyids': [role_privatekey['keyid']],
+          'signing_keyids': [role_privatekey['keyid']],
+          'partial_loaded': False, 'paths': {},
           'signatures': [], 'version': 1, 'expires': expiration,
           'delegations': {'keys': {}, 'roles': []}}
 
@@ -510,8 +518,8 @@ def sign_role(parsed_arguments):
       repository.targets(parsed_arguments.role).load_signing_key(role_privatekey)
       repository.write(parsed_arguments.role, increment_version_number=False)
 
-  # Update the required top-level roles, Snapshot and Timestamp, to make a new
-  # release.
+  # Write the updated top-level roles, if any.  Also write Snapshot and
+  # Timestamp to make a new release.
   snapshot_private = import_privatekey_from_file(
       os.path.join(parsed_arguments.path, KEYSTORE_DIR, SNAPSHOT_KEY_NAME),
       parsed_arguments.snapshot_pw)
@@ -958,7 +966,7 @@ def parse_arguments():
       help='Revoke trust of target files from a delegated role.')
 
   # Add the parser arguments supported by PROG_NAME.
-  parser.add_argument('-v', '--verbose', type=int, default=1,
+  parser.add_argument('-v', '--verbose', type=int, default=2,
       choices=range(0, 6), help='Set the verbosity level of logging messages.'
       ' The lower the setting, the greater the verbosity.  Supported logging'
       ' levels: 0=UNSET, 1=DEBUG, 2=INFO, 3=WARNING, 4=ERROR,'

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -120,10 +120,10 @@ def process_arguments(parsed_arguments):
 
   # Do we have a valid argparse Namespace?
   if not isinstance(parsed_arguments, argparse.Namespace):
-    raise tuf.exception.Error('Invalid namespace.')
+    raise tuf.exception.Error('Invalid namespace: ' + repr(parsed_arguments))
 
   else:
-    logger.debug('We have a valid argparse Namespace: ' + repr(parsed_arguments))
+    logger.debug('We have a valid argparse Namespace.')
 
   # TODO: Process all of the supported command-line actions.  --init, --clean,
   # --add, --sign, --key are currently implemented.
@@ -483,7 +483,7 @@ def sign_role(parsed_arguments):
 
   else:
     # TODO: repository_tool.py will be refactored to clean up the following
-    # approach, which adds and signs for a non-existent role.
+    # code, which adds and signs for a non-existent role.
     if not tuf.roledb.role_exists(parsed_arguments.role):
 
       # Load the private key keydb and set the roleinfo in roledb so that
@@ -958,7 +958,7 @@ def parse_arguments():
       help='Revoke trust of target files from a delegated role.')
 
   # Add the parser arguments supported by PROG_NAME.
-  parser.add_argument('-v', '--verbose', type=int, default=2,
+  parser.add_argument('-v', '--verbose', type=int, default=1,
       choices=range(0, 6), help='Set the verbosity level of logging messages.'
       ' The lower the setting, the greater the verbosity.  Supported logging'
       ' levels: 0=UNSET, 1=DEBUG, 2=INFO, 3=WARNING, 4=ERROR,'


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

This pull request adapts the --sign function to also allow the Snapshot, Root, and Timestamp files to be signed.

```Bash
$ repo.py --init
(env) $ repo.py --key ed25519 --filename new_key
(env) $ repo.py --trust --pubkeys tufkeystore/new_key.pub --role timestamp
(env) $ repo.py --sign tufkeystore/root_key --role root
Enter a password for the encrypted key (tufkeystore/root_key):
(env) $ repo.py --sign tufkeystore/new_key --role timestamp
Enter a password for the encrypted key (tufkeystore/new_key):
(env) $ cat tufrepo/metadata/timestamp.json
{
 "signatures": [
  {
   "keyid": "90d4cd66c4a791e0713b60c3d6ce3799704bf6371a3d67ec50f627931e404b84",
   "sig": "304502202fda9b9051c7ce01088d2ec8ae5d5bf07dce47fc4819eead8a220b9c7d118bfe022100cd20dffd2f94eecc0f33fa97762a69c1f0a711a217d840ec8020ad6cf4965650"
  },
  {
   "keyid": "f17890ae2b6ade84cc0cbc3104467ac344c7e6d3997748827153aaeafed5e4cf",
   "sig": "7c904689bc7b3ac8e6007327167457fdabc29d56ebd042cb6895e79ad8686d87341ed232d31adcbb3230a7e391eb6df8904b4788076d76121c1759ca3de49e0f"
  }
 ],
 "signed": {
  "_type": "timestamp",
  "expires": "2018-03-31T19:03:03Z",
  "meta": {
   "snapshot.json": {
    "hashes": {
     "sha256": "872890b318751eb2f366b0d9e7128796ca4fce624373edffbb5f6737fb0b1ee1"
    },
    "length": 484,
    "version": 3
   }
  },
  "spec_version": "1.0",
  "version": 3
 }
}
``` 

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>