### PR TITLE
Ensure URLs in mirrors.py do not contain backward slashes

### DIFF
--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -240,9 +240,10 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
 
       # Verify that the expected 'tuf.exceptions.DownloadLengthMismatchError' exception
       # is raised for 'url_file'.
-      self.assertTrue(url_file in exception.mirror_errors)
-      self.assertTrue(isinstance(exception.mirror_errors[url_file],
-                                 securesystemslib.exceptions.BadHashError))
+      self.assertTrue(url_file.replace('\\', '/') in exception.mirror_errors)
+      self.assertTrue(
+          isinstance(exception.mirror_errors[url_file.replace('\\', '/')],
+          securesystemslib.exceptions.BadHashError))
 
     else:
       self.fail('TUF did not prevent an arbitrary package attack.')
@@ -292,9 +293,10 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
       self.assertTrue(len(exception.mirror_errors), 1)
 
       # Verify that the specific and expected mirror exception is raised.
-      self.assertTrue(url_file in exception.mirror_errors)
-      self.assertTrue(isinstance(exception.mirror_errors[url_file],
-                                 securesystemslib.exceptions.BadHashError))
+      self.assertTrue(url_file.replace('\\', '/') in exception.mirror_errors)
+      self.assertTrue(
+          isinstance(exception.mirror_errors[url_file.replace('\\', '/')],
+          securesystemslib.exceptions.BadHashError))
 
     else:
       self.fail('TUF did not prevent an arbitrary package attack.')

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -227,7 +227,7 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
         url_file = os.path.join(url_prefix, 'metadata', 'role1.json')
 
         # Verify that 'role1.json' is the culprit.
-        self.assertEqual(url_file, mirror_url)
+        self.assertEqual(url_file.replace('\\', '/'), mirror_url)
         self.assertTrue(isinstance(mirror_error, securesystemslib.exceptions.BadSignatureError))
 
     else:

--- a/tests/test_mirrors.py
+++ b/tests/test_mirrors.py
@@ -68,7 +68,7 @@ class TestMirrors(unittest_toolbox.Modified_TestCase):
     mirror_list = mirrors.get_list_of_mirrors('meta', 'release.txt', self.mirrors)
     self.assertEqual(len(mirror_list), 3)
     for mirror, mirror_info in six.iteritems(self.mirrors):
-      url = mirror_info['url_prefix']+'/metadata/release.txt'
+      url = mirror_info['url_prefix'] + '/metadata/release.txt'
       self.assertTrue(url in mirror_list)
 
     mirror_list = mirrors.get_list_of_mirrors('target', 'a.txt', self.mirrors)

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -248,7 +248,7 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
         url_file = os.path.join(url_prefix, 'metadata', 'role1.json')
 
         # Verify that 'role1.json' is the culprit.
-        self.assertEqual(url_file, mirror_url)
+        self.assertEqual(url_file.replace('\\', '/'), mirror_url)
         self.assertTrue(isinstance(mirror_error,
                         securesystemslib.exceptions.BadVersionNumberError))
 

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -332,7 +332,7 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
         url_file = os.path.join(url_prefix, 'metadata', 'timestamp.json')
 
         # Verify that 'timestamp.json' is the culprit.
-        self.assertEqual(url_file, mirror_url)
+        self.assertEqual(url_file.replace('\\', '/'), mirror_url)
         self.assertTrue(isinstance(mirror_error, tuf.exceptions.ReplayedMetadataError))
 
     else:

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -241,7 +241,7 @@ class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
         url_file = os.path.join(url_prefix, 'targets', 'file1.txt')
 
         # Verify that 'file1.txt' is the culprit.
-        self.assertEqual(url_file, mirror_url)
+        self.assertEqual(url_file.replace('\\', '/'), mirror_url)
         self.assertTrue(isinstance(mirror_error, tuf.exceptions.SlowRetrievalError))
 
     else:

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -260,7 +260,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         url_file = os.path.join(url_prefix, 'metadata', '2.root.json')
 
         # Verify that '2.root.json' is the culprit.
-        self.assertEqual(url_file, mirror_url)
+        self.assertEqual(url_file.replace('\\', '/'), mirror_url)
         self.assertTrue(isinstance(mirror_error,
           securesystemslib.exceptions.BadSignatureError))
 

--- a/tuf/mirrors.py
+++ b/tuf/mirrors.py
@@ -123,6 +123,8 @@ def get_list_of_mirrors(file_type, file_path, mirrors_dict):
     # http://bugs.python.org/issue1712522
     file_path = six.moves.urllib.parse.quote(file_path)
     url = os.path.join(base, file_path)
-    list_of_mirrors.append(url)
+
+    # Make sure the URL doesn't contain backward slashes on Windows.
+    list_of_mirrors.append(url.replace('\\', '/'))
 
   return list_of_mirrors


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request prevents the URLs in `mirrors.get_list_of_mirrors` from containing backward slashes, which can happen in Windows.  This issue is similar to the one addressed in pull request #701.

The pull request also updates the affected unit tests to make sure that they compare URLs that do not contain backward slashes.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>