### PR TITLE
Do not test for an invalid consistent method in Windows

### DIFF
--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -38,6 +38,7 @@ import shutil
 import stat
 import sys
 import unittest
+import platform
 
 import tuf
 import tuf.formats
@@ -806,9 +807,16 @@ class TestRepositoryToolFunctions(unittest.TestCase):
 
     # Test for an improper settings.CONSISTENT_METHOD string value.
     tuf.settings.CONSISTENT_METHOD = 'somebadidea'
-    self.assertRaises(securesystemslib.exceptions.InvalidConfigurationError,
-        repo_lib.write_metadata_file, root_signable, output_filename,
-        version_number, consistent_snapshot=True)
+
+    # Test for invalid consistent methods on systems other than Windows,
+    # which always uses the copy method.
+    if platform.system() == 'Windows':
+      pass
+
+    else:
+      self.assertRaises(securesystemslib.exceptions.InvalidConfigurationError,
+          repo_lib.write_metadata_file, root_signable, output_filename,
+          version_number, consistent_snapshot=True)
 
     # Try to create a link to root.json when root.json doesn't exist locally.
     # repository_lib should log a message if this is the case.


### PR DESCRIPTION
**Fixes issue #**:

Address #690.

**Description of the changes being introduced by the pull request**:

This pull request avoids the test for an inconsistent method when writing metadata in Windows.  In Windows, the consistent method is always `copy`, regardless of the setting chosen in `tuf.settings.CONSISTENT_METHOD`.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>