### PR TITLE
WIP: CLI --sign: Allow multiple signing keys

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -40,7 +40,7 @@ Create a TUF repository with [consistent
 snapshots](https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#7-consistent-snapshots)
 enabled, where all target files have their hash prepended to the filename.
 ```Bash
-$ repo.py --init --consistent_snapshot
+$ repo.py --init --consistent
 ```
 
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -140,12 +140,12 @@ $ repo.py --distrust --pubkeys keystore/my_key_too.pub --role root
 
 
 ## Sign metadata ##
-Sign, with the specified key, the metadata of the role indicated in --role.  If
-no key argument or --role is given, the Targets role or its key is used.  The
-Snapshot and Timestamp role are also automatically signed, if possible.
+Sign, with the specified key(s), the metadata of the role indicated in --role.
+If no key argument or --role is given, the Targets role or its key is used.
+The Snapshot and Timestamp role are also automatically signed, if possible.
 ```Bash
 $ repo.py --sign
-$ repo.py --sign </path/to/key> [--role <rolename>, --path </path/to/repo>]
+$ repo.py --sign </path/to/key> ... [--role <rolename>, --path </path/to/repo>]
 ```
 
 For example, to sign the delegated `foo` metadata:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -141,10 +141,8 @@ $ repo.py --distrust --pubkeys keystore/my_key_too.pub --role root
 
 ## Sign metadata ##
 Sign, with the specified key(s), the metadata of the role indicated in --role.
-If no key argument or --role is given, the Targets role or its key is used.
 The Snapshot and Timestamp role are also automatically signed, if possible.
 ```Bash
-$ repo.py --sign
 $ repo.py --sign </path/to/key> ... [--role <rolename>, --path </path/to/repo>]
 ```
 

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -26,7 +26,7 @@
   Note: arguments within brackets are optional.
 
   $ repo.py --init
-      [--consistent_snapshot, --bare, --path, --root_pw, --targets_pw,
+      [--consistent, --bare, --path, --root_pw, --targets_pw,
       --snapshot_pw, --timestamp_pw]
   $ repo.py --add <target> <dir> ... [--path, --recursive]
   $ repo.py --remove <glob pattern>
@@ -727,11 +727,11 @@ def init_repo(parsed_arguments):
   if not parsed_arguments.bare:
     set_top_level_keys(repository)
     repository.writeall(
-        consistent_snapshot=parsed_arguments.consistent_snapshot)
+        consistent_snapshot=parsed_arguments.consistent)
 
   else:
     repository.write(
-        'root', consistent_snapshot=parsed_arguments.consistent_snapshot)
+        'root', consistent_snapshot=parsed_arguments.consistent)
     repository.write('targets')
     repository.write('snapshot')
     repository.write('timestamp')
@@ -830,7 +830,7 @@ def parse_arguments():
       # top-level roles are created, each containing one key.
       $ repo.py --init
 
-      $ repo.py --init --bare --consistent-snapshot --verbose 3
+      $ repo.py --init --bare --consistent --verbose 3
 
     If a required argument is unset, a parser error is printed and the script
     exits.
@@ -865,7 +865,7 @@ def parse_arguments():
       help='If initializing a repository, neither create nor set keys'
       ' for any of the top-level roles.  False, by default.')
 
-  parser.add_argument('--consistent_snapshot', action='store_true',
+  parser.add_argument('--consistent', action='store_true',
       help='Set consistent snapshots for an initialized repository.'
       '  Consistent snapshot is False by default.')
 

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -466,15 +466,7 @@ def sign_role(parsed_arguments):
 
   for keypath in parsed_arguments.sign:
 
-    # Was a private key path given with --sign?  If so, load the specified
-    # private key. Otherwise, load the default Targets key.
-    if keypath != '.':
-      role_privatekey = import_privatekey_from_file(keypath)
-
-    else:
-      role_privatekey = import_privatekey_from_file(
-          os.path.join(parsed_arguments.path, KEYSTORE_DIR, TARGETS_KEY_NAME),
-          parsed_arguments.targets_pw)
+    role_privatekey = import_privatekey_from_file(keypath)
 
     if parsed_arguments.role in ['targets']:
       repository.targets.load_signing_key(role_privatekey)
@@ -781,6 +773,21 @@ def set_top_level_keys(repository):
       os.path.join(parsed_arguments.path, KEYSTORE_DIR,
       TIMESTAMP_KEY_NAME), password=parsed_arguments.timestamp_pw)
 
+  # Import the private keys.  They are needed to generate the signatures
+  # included in metadata.
+  root_private = import_privatekey_from_file(
+      os.path.join(parsed_arguments.path, KEYSTORE_DIR,
+      ROOT_KEY_NAME), parsed_arguments.root_pw)
+  targets_private = import_privatekey_from_file(
+      os.path.join(parsed_arguments.path, KEYSTORE_DIR,
+      TARGETS_KEY_NAME), parsed_arguments.targets_pw)
+  snapshot_private = import_privatekey_from_file(
+      os.path.join(parsed_arguments.path, KEYSTORE_DIR,
+      SNAPSHOT_KEY_NAME), parsed_arguments.snapshot_pw)
+  timestamp_private = import_privatekey_from_file(
+      os.path.join(parsed_arguments.path, KEYSTORE_DIR,
+      TIMESTAMP_KEY_NAME), parsed_arguments.timestamp_pw)
+
   # Import the public keys.  They are needed so that metadata roles are
   # assigned verification keys, which clients need in order to verify the
   # signatures created by the corresponding private keys.
@@ -796,21 +803,6 @@ def set_top_level_keys(repository):
   timestamp_public = import_publickey_from_file(
       os.path.join(parsed_arguments.path, KEYSTORE_DIR,
       TIMESTAMP_KEY_NAME) + '.pub')
-
-  # Import the private keys.  They are needed to generate the signatures
-  # included in metadata.
-  root_private = import_privatekey_from_file(
-      os.path.join(parsed_arguments.path, KEYSTORE_DIR,
-      ROOT_KEY_NAME), parsed_arguments.root_pw)
-  targets_private = import_privatekey_from_file(
-      os.path.join(parsed_arguments.path, KEYSTORE_DIR,
-      TARGETS_KEY_NAME), parsed_arguments.targets_pw)
-  snapshot_private = import_privatekey_from_file(
-      os.path.join(parsed_arguments.path, KEYSTORE_DIR,
-      SNAPSHOT_KEY_NAME), parsed_arguments.snapshot_pw)
-  timestamp_private = import_privatekey_from_file(
-      os.path.join(parsed_arguments.path, KEYSTORE_DIR,
-      TIMESTAMP_KEY_NAME), parsed_arguments.timestamp_pw)
 
   # Add the verification keys to the top-level roles.
   repository.root.add_verification_key(root_public)
@@ -917,7 +909,7 @@ def parse_arguments():
       help='Discontinue trust of key(s) (via --pubkeys) for the role in --role.'
       '  This action modifies Root metadata by removing trusted key(s).')
 
-  parser.add_argument('--sign', nargs='+', default='.', type=str,
+  parser.add_argument('--sign', nargs='+', type=str,
       metavar='</path/to/privkey>', help='Sign the "targets"'
       ' metadata (or the one for --role) with the specified key(s).')
 


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request allows users to specify multiple keys with --sign.

```Bash
(env) $ repo.py --init
(env) $ repo.py --key ed25519 --filename new_key
(env) $ repo.py --sign tufkeystore/timestamp_key tufkeystore/new_key --role timestamp
Enter a password for the encrypted key (tufkeystore/timestamp_key):
Enter a password for the encrypted key (tufkeystore/new_key):
(env) $ cat tufrepo/metadata/timestamp.json
{
 "signatures": [
  {
   "keyid": "b5b8276e68b481d3a322b512e1afab7731c9b2aa8942bfbb993656a9cad244d3",
   "sig": "3045022061c868abb74c585d7d04574fbc36335140fd2be5e871296523286ae61fe9fcb4022100ed5f3be1af94e41b22bbad64235271eabe214b7566827b835ef1ced24152af20"
  },
  {
   "keyid": "461db8db046606d3311d2d0fdd7f5458742e3157ae1738ffdce842d8003a9c3f",
   "sig": "fec2100ae180c046f7b1c65a70e5014c27b7d08e2ee7183b5c37d3f4fc4946c0daffcf657a9b870e07e3777e86fdde074febdf93ac8f138fb941ae60d4237e00"
  }
 ],
 "signed": {
  "_type": "timestamp",
  "expires": "2018-04-03T18:00:50Z",
  "meta": {
   "snapshot.json": {
    "hashes": {
     "sha256": "fdce8705f9f35676b2bef5a501faa5900b4591bdf2de7e7432d6dd544d19e4d3"
    },
    "length": 484,
    "version": 2
   }
  },
  "spec_version": "1.0",
  "version": 2
 }
```

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>