### PR TITLE
Set long description content type in setup.py.  Fix issue #753

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.rst
+include README.md
 include tox.ini
 include tests/repository_data/keystore/delegation_key
 include tests/repository_data/keystore/root_key

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
   version = '0.11.1',
   description = 'A secure updater framework for Python',
   long_description = long_description,
+  long_description_content_type='text/markdown',
   author = 'https://www.updateframework.com',
   author_email = 'theupdateframework@googlegroups.com',
   url = 'https://www.updateframework.com',


### PR DESCRIPTION
**Fixes issue #**:

Close #753.

**Description of the changes being introduced by the pull request**:

This pull request sets `long_description_content_type` in setup.py, so that the README.md is correctly rendered on PyPI.  It also specifies the correct README in `MANIFEST.in`, although this is not required to fix issue #753.   See https://packaging.python.org/specifications/core-metadata/#description-content-type-optional.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>