### PR TITLE
Fix invalid win32 application exceptions under Windows: Issue #694

### DIFF
--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -128,8 +128,8 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
     while self.SERVER_PORT == self.SERVER_PORT2:
       self.SERVER_PORT2 = random.SystemRandom().randint(30000, 45000)
 
-    command = ['simple_server.py', str(self.SERVER_PORT)]
-    command2 = ['simple_server.py', str(self.SERVER_PORT2)]
+    command = ['python', 'simple_server.py', str(self.SERVER_PORT)]
+    command2 = ['python', 'simple_server.py', str(self.SERVER_PORT2)]
 
     self.server_process = subprocess.Popen(command, stderr=subprocess.PIPE,
         cwd=self.repository_directory)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1701,8 +1701,8 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     self.SERVER_PORT = 30001
     self.SERVER_PORT2 = 30002
 
-    command = ['simple_server.py', str(self.SERVER_PORT)]
-    command2 = ['simple_server.py', str(self.SERVER_PORT2)]
+    command = ['python', 'simple_server.py', str(self.SERVER_PORT)]
+    command2 = ['python', 'simple_server.py', str(self.SERVER_PORT2)]
 
     self.server_process = subprocess.Popen(command, stderr=subprocess.PIPE,
         cwd=self.repository_directory)


### PR DESCRIPTION
**Fixes issue #**:

Close #694.

**Description of the changes being introduced by the pull request**:

This pull request includes `python` with the command string executed by subprocess calls in `test_updater.py` and `test_multiple_repositories_integration.py.`  For example:

``` Python
command = ['python', 'simple_server.py', str(cls.SERVER_PORT)]
subprocess.Popen(command, stderr=subprocess.PIPE)
```

Excluding the `python` string results in "%1 is not a valid Win32 application" exceptions when running the unit tests under Windows (but not Linux and MacOS).

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>