### PR TITLE
Ensure consistent style of slashes for paths in metadata

### DIFF
--- a/tests/test_developer_tool.py
+++ b/tests/test_developer_tool.py
@@ -162,24 +162,12 @@ class TestProject(unittest.TestCase):
 
     tuf.roledb.clear_roledb()
     tuf.keydb.clear_keydb()
-    self.assertRaises(OSError, developer_tool.create_new_project ,project_name,
+    self.assertRaises(OSError, developer_tool.create_new_project, project_name,
         metadata_directory, location_in_repository, targets_directory,
         project_key)
 
     os.chmod(local_tmp, 0o0777)
 
-    shutil.rmtree(metadata_directory)
-    os.chmod(local_tmp, 0o0555)
-
-    tuf.roledb.clear_roledb()
-    tuf.keydb.clear_keydb()
-    self.assertRaises(OSError, developer_tool.create_new_project ,project_name,
-        metadata_directory, location_in_repository, targets_directory,
-        project_key)
-
-
-    os.chmod(local_tmp, 0o0777)
-    shutil.rmtree(local_tmp)
 
 
 

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -266,9 +266,9 @@ class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
       file1_target = self.repository_updater.get_one_valid_targetinfo('file1.txt')
       self.repository_updater.download_target(file1_target, self.client_directory)
 
-    # Verify that the specific 'tuf.exceptions.SlowRetrievalError' exception is raised by
-    # each mirror.  'file1.txt' should be large enough to trigger a slow
-    # retrieval attack, otherwise the expected exception may not be
+    # Verify that the specific 'tuf.exceptions.SlowRetrievalError' exception is
+    # raised by each mirror.  'file1.txt' should be large enough to trigger a
+    # slow retrieval attack, otherwise the expected exception may not be
     # consistently raised.
     except tuf.exceptions.NoWorkingMirrorError as exception:
       for mirror_url, mirror_error in six.iteritems(exception.mirror_errors):
@@ -276,7 +276,7 @@ class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
         url_file = os.path.join(url_prefix, 'targets', 'file1.txt')
 
         # Verify that 'file1.txt' is the culprit.
-        self.assertEqual(url_file, mirror_url)
+        self.assertEqual(url_file.replace('\\', '/'), mirror_url)
         self.assertTrue(isinstance(mirror_error, tuf.exceptions.SlowRetrievalError))
 
     else:

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1047,7 +1047,8 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # Test: invalid target path.
     self.assertRaises(tuf.exceptions.UnknownTargetError,
-        self.repository_updater.get_one_valid_targetinfo, self.random_path().lstrip(os.sep))
+        self.repository_updater.get_one_valid_targetinfo,
+        self.random_path().lstrip(os.sep).lstrip('/'))
 
     # Test updater.get_one_valid_targetinfo() backtracking behavior (enabled by
     # default.)

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -2629,6 +2629,8 @@ class Updater(object):
     # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
     securesystemslib.formats.RELPATH_SCHEMA.check_match(target_filepath)
 
+    target_filepath = target_filepath.replace('\\', '/')
+
     if target_filepath.startswith('/'):
       raise tuf.exceptions.FormatError('The requested target file cannot'
           ' contain a leading path separator: ' + repr(target_filepath))

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1397,7 +1397,7 @@ def generate_targets_metadata(targets_directory, target_files, version,
     if len(custom):
       custom_data = custom
 
-    filedict[relative_targetpath] = \
+    filedict[relative_targetpath.replace('\\', '/').lstrip('/')] = \
       get_metadata_fileinfo(target_path, custom_data)
 
     # Copy 'target_path' to 'digest_target' if consistent hashing is enabled.

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -1924,7 +1924,7 @@ class Targets(Metadata):
       # targets directory.
       targets_directory_length = len(self._targets_directory) + 1
       roleinfo = tuf.roledb.get_roleinfo(self._rolename, self._repository_name)
-      relative_path = filepath[targets_directory_length:]
+      relative_path = filepath[targets_directory_length:].replace('\\', '/')
 
       if relative_path not in roleinfo['paths']:
         logger.debug('Adding new target: ' + repr(relative_path))
@@ -1996,7 +1996,8 @@ class Targets(Metadata):
       filepath = os.path.join(self._targets_directory, target)
 
       if os.path.isfile(filepath):
-        relative_list_of_targets.append(filepath[targets_directory_length+1:])
+        relative_list_of_targets.append(
+            filepath[targets_directory_length + 1:].replace('\\', '/'))
 
       else:
         raise securesystemslib.exceptions.Error(repr(filepath) + ' is not'


### PR DESCRIPTION
**Fixes issue #**:

Addresses #690.

**Description of the changes being introduced by the pull request**:

This pull request makes sure that forward slashes are consistently used when comparing and writing paths to metadata.

Unrelated changes:
(1) Fix unit test failures that compared URLs with different style of slashes.
(2) Remove duplicate code in `test_developer_tool.py.`

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>