### PR TITLE
Refactor how previous keyids are saved in add_verification_key()

### DIFF
--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -137,7 +137,8 @@ class TestRepository(unittest.TestCase):
     # sub-directory in 'temporary_directory' if it does not exist.
     repository_directory = os.path.join(temporary_directory, 'repository')
     metadata_directory = os.path.join(repository_directory,
-                                      repo_tool.METADATA_STAGED_DIRECTORY_NAME)
+        repo_tool.METADATA_STAGED_DIRECTORY_NAME)
+
     repository = repo_tool.create_new_repository(repository_directory, repository_name)
 
     # (1) Load the public and private keys of the top-level roles, and one
@@ -230,7 +231,8 @@ class TestRepository(unittest.TestCase):
       role_filepath = os.path.join(metadata_directory, role)
       role_signable = securesystemslib.util.load_json_file(role_filepath)
 
-      # Raise 'securesystemslib.exceptions.FormatError' if 'role_signable' is an invalid signable.
+      # Raise 'securesystemslib.exceptions.FormatError' if 'role_signable' is
+      # an invalid signable.
       tuf.formats.check_signable_object_format(role_signable)
 
       self.assertTrue(os.path.exists(role_filepath))

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -671,10 +671,13 @@ class Metadata(object):
     keyid = key['keyid']
     roleinfo = tuf.roledb.get_roleinfo(self.rolename, self._repository_name)
 
-    previous_keyids = roleinfo['keyids']
+    # Save the keyids that are being replaced since certain roles will need to
+    # re-sign metadata with these keys (e.g., root).  Use list() to make a copy
+    # of roleinfo['keyids'] to ensure we're modifying distinct lists.
+    previous_keyids = list(roleinfo['keyids'])
 
-    # Add 'key' to the role's entry in 'tuf.roledb.py' and avoid duplicates.
-    if keyid not in previous_keyids:
+    # Add 'key' to the role's entry in 'tuf.roledb.py', and avoid duplicates.
+    if keyid not in roleinfo['keyids']:
       roleinfo['keyids'].append(keyid)
       roleinfo['previous_keyids'] = previous_keyids
 


### PR DESCRIPTION
**Fixes issue #**:

Addresses #690.

**Description of the changes being introduced by the pull request**:

This pull request refactors `add_verification_key()` so that a copy of roleinfo['keyids'] is saved to roleinfo['previous_keyids'].

Note: This change is expected to break other unit tests that incorrectly passed because of the incorrect code.  The other unit tests will be fixed in a subsequent pull request.

Unrelated: Indentation is fixed in `test_repository_tool.py`. 

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>