### PR TITLE
Add repo.py --no_release option to disable auto signing Snapshot and Timestamp

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -76,7 +76,8 @@ $ repo.py --add <foo.tar.gz> --path </path/to/my_repo>
 
 Remove a target file from the Targets metadata (or the Targets role specified
 in --role).  More than one target file or glob pattern may be specified in
---remove.
+--remove.  The Snapshot and Timestamp metadata are also updated and signed
+automatically, but this behavior can be toggled off with --no_release.
 
 ```Bash
 $ repo.py --remove <glob_pattern> ...

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -172,9 +172,13 @@ signing of Snapshot and Timestamp metadata.
 
 ## Delegation ##
 
-Delegate trust of target files from the Targets role (or the one specified
-in --role) to some other role (--delegatee).  --delegatee is trusted to
-sign for target files that match the delegated glob patterns.
+Delegate trust of target files from the Targets role (or the one specified in
+--role) to some other role (--delegatee).  --delegatee is trusted to sign for
+target files that match the delegated glob pattern(s).  The --delegate option
+does not create metadata for the delegated role, rather it updates the
+delegator's metadata to list the delegation to --delegatee.  The Snapshot and
+Timestamp metadata are also updated and signed automatically, but this behavior
+can be toggled off with --no_release.
 
 ```Bash
 $ repo.py --delegate <glob pattern> ... --delegatee <rolename> --pubkeys
@@ -193,7 +197,13 @@ $ repo.py --delegate "foo*.tgz" --delegatee foo --pubkeys tufkeystore/foo.pub
 ## Revocation ##
 
 Revoke trust of target files from a delegated role (--delegatee).  The
-"targets" role performs the revocation if --role is not specified.
+"targets" role performs the revocation if --role is not specified.  The
+--revoke option does not delete the metadata belonging to --delegatee, instead
+it removes the delegation to it from the delegator's (or --role) metadata.  The
+Snapshot and Timestamp metadata are also updated and signed automatically, but
+this behavior can be toggled off with --no_release.
+
+
 ```Bash
 $ repo.py --revoke --delegatee <rolename> [--role <rolename>
 --sign </path/to/role_privkey>]

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -54,7 +54,9 @@ $ repo.py --init --consistent
 Copy a target file to the repo and add it to the Targets metadata (or the
 Targets role specified in --role).  More than one target file, or directory,
 may be specified in --add.  The --recursive option may be toggled to also
-include files in subdirectories of a specified directory.
+include files in subdirectories of a specified directory.  The Snapshot
+and Timestamp metadata are also updated and signed automatically, but this
+behavior can be toggled off with --no_release.
 ```Bash
 $ repo.py --add <foo.tar.gz> <bar.tar.gz>
 $ repo.py --add </path/to/dir> [--recursive]
@@ -64,6 +66,8 @@ Similar to the --init case, the repository location can be chosen.
 ```Bash
 $ repo.py --add <foo.tar.gz> --path </path/to/my_repo>
 ```
+
+
 
 
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -155,7 +155,8 @@ $ repo.py --distrust --pubkeys tufkeystore/my_key_too.pub --role root
 
 ## Sign metadata ##
 Sign, with the specified key(s), the metadata of the role indicated in --role.
-The Snapshot and Timestamp role are also automatically signed, if possible.
+The Snapshot and Timestamp role are also automatically signed, if possible, but
+this behavior can be disabled with --no_release.
 ```Bash
 $ repo.py --sign </path/to/key> ... [--role <rolename>, --path </path/to/repo>]
 ```

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -209,16 +209,18 @@ def delegate(parsed_arguments):
         increment_version_number=True)
 
   # Update the required top-level roles, Snapshot and Timestamp, to make a new
-  # release.
-  snapshot_private = import_privatekey_from_file(
-      os.path.join(parsed_arguments.path, KEYSTORE_DIR, SNAPSHOT_KEY_NAME),
-      parsed_arguments.snapshot_pw)
-  timestamp_private = import_privatekey_from_file(
-      os.path.join(parsed_arguments.path, KEYSTORE_DIR,
-      TIMESTAMP_KEY_NAME), parsed_arguments.timestamp_pw)
+  # release.  Automatically making a new release can be disabled via
+  # --no_release.
+  if not parsed_arguments.no_release:
+    snapshot_private = import_privatekey_from_file(
+        os.path.join(parsed_arguments.path, KEYSTORE_DIR, SNAPSHOT_KEY_NAME),
+        parsed_arguments.snapshot_pw)
+    timestamp_private = import_privatekey_from_file(
+        os.path.join(parsed_arguments.path, KEYSTORE_DIR,
+        TIMESTAMP_KEY_NAME), parsed_arguments.timestamp_pw)
 
-  repository.snapshot.load_signing_key(snapshot_private)
-  repository.timestamp.load_signing_key(timestamp_private)
+    repository.snapshot.load_signing_key(snapshot_private)
+    repository.timestamp.load_signing_key(timestamp_private)
 
   consistent_snapshot = tuf.roledb.get_roleinfo('root',
       repository._repository_name)['consistent_snapshot']
@@ -253,16 +255,18 @@ def revoke(parsed_arguments):
     repository.targets(parsed_arguments.role).load_signing_key(role_privatekey)
 
   # Update the required top-level roles, Snapshot and Timestamp, to make a new
-  # release.
-  snapshot_private = import_privatekey_from_file(
-      os.path.join(parsed_arguments.path, KEYSTORE_DIR, SNAPSHOT_KEY_NAME),
-      parsed_arguments.snapshot_pw)
-  timestamp_private = import_privatekey_from_file(
-      os.path.join(parsed_arguments.path, KEYSTORE_DIR,
-      TIMESTAMP_KEY_NAME), parsed_arguments.timestamp_pw)
+  # release.  Automatically making a new release can be disabled via
+  # --no_release.
+  if not parsed_arguments.no_release:
+    snapshot_private = import_privatekey_from_file(
+        os.path.join(parsed_arguments.path, KEYSTORE_DIR, SNAPSHOT_KEY_NAME),
+        parsed_arguments.snapshot_pw)
+    timestamp_private = import_privatekey_from_file(
+        os.path.join(parsed_arguments.path, KEYSTORE_DIR,
+        TIMESTAMP_KEY_NAME), parsed_arguments.timestamp_pw)
 
-  repository.snapshot.load_signing_key(snapshot_private)
-  repository.timestamp.load_signing_key(timestamp_private)
+    repository.snapshot.load_signing_key(snapshot_private)
+    repository.timestamp.load_signing_key(timestamp_private)
 
   consistent_snapshot = tuf.roledb.get_roleinfo('root',
       repository._repository_name)['consistent_snapshot']
@@ -542,15 +546,17 @@ def sign_role(parsed_arguments):
 
   # Write the updated top-level roles, if any.  Also write Snapshot and
   # Timestamp to make a new release.
-  snapshot_private = import_privatekey_from_file(
-      os.path.join(parsed_arguments.path, KEYSTORE_DIR, SNAPSHOT_KEY_NAME),
-      parsed_arguments.snapshot_pw)
-  timestamp_private = import_privatekey_from_file(
-      os.path.join(parsed_arguments.path, KEYSTORE_DIR,
-      TIMESTAMP_KEY_NAME), parsed_arguments.timestamp_pw)
 
-  repository.snapshot.load_signing_key(snapshot_private)
-  repository.timestamp.load_signing_key(timestamp_private)
+  if not parsed_arguments.no_release:
+    snapshot_private = import_privatekey_from_file(
+        os.path.join(parsed_arguments.path, KEYSTORE_DIR, SNAPSHOT_KEY_NAME),
+        parsed_arguments.snapshot_pw)
+    timestamp_private = import_privatekey_from_file(
+        os.path.join(parsed_arguments.path, KEYSTORE_DIR,
+        TIMESTAMP_KEY_NAME), parsed_arguments.timestamp_pw)
+
+    repository.snapshot.load_signing_key(snapshot_private)
+    repository.timestamp.load_signing_key(timestamp_private)
 
   repository.writeall(consistent_snapshot=consistent_snapshot)
 
@@ -682,15 +688,19 @@ def add_targets(parsed_arguments):
         consistent_snapshot=consistent_snapshot, increment_version_number=True)
     return
 
-  snapshot_private = import_privatekey_from_file(
-      os.path.join(parsed_arguments.path, KEYSTORE_DIR, SNAPSHOT_KEY_NAME),
-      parsed_arguments.snapshot_pw)
-  timestamp_private = import_privatekey_from_file(
-      os.path.join(parsed_arguments.path, KEYSTORE_DIR,
-      TIMESTAMP_KEY_NAME), parsed_arguments.timestamp_pw)
+  # Update the required top-level roles, Snapshot and Timestamp, to make a new
+  # release.  Automatically making a new release can be disabled via
+  # --no_release.
+  if not parsed_arguments.no_release:
+    snapshot_private = import_privatekey_from_file(
+        os.path.join(parsed_arguments.path, KEYSTORE_DIR, SNAPSHOT_KEY_NAME),
+        parsed_arguments.snapshot_pw)
+    timestamp_private = import_privatekey_from_file(
+        os.path.join(parsed_arguments.path, KEYSTORE_DIR,
+        TIMESTAMP_KEY_NAME), parsed_arguments.timestamp_pw)
 
-  repository.snapshot.load_signing_key(snapshot_private)
-  repository.timestamp.load_signing_key(timestamp_private)
+    repository.snapshot.load_signing_key(snapshot_private)
+    repository.timestamp.load_signing_key(timestamp_private)
 
   repository.writeall(consistent_snapshot=consistent_snapshot)
 
@@ -715,20 +725,23 @@ def remove_targets(parsed_arguments):
     parsed_arguments.pw = securesystemslib.interface.get_password(
         prompt='Enter a password for the top-level role keys: ', confirm=True)
 
-  # Load the top-level, non-root, keys to make a new release.
   targets_private = import_privatekey_from_file(
       os.path.join(parsed_arguments.path, KEYSTORE_DIR, TARGETS_KEY_NAME),
       parsed_arguments.targets_pw)
-  snapshot_private = import_privatekey_from_file(
-      os.path.join(parsed_arguments.path, KEYSTORE_DIR, SNAPSHOT_KEY_NAME),
-      parsed_arguments.snapshot_pw)
-  timestamp_private = import_privatekey_from_file(
-      os.path.join(parsed_arguments.path, KEYSTORE_DIR,
-      TIMESTAMP_KEY_NAME), parsed_arguments.timestamp_pw)
-
   repository.targets.load_signing_key(targets_private)
-  repository.snapshot.load_signing_key(snapshot_private)
-  repository.timestamp.load_signing_key(timestamp_private)
+
+  # Load the top-level keys for Snapshot and Timestamp to make a new release.
+  # Automatically making a new release can be disabled via --no_release.
+  if not parsed_arguments.no_release:
+    snapshot_private = import_privatekey_from_file(
+        os.path.join(parsed_arguments.path, KEYSTORE_DIR, SNAPSHOT_KEY_NAME),
+        parsed_arguments.snapshot_pw)
+    timestamp_private = import_privatekey_from_file(
+        os.path.join(parsed_arguments.path, KEYSTORE_DIR,
+        TIMESTAMP_KEY_NAME), parsed_arguments.timestamp_pw)
+
+    repository.snapshot.load_signing_key(snapshot_private)
+    repository.timestamp.load_signing_key(timestamp_private)
 
   consistent_snapshot = tuf.roledb.get_roleinfo('root',
       repository._repository_name)['consistent_snapshot']
@@ -888,6 +901,10 @@ def parse_arguments():
   parser.add_argument('-b', '--bare', action='store_true',
       help='If initializing a repository, neither create nor set keys'
       ' for any of the top-level roles.  False, by default.')
+
+  parser.add_argument('--no_release', action='store_true',
+      help='Do not automatically sign Snapshot and Timestamp metadata.'
+      '  False, by default.')
 
   parser.add_argument('--consistent', action='store_true',
       help='Set consistent snapshots for an initialized repository.'

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -545,8 +545,8 @@ def sign_role(parsed_arguments):
       consistent_snapshot=consistent_snapshot, increment_version_number=False)
 
   # Write the updated top-level roles, if any.  Also write Snapshot and
-  # Timestamp to make a new release.
-
+  # Timestamp to make a new release.  Automatically making a new release can be
+  # disabled via --no_release.
   if not parsed_arguments.no_release:
     snapshot_private = import_privatekey_from_file(
         os.path.join(parsed_arguments.path, KEYSTORE_DIR, SNAPSHOT_KEY_NAME),


### PR DESCRIPTION
**Fixes issue #**:

The issue tracker does not have an issue for this task.

**Description of the changes being introduced by the pull request**:

This pull request implements and documents the `--no_release` command-line option for `repo.py`.  By default, and for convenience, the Snapshot and Timestamp metadata is signed automatically when needed (for example, after adding files to Targets metadata).  However, this behavior can be toggled off with the `--no_release` option.

This pull request also updates the CLI docs to document the `--no_release` option and the affected command-line options.

(1) delegate()
(2) revoke()
(3) sign_role()
(4) add_targets()
(5) remove_targets()

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>