### PR TITLE
Use six.moves.reload_module in test_log.py

### DIFF
--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -22,13 +22,14 @@
 
 import logging
 import unittest
-import imp
 
 import tuf
 import tuf.log
 import tuf.settings
 
 import securesystemslib
+from six.moves import reload_module
+
 
 logger = logging.getLogger('tuf.test_log')
 
@@ -75,8 +76,7 @@ class TestLog(unittest.TestCase):
     # Test that the log level of the file handler cannot be set because
     # file logging is disabled (via tuf.settings.ENABLE_FILE_LOGGING).
     tuf.settings.ENABLE_FILE_LOGGING = False
-    imp.reload(tuf.log)
-    #self.assertRaises(securesystemslib.exceptions.Error, tuf.log.set_filehandler_log_level, logging.INFO)
+    reload_module(tuf.log)
 
     # Test for improperly formatted argument.
     self.assertRaises(securesystemslib.exceptions.FormatError, tuf.log.set_filehandler_log_level, '123')


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request ensures that `six.moves.reload_module()` is used in `test_log.py` for Python 2+3 compatibility with the imp (Python 2) and importlib (Python 3) modules.  It removes an `imp` DeprecationWarning emitted under Python 3.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>