### PR TITLE
Resolve WindowsError exceptions after calling shutil.rmtree

### DIFF
--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -150,7 +150,7 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
 
     # NOTE: Following error is raised if a delay is not applied:
     # <urlopen error [Errno 111] Connection refused>
-    time.sleep(.8)
+    time.sleep(.3)
 
     url_prefix = 'http://localhost:' + str(self.SERVER_PORT)
     url_prefix2 = 'http://localhost:' + str(self.SERVER_PORT2)
@@ -178,10 +178,6 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
     # directories that may have been created during each test case.
     unittest_toolbox.Modified_TestCase.tearDown(self)
 
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated of all the test cases.
-    shutil.rmtree(self.temporary_directory)
-
     # Kill the SimpleHTTPServer process.
     if self.server_process.returncode is None:
       logger.info('Server process ' + str(self.server_process.pid) + ' terminated.')
@@ -194,6 +190,12 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
     # updater.Updater() populates the roledb with the name "test_repository1"
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
+
+    # Remove the temporary repository directory, which should contain all the
+    # metadata, targets, and key files generated of all the test cases.
+    # sleep for a bit to allow the kill'd server processes to terminate.
+    time.sleep(.3)
+    shutil.rmtree(self.temporary_directory)
 
 
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -116,14 +116,16 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # tearDownModule() is called after all the tests have run.
     # http://docs.python.org/2/library/unittest.html#class-and-module-fixtures
 
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated for the test cases.
-    shutil.rmtree(cls.temporary_directory)
-
     # Kill the SimpleHTTPServer process.
     if cls.server_process.returncode is None:
       logger.info('\tServer process ' + str(cls.server_process.pid) + ' terminated.')
       cls.server_process.kill()
+
+    # Remove the temporary repository directory, which should contain all the
+    # metadata, targets, and key files generated for the test cases.  sleep
+    # for a bit to allow the kill'd server process to terminate.
+    time.sleep(.3)
+    shutil.rmtree(cls.temporary_directory)
 
 
 
@@ -1722,7 +1724,7 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
 
     # NOTE: Following error is raised if a delay is not applied:
     # <urlopen error [Errno 111] Connection refused>
-    time.sleep(.8)
+    time.sleep(.3)
 
     url_prefix = 'http://localhost:' + str(self.SERVER_PORT)
     url_prefix2 = 'http://localhost:' + str(self.SERVER_PORT2)
@@ -1758,10 +1760,6 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     # directories that may have been created during each test case.
     unittest_toolbox.Modified_TestCase.tearDown(self)
 
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated of all the test cases.
-    shutil.rmtree(self.temporary_directory)
-
     # Kill the SimpleHTTPServer process.
     if self.server_process.returncode is None:
       logger.info('Server process ' + str(self.server_process.pid) + ' terminated.')
@@ -1774,6 +1772,12 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     # updater.Updater() populates the roledb with the name "test_repository1"
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
+
+    # Remove the temporary repository directory, which should contain all the
+    # metadata, targets, and key files generated of all the test cases.  sleep
+    # for a bit to allow the kill'd server processes to terminate.
+    time.sleep(.3)
+    shutil.rmtree(self.temporary_directory)
 
 
 


### PR DESCRIPTION
**Fixes issue #**:

Addresses #690.

**Description of the changes being introduced by the pull request**:

This pull request ensures that `shutil.rmtree()` is called after (and not before) the subprocess'd server scripts are killed, otherwise it results in `WindowsErrors: "The process cannot access the file because it is being used by another process"` exceptions.  A `time.sleep()` is added before the `shutil.rmtree()` to give the server scripts time to successfully terminate.

Affected modules: `test_updater.py` and `test_multiple_repositories_integration.py.`

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>