### PR TITLE
Replace %xx escapes in urls

### DIFF
--- a/tuf/download.py
+++ b/tuf/download.py
@@ -244,10 +244,12 @@ def _download_file(url, required_length, STRICT_REQUIRED_LENGTH=True):
   securesystemslib.formats.URL_SCHEMA.check_match(url)
   securesystemslib.formats.LENGTH_SCHEMA.check_match(required_length)
 
-  # 'url.replace()' is for compatibility with Windows-based systems because
-  # they might put back-slashes in place of forward-slashes.  This converts it
-  # to the common format.
-  url = url.replace('\\', '/')
+  # 'url.replace('\\', '/')' is needed for compatibility with Windows-based
+  # systems, because they might use back-slashes in place of forward-slashes.
+  # This converts it to the common format.  unquote() replaces %xx escapes in a
+  # url with their single-character equivalent.  A back-slash may be encoded as
+  # %5c in the url, which should also be replaced with a forward slash.
+  url = six.moves.urllib.parse.unquote(url).replace('\\', '/')
   logger.info('Downloading: ' + repr(url))
 
   # This is the temporary file that we will return to contain the contents of


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request ensures that %xx escapes in urls are replaced with their single-character equivalent.  It is possible for urls to incorrectly contain backslashes (as a single `\\` character or %5c) in Windows, for example, so these should be replaced by forward slashes.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>