### PR TITLE
Ensure consistent behavior between add_targets() and add_target()

### DIFF
--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1090,12 +1090,12 @@ class TestTargets(unittest.TestCase):
     # Add a 'target1_filepath' duplicate for testing purposes
     # ('target1_filepath' should not be added twice.)
     target_files = \
-      [target1_filepath, target2_filepath, target3_filepath, target1_filepath]
+      ['file1.txt', 'file2.txt', 'file3.txt', 'file1.txt']
     self.targets_object.add_targets(target_files)
 
     self.assertEqual(len(self.targets_object.target_files), 3)
     self.assertEqual(self.targets_object.target_files,
-                     {'/file1.txt': {}, '/file2.txt': {}, '/file3.txt': {}})
+        {'file1.txt': {}, 'file2.txt': {}, 'file3.txt': {}})
 
     # Attempt to replace targets that has already been added.
     self.targets_object.add_targets(target_files)

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -1993,15 +1993,10 @@ class Targets(Metadata):
     # freedom to add targets and parent restrictions in any order, and minimize
     # the number of times these checks are performed.
     for target in list_of_targets:
-      filepath = os.path.abspath(target)
-
-      if not filepath.startswith(self._targets_directory+os.sep):
-        raise securesystemslib.exceptions.Error(repr(filepath) + ' is not'
-          ' located in the Repository\'s targets'
-          ' directory: ' + repr(self._targets_directory))
+      filepath = os.path.join(self._targets_directory, target)
 
       if os.path.isfile(filepath):
-        relative_list_of_targets.append(filepath[targets_directory_length:])
+        relative_list_of_targets.append(filepath[targets_directory_length+1:])
 
       else:
         raise securesystemslib.exceptions.Error(repr(filepath) + ' is not'


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request modifies `add_targets()` so that it doesn't check that the repo's targets directory is a prefix of the given path.  Instead, it raising an exception if the given path is not a file in the targets directory (similar to `add_target()`).

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>