### PR TITLE
Generate Ed25519 keys by default.  Address issue#727

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -94,7 +94,7 @@ $ repo.py --remove "*" --role my_role --sign tufkeystore/my_role_key
 ## Generate key ##
 Generate a cryptographic key.  The generated key can later be used to sign
 specific metadata with `--sign`.  The supported key types are: `ecdsa`,
-`ed25519`, and `rsa`.  If a keytype is not given, an ECDSA key is generated.
+`ed25519`, and `rsa`.  If a keytype is not given, an Ed25519 key is generated.
 Note: If adding a top-level key to a bare repo (i.e., repo.py --init --bare),
 the top-level keys should be named "root_key," "targets_key," "snapshot_key,"
 "timestamp_key."  Additional top-level keys may be named anything, and must be
@@ -109,7 +109,7 @@ $ repo.py --key <keytype> [--path </path/to/repo_dir> --pw [my_password],
 Instead of using a default password, the user can enter one on the command
 line or be prompted for it via password masking.
 ```Bash
-$ repo.py --key ed25519 --pw my_password
+$ repo.py --key ecdsa --pw my_password
 ```
 
 ```Bash

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -916,9 +916,9 @@ def parse_arguments():
       ' recursively.  If unset, the default behavior is to not add target'
       ' files in subdirectories.')
 
-  parser.add_argument('-k', '--key', type=str, nargs='?', const='ecdsa',
+  parser.add_argument('-k', '--key', type=str, nargs='?', const='ed25519',
       default=None, choices=['ecdsa', 'ed25519', 'rsa'],
-      help='Generate an ECDSA, Ed25519, or RSA key.  An ECDSA key is'
+      help='Generate an ECDSA, Ed25519, or RSA key.  An Ed25519 key is'
       ' created if the key type is unspecified.')
 
   parser.add_argument('--filename', nargs='?', default=None, const=None,

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -784,16 +784,16 @@ def set_top_level_keys(repository, parsed_arguments):
     parsed_arguments.pw = securesystemslib.interface.get_password(
         prompt='Enter a password for the top-level role keys: ', confirm=True)
 
-  repo_tool.generate_and_write_ecdsa_keypair(
+  repo_tool.generate_and_write_ed25519_keypair(
       os.path.join(parsed_arguments.path, KEYSTORE_DIR,
       ROOT_KEY_NAME), password=parsed_arguments.root_pw)
-  repo_tool.generate_and_write_ecdsa_keypair(
+  repo_tool.generate_and_write_ed25519_keypair(
       os.path.join(parsed_arguments.path, KEYSTORE_DIR,
       TARGETS_KEY_NAME), password=parsed_arguments.targets_pw)
-  repo_tool.generate_and_write_ecdsa_keypair(
+  repo_tool.generate_and_write_ed25519_keypair(
       os.path.join(parsed_arguments.path, KEYSTORE_DIR,
       SNAPSHOT_KEY_NAME), password=parsed_arguments.snapshot_pw)
-  repo_tool.generate_and_write_ecdsa_keypair(
+  repo_tool.generate_and_write_ed25519_keypair(
       os.path.join(parsed_arguments.path, KEYSTORE_DIR,
       TIMESTAMP_KEY_NAME), password=parsed_arguments.timestamp_pw)
 


### PR DESCRIPTION
**Fixes issue #**:

Addresses #727.

**Description of the changes being introduced by the pull request**:

This pull request ensures that repo.py generates Ed25519 keys, by default.  It should make it easier for clients to test a repo in pure Python (once https://github.com/secure-systems-lab/securesystemslib/pull/149 is merged here).

`repo.py --init` generates Ed25519 keys for all the top-level roles.
`repo.py --key` generates an Ed25519 key.

```Bash
(env) $ repo.py --init
(env) $ echo 'test file' > testfile
(env) $ repo.py --add testfile
(env) $ cat tufrepo/metadata/root.json
{
 "signatures": [
  {
   "keyid": "2627cc54117a2ca90cd8fc913914b05a8cd05d28d2363fc10205cb1a24751111",
   "sig": "62dae8c54424553066e1f853423bdd9d6ddfa852b88447a592579407ff95c019337a2dd44f16c61f66887aa64994510e02d2cd25e321bd3ca18eb94c4ea43a0b"
  }
 ],
 "signed": {
  "_type": "root",
  "consistent_snapshot": false,
  "expires": "2019-05-19T01:08:52Z",
  "keys": {
   "242a349ae9f390e6a572dd37c5f17025fc34b5bb8d040d72efc7bdec1121973a": {
    "keyid_hash_algorithms": [
     "sha256",
     "sha512"
    ],
    "keytype": "ed25519",
    "keyval": {
     "public": "ad0326133a4cb5524ceea5ea09a45dcab9dd5e4ea0dc128ecfcfcdfeb1f49785"
    },
    "scheme": "ed25519"
   },
   "2627cc54117a2ca90cd8fc913914b05a8cd05d28d2363fc10205cb1a24751111": {
    "keyid_hash_algorithms": [
     "sha256",
     "sha512"
    ],
    "keytype": "ed25519",
    "keyval": {
     "public": "cdf972ed925d49070fb54727fd6bbb936b87ba9265aa7ac20de13d6aa741a57d"
    },
    "scheme": "ed25519"
   },
   "30b0261ac7a778fb95166a957fe93f5abcdf6c7ea8f4e8f7f06041551c2f80d2": {
    "keyid_hash_algorithms": [
     "sha256",
     "sha512"
    ],
    "keytype": "ed25519",
    "keyval": {
     "public": "72b9df5202552dfeb32d73937af7143619343e503c9214012d1b8a58d0be34b9"
    },
    "scheme": "ed25519"
   },
   "999d1d75d9dfd1aafd825079dccd6d38e6a7677c5b748c0a47a785d4a11eadbb": {
    "keyid_hash_algorithms": [
     "sha256",
     "sha512"
    ],
    "keytype": "ed25519",
    "keyval": {
     "public": "02e575dcba532dc863e94294f116b5584e3d820df6941f5da103f0f1dd0cd5f2"
    },
    "scheme": "ed25519"
   }
  },
  "roles": {
   "root": {
    "keyids": [
     "2627cc54117a2ca90cd8fc913914b05a8cd05d28d2363fc10205cb1a24751111"
    ],
    "threshold": 1
   },
   "snapshot": {
    "keyids": [
     "242a349ae9f390e6a572dd37c5f17025fc34b5bb8d040d72efc7bdec1121973a"
    ],
    "threshold": 1
   },
   "targets": {
    "keyids": [
     "999d1d75d9dfd1aafd825079dccd6d38e6a7677c5b748c0a47a785d4a11eadbb"
    ],
    "threshold": 1
   },
   "timestamp": {
    "keyids": [
     "30b0261ac7a778fb95166a957fe93f5abcdf6c7ea8f4e8f7f06041551c2f80d2"
    ],
    "threshold": 1
   }
  },
  "spec_version": "1.0",
  "version": 1
 }
}(env) $
```

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>