### PR TITLE
Refactor _get_target_from_targets_role()

### DIFF
--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -2783,23 +2783,20 @@ class Updater(object):
       'tuf.formats.TARGETINFO_SCHEMA'.
     """
 
-    target = None
-
     # Does the current role name have our target?
-    logger.debug('Asking role ' + repr(role_name) + ' about target ' +\
-      repr(target_filepath))
+    logger.debug('Asking role ' + repr(role_name) + ' about'
+        ' target ' + repr(target_filepath))
 
-    for filepath, fileinfo in six.iteritems(targets):
-      if filepath == target_filepath:
-        logger.debug('Found target ' + target_filepath + ' in role ' + role_name)
-        target = {'filepath': filepath, 'fileinfo': fileinfo}
-        break
+    target = targets.get(target_filepath)
 
-      else:
-        logger.debug('No target ' + target_filepath + ' in role ' + role_name)
+    if target:
+      logger.debug('Found target ' + target_filepath + ' in role ' + role_name)
+      return {'filepath': target_filepath, 'fileinfo': target}
 
-    return target
-
+    else:
+      logger.debug(
+          'Target file ' + target_filepath + ' not found in role ' + role_name)
+      return None
 
 
 


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request refactors `updater._get_target_from_targets_role()`, which iterates the "targets" field of Targets metadata.  Instead of iterating over N items, it more efficiently uses get() to retrieve the target file.

@trishankatdatadog Thanks for reporting this issue.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>