### PR TITLE
Remove some unnecessary try-reraise constructions (pylint passing)

### DIFF
--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -296,11 +296,7 @@ class Project(Targets):
     if len(self.keys) > 0:
       raise securesystemslib.exceptions.Error("This project already contains a key.")
 
-    try:
-      super(Project, self).add_verification_key(key, expires)
-
-    except securesystemslib.exceptions.FormatError:
-      raise
+    super(Project, self).add_verification_key(key, expires)
 
 
 
@@ -791,12 +787,8 @@ def load_project(project_directory, prefix='', new_targets_location=None,
   # Load the cfg file and the project.
   config_filename = os.path.join(project_directory, PROJECT_FILENAME)
 
-  try:
-    project_configuration = securesystemslib.util.load_json_file(config_filename)
-    tuf.formats.PROJECT_CFG_SCHEMA.check_match(project_configuration)
-
-  except (OSError, IOError, securesystemslib.exceptions.FormatError):
-    raise
+  project_configuration = securesystemslib.util.load_json_file(config_filename)
+  tuf.formats.PROJECT_CFG_SCHEMA.check_match(project_configuration)
 
   targets_directory = os.path.join(project_directory,
       project_configuration['targets_location'])
@@ -906,11 +898,7 @@ def load_project(project_directory, prefix='', new_targets_location=None,
         continue
 
       signable = None
-      try:
-        signable = securesystemslib.util.load_json_file(metadata_path)
-
-      except (ValueError, IOError, securesystemslib.exceptions.Error):
-        raise
+      signable = securesystemslib.util.load_json_file(metadata_path)
 
       # Strip the prefix from the local working copy, it will be added again
       # when the targets metadata is written to disk.

--- a/tuf/download.py
+++ b/tuf/download.py
@@ -396,17 +396,12 @@ def _download_fixed_amount_of_data(connection, temp_file, required_length):
         break
 
   except:
-    raise
-
-  else:
-    # This else block returns and skips closing the connection in the finally
-    # block, so close the connection here.
-    connection.close()
-    return number_of_bytes_received, average_download_speed
-
-  finally:
     # Whatever happens, make sure that we always close the connection.
     connection.close()
+    raise
+
+  connection.close()
+  return number_of_bytes_received, average_download_speed
 
 
 

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -952,14 +952,10 @@ def make_versioninfo(version_number):
 
   # Raise 'securesystemslib.exceptions.FormatError' if 'versioninfo' is
   # improperly formatted.
-  try:
-    securesystemslib.formats.VERSIONINFO_SCHEMA.check_match(versioninfo)
+  securesystemslib.formats.VERSIONINFO_SCHEMA.check_match(versioninfo)
 
-  except:
-    raise
+  return versioninfo
 
-  else:
-    return versioninfo
 
 
 

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -569,11 +569,10 @@ def role_exists(rolename, repository_name='default'):
 
   # Raise securesystemslib.exceptions.FormatError,
   # securesystemslib.exceptions.InvalidNameError if the arguments are invalid.
+  # We do not intercept securesystemslib.exceptions.FormatError
+  # or securesystemslib.exceptions.InvalidNameError exceptions.
   try:
     _check_rolename(rolename, repository_name)
-
-  except (securesystemslib.exceptions.FormatError, securesystemslib.exceptions.InvalidNameError):
-    raise
 
   except tuf.exceptions.UnknownRoleError:
     return False

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -185,18 +185,15 @@ def get_signature_status(signable, role=None, repository_name='default',
     if valid_sig:
       if role is not None:
 
-        try:
-          # Is this an unauthorized key? (a keyid associated with 'role')
-          if keyids is None:
-            keyids = tuf.roledb.get_role_keyids(role, repository_name)
+        # Is this an unauthorized key? (a keyid associated with 'role')
+        # Note that if the role is not known, tuf.exceptions.UnknownRoleError
+        # is raised here.
+        if keyids is None:
+          keyids = tuf.roledb.get_role_keyids(role, repository_name)
 
-          if keyid not in keyids:
-            untrusted_sigs.append(keyid)
-            continue
-
-        # Unknown role, re-raise exception.
-        except tuf.exceptions.UnknownRoleError:
-          raise
+        if keyid not in keyids:
+          untrusted_sigs.append(keyid)
+          continue
 
       # This is an unset role, thus an unknown signature.
       else:
@@ -215,12 +212,10 @@ def get_signature_status(signable, role=None, repository_name='default',
   # role.
   if role is not None:
     if threshold is None:
-      try:
-        threshold = \
-          tuf.roledb.get_role_threshold(role, repository_name=repository_name)
-
-      except tuf.exceptions.UnknownRoleError:
-        raise
+      # Note that if the role is not known, tuf.exceptions.UnknownRoleError is
+      # raised here.
+      threshold = tuf.roledb.get_role_threshold(
+          role, repository_name=repository_name)
 
     else:
       logger.debug('Not using roledb.py\'s threshold for ' + repr(role))


### PR DESCRIPTION
These changes simplify logic, removing some try/except structures that were unnecessary and potentially confusing, and get us back to passing pylint.

pylint 2.0.0 adds try-except-raise tests, to catch immediate
re-raising after catching an exception, outside of some special
cases. See this GitHub comment for more info:
https://github.com/theupdateframework/tuf/pull/770#issuecomment-412993992

**Fixes issue #**: No issue previously listed for this

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


