### PR TITLE
Allow 'OSError.ENOENT' exception in test condition (expected in Windows)

### DIFF
--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1216,7 +1216,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
       self.repository_updater.download_target(targetinfo, bad_destination_directory)
 
     except OSError as e:
-      self.assertTrue(e.errno == errno.ENAMETOOLONG)
+      self.assertTrue(e.errno == errno.ENAMETOOLONG or e.errno == errno.ENOENT)
 
     # Test: Invalid arguments.
     self.assertRaises(securesystemslib.exceptions.FormatError,


### PR DESCRIPTION
**Fixes issue #**:

Addresses #690.

**Description of the changes being introduced by the pull request**:

One of the unit tests fails in Windows because OSError `errno.ENOENT` is raised instead of `errno.ENAMETOOLONG`.  This pull request allows `errno.ENOENT` in the list of expected exceptions raised in `test_updater.test_6_download_target().`

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>