### PR TITLE
Remove incorrect use of os.path.join in repo.py

### DIFF
--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -651,7 +651,6 @@ def remove_target_files_from_metadata(repository):
 
 
 def add_targets(parsed_arguments):
-  target_paths = os.path.join(parsed_arguments.add)
   repo_targets_path = os.path.join(parsed_arguments.path, REPO_DIR, 'targets')
   repository = repo_tool.load_repository(
       os.path.join(parsed_arguments.path, REPO_DIR))
@@ -659,7 +658,7 @@ def add_targets(parsed_arguments):
   # Copy the target files in --path to the repo directory, and
   # add them to Targets metadata.  Make sure to also copy & add files
   # in directories (and subdirectories, if --recursive is True).
-  for target_path in target_paths:
+  for target_path in parsed_arguments.add:
     if os.path.isdir(target_path):
       for sub_target_path in repository.get_filepaths_in_directory(
           target_path, parsed_arguments.recursive):


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request removes an incorrect use of `os.path.join()` in repo.py's `add_targets().`  The offending line of code attempts to join() a list, which results in an exception in Windows, but not in MacOS.

Under Python 2.7.12 and MacOS, the incorrect use of os.path.join() executes without error:

```Bash
 python
Python 2.7.12 (default, Sep 28 2016, 18:38:03)
[GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> mylist = ['my', 'list']
>>> os.path.join(mylist)
['my', 'list']
```

However, under Python 2.7.12 and Windows:

```Bash
Python 2.7.14 (v2.7.14:84471935ed, Sep 16 2017, 20:25:58) [MSC v.1500 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> mylist = ['my', 'list']
>>> os.path.join(mylist)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\User\projects\tuf\env\lib\ntpath.py", line 65, in join
    result_drive, result_path = splitdrive(path)
  File "C:\Users\User\projects\tuf\env\lib\ntpath.py", line 116, in splitdrive
    normp = p.replace(altsep, sep)
AttributeError: 'list' object has no attribute 'replace'
```

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>