### PR TITLE
Add deprecation warning for all_targets() and targets_of_role()

### DIFF
--- a/tuf/client/README.md
+++ b/tuf/client/README.md
@@ -47,7 +47,7 @@ can decide how to proceed rather than automatically downloading a new Root file.
 
 
 ## Example Client
-### Refresh TUF Metadata and Download Target Files
+### Refresh TUF Metadata
 ```Python
 # The client first imports the 'updater.py' module, the only module the
 # client is required to import.  The client will utilize a single class
@@ -87,47 +87,8 @@ updater = tuf.client.updater.Updater('updater', repository_mirrors)
 # copies of the top-level metadata files (i.e., Root, Targets, Snapshot,
 # Timestamp).
 updater.refresh()
-
-# The target file information of all the repository targets is determined next.
-# Since all_targets() downloads the target files of every role, all role
-# metadata is updated.
-targets = updater.all_targets()
-
-# Among these targets, determine the ones that have changed since the client's
-# last refresh().  A target is considered updated if it does not exist in
-# 'destination_directory' (current directory) or the target located there has
-# changed.
-destination_directory = '.'
-updated_targets = updater.updated_targets(targets, destination_directory)
-
-# Lastly, attempt to download each target among those that have changed.
-# The updated target files are saved locally to 'destination_directory'.
-for target in updated_targets:
-  updater.download_target(target, destination_directory)
-
-# Remove any files from the destination directory that are no longer being
-# tracked. For example, a target file from a previous snapshot that has since
-# been removed on the remote repository.
-updater.remove_obsolete_targets(destination_directory)
 ```
 
-### Download Target Files of a Role
-```Python
-# Example demonstrating an update that only downloads the targets of
-# a specific role (i.e., 'targets/django').
-
-# Refresh the metadata of the top-level roles (i.e., Root, Targets, Snapshot, Timestamp).
-updater.refresh()
-
-# Update the 'targets/django' role, and determine the target files that have changed.
-# targets_of_role() refreshes the minimum metadata needed to download the target files
-# of the specified role (e.g., R1->R4->R5, where R2 and R3 are excluded).
-targets_of_django = updater.targets_of_role('targets/django')
-updated_targets = updater.updated_targets(targets_of_django, destination_directory)
-
-for target in updated_targets:
-  updater.download_target(target, destination_directory)
-```
 
 ### Download Specific Target File
 ```Python
@@ -151,12 +112,17 @@ for target in updated_target:
   target_length = target['fileinfo']['length']
   target_hashes = target['fileinfo']['hashes']
   target_custom_data = target['fileinfo']['custom']
+
+  # Remove any files from the destination directory that are no longer being
+  # tracked. For example, a target file from a previous snapshot that has since
+  # been removed on the remote repository.
+  updater.remove_obsolete_targets(destination_directory)
 ```
 
-### A Simple Integration Example with basic_client.py
+### A Simple Integration Example with client.py
 ``` Bash
-# Assume a simple TUF repository has been setup with 'tuf.repository_tool.py'.
-$ basic_client.py --repo http://localhost:8001
+# Assume a simple TUF repository has been setup with 'repo.py'.
+$ client.py --repo http://localhost:8001
 
 # Metadata and target files are silently updated.  An exception is only raised if an error,
 # or attack, is detected.  Inspect 'tuf.log' for the outcome of the update process.

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -119,6 +119,7 @@ import shutil
 import time
 import fnmatch
 import copy
+import warnings
 
 import tuf
 import tuf.download
@@ -588,18 +589,9 @@ class Updater(object):
       The expiration time for downloaded metadata is also verified.
 
       The metadata for delegated roles are not refreshed by this method, but by
-      the target methods (e.g., all_targets(), targets_of_role(),
-      get_one_valid_targetinfo()).  The refresh() method should be called by
-      the client before any target requests.
-
-    all_targets():
-      Returns the target information for the 'targets' and delegated roles.
-      Prior to extracting the target information, this method attempts a file
-      download of all the target metadata that have changed.
-
-    targets_of_role('targets'):
-      Returns the target information for the targets of a specified role.
-      Like all_targets(), delegated metadata is updated if it has changed.
+      the method that returns targetinfo (i.e., get_one_valid_targetinfo()).
+      The refresh() method should be called by the client before any target
+      requests.
 
     get_one_valid_targetinfo(file_path):
       Returns the target information for a specific file identified by its file
@@ -2380,6 +2372,11 @@ class Updater(object):
      'tuf.formats.TARGETINFOS_SCHEMA'.
     """
 
+    warnings.warn(
+        'Support for all_targets() will be removed in a future release.'
+        '  get_one_valid_targetinfo() should be used instead.',
+        DeprecationWarning)
+
     # Load the most up-to-date targets of the 'targets' role and all
     # delegated roles.
     self._refresh_targets_metadata(refresh_all_delegated_roles=True)
@@ -2589,6 +2586,11 @@ class Updater(object):
       A list of targets, conformant to
       'tuf.formats.TARGETINFOS_SCHEMA'.
     """
+
+    warnings.warn(
+        'Support for targets_of_role() will be removed in a future release.'
+        '  get_one_valid_targetinfo() should be used instead.',
+        DeprecationWarning)
 
     # Does 'rolename' have the correct format?
     # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -88,20 +88,28 @@
   # copies of the metadata files.
   updater.refresh()
 
-  # The target file information for all the repository targets is determined.
-  targets = updater.all_targets()
+  # get_one_valid_targetinfo() updates role metadata when required.  In other
+  # words, if the client doesn't possess the metadata that lists 'LICENSE.txt',
+  # get_one_valid_targetinfo() will try to fetch / update it.
+  target = updater.get_one_valid_targetinfo('LICENSE.txt')
 
-  # Among these targets, determine the ones that have changed since the client's
-  # last refresh().  A target is considered updated if it does not exist in
+  # Determine if 'target' has changed since the client's last refresh().  A
+  # target is considered updated if it does not exist in
   # 'destination_directory' (current directory) or the target located there has
   # changed.
   destination_directory = '.'
-  updated_targets = updater.updated_targets(targets, destination_directory)
+  updated_target = updater.updated_targets([target], destination_directory)
 
-  # Lastly, attempt to download each target among those that have changed.
-  # The updated target files are saved locally to 'destination_directory'.
-  for target in updated_targets:
+  for target in updated_target:
     updater.download_target(target, destination_directory)
+    # Client code here may also reference target information (including
+    # 'custom') by directly accessing the dictionary entries of the target.
+    # The 'custom' entry is additional file information explicitly set by the
+    # remote repository.
+    target_path = target['filepath']
+    target_length = target['fileinfo']['length']
+    target_hashes = target['fileinfo']['hashes']
+    target_custom_data = target['fileinfo']['custom']
 """
 
 # Help with Python 3 compatibility, where the print statement is a function, an

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -625,12 +625,12 @@ class Updater(object):
     """
     <Purpose>
       Constructor.  Instantiating an updater object causes all the metadata
-      files for the top-level roles to be read from disk, including the key
-      and role information for the delegated targets of 'targets'.  The actual
-      metadata for delegated roles is not loaded in __init__.  The metadata
-      for these delegated roles, including nested delegated roles, are
-      loaded, updated, and saved to the 'self.metadata' store by the target
-      methods, like all_targets() and targets_of_role().
+      files for the top-level roles to be read from disk, including the key and
+      role information for the delegated targets of 'targets'.  The actual
+      metadata for delegated roles is not loaded in __init__.  The metadata for
+      these delegated roles, including nested delegated roles, are loaded,
+      updated, and saved to the 'self.metadata' store, as needed, by
+      get_one_valid_targetinfo().
 
       The initial set of metadata files are provided by the software update
       system utilizing TUF.
@@ -889,11 +889,11 @@ class Updater(object):
 
     # Clobbering this means all delegated metadata files are rendered outdated
     # and will need to be reloaded.  However, reloading the delegated metadata
-    # files is avoided here because fetching target information with methods
-    # like all_targets() and get_one_valid_targetinfo() always cause a refresh
-    # of these files.  The metadata files for delegated roles are also not
-    # loaded when the repository is first instantiated.  Due to this setup,
-    # reloading delegated roles is not required here.
+    # files is avoided here because fetching target information with
+    # get_one_valid_targetinfo() always causes a refresh of these files.  The
+    # metadata files for delegated roles are also not loaded when the
+    # repository is first instantiated.  Due to this setup, reloading delegated
+    # roles is not required here.
     tuf.keydb.create_keydb_from_root_metadata(self.metadata['current']['root'],
         self.repository_name)
 
@@ -1001,8 +1001,7 @@ class Updater(object):
       timestamp -> snapshot -> root (if necessary) -> targets.
 
       Delegated metadata is not refreshed by this method. After this method is
-      called, the use of target methods (e.g., all_targets(),
-      targets_of_role(), or get_one_valid_targetinfo()) will update delegated
+      called, the use of get_one_valid_targetinfo() will update delegated
       metadata, when required.  Calling refresh() ensures that top-level
       metadata is up-to-date, so that the target methods can refer to the
       latest available content. Thus, refresh() should always be called by the
@@ -2412,8 +2411,8 @@ class Updater(object):
       refresh() by the _update_metadata_if_changed('targets') call, not here.
       Delegated roles are not loaded when the repository is first initialized.
       They are loaded from disk, updated if they have changed, and stored to
-      the 'self.metadata' store by this method.  This method is called by the
-      target methods, like all_targets() and targets_of_role().
+      the 'self.metadata' store by this method.  This method is called by
+      get_one_valid_targetinfo().
 
     <Arguments>
       rolename:


### PR DESCRIPTION
**Fixes issue #**:

Address https://github.com/theupdateframework/tuf/pull/737#discussion_r194484613.

**Description of the changes being introduced by the pull request**:

This pull request adds a deprecation warning for `all_targets()` and `targets_of_role()` in `updater.py`.  These two methods should be replaced with `get_one_valid_targetinfo()`, which correctly validates metadata given a graph of delegations.  The two methods being replaced made more sense when the delegation tree resembled a tree.

This pull request also removes references to these two methods from docstrings.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>