### PR TITLE
Catch errno.ENOENT exceptions raised in Windows

### DIFF
--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1616,7 +1616,8 @@ class TestRepositoryToolFunctions(unittest.TestCase):
       repo_tool.create_new_repository('bad' * 2000, repository_name)
 
     except OSError as e:
-      self.assertTrue(e.errno == errno.ENAMETOOLONG)
+      # errno.ENOENT is raised in Windows.
+      self.assertTrue(e.errno == errno.ENAMETOOLONG or e.errno == errno.ENOENT)
 
     # Reset the 'repository_directory' so that the metadata and targets
     # directories can be tested likewise.
@@ -1631,7 +1632,8 @@ class TestRepositoryToolFunctions(unittest.TestCase):
       repo_tool.create_new_repository(repository_directory, repository_name)
 
     except OSError as e:
-      self.assertTrue(e.errno == errno.ENAMETOOLONG)
+      # errno.ENOENT is raised in Windows.
+      self.assertTrue(e.errno == errno.ENAMETOOLONG or e.errno == errno.ENOENT)
 
     # Reset metadata staged directory so that the targets directory can be
     # tested...
@@ -1645,7 +1647,8 @@ class TestRepositoryToolFunctions(unittest.TestCase):
       repo_tool.create_new_repository(repository_directory, repository_name)
 
     except OSError as e:
-      self.assertTrue(e.errno == errno.ENAMETOOLONG)
+      # errno.ENOENT is raised in Windows.
+      self.assertTrue(e.errno == errno.ENAMETOOLONG or e.errno == errno.ENOENT)
 
     tuf.repository_tool.TARGETS_DIRECTORY_NAME = \
       original_targets_directory


### PR DESCRIPTION
**Fixes issue #**:

Addresses #690.

**Description of the changes being introduced by the pull request**:

This pull request modifies several test conditions in `test_repository_tool.py` to catch the additional
`errno.ENOENT` exception that is raised in Windows.  For this particular test, only `errno.ENAMETOOLONG` is raised in Linux and MacOS.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>