### PR TITLE
Tweak settings.py for production environments

### DIFF
--- a/tuf/settings.py
+++ b/tuf/settings.py
@@ -79,18 +79,18 @@ DEFAULT_SNAPSHOT_REQUIRED_LENGTH = 2000000 #bytes
 DEFAULT_TARGETS_REQUIRED_LENGTH = 5000000 #bytes
 
 # Set a timeout value in seconds (float) for non-blocking socket operations.
-SOCKET_TIMEOUT = 2 #seconds
+SOCKET_TIMEOUT = 4 #seconds
 
 # The maximum chunk of data, in bytes, we would download in every round.
 #CHUNK_SIZE = 8192 #bytes
-CHUNK_SIZE = 100000 #bytes
+CHUNK_SIZE = 400000 #bytes
 
 # The minimum average download speed (bytes/second) that must be met to
 # avoid being considered as a slow retrieval attack.
-MIN_AVERAGE_DOWNLOAD_SPEED = 100 #bytes/second
+MIN_AVERAGE_DOWNLOAD_SPEED = 50 #bytes/second
 
 # The time (in seconds) we ignore a server with a slow initial retrieval speed.
-SLOW_START_GRACE_PERIOD = 0.01 #seconds
+SLOW_START_GRACE_PERIOD = 0.1 #seconds
 
 # Software updaters that integrate the framework are required to specify
 # the URL prefix for the mirrors that clients can contact to download updates.


### PR DESCRIPTION
**Fixes issue #**:

Close #728.

**Description of the changes being introduced by the pull request**:

This pull request tweaks the following options in `settings.py`:
(1) SOCKET_TIMEOUT
(2) MIN_AVERAGE_DOWNLOAD_SPEED
(3) CHUNK_SIZE
(4) SLOW_START_GRACE_PERIOD

current values: 2 seconds, 100 bytes, 100K, 0.01 seconds
new values: 4 seconds, 50 bytes, 400K, 0.1 seconds

Execution time...

current update execution time:
```
real	0m0.425s
user	0m0.350s
sys	0m0.063s
```

new update execution time:
```
real	0m0.797s
user	0m0.714s
sys	0m0.068s
```

Notes: Modifying SLOW_START_GRACE_PERIOD results in the greatest increase in execution time.

I tested a basic repo with only four metadata files (top-level roles) and 1 target file.

```Bash
$ repo.py --init
$ repo.py --add testfile
$ cd tufrepo
$ python -m SimpleHTTPServer 8001
```

```Bash
$ cd tufclient
$ time client.py --repo http://localhost:8001 testfile
```


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>