### PR TITLE
Add missing org to AUTHORS.txt

### DIFF
--- a/docs/AUTHORS.txt
+++ b/docs/AUTHORS.txt
@@ -6,6 +6,7 @@ Organizations
 -------------
 
 Advanced Telematic Systems
+Datadog
 Docker
 Flynn
 LEAP


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request adds a missing organization (Datadog) to `AUTHORS.txt.`

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>