### PR TITLE
Add Python 3.4 & 3.5 to appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,14 @@ environment:
       PYTHON_VERSION: 3.6
       PYTHON_ARCH: 32
 
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: 3.5
+      PYTHON_ARCH: 32
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: 3.4
+      PYTHON_ARCH: 32
+
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: 2.7
       PYTHON_ARCH: 32


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request adds Python 3.4 & 3.5 to `appveyor.yml`.  These two Python version were previously excluded from appveyor due to testing failures (specifically, the failure of subprocess calls in the unit tests).  https://github.com/theupdateframework/tuf/pull/722 appears to resolve the issue with the subprocess failures, where child processes were not cleaned up properly.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>