### PR TITLE
Do not automatically load a role's previous keys

### DIFF
--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -363,9 +363,9 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
     repository.root.load_signing_key(self.role_keys['timestamp']['private'])
 
     # Note: We added the Snapshot, Targets, and Timetamp keys to the Root role.
-    # The Root's expected private key has not been loaded yet, so that
-    # we can verify that refresh() correctly raises a securesystemslib.exceptions.BadSignatureError
-    # exception.
+    # The Root's expected private key has not been loaded yet, so that we can
+    # verify that refresh() correctly raises a
+    # securesystemslib.exceptions.BadSignatureError exception.
     repository.snapshot.load_signing_key(self.role_keys['snapshot']['private'])
     repository.timestamp.load_signing_key(self.role_keys['timestamp']['private'])
 
@@ -384,7 +384,8 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
 
     except tuf.exceptions.NoWorkingMirrorError as exception:
       for mirror_exception in exception.mirror_errors.values():
-        self.assertTrue(isinstance(mirror_exception, securesystemslib.exceptions.BadSignatureError))
+        self.assertTrue(isinstance(mirror_exception,
+            securesystemslib.exceptions.BadSignatureError))
 
     repository.root.add_verification_key(self.role_keys['root']['public'])
     repository.root.load_signing_key(self.role_keys['root']['private'])
@@ -427,6 +428,13 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
 
     repository.root.remove_verification_key(self.role_keys['targets']['public'])
     repository.root.unload_signing_key(self.role_keys['targets']['private'])
+
+    # The following should fail because root rotation requires the new Root
+    # to be signed with the previous self.role_keys['targets'] key.
+    self.assertRaises(tuf.exceptions.UnsignedMetadataError,
+        repository.writeall)
+
+    repository.root.load_signing_key(self.role_keys['targets']['private'])
     repository.writeall()
 
     # Move the staged metadata to the "live" metadata.

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -112,7 +112,7 @@ def _generate_and_write_metadata(rolename, metadata_filename,
   roleinfo = tuf.roledb.get_roleinfo(rolename, repository_name)
   previous_keyids = roleinfo.get('previous_keyids', [])
   previous_threshold = roleinfo.get('previous_threshold', 1)
-  signing_keyids = list(set(roleinfo['signing_keyids'] + previous_keyids))
+  signing_keyids = list(set(roleinfo['signing_keyids']))
 
   # Generate the appropriate role metadata for 'rolename'.
   if rolename == 'root':


### PR DESCRIPTION
**Fixes issue #**:

Addresses #690.

**Description of the changes being introduced by the pull request**:

This is a follow-on pull request to #712.  The current behavior of automatically loading a role's previous keys breaks write() and writeall() in unexpected ways, and makes it difficult to determine the signing keys that have been loaded.

An exception is now raised if a role, like root, is not signed by the previous set of keyids that is required for key rotation.  Affected unit tests have been updated to reflect the expected behavior and demonstrate how previous keys for the Root role must be loaded.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>