### PR TITLE
Remove futures from dev-requirements for Python3 compatibility

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,6 @@ colorama==0.3.9           # via securesystemslib
 configparser==3.5.0       # via pylint
 cryptography==2.2.1
 enum34==1.1.6             # via astroid, cryptography
-futures==3.2.0            # via isort
 gitdb2==2.0.3             # via gitpython
 gitpython==2.1.9          # via bandit
 idna==2.6                 # via cryptography


### PR DESCRIPTION
### Summary
pip install -r dev-requirements.txt using Python3 currently
breaks due to futures 3.2.0 not being available for Python3.
This fixes that.
**Fixes issue #**: No issue previously listed.


### Background
dev-requirements.txt was recently flattened (using pip-compile).

This flattening was performed in a Python2 environment.
Dependencies will vary in different environments.

### Details
Currently, futures 3.2.0 appears in the dev-requirements file
that pip-compile generated while running in Python2. If you try
installing futures 3.2.0 in a Python3 environment (if you try
`pip install -r dev-requirements.txt` running Python3, in other
words), you will encounter an error. Removing futures from
flattened dev-requirements fixes this.

### Peripheral Issues
There are several larger issues here that are not addressed and
must have issues created for them:
 - pip-compile on existing dev-requirements.txt to generate new
   dev-requirements.txt will retain orphaned dependencies,
   accumulating cruft; you need a one-layer (non-flattened)
   dev-dependencies file to use as a source file for pip-compile,
   I think
 - Python2 and Python3 dependencies will frequently vary, so
   it MAY be worth having dev-requirements-python2.txt and
   dev-requirements-python3.txt
 - Perhaps as a result of all this, we should reconsider pinning?



### PR Checklist
- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ N/A ] Tests have been added for the bug fix or new feature
- [ N/A ] Docs have been added for the bug fix or new feature