### PR TITLE
Fix bug in sig.py's get_signature_status()

### DIFF
--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -67,7 +67,7 @@ iso8601_logger.disabled = True
 
 
 def get_signature_status(signable, role=None, repository_name='default',
-                         threshold=None, keyids=None):
+    threshold=None, keyids=None):
   """
   <Purpose>
     Return a dictionary representing the status of the signatures listed in
@@ -214,12 +214,16 @@ def get_signature_status(signable, role=None, repository_name='default',
   # securesystemslib.exceptions.UnknownRoleError if we were given an invalid
   # role.
   if role is not None:
-    try:
-      threshold = \
-        tuf.roledb.get_role_threshold(role, repository_name=repository_name)
+    if threshold is None:
+      try:
+        threshold = \
+          tuf.roledb.get_role_threshold(role, repository_name=repository_name)
 
-    except tuf.exceptions.UnknownRoleError:
-      raise
+      except tuf.exceptions.UnknownRoleError:
+        raise
+
+    else:
+      logger.debug('Not using roledb.py\'s threshold for ' + repr(role))
 
   else:
     threshold = 0


### PR DESCRIPTION
**Fixes issue #**:

Addresses #690.

**Description of the changes being introduced by the pull request**:

This pull request fixes a bug in `tuf.sig.get_signature_status()` where it incorrectly uses the role's threshold in roledb instead of using the one supplied in the `threshold` argument to the function.  The `threshold` argument is often given when the user wants to generate a signature status for a previous threshold and keyids instead of their current values.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>