### PR TITLE
Generate local keyids by using the hashing algorithms selected by the repo

### DIFF
--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -953,7 +953,12 @@ class Updater(object):
         # We specify the keyid to ensure that it's the correct keyid
         # for the key.
         try:
+
+          hash_algorithms = securesystemslib.settings.HASH_ALGORITHMS
+          securesystemslib.settings.HASH_ALGORITHMS = keyinfo['keyid_hash_algorithms']
           key, keyids = securesystemslib.keys.format_metadata_to_key(keyinfo)
+          securesystemslib.settings.HASH_ALGORITHMS = hash_algorithms
+
           for key_id in keyids:
             key['keyid'] = key_id
             tuf.keydb.add_key(key, keyid=None, repository_name=self.repository_name)

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -954,6 +954,9 @@ class Updater(object):
         # for the key.
         try:
 
+          # The repo may have used hashing algorithms for the generated keyids
+          # that doesn't match the client's set of hash algorithms.  Make sure
+          # to only used the repo's selected hashing algorithms.
           hash_algorithms = securesystemslib.settings.HASH_ALGORITHMS
           securesystemslib.settings.HASH_ALGORITHMS = keyinfo['keyid_hash_algorithms']
           key, keyids = securesystemslib.keys.format_metadata_to_key(keyinfo)

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -123,6 +123,9 @@ def create_keydb_from_root_metadata(root_metadata, repository_name='default'):
       # default keyid listed in 'key_dict'.  The additional keyids are
       # generated according to securesystemslib.settings.HASH_ALGORITHMS.
 
+      # The repo may have used hashing algorithms for the generated keyids that
+      # doesn't match the client's set of hash algorithms.  Make sure to only
+      # used the repo's selected hashing algorithms.
       hash_algorithms = securesystemslib.settings.HASH_ALGORITHMS
       securesystemslib.settings.HASH_ALGORITHMS = key_metadata['keyid_hash_algorithms']
       key_dict, keyids = securesystemslib.keys.format_metadata_to_key(key_metadata)

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -117,12 +117,16 @@ def create_keydb_from_root_metadata(root_metadata, repository_name='default'):
   for junk, key_metadata in six.iteritems(root_metadata['keys']):
     if key_metadata['keytype'] in _SUPPORTED_KEY_TYPES:
       # 'key_metadata' is stored in 'KEY_SCHEMA' format.  Call
-      # create_from_metadata_format() to get the key in 'RSAKEY_SCHEMA'
-      # format, which is the format expected by 'add_key()'.  Note:
-      # The 'keyids' returned by format_metadata_to_key() include keyids in
-      # addition to the default keyid listed in 'key_dict'.  The additional
-      # keyids are generated according to settings.REPOSITORY_HASH_ALGORITHMS.
+      # create_from_metadata_format() to get the key in 'RSAKEY_SCHEMA' format,
+      # which is the format expected by 'add_key()'.  Note: The 'keyids'
+      # returned by format_metadata_to_key() include keyids in addition to the
+      # default keyid listed in 'key_dict'.  The additional keyids are
+      # generated according to securesystemslib.settings.HASH_ALGORITHMS.
+
+      hash_algorithms = securesystemslib.settings.HASH_ALGORITHMS
+      securesystemslib.settings.HASH_ALGORITHMS = key_metadata['keyid_hash_algorithms']
       key_dict, keyids = securesystemslib.keys.format_metadata_to_key(key_metadata)
+      securesystemslib.settings.HASH_ALGORITHMS = hash_algorithms
 
       try:
         for keyid in keyids:

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -685,7 +685,10 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
 
     # Add the keys specified in the delegations field of the Targets role.
     for key_metadata in six.itervalues(targets_metadata['delegations']['keys']):
+      hash_algorithms = securesystemslib.settings.HASH_ALGORITHMS
+      securesystemslib.settings.HASH_ALGORITHMS = key_metadata['keyid_hash_algorithms']
       key_object, keyids = securesystemslib.keys.format_metadata_to_key(key_metadata)
+      securesystemslib.settings.HASH_ALGORITHMS = hash_algorithms
 
       # Add 'key_object' to the list of recognized keys.  Keys may be shared,
       # so do not raise an exception if 'key_object' has already been loaded.

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -685,6 +685,10 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
 
     # Add the keys specified in the delegations field of the Targets role.
     for key_metadata in six.itervalues(targets_metadata['delegations']['keys']):
+
+      # The repo may have used hashing algorithms for the generated keyids
+      # that doesn't match the client's set of hash algorithms.  Make sure
+      # to only used the repo's selected hashing algorithms.
       hash_algorithms = securesystemslib.settings.HASH_ALGORITHMS
       securesystemslib.settings.HASH_ALGORITHMS = key_metadata['keyid_hash_algorithms']
       key_object, keyids = securesystemslib.keys.format_metadata_to_key(key_metadata)

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -3024,6 +3024,10 @@ def load_repository(repository_directory, repository_name='default'):
     # The repository maintainer should have also been made aware of the
     # duplicate key when it was added.
     for key_metadata in six.itervalues(metadata_object['delegations']['keys']):
+
+      # The repo may have used hashing algorithms for the generated keyids
+      # that doesn't match the client's set of hash algorithms.  Make sure
+      # to only used the repo's selected hashing algorithms.
       hash_algorithms = securesystemslib.settings.HASH_ALGORITHMS
       securesystemslib.settings.HASH_ALGORITHMS = key_metadata['keyid_hash_algorithms']
       key_object, keyids = securesystemslib.keys.format_metadata_to_key(key_metadata)

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -3024,7 +3024,10 @@ def load_repository(repository_directory, repository_name='default'):
     # The repository maintainer should have also been made aware of the
     # duplicate key when it was added.
     for key_metadata in six.itervalues(metadata_object['delegations']['keys']):
+      hash_algorithms = securesystemslib.settings.HASH_ALGORITHMS
+      securesystemslib.settings.HASH_ALGORITHMS = key_metadata['keyid_hash_algorithms']
       key_object, keyids = securesystemslib.keys.format_metadata_to_key(key_metadata)
+      securesystemslib.settings.HASH_ALGORITHMS = hash_algorithms
       try:
         for keyid in keyids: # pragma: no branch
           key_object['keyid'] = keyid


### PR DESCRIPTION
**Fixes issue #**:

Close #685.

**Description of the changes being introduced by the pull request**:

This pull request ensures that the client generates keyids by selecting the hashing algorithms specified in the "keyid_hash_algorithms" field of metadata.

```Bash

>>> from tuf.repository_tool import *
>>> repo = load_repository('.')
u'timestamp.json' expires Fri Apr 13 15:07:59 2018 (UTC).  0.9934375 day(s) until it expires.
>>> repo.timestamp.keys
[u'23cd05540641d0afd4f02f98f16a7952d4325fbfc1558639b3a4bcad2e47126f']
>>> from securesystemslib import settings
>>> settings.HASH_ALGORITHMS
[u'sha256', u'sha512']
>>> repo.timestamp.keys[0] in sorted(tuf.keydb._keydb_dict['default'].keys())
True
```

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>