### PR TITLE
Use PEP 508 to make dev-requirements compatible with Python 2 & 3

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,8 @@
 #
 -e .
 asn1crypto==0.24.0
-astroid==2.0.4
+astroid==1.6.5 ; python_version < "3.0"
+astroid==2.0.4 ; python_version >= "3.0"
 backports.functools-lru-cache==1.5
 bandit==1.4.0
 cffi==1.11.5
@@ -26,7 +27,8 @@ pbr==4.2.0
 pluggy==0.7.1
 py==1.5.4
 pycparser==2.18
-pylint==2.1.1
+pylint==2.1.1 ; python_version >= "3.0"
+pylint==1.9.3 ; python_version < "3.0"
 pynacl==1.2.1
 pyyaml==3.13
 securesystemslib[crypto,pynacl]==0.11.2


### PR DESCRIPTION
Use PEP 508 to make dev-requirements compatible with Python 2 & 3
by specifying the appropriate versions of pylint and astroid
for Python2. pylint and astroid dropped Python2 compatibility
for their latest major revisions, so dev-requirements now pins
the latest compatible revision for Python2 if installing in a
Python2 environment.

**Fixes issue #**: No issue previously identified

