### PR TITLE
Fix "nonnumeric ports" exceptions raised in Windows.  Issue #695

### DIFF
--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -184,7 +184,9 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
 
     url_prefix = self.repository_mirrors['mirror1']['url_prefix']
     url_file = os.path.join(url_prefix, 'targets', 'file1.txt')
-    six.moves.urllib.request.urlretrieve(url_file, client_target_path)
+
+    # On Windows, the URL portion should not contain back slashes.
+    six.moves.urllib.request.urlretrieve(url_file.replace('\\', '/'), client_target_path)
 
     self.assertTrue(os.path.exists(client_target_path))
     length, hashes = securesystemslib.util.get_file_details(client_target_path)
@@ -197,7 +199,8 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
     length, hashes = securesystemslib.util.get_file_details(target_path)
     malicious_fileinfo = tuf.formats.make_fileinfo(length, hashes)
 
-    six.moves.urllib.request.urlretrieve(url_file, client_target_path)
+    # On Windows, the URL portion should not contain back slashes.
+    six.moves.urllib.request.urlretrieve(url_file.replace('\\', '/'), client_target_path)
 
     length, hashes = securesystemslib.util.get_file_details(client_target_path)
     download_fileinfo = tuf.formats.make_fileinfo(length, hashes)

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -188,7 +188,9 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
 
     url_prefix = self.repository_mirrors['mirror1']['url_prefix']
     url_file = os.path.join(url_prefix, 'targets', 'file1.txt')
-    six.moves.urllib.request.urlretrieve(url_file, client_target_path)
+
+    # On Windows, the URL portion should not contain backslashes.
+    six.moves.urllib.request.urlretrieve(url_file.replace('\\', '/'), client_target_path)
 
     self.assertTrue(os.path.exists(client_target_path))
     length, hashes = securesystemslib.util.get_file_details(client_target_path)
@@ -206,7 +208,8 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
     # Is the modified file actually larger?
     self.assertTrue(large_length > length)
 
-    six.moves.urllib.request.urlretrieve(url_file, client_target_path)
+    # On Windows, the URL portion should not contain backslashes.
+    six.moves.urllib.request.urlretrieve(url_file.replace('\\', '/'), client_target_path)
 
     length, hashes = securesystemslib.util.get_file_details(client_target_path)
     download_fileinfo = tuf.formats.make_fileinfo(length, hashes)

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -102,7 +102,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
     # NOTE: Following error is raised if a delay is not applied:
     # <urlopen error [Errno 111] Connection refused>
-    time.sleep(.8)
+    time.sleep(.3)
 
 
 
@@ -222,8 +222,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
                    sort_keys=True).encode('utf-8')
       file_object.write(timestamp_content)
 
-    client_timestamp_path = os.path.join(self.client_directory,
-                                         'timestamp.json')
+    client_timestamp_path = os.path.join(self.client_directory, 'timestamp.json')
     shutil.copy(timestamp_path, client_timestamp_path)
 
     length, hashes = securesystemslib.util.get_file_details(timestamp_path)
@@ -232,7 +231,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     url_prefix = self.repository_mirrors['mirror1']['url_prefix']
     url_file = os.path.join(url_prefix, 'metadata', 'timestamp.json')
 
-    six.moves.urllib.request.urlretrieve(url_file, client_timestamp_path)
+    six.moves.urllib.request.urlretrieve(url_file.replace('\\', '/'), client_timestamp_path)
 
     length, hashes = securesystemslib.util.get_file_details(client_timestamp_path)
     download_fileinfo = tuf.formats.make_fileinfo(length, hashes)

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -234,7 +234,8 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
     client_timestamp_path = os.path.join(self.client_directory,
         self.repository_name, 'metadata', 'current', 'timestamp.json')
 
-    six.moves.urllib.request.urlretrieve(url_file, client_timestamp_path)
+    # On Windows, the URL portion should not contain back slashes.
+    six.moves.urllib.request.urlretrieve(url_file.replace('\\', '/'), client_timestamp_path)
 
     length, hashes = securesystemslib.util.get_file_details(client_timestamp_path)
     download_fileinfo = tuf.formats.make_fileinfo(length, hashes)
@@ -246,7 +247,8 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
     # and verify that the non-TUF client downloads it (expected, but not ideal).
     shutil.move(backup_timestamp, timestamp_path)
 
-    six.moves.urllib.request.urlretrieve(url_file, client_timestamp_path)
+    # On Windows, the URL portion should not contain back slashes.
+    six.moves.urllib.request.urlretrieve(url_file.replace('\\', '/'), client_timestamp_path)
 
     length, hashes = securesystemslib.util.get_file_details(client_timestamp_path)
     download_fileinfo = tuf.formats.make_fileinfo(length, hashes)


### PR DESCRIPTION
**Fixes issue #**:

Close #695.

**Description of the changes being introduced by the pull request**:

This pull request resolves the nonnumeric ports" exceptions raised in Windows by removing back slashes that might be included in a URL given to `urllib.urlretrieve().`  A back slash causes parsing issues with `urllib.urlretrieve()`.

Affected unit tests:
`test_replay_attack.py`
`test_arbitrary_package_attack.py`
`test_endless_data_attack.py`
`test_indefinite_freeze_attack.py`

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>