### PR TITLE
Have repository_tool.get_filepaths_in_directory use absolute paths

### DIFF
--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -521,7 +521,7 @@ class Repository(object):
     for dirpath, dirnames, filenames in os.walk(files_directory,
                                                 followlinks=followlinks):
       for filename in filenames:
-        full_target_path = os.path.join(dirpath, filename)
+        full_target_path = os.path.join(os.path.abspath(dirpath), filename)
         targets.append(full_target_path)
 
       # Prune the subdirectories to walk right now if we do not wish to


### PR DESCRIPTION
Two changes:
- Have repository_tool.get_filepaths_in_directory use absolute paths as its docstring says that it does.
- Have the test for that function correctly test for such (and also test functionality a bit more).

I'm not sure if this changed through some accident along the way, but in any case, before this PR, the docstring for `repository_tool.get_filepaths_in_directory()` said that it yielded a list of absolute paths, but it did not. Now it does.

**Fixes issue #**: No prior issue identified

**Please verify and check that the pull request fulfills the following
requirements**:
- [ N/A ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ N/A ] Tests have been added for the bug fix or new feature
- [ N/A ] Docs have been added for the bug fix or new feature