### PR TITLE
Use the keyids and threshold set by delegating roles to verify delegated metadata

### DIFF
--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1560,7 +1560,8 @@ class Updater(object):
           except KeyError:
             logger.info(metadata_role + ' not available locally.')
 
-        self._verify_uncompressed_metadata_file(file_object, metadata_role)
+        self._verify_uncompressed_metadata_file(file_object, metadata_role,
+            keyids=keyids, threshold=threshold)
 
       except Exception as exception:
         # Remember the error from this mirror, and "reset" the target file.
@@ -1774,7 +1775,7 @@ class Updater(object):
 
     metadata_file_object = \
       self._get_metadata_file(metadata_role, remote_filename,
-        upperbound_filelength, version)
+        upperbound_filelength, version, keyids=keyids, threshold=threshold)
 
     # The metadata has been verified. Move the metadata file into place.
     # First, move the 'current' metadata file to the 'previous' directory

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1386,7 +1386,7 @@ class Updater(object):
         An integer value that sets the role's threshold value, or the miminum
         number of signatures needed for metadata to be considered fully signed.
         Use the given 'threshold' to determine if 'metadata_file_object' is
-        properly signed, as set by root or some delegating role.
+        properly signed, as set by root or a delegating role.
 
     <Exceptions>
       securesystemslib.exceptions.FormatError:
@@ -1468,14 +1468,14 @@ class Updater(object):
         downloaded.  'expected_version' is an integer.
 
       keyids:
-        The trusted keyids of 'metadata_role,' as set by root or some
+        The trusted keyids of 'metadata_role,' as set by root or a
         delegating role.
 
       threshold:
         An integer value that sets the role's threshold value, or the miminum
         number of signatures needed for metadata to be considered fully signed.
         Use the given 'threshold' to determine if 'metadata_role' is
-        properly signed, as set by root or some delegating role.
+        properly signed, as set by root or a delegating role.
 
     <Exceptions>
       tuf.exceptions.NoWorkingMirrorError:
@@ -1725,7 +1725,7 @@ class Updater(object):
         An integer value that sets the role's threshold value, or the miminum
         number of signatures needed for metadata to be considered fully signed.
         Use the given 'threshold' to determine if 'metadata_role' is
-        properly signed, as set by root or some delegating role.
+        properly signed, as set by root or a delegating role.
 
     <Exceptions>
       tuf.exceptions.NoWorkingMirrorError:
@@ -1870,7 +1870,7 @@ class Updater(object):
         An integer value that sets the role's threshold value, or the miminum
         number of signatures needed for metadata to be considered fully signed.
         Use the given 'threshold' to determine if 'metadata_role' is
-        properly signed, as set by root or some delegating role.
+        properly signed, as set by root or a delegating role.
 
     <Exceptions>
       tuf.exceptions.NoWorkingMirrorError:
@@ -2482,7 +2482,7 @@ class Updater(object):
         An integer value that sets the role's threshold value, or the miminum
         number of signatures needed for metadata to be considered fully signed.
         Use the given 'threshold' to determine if 'rolename' is properly
-        signed, as set by root or some delegating role.
+        signed, as set by root or a delegating role.
 
     <Exceptions>
       tuf.exceptions.RepositoryError:
@@ -2823,7 +2823,7 @@ class Updater(object):
           if child_role['terminating'] and child_role_name is not None:
             logger.debug('Adding child role ' + repr(child_role_name))
             logger.debug('Not backtracking to other roles.')
-            role_names = []
+            roles_to_update = []
             child_roles_to_visit.append({child_role_name:
                 {'keyids': child_role['keyids'], 'threshold': child_role['threshold']}})
             break
@@ -2837,8 +2837,8 @@ class Updater(object):
                 {'keyids': child_role['keyids'], 'threshold': child_role['threshold']}})
 
         # Push 'child_roles_to_visit' in reverse order of appearance onto
-        # 'role_names'.  Roles are popped from the end of the 'role_names'
-        # list.
+        # 'role_to_update'.  Roles are popped from the end of the
+        # 'role_to_update' list.
         child_roles_to_visit.reverse()
         roles_to_update.extend(child_roles_to_visit)
 

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -2784,7 +2784,9 @@ class Updater(object):
 
       # Pop the role name from the top of the stack.
       role = roles_to_update.pop(-1)
-      rolename = role.keys()[0]
+
+      # Use list() for Python 3+2 compatibility.
+      rolename = list(role.keys())[0]
 
       # Skip any visited current role to prevent cycles.
       if rolename in visited_role_names:


### PR DESCRIPTION
**Fixes issue #**:

Addresses https://github.com/theupdateframework/tuf/issues/660, https://github.com/theupdateframework/tuf/pull/590, https://github.com/theupdateframework/tuf/issues/589, and https://github.com/theupdateframework/tuf/issues/658.

**Description of the changes being introduced by the pull request**:

This pull request verifies the signature(s) in targets metadata by using the `keyids` and `threshold` set by the delegating role (or in the case of the top-level targets role, the `keyids` and `threshold` specified in the root metadata file).

Note: The unit tests in https://github.com/theupdateframework/tuf/pull/590 (WIP) should be merged with this fix to verify the expected behavior.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

Signed-off-by: Vladimir Diaz \<vladimir.v.diaz@gmail.com>