### PR TITLE
Resolve Pylint warnings for newly added repo.py and client.py

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -344,7 +344,7 @@ defining-attr-methods=__init__,__new__,setUp
 
 # List of member names, which should be excluded from the protected access
 # warning.
-exclude-protected=_asdict, _fields, _replace, _source, _make, _generate_and_write_metadata, _delete_obsolete_metadata, _log_status_of_top_level_roles, _load_top_level_metadata, _strip_version_number, _delegated_roles, _remove_invalid_and_duplicate_signatures
+exclude-protected=_asdict, _fields, _replace, _source, _make, _generate_and_write_metadata, _delete_obsolete_metadata, _log_status_of_top_level_roles, _load_top_level_metadata, _strip_version_number, _delegated_roles, _remove_invalid_and_duplicate_signatures, _repository_name, _targets_directory
 
 # List of valid names for the first argument in a class method.
 valid-classmethod-first-arg=cls

--- a/tuf/scripts/client.py
+++ b/tuf/scripts/client.py
@@ -223,12 +223,12 @@ def parse_arguments():
 if __name__ == '__main__':
 
   # Parse the command-line arguments and set the logging level.
-  parsed_arguments = parse_arguments()
+  arguments = parse_arguments()
 
   # Perform an update of all the files in the 'targets' directory located in
   # the current directory.
   try:
-    update_client(parsed_arguments)
+    update_client(arguments)
 
   except (tuf.exceptions.NoWorkingMirrorError, tuf.exceptions.RepositoryError,
       tuf.exceptions.FormatError) as e:

--- a/tuf/scripts/client.py
+++ b/tuf/scripts/client.py
@@ -70,8 +70,6 @@ import tuf.client.updater
 import tuf.settings
 import tuf.log
 
-import securesystemslib
-
 # See 'log.py' to learn how logging is handled in TUF.
 logger = logging.getLogger('tuf.scripts.client')
 

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -700,9 +700,6 @@ def add_targets(parsed_arguments):
 
 
 def remove_targets(parsed_arguments):
-  target_paths = os.path.join(parsed_arguments.remove)
-
-  repo_targets_path = os.path.join(parsed_arguments.path, REPO_DIR, 'targets')
   repository = repo_tool.load_repository(
       os.path.join(parsed_arguments.path, REPO_DIR))
 

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -357,7 +357,7 @@ def import_privatekey_from_file(keypath, password=None):
       key_object = securesystemslib.keys.import_rsakey_from_private_pem(
           encrypted_key, 'rsassa-pss-sha256', password)
 
-    except securesystemslib.exceptions.CryptoError as e:
+    except securesystemslib.exceptions.CryptoError:
       raise tuf.exceptions.Error(repr(keypath) + ' cannot be imported, possibly'
           ' because an invalid key file is given or the decryption password is'
           ' incorrect.')

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -120,7 +120,7 @@ def process_arguments(parsed_arguments):
 
   # Do we have a valid argparse Namespace?
   if not isinstance(parsed_arguments, argparse.Namespace):
-    raise tuf.exception.Error('Invalid namespace: ' + repr(parsed_arguments))
+    raise tuf.exceptions.Error('Invalid namespace: ' + repr(parsed_arguments))
 
   else:
     logger.debug('We have a valid argparse Namespace.')
@@ -403,7 +403,7 @@ def import_publickey_from_file(keypath):
 
 def add_verification_key(parsed_arguments):
   if not parsed_arguments.pubkeys:
-    raise tuf.exception.Error('--pubkeys must be given with --trust.')
+    raise tuf.exceptions.Error('--pubkeys must be given with --trust.')
 
   repository = repo_tool.load_repository(
       os.path.join(parsed_arguments.path, REPO_DIR))
@@ -424,7 +424,7 @@ def add_verification_key(parsed_arguments):
       repository.timestamp.add_verification_key(imported_pubkey)
 
     else:
-      raise tuf.exception.Error('The given --role is not a top-level role.')
+      raise tuf.exceptions.Error('The given --role is not a top-level role.')
 
   consistent_snapshot = tuf.roledb.get_roleinfo('root',
       repository._repository_name)['consistent_snapshot']
@@ -440,7 +440,7 @@ def add_verification_key(parsed_arguments):
 
 def remove_verification_key(parsed_arguments):
   if not parsed_arguments.pubkeys:
-    raise tuf.exception.Error('--pubkeys must be given with --distrust.')
+    raise tuf.exceptions.Error('--pubkeys must be given with --distrust.')
 
   repository = repo_tool.load_repository(
       os.path.join(parsed_arguments.path, REPO_DIR))
@@ -462,7 +462,7 @@ def remove_verification_key(parsed_arguments):
         repository.timestamp.remove_verification_key(imported_pubkey)
 
       else:
-        raise tuf.exception.Error('The given --role is not a top-level role.')
+        raise tuf.exceptions.Error('The given --role is not a top-level role.')
 
     except securesystemslib.exceptions.Error:
       print(repr(keypath) + ' is not a trusted key.  Skipping.')

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -227,7 +227,7 @@ def delegate(parsed_arguments):
   repository.writeall(consistent_snapshot=consistent_snapshot)
 
   # Move staged metadata directory to "live" metadata directory.
-  write_to_live_repo()
+  write_to_live_repo(parsed_arguments)
 
 
 
@@ -271,7 +271,7 @@ def revoke(parsed_arguments):
   repository.writeall(consistent_snapshot=consistent_snapshot)
 
   # Move staged metadata directory to "live" metadata directory.
-  write_to_live_repo()
+  write_to_live_repo(parsed_arguments)
 
 
 
@@ -432,7 +432,7 @@ def add_verification_key(parsed_arguments):
       increment_version_number=False)
 
   # Move staged metadata directory to "live" metadata directory.
-  write_to_live_repo()
+  write_to_live_repo(parsed_arguments)
 
 
 
@@ -473,7 +473,7 @@ def remove_verification_key(parsed_arguments):
       increment_version_number=False)
 
   # Move staged metadata directory to "live" metadata directory.
-  write_to_live_repo()
+  write_to_live_repo(parsed_arguments)
 
 
 
@@ -557,7 +557,7 @@ def sign_role(parsed_arguments):
   repository.writeall(consistent_snapshot=consistent_snapshot)
 
   # Move staged metadata directory to "live" metadata directory.
-  write_to_live_repo()
+  write_to_live_repo(parsed_arguments)
 
 
 
@@ -572,7 +572,7 @@ def clean_repo(parsed_arguments):
 
 
 
-def write_to_live_repo():
+def write_to_live_repo(parsed_arguments):
   staged_meta_directory = os.path.join(
       parsed_arguments.path, REPO_DIR, STAGED_METADATA_DIR)
   live_meta_directory = os.path.join(
@@ -583,7 +583,7 @@ def write_to_live_repo():
 
 
 
-def add_target_to_repo(target_path, repo_targets_path, repository, custom=None):
+def add_target_to_repo(parsed_arguments, target_path, repo_targets_path, repository, custom=None):
   """
   (1) Copy 'target_path' to 'repo_targets_path'.
   (2) Add 'target_path' to Targets metadata of 'repository'.
@@ -620,7 +620,7 @@ def add_target_to_repo(target_path, repo_targets_path, repository, custom=None):
 
 
 
-def remove_target_files_from_metadata(repository):
+def remove_target_files_from_metadata(parsed_arguments, repository):
 
   if parsed_arguments.role in ['root', 'snapshot', 'timestamp']:
     raise tuf.exceptions.Error(
@@ -662,10 +662,10 @@ def add_targets(parsed_arguments):
     if os.path.isdir(target_path):
       for sub_target_path in repository.get_filepaths_in_directory(
           target_path, parsed_arguments.recursive):
-        add_target_to_repo(sub_target_path, repo_targets_path, repository)
+        add_target_to_repo(parsed_arguments, sub_target_path, repo_targets_path, repository)
 
     else:
-      add_target_to_repo(target_path, repo_targets_path, repository)
+      add_target_to_repo(parsed_arguments, target_path, repo_targets_path, repository)
 
   consistent_snapshot = tuf.roledb.get_roleinfo('root',
       repository._repository_name)['consistent_snapshot']
@@ -697,7 +697,7 @@ def add_targets(parsed_arguments):
   repository.writeall(consistent_snapshot=consistent_snapshot)
 
   # Move staged metadata directory to "live" metadata directory.
-  write_to_live_repo()
+  write_to_live_repo(parsed_arguments)
 
 
 
@@ -710,7 +710,7 @@ def remove_targets(parsed_arguments):
 
   # Remove target files from the Targets metadata (or the role specified in
   # --role) that match the glob patterns specified in --remove.
-  remove_target_files_from_metadata(repository)
+  remove_target_files_from_metadata(parsed_arguments, repository)
 
   # Examples of how the --pw command-line option is interpreted:
   # repo.py --init': parsed_arguments.pw = 'pw'
@@ -740,7 +740,7 @@ def remove_targets(parsed_arguments):
   repository.writeall(consistent_snapshot=consistent_snapshot)
 
   # Move staged metadata directory to "live" metadata directory.
-  write_to_live_repo()
+  write_to_live_repo(parsed_arguments)
 
 
 
@@ -755,7 +755,7 @@ def init_repo(parsed_arguments):
   repository = repo_tool.create_new_repository(repo_path)
 
   if not parsed_arguments.bare:
-    set_top_level_keys(repository)
+    set_top_level_keys(repository, parsed_arguments)
     repository.writeall(consistent_snapshot=parsed_arguments.consistent)
 
   else:
@@ -765,7 +765,7 @@ def init_repo(parsed_arguments):
     repository.write('snapshot', consistent_snapshot=parsed_arguments.consistent)
     repository.write('timestamp', consistent_snapshot=parsed_arguments.consistent)
 
-  write_to_live_repo()
+  write_to_live_repo(parsed_arguments)
 
   # Create the client files.  The client directory contains the required
   # directory structure and metadata files for clients to successfully perform
@@ -776,7 +776,7 @@ def init_repo(parsed_arguments):
 
 
 
-def set_top_level_keys(repository):
+def set_top_level_keys(repository, parsed_arguments):
   """
   Generate, write, and set the top-level keys.  'repository' is modified.
   """
@@ -1025,7 +1025,7 @@ def parse_arguments():
 if __name__ == '__main__':
 
   # Parse the arguments and set the logging level.
-  parsed_arguments = parse_arguments()
+  arguments = parse_arguments()
 
   # Create or modify the repository depending on the option specified on the
   # command line.  For example, the following adds the 'foo.bar.gz' to the
@@ -1034,7 +1034,7 @@ if __name__ == '__main__':
   # $ repo.py --add foo.bar.gz
 
   try:
-    process_arguments(parsed_arguments)
+    process_arguments(arguments)
 
   except (tuf.exceptions.Error) as e:
     sys.stderr.write('Error: ' + str(e) + '\n')

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -61,8 +61,6 @@ import sys
 import logging
 import argparse
 import shutil
-import errno
-import getpass
 import time
 import fnmatch
 


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request resolves all of the Pylint warnings for the `repo.py` and `client.py` modules.  These two modules were unexpectedly excluded from Pylint and Bandit because the `__init__.py` file wasn't in the `tuf/scripts` directory.

Note: Pull request #697 added `__init__.py` to resolve a separate issue with running subprocess scripts in Windows.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>