### PR TITLE
Fix TUTORIAL.md and add regression testing for future issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ init:
 
 install:
   - set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
-  - python -m pip install -U pip
+  - python -m pip install -U pip setuptools
   - pip install -e .
   - pip install securesystemslib[crypto,pynacl]
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ install:
   - python -m pip install -U pip setuptools
   - pip install -e .
   - pip install securesystemslib[crypto,pynacl]
+  - if %PYTHON_VERSION%==2.7 pip install mock
 
 build: false
 

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -7,3 +7,4 @@ bandit
 # Pin to versions supported by `coveralls` (see .travis.yml)
 # https://github.com/coveralls-clients/coveralls-python/releases/tag/1.8.1
 coverage<5.0
+mock; python_version < "3.3"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -40,6 +40,7 @@ iso8601==0.1.12
 isort==4.3.21
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
+mock==3.0.5; python_version < "3.3"
 more-itertools==7.2.0 ; python_version >= "3.0" # via zipp
 more-itertools==5.0.0 ; python_version < "3.0" # pyup: ignore
 packaging==19.2 # via tox

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -115,7 +115,8 @@ The following four key files should now exist:
 
 If a filepath is not given, the KEYID of the generated key is used as the
 filename.  The key files are written to the current working directory.
-```
+```python
+# Continuing from the previous section . . .
 >>> generate_and_write_rsa_keypair()
 Enter a password for the encrypted RSA key (/path/to/b5b8de8aeda674bce948fbe82cab07e309d6775fc0ec299199d16746dc2bd54c):
 Confirm:
@@ -334,6 +335,11 @@ repository, the `add_targets()` method of a Targets role can be called to add
 the target filepaths to metadata.
 
 ```python
+# Continuing from the previous section . . .
+
+# NOTE: If you exited the Python interactive interpreter above you need to
+# re-import the repository_tool-functions and re-load the repository and
+# signing keys.
 >>> from tuf.repository_tool import *
 
 # The 'os' module is needed to gather file attributes, which will be included
@@ -387,8 +393,10 @@ metadata.  `snapshot.json` keys must be loaded and its metadata signed because
 `timestamp.json` role must also be signed.
 
 ```Python
-# The private key of the updated targets metadata must be loaded before it can
-# be signed and written (Note the load_repository() call above).
+# Continuing from the previous section . . .
+
+# The private key of the updated targets metadata must be re-loaded before it
+# can be signed and written (Note the load_repository() call above).
 >>> private_targets_key = import_rsa_privatekey_from_file('targets_key')
 Enter a password for the encrypted RSA key (/path/to/targets_key):
 
@@ -600,7 +608,10 @@ delegate_hashed_bins(list_of_targets, keys_of_hashed_bins, number_of_bins)
 We next provide a complete example of retrieving target paths to add to hashed
 bins, performing the hashed bin delegations, signing them, and delegating paths
 to some role.
+
 ```Python
+# Continuing from the previous section . . .
+
 # Get a list of target paths for the hashed bins.
 >>> targets = \
   repository.get_filepaths_in_directory('repository/targets/myproject', recursive_walk=True)

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -521,7 +521,7 @@ Enter a password for the encrypted RSA key (/path/to/unclaimed_key):
 <!--
 TODO: Integrate section with an updated delegation tutorial.
 As it is now, it just messes up the state of the repository, i.e. marks
-"unclaimed" as dirty, although there is nothing newto write.
+"unclaimed" as dirty, although there is nothing new to write.
 
 #### Revoke Delegated Role ####
 ```python

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -647,11 +647,24 @@ to some role.
 >>> targets = repository.get_filepaths_in_directory(
 ...     'repository/targets/myproject', recursive_walk=True)
 
+# Delegate trust to 32 hashed bin roles. Each role is responsible for the set
+# of target files, determined by the path hash prefix. TUF evenly distributes
+# hexadecimal ranges over the chosen number of bins (see output).
+# To initialize the bins we use one key, which TUF warns us about (see output).
+# However, we can assign separate keys to each bin, with the method used in
+# previous sections, accessing a bin by its hash prefix range name, e.g.:
+# "repository.targets('00-07').add_verification_key('public_00-07_key')".
 >>> repository.targets('unclaimed').delegate_hashed_bins(
 ...     targets, [public_unclaimed_key], 32)
+Creating hashed bin delegations.
+1 total targets.
+32 hashed bins.
+256 total hash prefixes.
+Each bin ranges over 8 hash prefixes.
+Adding a verification key that has already been used. [repeated 32x]
 
-# delegated_hashed_bins() only assigns the public key(s) of the hashed bins, so
-# the private keys may be manually loaded as follows:
+# The hashed bin roles can also be accessed by iterating the "delegations"
+# property of the delegating role, which we do here to load the signing key.
 >>> for delegation in repository.targets('unclaimed').delegations:
 ...   delegation.load_signing_key(private_unclaimed_key)
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -581,14 +581,24 @@ target file names specified in metadata do not contain digests in their names.)
 The repository maintainer is responsible for the duration of multiple versions
 of metadata and target files available on a repository.  Generating consistent
 metadata and target files on the repository is enabled by setting the
-`consistent_snapshot` argument of writeall() or write(). Note that changing the
-consistent_snapshot setting involves writing a new version of root.
+`consistent_snapshot` argument of `writeall()` or `write()` . Note that
+changing the consistent_snapshot setting involves writing a new version of
+root.
+
+<!--
+TODO: Integrate section with an updated consistent snapshot tutorial.
+As it is now, it just messes up the state of the repository, i.e. marks
+"root" as dirty, although all other metadata needs to be re-written with
+<VERSION> prefix and target files need to be re-written with <HASH> prefix in
+their filenames.
+
 ```Python
     # ----- Tutorial Section: Consistent Snapshots
 >>> repository.root.load_signing_key(private_root_key)
 >>> repository.root.load_signing_key(private_root_key2)
 >>> repository.writeall(consistent_snapshot=True)
 ```
+-->
 
 ## Delegate to Hashed Bins ##
 Why use hashed bin delegations?

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -227,12 +227,6 @@ top-level roles, including itself.
 >>> repository.root.load_signing_key(private_root_key)
 >>> repository.root.load_signing_key(private_root_key2)
 
-# Print the roles that are "dirty" (i.e., that have changed and have not yet
-# been written to disk.  Root should be dirty because verification keys were
-# added, signing keys loaded, and a threshold added)
->>> repository.dirty_roles()
-Dirty roles: ['root']
-
 # repository.status() shows missing verification and signing keys for the
 # top-level roles, and whether signatures can be created (also see #955).
 # This output shows that so far only the "root" role meets the key threshold and
@@ -297,8 +291,8 @@ Enter a password for the encrypted RSA key (/path/to/timestamp_key):
 # week), timestamp(1 day).
 >>> repository.timestamp.expiration = datetime.datetime(2080, 10, 28, 12, 8)
 
->>> repository.dirty_roles()
-Dirty roles: ['snapshot', 'targets', 'timestamp']
+# Mark roles for metadata update (see #964, #958)
+>>> repository.mark_dirty(['root', 'snapshot', 'targets', 'timestamp'])
 
 # Write all metadata to "repository/metadata.staged/"
 >>> repository.writeall()
@@ -414,8 +408,8 @@ Enter a password for the encrypted RSA key (/path/to/snapshot_key):
 Enter a password for the encrypted RSA key (/path/to/timestamp_key):
 >>> repository.timestamp.load_signing_key(private_timestamp_key)
 
->>> repository.dirty_roles()
-Dirty roles: ['root', 'snapshot', 'targets', 'timestamp']
+# Mark roles for metadata update (see #964, #958)
+>>> repository.mark_dirty(['snapshot', 'targets', 'timestamp'])
 
 # Generate new versions of the modified top-level metadata (targets, snapshot,
 # and timestamp).
@@ -433,11 +427,10 @@ new metadata to disk.
 # Remove a target file listed in the "targets" metadata.  The target file is
 # not actually deleted from the file system.
 >>> repository.targets.remove_target('myproject/file4.txt')
->>> repository.dirty_roles()
-Dirty roles: ['targets']
 
-# Mark roles as dirty that have not changed but need to be updated (see #958)
->>> repository.mark_dirty(['snapshot', 'timestamp'])
+# Mark roles for metadata update (see #964, #958)
+>>> repository.mark_dirty(['snapshot', 'targets', 'timestamp'])
+
 >>> repository.writeall()
 ```
 
@@ -519,18 +512,16 @@ Enter a password for the encrypted RSA key (/path/to/unclaimed_key):
 
 >>> repository.targets("unclaimed").load_signing_key(private_unclaimed_key)
 
->>> repository.dirty_roles()
-Dirty roles: ['targets', 'unclaimed']
+# Mark roles for metadata update (see #964, #958)
+>>> repository.mark_dirty(['snapshot', 'targets','timestamp', 'unclaimed'])
 
-# Mark roles as dirty that have not changed but need to be updated (see #958)
->>> repository.mark_dirty(["snapshot", "timestamp"])
 >>> repository.writeall()
 ```
 
 <!--
 TODO: Integrate section with an updated delegation tutorial.
 As it is now, it just messes up the state of the repository, i.e. marks
-"unclaimed" as dirty, although there is nothing new to write.
+"unclaimed" as dirty, although there is nothing newto write.
 
 #### Revoke Delegated Role ####
 ```python
@@ -668,12 +659,13 @@ Adding a verification key that has already been used. [repeated 32x]
 >>> for delegation in repository.targets('unclaimed').delegations:
 ...   delegation.load_signing_key(private_unclaimed_key)
 
+# Mark roles for metadata update (see #964, #958)
+>>> repository.mark_dirty(['00-07', '08-0f', '10-17', '18-1f', '20-27', '28-2f',
+...   '30-37', '38-3f', '40-47', '48-4f', '50-57', '58-5f', '60-67', '68-6f',
+...   '70-77', '78-7f', '80-87', '88-8f', '90-7', '98-9f', 'a0-a7', 'a8-af',
+...   'b0-b7', 'b8-bf', 'c0-c7', 'c8-cf', 'd0-d7', 'd8-df', 'e0-e7', 'e8-ef',
+...   'f0-f7', 'f8-ff', 'snapshot', 'timestamp', 'unclaimed'])
 
->>> repository.dirty_roles()
-Dirty roles: ['00-07', '08-0f', '10-17', '18-1f', '20-27', '28-2f', '30-37', '38-3f', '40-47', '48-4f', '50-57', '58-5f', '60-67', '68-6f', '70-77', '78-7f', '80-87', '88-8f', '90-7', '98-9f', 'a0-a7', 'a8-af', 'b0-b7', 'b8-bf', 'c0-c7', 'c8-cf', 'd0-d7', 'd8-df', 'e0-e7', 'e8-ef', 'f0-f7', 'f8-ff', 'unclaimed']
-
-# Mark roles as dirty that have not changed but need to be updated (see #958)
->>> repository.mark_dirty(["snapshot", "timestamp"])
 >>> repository.writeall()
 
 ```

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -617,8 +617,6 @@ to some role.
 >>> for delegation in repository.targets('unclaimed').delegations:
 ...   delegation.load_signing_key(private_unclaimed_key)
 
-# Delegated roles can be restricted to particular paths with add_restricted_paths().
->>> repository.targets('unclaimed').add_restricted_paths('repository/targets/myproject/*', 'django')
 ```
 
 ## How to Perform an Update ##

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -433,7 +433,7 @@ new metadata to disk.
 
 # Remove a target file listed in the "targets" metadata.  The target file is
 # not actually deleted from the file system.
->>> repository.targets.remove_target("repository/targets/file3.txt")
+>>> repository.targets.remove_target('file3.txt')
 
 # repository.writeall() writes any required metadata files (e.g., if
 # targets.json is updated, snapshot.json and timestamp.json are also written

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -487,10 +487,14 @@ default.
 
 In the next sub-section, the `unclaimed` role is delegated from the top-level
 `targets` role.  The `targets` role specifies the delegated role's public keys,
-the paths it is trusted to provide, and its role name. Furthermore, the example
-below demonstrates a nested delegation from `unclaimed` to `django`.  Once a
+the paths it is trusted to provide, and its role name. <!--
+TODO: Uncomment together with "Revoke Delegated Role" section below
+
+Furthermore, the example
+below demonstrates a nested delegation from `unclaimed` to `django`. Once a
 role has delegated trust to another, the delegated role may independently add
 targets and generate signed metadata.
+-->
 
 ```python
 # Continuing from the previous section . . .
@@ -501,6 +505,7 @@ targets and generate signed metadata.
 
 # Make a delegation (delegate trust of 'myproject/*.txt' files) from "targets"
 # to "unclaimed", where "unclaimed" initially contains zero targets.
+# NOTE: Please ignore the warning about the path pattern's location (see #963)
 >>> repository.targets.delegate('unclaimed', [public_unclaimed_key], ['myproject/*.txt'])
 
 # Thereafter, we can access the delegated role by its name to e.g. add target

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -445,23 +445,35 @@ new metadata to disk.
 >>> repository.writeall()
 ```
 
-#### Dump Metadata and Append Signature ####
+#### Excursion: Dump Metadata and Append Signature ####
 
 The following two functions are intended for those that wish to independently
 sign metadata.  Repository maintainers can dump the portion of metadata that is
 normally signed, sign it with an external signing tool, and append the
 signature to already existing metadata.
 
-First, the signable portion of metadata can be generated
-as follows:
+First, the signable portion of metadata can be generated as follows:
 
 ```Python
->>> signable_content = dump_signable_metadata('targets.json')
+>>> signable_content = dump_signable_metadata('repository/metadata.staged/timestamp.json')
 ```
 
-The externally generated signature can then be appended to metadata:
+Then, use a tool like securesystemslib to create a signature over the signable
+portion. *Note, to make the signing key count towards the role's signature
+threshold, it needs to be added to `root.json`, e.g. via
+`repository.timestamp.add_verification_key(key)` (not shown in below snippet).*
+```python
+>>> from securesystemslib.formats import encode_canonical
+>>> from securesystemslib.keys import create_signature
+>>> private_ed25519_key = import_ed25519_privatekey_from_file('ed25519_key')
+Enter a password for the encrypted Ed25519 key (/path/to/ed25519_key):
+>>> signature = create_signature(
+...     private_ed25519_key, encode_canonical(signable_content).encode())
+```
+
+Finally, append the signature to the metadata
 ```Python
->>> append_signature(signature, 'targets.json')
+>>> append_signature(signature, 'repository/metadata.staged/timestamp.json')
 ```
 
 Note that the format of the signature is the format expected in metadata, which

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -571,8 +571,12 @@ target file names specified in metadata do not contain digests in their names.)
 The repository maintainer is responsible for the duration of multiple versions
 of metadata and target files available on a repository.  Generating consistent
 metadata and target files on the repository is enabled by setting the
-`consistent_snapshot` argument of writeall() or write():
+`consistent_snapshot` argument of writeall() or write(). Note that changing the
+consistent_snapshot setting involves writing a new version of root.
 ```Python
+    # ----- Tutorial Section: Consistent Snapshots
+>>> repository.root.load_signing_key(private_root_key)
+>>> repository.root.load_signing_key(private_root_key2)
 >>> repository.writeall(consistent_snapshot=True)
 ```
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -201,7 +201,7 @@ top-level roles, including itself.
 # Metadata files are created when repository.writeall() or repository.write()
 # are called.  The repository directory is created if it does not exist.  You
 # may see log messages indicating any directories created.
->>> repository = create_new_repository("repository/")
+>>> repository = create_new_repository("repository")
 
 # The Repository instance, 'repository', initially contains top-level Metadata
 # objects.  Add one of the public keys, created in the previous section, to the
@@ -353,7 +353,7 @@ the target filepaths to metadata.
 # Load the repository created in the previous section.  This repository so far
 # contains metadata for the top-level roles, but no target paths are yet listed
 # in targets metadata.
->>> repository = load_repository("repository/")
+>>> repository = load_repository('repository')
 
 # get_filepaths_in_directory() returns a list of file paths in a directory.  It can also return
 # files in sub-directories if 'recursive_walk' is True.
@@ -488,11 +488,11 @@ targets and generate signed metadata.
 >>> generate_and_write_rsa_keypair('unclaimed_key', bits=2048, password='password')
 >>> public_unclaimed_key = import_rsa_publickey_from_file('unclaimed_key.pub')
 
-# Make a delegation (delegate trust of '/foo*.tgz' files) from "targets" to
+# Make a delegation (delegate trust of 'foo*.tgz' files) from "targets" to
 # "unclaimed", where 'unclaimed' initially contains zero targets.
 # delegate(rolename, list_of_public_keys, paths, threshold=1,
 #     list_of_targets=None, path_hash_prefixes=None)
->>> repository.targets.delegate("unclaimed", [public_unclaimed_key], ['/foo*.tgz'])
+>>> repository.targets.delegate('unclaimed', [public_unclaimed_key], ['foo*.tgz'])
 
 # Thereafter, we can access a delegated role this way:
 >>> repository.targets("<delegated rolename")
@@ -524,7 +524,7 @@ Dirty roles: ['timestamp', 'snapshot', 'targets', 'unclaimed']
 # Continuing from the previous section . . .
 
 # Create a delegated role that will be revoked in the next step...
->>> repository.targets('unclaimed').delegate("django", [public_unclaimed_key], ['/bar*.tgz'])
+>>> repository.targets('unclaimed').delegate("django", [public_unclaimed_key], ['bar*.tgz'])
 
 # Revoke "django" and write the metadata of all remaining roles.
 >>> repository.targets('unclaimed').revoke("django")

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -233,9 +233,9 @@ top-level roles, including itself.
 >>> repository.dirty_roles()
 Dirty roles: ['root']
 
-# `repository.status()` shows missing verification and signing keys for the
+# repository.status() shows missing verification and signing keys for the
 # top-level roles, and whether signatures can be created (also see #955).
-# Thi output shows that so far only the "root" role meets the key threshold and
+# This output shows that so far only the "root" role meets the key threshold and
 # can successfully sign its metadata.
 >>> repository.status()
 'targets' role contains 0 / 1 public keys.
@@ -244,7 +244,7 @@ Dirty roles: ['root']
 'root' role contains 2 / 2 signatures.
 'targets' role contains 0 / 1 signatures.
 
-# In the next section, update the other top-level roles and create a repository
+# In the next section we update the other top-level roles and create a repository
 # with valid metadata.
 ```
 
@@ -379,7 +379,7 @@ the target filepaths to metadata.
 
 # Individual target files may also be added to roles, including custom data
 # about the target.  In the example below, file permissions of the target
-# (octal number specifying file access for owner, group, others (e.g., 0755) is
+# (octal number specifying file access for owner, group, others e.g., 0755) is
 # added alongside the default fileinfo.  All target objects in metadata include
 # the target's filepath, hash, and length.
 >>> target4_filepath = os.path.abspath("repository/targets/myproject/file4.txt")
@@ -710,4 +710,3 @@ tufrepo  tuftargets
 tuftargets/:
 file1.txt
 ```
-

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -356,15 +356,15 @@ the target filepaths to metadata.
 # in targets metadata.
 >>> repository = load_repository('repository')
 
-# get_filepaths_in_directory() returns a list of file paths in a directory.  It can also return
-# files in sub-directories if 'recursive_walk' is True.
->>> list_of_targets = repository.get_filepaths_in_directory("repository/targets/",
-                                                        recursive_walk=False, followlinks=True)
+# get_filepaths_in_directory() returns a list of file paths in a directory. It
+# can also return files in sub-directories if 'recursive_walk' is True.
+>>> list_of_targets = repository.get_filepaths_in_directory(
+...     "repository/targets/", recursive_walk=False, followlinks=True)
 
 # Note: Since we set the 'recursive_walk' argument to false, the 'myproject'
 # sub-directory is excluded from 'list_of_targets'.
 >>> list_of_targets
-['repository/targets/file2.txt', 'repository/targets/file1.txt', 'repository/targets/file3.txt']
+['/path/to/repository/targets/file2.txt', '/path/to/repository/targets/file1.txt', '/path/to/repository/targets/file3.txt']
 
 # Add the list of target paths to the metadata of the top-level Targets role.
 # Any target file paths that might already exist are NOT replaced, and
@@ -385,7 +385,7 @@ the target filepaths to metadata.
 # (octal number specifying file access for owner, group, others (e.g., 0755) is
 # added alongside the default fileinfo.  All target objects in metadata include
 # the target's filepath, hash, and length.
->>> target4_filepath = "repository/targets/myproject/file4.txt"
+>>> target4_filepath = os.path.abspath("repository/targets/myproject/file4.txt")
 >>> octal_file_permissions = oct(os.stat(target4_filepath).st_mode)[4:]
 >>> custom_file_permissions = {'file_permissions': octal_file_permissions}
 >>> repository.targets.add_target(target4_filepath, custom_file_permissions)

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -233,11 +233,16 @@ top-level roles, including itself.
 >>> repository.dirty_roles()
 Dirty roles: ['root']
 
-# The status() function also prints the next role that needs editing.  In this
-# example, the 'targets' role needs editing next, since the root role is now
-# fully valid.
+# `repository.status()` shows missing verification and signing keys for the
+# top-level roles, and whether signatures can be created (also see #955).
+# Thi output shows that so far only the "root" role meets the key threshold and
+# can successfully sign its metadata.
 >>> repository.status()
 'targets' role contains 0 / 1 public keys.
+'snapshot' role contains 0 / 1 public keys.
+'timestamp' role contains 0 / 1 public keys.
+'root' role contains 2 / 2 signatures.
+'targets' role contains 0 / 1 signatures.
 
 # In the next section, update the other top-level roles and create a repository
 # with valid metadata.

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -675,7 +675,7 @@ saved on the client side.
 
 ```python
 >>> from tuf.repository_tool import *
->>> create_tuf_client_directory("repository/", "client/")
+>>> create_tuf_client_directory("repository/", "client/tufrepo/")
 ```
 
 `create_tuf_client_directory()` moves metadata from `repository/metadata` to
@@ -695,21 +695,19 @@ $ cd "repository/"; python3 -m http.server 8001
 
 We next retrieve targets from the TUF repository and save them to `client/`.
 The `client.py` script is available to download metadata and files from a
-specified repository.  In a different command-line prompt . . .
+specified repository.  In a different command-line prompt, where `tuf` is
+installed . . .
 ```Bash
 $ cd "client/"
 $ ls
-metadata/
+tufrepo/
 
-# Note: You should activate another "tufenv" virtualenv if using a new
-# windows/tab, otherwise the local Python installation would be incorrectly
-# used.
 $ client.py --repo http://localhost:8001 file1.txt
-$ ls . targets/
+$ ls . tuftargets/
 .:
-metadata  targets
+tufrepo  tuftargets
 
-targets/:
+tuftargets/:
 file1.txt
 ```
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -104,18 +104,16 @@ text without prepended symbols is the output of a command.
 
 # Generate and write the first of two root keys for the TUF repository.  The
 # following function creates an RSA key pair, where the private key is saved to
-# "keystore/root_key" and the public key to "keystore/root_key.pub" (both saved
-# to the current working directory).  The 'keystore' directory can be manually
-# created in the current directory to store the keys created in these examples.
-# If 'keystore' directory does not exist, it will be created.
->>> generate_and_write_rsa_keypair("keystore/root_key", bits=2048, password="password")
+# "root_key" and the public key to "root_key.pub" (both saved to the current
+# working directory).
+>>> generate_and_write_rsa_keypair("root_key", bits=2048, password="password")
 
 # If the key length is unspecified, it defaults to 3072 bits. A length of less
 # than 2048 bits raises an exception. A password may be supplied as an
 # argument, otherwise a user prompt is presented.  If an empty password
 # is entered, the private key is saved unencrypted.
->>> generate_and_write_rsa_keypair("keystore/root_key2")
-Enter a password for the RSA key (/path/to/keystore/root_key2):
+>>> generate_and_write_rsa_keypair("root_key2")
+Enter a password for the RSA key (/path/to/root_key2):
 Confirm:
 ```
 The following four key files should now exist:
@@ -129,7 +127,7 @@ If a filepath is not given, the KEYID of the generated key is used as the
 filename.  The key files are written to the current working directory.
 ```
 >>> generate_and_write_rsa_keypair()
-Enter a password for the encrypted RSA key (/path/to/keystore/b5b8de8aeda674bce948fbe82cab07e309d6775fc0ec299199d16746dc2bd54c):
+Enter a password for the encrypted RSA key (/path/to/b5b8de8aeda674bce948fbe82cab07e309d6775fc0ec299199d16746dc2bd54c):
 Confirm:
 ```
 
@@ -138,12 +136,12 @@ Confirm:
 # Continuing from the previous section . . .
 
 # Import an existing public key.
->>> public_root_key = import_rsa_publickey_from_file("keystore/root_key.pub")
+>>> public_root_key = import_rsa_publickey_from_file("root_key.pub")
 
 # Import an existing private key.  Importing a private key requires a password,
 # whereas importing a public key does not.
->>> private_root_key = import_rsa_privatekey_from_file("keystore/root_key")
-Enter a password for the encrypted RSA key (/path/to/keystore/root_key):
+>>> private_root_key = import_rsa_privatekey_from_file("root_key")
+Enter a password for the encrypted RSA key (/path/to/root_key):
 ```
 
 `import_rsa_privatekey_from_file()` raises a
@@ -163,16 +161,16 @@ generated from the encrypted PEM string: Bad decrypt. Incorrect password?
 # supplied, otherwise a prompt is presented.  The private key is saved
 # encrypted if a non-empty password is given, and unencrypted if the password
 # is empty.
->>> generate_and_write_ed25519_keypair('keystore/ed25519_key')
-Enter a password for the Ed25519 key (/path/to/keystore/ed25519_key):
+>>> generate_and_write_ed25519_keypair('ed25519_key')
+Enter a password for the Ed25519 key (/path/to/ed25519_key):
 Confirm:
 
 # Import the ed25519 public key just created . . .
->>> public_ed25519_key = import_ed25519_publickey_from_file('keystore/ed25519_key.pub')
+>>> public_ed25519_key = import_ed25519_publickey_from_file('ed25519_key.pub')
 
 # and its corresponding private key.
->>> private_ed25519_key = import_ed25519_privatekey_from_file('keystore/ed25519_key')
-Enter a password for the encrypted Ed25519 key (/path/to/keystore/ed25519_key):
+>>> private_ed25519_key = import_ed25519_privatekey_from_file('ed25519_key')
+Enter a password for the encrypted Ed25519 key (/path/to/ed25519_key):
 ```
 
 Note: Methods are also available to generate and write keys from memory.
@@ -221,7 +219,7 @@ top-level roles, including itself.
 # Add a second public key to the root role.  Although previously generated and
 # saved to a file, the second public key must be imported before it can added
 # to a role.
->>> public_root_key2 = import_rsa_publickey_from_file("keystore/root_key2.pub")
+>>> public_root_key2 = import_rsa_publickey_from_file("root_key2.pub")
 >>> repository.root.add_verification_key(public_root_key2)
 
 # The threshold of each role defaults to 1.   Maintainers may change the
@@ -230,7 +228,7 @@ top-level roles, including itself.
 # is considered valid if it's signed by at least two valid keys.  We also load
 # the second private key, which hasn't been imported yet.
 >>> repository.root.threshold = 2
->>> private_root_key2 = import_rsa_privatekey_from_file("keystore/root_key2", password="password")
+>>> private_root_key2 = import_rsa_privatekey_from_file("root_key2", password="password")
 
 # Load the root signing keys to the repository, which writeall() or write()
 # (write multiple roles, or a single role, to disk) use to sign the root
@@ -272,25 +270,25 @@ secure manner.
 
 # Generate keys for the remaining top-level roles.  The root keys have been set above.
 # The password argument may be omitted if a password prompt is needed.
->>> generate_and_write_rsa_keypair("keystore/targets_key", password="password")
->>> generate_and_write_rsa_keypair("keystore/snapshot_key", password="password")
->>> generate_and_write_rsa_keypair("keystore/timestamp_key", password="password")
+>>> generate_and_write_rsa_keypair('targets_key', password='password')
+>>> generate_and_write_rsa_keypair('snapshot_key', password='password')
+>>> generate_and_write_rsa_keypair('timestamp_key', password='password')
 
 # Add the verification keys of the remaining top-level roles.
 
->>> repository.targets.add_verification_key(import_rsa_publickey_from_file("keystore/targets_key.pub"))
->>> repository.snapshot.add_verification_key(import_rsa_publickey_from_file("keystore/snapshot_key.pub"))
->>> repository.timestamp.add_verification_key(import_rsa_publickey_from_file("keystore/timestamp_key.pub"))
+>>> repository.targets.add_verification_key(import_rsa_publickey_from_file('targets_key.pub'))
+>>> repository.snapshot.add_verification_key(import_rsa_publickey_from_file('snapshot_key.pub'))
+>>> repository.timestamp.add_verification_key(import_rsa_publickey_from_file('timestamp_key.pub'))
 
 # Import the signing keys of the remaining top-level roles.  Prompt for passwords.
->>> private_targets_key = import_rsa_privatekey_from_file("keystore/targets_key")
-Enter a password for the encrypted RSA key (/path/to/keystore/targets_key):
+>>> private_targets_key = import_rsa_privatekey_from_file('targets_key')
+Enter a password for the encrypted RSA key (/path/to/targets_key):
 
->>> private_snapshot_key = import_rsa_privatekey_from_file("keystore/snapshot_key")
-Enter a password for the encrypted RSA key (/path/to/keystore/snapshot_key):
+>>> private_snapshot_key = import_rsa_privatekey_from_file('snapshot_key')
+Enter a password for the encrypted RSA key (/path/to/snapshot_key):
 
->>> private_timestamp_key = import_rsa_privatekey_from_file("keystore/timestamp_key")
-Enter a password for the encrypted RSA key (/path/to/keystore/timestamp_key):
+>>> private_timestamp_key = import_rsa_privatekey_from_file('timestamp_key')
+Enter a password for the encrypted RSA key (/path/to/timestamp_key):
 
 # Load the signing keys of the remaining roles so that valid signatures are
 # generated when repository.writeall() is called.
@@ -401,19 +399,19 @@ metadata.  `snapshot.json` keys must be loaded and its metadata signed because
 ```Python
 # The private key of the updated targets metadata must be loaded before it can
 # be signed and written (Note the load_repository() call above).
->>> private_targets_key = import_rsa_privatekey_from_file("keystore/targets_key")
-Enter a password for the encrypted RSA key (/path/to/keystore/targets_key):
+>>> private_targets_key = import_rsa_privatekey_from_file('targets_key')
+Enter a password for the encrypted RSA key (/path/to/targets_key):
 
 >>> repository.targets.load_signing_key(private_targets_key)
 
 # Due to the load_repository() and new versions of metadata, we must also load
 # the private keys of Snapshot and Timestamp to generate a valid set of metadata.
->>> private_snapshot_key = import_rsa_privatekey_from_file("keystore/snapshot_key")
-Enter a password for the encrypted RSA key (/path/to/keystore/snapshot_key):
+>>> private_snapshot_key = import_rsa_privatekey_from_file('snapshot_key')
+Enter a password for the encrypted RSA key (/path/to/snapshot_key):
 >>> repository.snapshot.load_signing_key(private_snapshot_key)
 
->>> private_timestamp_key = import_rsa_privatekey_from_file("keystore/timestamp_key")
-Enter a password for the encrypted RSA key (/path/to/keystore/timestamp_key):
+>>> private_timestamp_key = import_rsa_privatekey_from_file('timestamp_key')
+Enter a password for the encrypted RSA key (/path/to/timestamp_key):
 >>> repository.timestamp.load_signing_key(private_timestamp_key)
 
 # Which roles are dirty?
@@ -487,8 +485,8 @@ targets and generate signed metadata.
 # Continuing from the previous section . . .
 
 # Generate a key for a new delegated role named "unclaimed".
->>> generate_and_write_rsa_keypair("keystore/unclaimed_key", bits=2048, password="password")
->>> public_unclaimed_key = import_rsa_publickey_from_file("keystore/unclaimed_key.pub")
+>>> generate_and_write_rsa_keypair('unclaimed_key', bits=2048, password='password')
+>>> public_unclaimed_key = import_rsa_publickey_from_file('unclaimed_key.pub')
 
 # Make a delegation (delegate trust of '/foo*.tgz' files) from "targets" to
 # "unclaimed", where 'unclaimed' initially contains zero targets.
@@ -502,8 +500,8 @@ targets and generate signed metadata.
 
 # Load the private key of "unclaimed" so that unclaimed's metadata can be
 # signed, and valid metadata created.
->>> private_unclaimed_key = import_rsa_privatekey_from_file("keystore/unclaimed_key")
-Enter a password for the encrypted RSA key (/path/to/keystore/unclaimed_key):
+>>> private_unclaimed_key = import_rsa_privatekey_from_file('unclaimed_key')
+Enter a password for the encrypted RSA key (/path/to/unclaimed_key):
 
 >>> repository.targets("unclaimed").load_signing_key(private_unclaimed_key)
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -38,17 +38,7 @@ updates](../tuf/ATTACKS.md).
 The [repository tool](../tuf/repository_tool.py) contains functions to generate
 all of the files needed to populate and manage a TUF repository.  The tool may
 either be imported into a Python module, or used with the Python interpreter in
-interactive mode.  For instance, here is an example of initializing a TUF
-repository in interactive mode:
-
-```Bash
-$ python
-Python 2.7.3 (default, Sep 26 2013, 20:08:41)
-[GCC 4.6.3] on linux2
-Type "help", "copyright", "credits" or "license" for more information.
->>> from tuf.repository_tool import *
->>> repo = create_new_repository("my_repo")
-```
+interactive mode.
 
 A repository object that encapsulates the metadata files of the repository can
 be created or loaded by the repository tool.  Repository maintainers can modify

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,9 @@ setup(
     'six>=1.11.0',
     'securesystemslib>=0.12.0'
   ],
+  tests_require = [
+    'mock; python_version < "3.3"'
+  ],
   packages = find_packages(exclude=['tests']),
   scripts = [
     'tuf/scripts/repo.py',

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -357,7 +357,7 @@ class TestRepository(unittest.TestCase):
     self.assertEqual([], tuf.roledb.get_dirty_roles(repository_name))
 
     repository.mark_dirty(['root', 'timestamp'])
-    self.assertEqual(['root', 'timestamp'], sorted(tuf.roledb.get_dirty_roles(repository_name)))
+    self.assertEqual(['root', 'timestamp'], tuf.roledb.get_dirty_roles(repository_name))
     repository.unmark_dirty(['root'])
     self.assertEqual(['timestamp'], tuf.roledb.get_dirty_roles(repository_name))
 

--- a/tests/test_roledb.py
+++ b/tests/test_roledb.py
@@ -710,7 +710,7 @@ class TestRoledb(unittest.TestCase):
     self.assertEqual([rolename], tuf.roledb.get_dirty_roles())
 
     tuf.roledb.mark_dirty(['dirty_role'])
-    self.assertEqual([rolename2, rolename], sorted(tuf.roledb.get_dirty_roles()))
+    self.assertEqual([rolename2, rolename], tuf.roledb.get_dirty_roles())
 
     # Verify that a role cannot be marked as dirty for a non-existent
     # repository.
@@ -735,9 +735,9 @@ class TestRoledb(unittest.TestCase):
     tuf.roledb.update_roleinfo(rolename2, roleinfo2, mark_role_as_dirty)
 
     tuf.roledb.unmark_dirty(['dirty_role'])
-    self.assertEqual([rolename], sorted(tuf.roledb.get_dirty_roles()))
+    self.assertEqual([rolename], tuf.roledb.get_dirty_roles())
     tuf.roledb.unmark_dirty(['targets'])
-    self.assertEqual([], sorted(tuf.roledb.get_dirty_roles()))
+    self.assertEqual([], tuf.roledb.get_dirty_roles())
 
     # What happens for a role that isn't dirty?  unmark_dirty() should just
     # log a message.

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -280,9 +280,11 @@ class TestTutorial(unittest.TestCase):
     repository.writeall()
 
 
-    # Copying metadata to live repository not done here, as it is not tested
-    # or worked with further in the tutorial (so we'd just copy and then
-    # delete.)
+    # Simulate the following shell command:
+    ## $ cp -r "repository/metadata.staged/" "repository/metadata/"
+    shutil.copytree(
+        os.path.join('repository', 'metadata.staged'),
+        os.path.join('repository', 'metadata'))
 
 
 

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -33,6 +33,7 @@ import unittest
 import datetime # part of TUTORIAL.md
 import os # part of TUTORIAL.md, but also needed separately
 import shutil
+import tempfile
 
 from tuf.repository_tool import *   # part of TUTORIAL.md
 
@@ -41,14 +42,13 @@ import securesystemslib.exceptions
 
 class TestTutorial(unittest.TestCase):
   def setUp(self):
-    clean_test_environment()
-
-
+    self.working_dir = os.getcwd()
+    self.test_dir = os.path.realpath(tempfile.mkdtemp())
+    os.chdir(self.test_dir)
 
   def tearDown(self):
-    clean_test_environment()
-
-
+    os.chdir(self.working_dir)
+    shutil.rmtree(self.test_dir)
 
   def test_tutorial(self):
     """
@@ -370,41 +370,6 @@ class TestTutorial(unittest.TestCase):
 
     # targets/:
     # file1.txt
-
-
-
-
-
-def clean_test_environment():
-  """
-  Delete temporary files and directories from this test (or with the same name
-  as those created by this test...).
-  """
-  for directory in ['repository', 'my_repo', 'client',
-      'repository/targets/my_project']:
-    if os.path.exists(directory):
-      shutil.rmtree(directory)
-
-  for fname in [
-        os.path.join('repository', 'targets', 'file1.txt'),
-        os.path.join('repository', 'targets', 'file2.txt'),
-        os.path.join('repository', 'targets', 'file3.txt'),
-        'root_key',
-        'root_key.pub',
-        'root_key2',
-        'root_key2.pub',
-        'ed25519_key',
-        'ed25519_key.pub',
-        'targets_key',
-        'targets_key.pub',
-        'snapshot_key',
-        'snapshot_key.pub',
-        'timestamp_key',
-        'timestamp_key.pub',
-        'unclaimed_key',
-        'unclaimed_key.pub']:
-    if os.path.exists(fname):
-      os.remove(fname)
 
 
 

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -207,18 +207,38 @@ class TestTutorial(unittest.TestCase):
     list_of_targets = repository.get_filepaths_in_directory(
         os.path.join('repository', 'targets'), recursive_walk=False, followlinks=True)
 
-    self.assertEqual(sorted(list_of_targets),
-        ['repository/targets/file1.txt', 'repository/targets/file2.txt',
-        'repository/targets/file3.txt'])
+    # Ensure that we have absolute paths. (Harmless before and after PR #774,
+    # which fixes the issue with non-absolute paths coming from
+    # get_filepaths_in_directory.)
+
+    list_of_targets_temp = []
+
+    for t in list_of_targets:
+      list_of_targets_temp.append(os.path.abspath(t))
+
+    list_of_targets = list_of_targets_temp
+
+
+    self.assertEqual(sorted(list_of_targets), [
+        os.path.abspath(os.path.join('repository', 'targets', 'file1.txt')),
+        os.path.abspath(os.path.join('repository', 'targets', 'file2.txt')),
+        os.path.abspath(os.path.join('repository', 'targets', 'file3.txt'))])
 
 
     repository.targets.add_targets(list_of_targets)
+
+    self.assertTrue('file1.txt' in repository.targets.target_files)
+    self.assertTrue('file2.txt' in repository.targets.target_files)
+    self.assertTrue('file3.txt' in repository.targets.target_files)
+
 
     target4_filepath = os.path.abspath(os.path.join(
         'repository', 'targets', 'myproject', 'file4.txt'))
     octal_file_permissions = oct(os.stat(target4_filepath).st_mode)[4:]
     custom_file_permissions = {'file_permissions': octal_file_permissions}
     repository.targets.add_target(target4_filepath, custom_file_permissions)
+    self.assertTrue(os.path.join(
+        'myproject', 'file4.txt') in repository.targets.target_files)
 
 
     # Skipping user entry of password

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -57,18 +57,15 @@ class TestTutorial(unittest.TestCase):
 
     # ----- Tutorial Section:  Keys
 
-    generate_and_write_rsa_keypair(
-        "keystore/root_key", bits=2048, password="password")
+    generate_and_write_rsa_keypair('root_key', bits=2048, password='password')
 
     # Skipping user entry of password
-    ## generate_and_write_rsa_keypair("keystore/root_key2")
-    generate_and_write_rsa_keypair("keystore/root_key2", password='password')
+    ## generate_and_write_rsa_keypair('root_key2')
+    generate_and_write_rsa_keypair('root_key2', password='password')
 
     # Tutorial tells users to expect these files to exist:
     # ['root_key', 'root_key.pub', 'root_key2', 'root_key2.pub']
-    for fname in [
-        'keystore/root_key', 'keystore/root_key.pub',
-        'keystore/root_key2', 'keystore/root_key2.pub']:
+    for fname in ['root_key', 'root_key.pub', 'root_key2', 'root_key2.pub']:
       self.assertTrue(os.path.exists(fname))
 
     # Note: Skipping the creation of an effectively-randomly named key file, as
@@ -79,35 +76,31 @@ class TestTutorial(unittest.TestCase):
 
     # ----- Tutorial Section:  Import RSA Keys
 
-
-    public_root_key = import_rsa_publickey_from_file("keystore/root_key.pub")
-
-    # Skipping user entry of password
-    ## private_root_key = import_rsa_privatekey_from_file("keystore/root_key")
-    private_root_key = import_rsa_privatekey_from_file(
-        "keystore/root_key", 'password')
+    public_root_key = import_rsa_publickey_from_file('root_key.pub')
 
     # Skipping user entry of password
-    ## import_rsa_privatekey_from_file('keystore/root_key')
+    ## private_root_key = import_rsa_privatekey_from_file('root_key')
+    private_root_key = import_rsa_privatekey_from_file('root_key', 'password')
+
+    # Skipping user entry of password
+    ## import_rsa_privatekey_from_file('root_key')
     with self.assertRaises(securesystemslib.exceptions.CryptoError):
-      import_rsa_privatekey_from_file('keystore/root_key', 'not_the_real_pw')
+      import_rsa_privatekey_from_file('root_key', 'not_the_real_pw')
 
 
 
     # ----- Tutorial Section: Create and Import Ed25519 Keys
 
     # Skipping user entry of password
-    ## generate_and_write_ed25519_keypair('keystore/ed25519_key')
-    generate_and_write_ed25519_keypair(
-        'keystore/ed25519_key', password='password')
+    ## generate_and_write_ed25519_keypair('ed25519_key')
+    generate_and_write_ed25519_keypair('ed25519_key', password='password')
 
-    public_ed25519_key = import_ed25519_publickey_from_file(
-        'keystore/ed25519_key.pub')
+    public_ed25519_key = import_ed25519_publickey_from_file('ed25519_key.pub')
 
     # Skipping user entry of password
-    ## private_ed25519_key = import_ed25519_privatekey_from_file('keystore/ed25519_key')
+    ## private_ed25519_key = import_ed25519_privatekey_from_file('ed25519_key')
     private_ed25519_key = import_ed25519_privatekey_from_file(
-        'keystore/ed25519_key', 'password')
+        'ed25519_key', 'password')
 
 
 
@@ -116,12 +109,12 @@ class TestTutorial(unittest.TestCase):
     repository.root.add_verification_key(public_root_key)
     self.assertTrue(repository.root.keys)
 
-    public_root_key2 = import_rsa_publickey_from_file("keystore/root_key2.pub")
+    public_root_key2 = import_rsa_publickey_from_file('root_key2.pub')
     repository.root.add_verification_key(public_root_key2)
 
     repository.root.threshold = 2
     private_root_key2 = import_rsa_privatekey_from_file(
-        "keystore/root_key2", password="password")
+        'root_key2', password='password')
 
     repository.root.load_signing_key(private_root_key)
     repository.root.load_signing_key(private_root_key2)
@@ -142,32 +135,31 @@ class TestTutorial(unittest.TestCase):
     repository.status()
 
 
-    generate_and_write_rsa_keypair("keystore/targets_key", password="password")
-    generate_and_write_rsa_keypair("keystore/snapshot_key", password="password")
-    generate_and_write_rsa_keypair(
-        "keystore/timestamp_key", password="password")
+    generate_and_write_rsa_keypair('targets_key', password='password')
+    generate_and_write_rsa_keypair('snapshot_key', password='password')
+    generate_and_write_rsa_keypair('timestamp_key', password='password')
 
     repository.targets.add_verification_key(import_rsa_publickey_from_file(
-        "keystore/targets_key.pub"))
+        'targets_key.pub'))
     repository.snapshot.add_verification_key(import_rsa_publickey_from_file(
-        "keystore/snapshot_key.pub"))
+        'snapshot_key.pub'))
     repository.timestamp.add_verification_key(import_rsa_publickey_from_file(
-        "keystore/timestamp_key.pub"))
+        'timestamp_key.pub'))
 
     # Skipping user entry of password
-    ## private_targets_key = import_rsa_privatekey_from_file("keystore/targets_key")
+    ## private_targets_key = import_rsa_privatekey_from_file('targets_key')
     private_targets_key = import_rsa_privatekey_from_file(
-        "keystore/targets_key", 'password')
+        'targets_key', 'password')
 
     # Skipping user entry of password
-    ## private_snapshot_key = import_rsa_privatekey_from_file("keystore/snapshot_key")
+    ## private_snapshot_key = import_rsa_privatekey_from_file('snapshot_key')
     private_snapshot_key = import_rsa_privatekey_from_file(
-        "keystore/snapshot_key", 'password')
+        'snapshot_key', 'password')
 
     # Skipping user entry of password
-    ## private_timestamp_key = import_rsa_privatekey_from_file("keystore/timestamp_key")
+    ## private_timestamp_key = import_rsa_privatekey_from_file('timestamp_key')
     private_timestamp_key = import_rsa_privatekey_from_file(
-        "keystore/timestamp_key", 'password')
+        'timestamp_key', 'password')
 
     repository.targets.load_signing_key(private_targets_key)
     repository.snapshot.load_signing_key(private_snapshot_key)
@@ -219,22 +211,22 @@ class TestTutorial(unittest.TestCase):
 
 
     # Skipping user entry of password
-    ## private_targets_key = import_rsa_privatekey_from_file("keystore/targets_key")
+    ## private_targets_key = import_rsa_privatekey_from_file('targets_key')
     private_targets_key = import_rsa_privatekey_from_file(
-        "keystore/targets_key", 'password')
+        'targets_key', 'password')
     repository.targets.load_signing_key(private_targets_key)
 
     # Skipping user entry of password
-    ## private_snapshot_key = import_rsa_privatekey_from_file("keystore/snapshot_key")
+    ## private_snapshot_key = import_rsa_privatekey_from_file('snapshot_key')
     private_snapshot_key = import_rsa_privatekey_from_file(
-        "keystore/snapshot_key", 'password')
+        'snapshot_key', 'password')
     repository.snapshot.load_signing_key(private_snapshot_key)
 
 
     # Skipping user entry of password
-    ## private_timestamp_key = import_rsa_privatekey_from_file("keystore/timestamp_key")
+    ## private_timestamp_key = import_rsa_privatekey_from_file('timestamp_key')
     private_timestamp_key = import_rsa_privatekey_from_file(
-        "keystore/timestamp_key", 'password')
+        'timestamp_key', 'password')
     repository.timestamp.load_signing_key(private_timestamp_key)
 
     # TODO: dirty_roles() doesn't return the list of dirty roles; it just
@@ -260,16 +252,15 @@ class TestTutorial(unittest.TestCase):
 
     # ----- Tutorial Section: Delegations
     generate_and_write_rsa_keypair(
-        "keystore/unclaimed_key", bits=2048, password="password")
-    public_unclaimed_key = import_rsa_publickey_from_file(
-        "keystore/unclaimed_key.pub")
+        'unclaimed_key', bits=2048, password='password')
+    public_unclaimed_key = import_rsa_publickey_from_file('unclaimed_key.pub')
     repository.targets.delegate(
         "unclaimed", [public_unclaimed_key], ['/foo*.tgz'])
 
     # Skipping user entry of password
-    ## private_unclaimed_key = import_rsa_privatekey_from_file("keystore/unclaimed_key")
+    ## private_unclaimed_key = import_rsa_privatekey_from_file('unclaimed_key')
     private_unclaimed_key = import_rsa_privatekey_from_file(
-        "keystore/unclaimed_key", 'password')
+        'unclaimed_key', 'password')
     repository.targets("unclaimed").load_signing_key(private_unclaimed_key)
 
     repository.targets("unclaimed").version = 2
@@ -284,8 +275,8 @@ class TestTutorial(unittest.TestCase):
 
     repository.writeall()
 
-    repository.targets('unclaimed').delegate("django", [public_unclaimed_key], ['/bar*.tgz'])
     repository.targets('unclaimed').revoke("django")
+    repository.targets('unclaimed').delegate('django', [public_unclaimed_key], ['/bar*.tgz'])
     repository.writeall()
 
 
@@ -349,17 +340,32 @@ class TestTutorial(unittest.TestCase):
 
 def clean_test_environment():
   """
-  Delete temporary files from this test and ensure expected starting state.
+  Delete temporary files and directories from this test (or with the same name
+  as those created by this test...).
   """
-  print('Warning: clean test environment not yet implemented.')
-
-  for directory in ['repository', 'my_repo', 'client', 'keystore',
+  for directory in ['repository', 'my_repo', 'client',
       'repository/targets/my_project']:
     if os.path.exists(directory):
       shutil.rmtree(directory)
 
-  for fname in ['repository/targets/file1.txt', 'repository/targets/file2.txt',
-      'repository/targets/file3.txt']:
+  for fname in [
+        os.path.join('repository', 'targets', 'file1.txt'),
+        os.path.join('repository', 'targets', 'file2.txt'),
+        os.path.join('repository', 'targets', 'file3.txt'),
+        'root_key',
+        'root_key.pub',
+        'root_key2',
+        'root_key2.pub',
+        'ed25519_key',
+        'ed25519_key.pub',
+        'targets_key',
+        'targets_key.pub',
+        'snapshot_key',
+        'snapshot_key.pub',
+        'timestamp_key',
+        'timestamp_key.pub',
+        'unclaimed_key',
+        'unclaimed_key.pub']:
     if os.path.exists(fname):
       os.remove(fname)
 

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -300,9 +300,6 @@ class TestTutorial(unittest.TestCase):
     for delegation in repository.targets('unclaimed').delegations:
       delegation.load_signing_key(private_unclaimed_key)
 
-    repository.targets('unclaimed').add_restricted_paths(
-        'repository/targets/myproject/*', 'django')
-
 
 
     # ----- Tutorial Section: How to Perform an Update

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python
+
+"""
+<Program Name>
+  test_tutorial.py
+
+<Copyright>
+  See LICENSE-MIT OR LICENSE for licensing information.
+
+<Purpose>
+  Regression test for the TUF tutorial as laid out in TUTORIAL.md.
+  This simply runs the tutorial and checks some results.
+"""
+
+# Help with Python 3 compatibility, where the print statement is a function, an
+# implicit relative import is invalid, and the '/' operator performs true
+# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+
+import unittest
+import datetime # part of TUTORIAL.md
+import os # part of TUTORIAL.md, but also needed separately
+import shutil
+
+from tuf.repository_tool import *   # part of TUTORIAL.md
+
+import securesystemslib.exceptions
+
+
+class TestTutorial(unittest.TestCase):
+  def setUp(self):
+    clean_test_environment()
+
+
+
+  def tearDown(self):
+    clean_test_environment()
+
+
+
+  def test_tutorial(self):
+    """
+    Run the TUTORIAL.md tutorial.
+    Note that anywhere the tutorial provides a command that prompts for the
+    user to enter a passphrase/password, this test is changed to simply provide
+    that as an argument. It's not worth trying to arrange automated testing of
+    the interactive password entry process here. Anywhere user entry has been
+    skipped from the tutorial instructions, "# Skipping user entry of password"
+    is written, with the original line below it, starting with ##.
+    """
+    repo = create_new_repository("my_repo")
+
+
+
+    # ----- Tutorial Section:  Keys
+
+    generate_and_write_rsa_keypair(
+        "keystore/root_key", bits=2048, password="password")
+
+    # Skipping user entry of password
+    ## generate_and_write_rsa_keypair("keystore/root_key2")
+    generate_and_write_rsa_keypair("keystore/root_key2", password='password')
+
+    # Tutorial tells users to expect these files to exist:
+    # ['root_key', 'root_key.pub', 'root_key2', 'root_key2.pub']
+    for fname in [
+        'keystore/root_key', 'keystore/root_key.pub',
+        'keystore/root_key2', 'keystore/root_key2.pub']:
+      self.assertTrue(os.path.exists(fname))
+
+    # Note: Skipping the creation of an effectively-randomly named key file, as
+    # that is harder to clean up.
+    ## generate_and_write_rsa_keypair()
+
+
+
+    # ----- Tutorial Section:  Import RSA Keys
+
+
+    public_root_key = import_rsa_publickey_from_file("keystore/root_key.pub")
+
+    # Skipping user entry of password
+    ## private_root_key = import_rsa_privatekey_from_file("keystore/root_key")
+    private_root_key = import_rsa_privatekey_from_file(
+        "keystore/root_key", 'password')
+
+    # Skipping user entry of password
+    ## import_rsa_privatekey_from_file('keystore/root_key')
+    with self.assertRaises(securesystemslib.exceptions.CryptoError):
+      import_rsa_privatekey_from_file('keystore/root_key', 'not_the_real_pw')
+
+
+
+    # ----- Tutorial Section: Create and Import Ed25519 Keys
+
+    # Skipping user entry of password
+    ## generate_and_write_ed25519_keypair('keystore/ed25519_key')
+    generate_and_write_ed25519_keypair(
+        'keystore/ed25519_key', password='password')
+
+    public_ed25519_key = import_ed25519_publickey_from_file(
+        'keystore/ed25519_key.pub')
+
+    # Skipping user entry of password
+    ## private_ed25519_key = import_ed25519_privatekey_from_file('keystore/ed25519_key')
+    private_ed25519_key = import_ed25519_privatekey_from_file(
+        'keystore/ed25519_key', 'password')
+
+
+
+    # ----- Tutorial Section: Create Top-level Metadata
+    repository = create_new_repository("repository/")
+    repository.root.add_verification_key(public_root_key)
+    self.assertTrue(repository.root.keys)
+
+    public_root_key2 = import_rsa_publickey_from_file("keystore/root_key2.pub")
+    repository.root.add_verification_key(public_root_key2)
+
+    repository.root.threshold = 2
+    private_root_key2 = import_rsa_privatekey_from_file(
+        "keystore/root_key2", password="password")
+
+    repository.root.load_signing_key(private_root_key)
+    repository.root.load_signing_key(private_root_key2)
+
+
+    # TODO: dirty_roles() doesn't return the list of dirty roles; it just
+    # prints the list. It should probably it should return it as well.
+    # If that's not changed, perhaps we should test the print output from the
+    # dirty_roles() statement here.
+    repository.dirty_roles()
+    # self.assertEqual(repository.dirty_roles(), ['root'])
+
+
+    # TODO: status() should return some sort of value that indicates what
+    # it prints. It's currently just printing status information.
+    # If that's not changed, perhaps we should test the print output from the
+    # status() statement here.
+    repository.status()
+
+
+    generate_and_write_rsa_keypair("keystore/targets_key", password="password")
+    generate_and_write_rsa_keypair("keystore/snapshot_key", password="password")
+    generate_and_write_rsa_keypair(
+        "keystore/timestamp_key", password="password")
+
+    repository.targets.add_verification_key(import_rsa_publickey_from_file(
+        "keystore/targets_key.pub"))
+    repository.snapshot.add_verification_key(import_rsa_publickey_from_file(
+        "keystore/snapshot_key.pub"))
+    repository.timestamp.add_verification_key(import_rsa_publickey_from_file(
+        "keystore/timestamp_key.pub"))
+
+    # Skipping user entry of password
+    ## private_targets_key = import_rsa_privatekey_from_file("keystore/targets_key")
+    private_targets_key = import_rsa_privatekey_from_file(
+        "keystore/targets_key", 'password')
+
+    # Skipping user entry of password
+    ## private_snapshot_key = import_rsa_privatekey_from_file("keystore/snapshot_key")
+    private_snapshot_key = import_rsa_privatekey_from_file(
+        "keystore/snapshot_key", 'password')
+
+    # Skipping user entry of password
+    ## private_timestamp_key = import_rsa_privatekey_from_file("keystore/timestamp_key")
+    private_timestamp_key = import_rsa_privatekey_from_file(
+        "keystore/timestamp_key", 'password')
+
+    repository.targets.load_signing_key(private_targets_key)
+    repository.snapshot.load_signing_key(private_snapshot_key)
+    repository.timestamp.load_signing_key(private_timestamp_key)
+
+    repository.timestamp.expiration = datetime.datetime(2080, 10, 28, 12, 8)
+
+    repository.writeall()
+
+
+
+    # ----- Tutorial Section: Targets
+    # These next commands in the tutorial are shown as bash commands, so I'll
+    # just simulate this with some Python commands.
+    ## $ cd repository/targets/
+    ## $ echo 'file1' > file1.txt
+    ## $ echo 'file2' > file2.txt
+    ## $ echo 'file3' > file3.txt
+    ## $ mkdir myproject; echo 'file4' > myproject/file4.txt
+    ## $ cd ../../
+
+    with open('repository/targets/file1.txt', 'w') as fobj:
+      fobj.write('file1')
+    with open('repository/targets/file2.txt', 'w') as fobj:
+      fobj.write('file2')
+    with open('repository/targets/file3.txt', 'w') as fobj:
+      fobj.write('file3')
+
+    os.mkdir('repository/targets/myproject')
+    with open('repository/targets/myproject/file4.txt', 'w') as fobj:
+      fobj.write('file4')
+
+
+    repository = load_repository("repository/")
+    list_of_targets = repository.get_filepaths_in_directory(
+        "repository/targets/", recursive_walk=False, followlinks=True)
+
+    self.assertEqual(sorted(list_of_targets),
+        ['repository/targets/file1.txt', 'repository/targets/file2.txt',
+        'repository/targets/file3.txt'])
+
+
+    repository.targets.add_targets(list_of_targets)
+
+    target4_filepath = "repository/targets/myproject/file4.txt"
+    octal_file_permissions = oct(os.stat(target4_filepath).st_mode)[4:]
+    custom_file_permissions = {'file_permissions': octal_file_permissions}
+    repository.targets.add_target(target4_filepath, custom_file_permissions)
+
+
+    # Skipping user entry of password
+    ## private_targets_key = import_rsa_privatekey_from_file("keystore/targets_key")
+    private_targets_key = import_rsa_privatekey_from_file(
+        "keystore/targets_key", 'password')
+    repository.targets.load_signing_key(private_targets_key)
+
+    # Skipping user entry of password
+    ## private_snapshot_key = import_rsa_privatekey_from_file("keystore/snapshot_key")
+    private_snapshot_key = import_rsa_privatekey_from_file(
+        "keystore/snapshot_key", 'password')
+    repository.snapshot.load_signing_key(private_snapshot_key)
+
+
+    # Skipping user entry of password
+    ## private_timestamp_key = import_rsa_privatekey_from_file("keystore/timestamp_key")
+    private_timestamp_key = import_rsa_privatekey_from_file(
+        "keystore/timestamp_key", 'password')
+    repository.timestamp.load_signing_key(private_timestamp_key)
+
+    # TODO: dirty_roles() doesn't return the list of dirty roles; it just
+    # prints the list. It should probably it should return it as well.
+    # If that's not changed, perhaps we should test the print output from the
+    # dirty_roles() statement here.
+    repository.dirty_roles()
+    # self.assertEqual(
+    #   repository.dirty_roles(), ['timestamp', 'snapshot', 'targets'])
+
+    repository.writeall()
+
+    repository.targets.remove_target("repository/targets/file3.txt")
+    self.assertTrue(os.path.exists('repository/targets/file3.txt'))
+
+    repository.writeall()
+
+
+    signable_content = dump_signable_metadata('targets.json')
+    append_signature(signature, 'targets.json')
+
+
+
+    # ----- Tutorial Section: Delegations
+    generate_and_write_rsa_keypair(
+        "keystore/unclaimed_key", bits=2048, password="password")
+    public_unclaimed_key = import_rsa_publickey_from_file(
+        "keystore/unclaimed_key.pub")
+    repository.targets.delegate(
+        "unclaimed", [public_unclaimed_key], ['/foo*.tgz'])
+
+    # Skipping user entry of password
+    ## private_unclaimed_key = import_rsa_privatekey_from_file("keystore/unclaimed_key")
+    private_unclaimed_key = import_rsa_privatekey_from_file(
+        "keystore/unclaimed_key", 'password')
+    repository.targets("unclaimed").load_signing_key(private_unclaimed_key)
+
+    repository.targets("unclaimed").version = 2
+
+    # TODO: dirty_roles() doesn't return the list of dirty roles; it just
+    # prints the list. It should probably it should return it as well.
+    # If that's not changed, perhaps we should test the print output from the
+    # dirty_roles() statement here.
+    repository.dirty_roles()
+    # self.assertEqual(repository.dirty_roles(),
+    #   ['timestamp', 'snapshot', 'targets', 'unclaimed'])
+
+    repository.writeall()
+
+    repository.targets('unclaimed').delegate("django", [public_unclaimed_key], ['/bar*.tgz'])
+    repository.targets('unclaimed').revoke("django")
+    repository.writeall()
+
+
+    # Copying metadata to live repository not done here, as it is not tested
+    # or worked with further in the tutorial (so we'd just copy and then
+    # delete.)
+
+
+
+    # ----- Tutorial Section: Consistent Snapshots
+
+    repository.writeall(consistent_snapshot=True)
+
+
+
+    # ----- Tutorial Section: Delegate to Hashed Bins
+
+    targets = repository.get_filepaths_in_directory(
+        'repository/targets/myproject', recursive_walk=True)
+
+    for delegation in repository.targets('unclaimed').delegations:
+      delegation.load_signing_key(private_unclaimed_key)
+
+    repository.targets('unclaimed').add_restricted_paths(
+        'repository/targets/myproject/*', 'django')
+
+
+
+    # ----- Tutorial Section: How to Perform an Update
+
+    # A separate tutorial is linked to for client use. That is not tested here.
+    create_tuf_client_directory("repository/", "client/")
+
+
+
+    # ----- Tutorial Section: Test TUF Locally
+
+    # TODO: Run subprocess to simulate the following bash instructions:
+
+    # $ cd "repository/"; python -m SimpleHTTPServer 8001
+    # If running Python 3:
+
+    # $ cd "repository/"; python3 -m http.server 8001
+    # We next retrieve targets from the TUF repository and save them to client/. The client.py script is available to download metadata and files from a specified repository. In a different command-line prompt . . .
+
+    # $ cd "client/"
+    # $ ls
+    # metadata/
+
+    # $ client.py --repo http://localhost:8001 file1.txt
+    # $ ls . targets/
+    # .:
+    # metadata  targets
+
+    # targets/:
+    # file1.txt
+
+
+
+
+
+def clean_test_environment():
+  """
+  Delete temporary files from this test and ensure expected starting state.
+  """
+  print('Warning: clean test environment not yet implemented.')
+
+  for directory in ['repository', 'my_repo', 'client', 'keystore',
+      'repository/targets/my_project']:
+    if os.path.exists(directory):
+      shutil.rmtree(directory)
+
+  for fname in ['repository/targets/file1.txt', 'repository/targets/file2.txt',
+      'repository/targets/file3.txt']:
+    if os.path.exists(fname):
+      os.remove(fname)
+
+
+
+# Run unit test.
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -9,7 +9,16 @@
 
 <Purpose>
   Regression test for the TUF tutorial as laid out in TUTORIAL.md.
-  This simply runs the tutorial and checks some results.
+  This essentially runs the tutorial and checks some results.
+
+  There are a few deviations from the TUTORIAL.md instructions:
+   - steps that involve user input (like passphrases) are modified slightly
+     to not require user input
+   - use of path separators '/' is replaced by join() calls. (We assume that
+     when following the tutorial, users will correctly deal with path
+     separators for their system if they happen to be using non-Linux systems.)
+   - shell instructions are mimicked using Python commands
+
 """
 
 # Help with Python 3 compatibility, where the print statement is a function, an
@@ -241,7 +250,7 @@ class TestTutorial(unittest.TestCase):
 
     repository.writeall()
 
-    repository.targets.remove_target("repository/targets/file3.txt")
+    repository.targets.remove_target('file3.txt')
     self.assertTrue(os.path.exists(os.path.join(
         'repository','targets', 'file3.txt')))
 

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -105,7 +105,7 @@ class TestTutorial(unittest.TestCase):
 
 
     # ----- Tutorial Section: Create Top-level Metadata
-    repository = create_new_repository("repository/")
+    repository = create_new_repository('repository')
     repository.root.add_verification_key(public_root_key)
     self.assertTrue(repository.root.keys)
 
@@ -193,7 +193,7 @@ class TestTutorial(unittest.TestCase):
       fobj.write('file4')
 
 
-    repository = load_repository("repository/")
+    repository = load_repository('repository')
     list_of_targets = repository.get_filepaths_in_directory(
         "repository/targets/", recursive_walk=False, followlinks=True)
 
@@ -255,7 +255,7 @@ class TestTutorial(unittest.TestCase):
         'unclaimed_key', bits=2048, password='password')
     public_unclaimed_key = import_rsa_publickey_from_file('unclaimed_key.pub')
     repository.targets.delegate(
-        "unclaimed", [public_unclaimed_key], ['/foo*.tgz'])
+        'unclaimed', [public_unclaimed_key], ['foo*.tgz'])
 
     # Skipping user entry of password
     ## private_unclaimed_key = import_rsa_privatekey_from_file('unclaimed_key')
@@ -275,8 +275,8 @@ class TestTutorial(unittest.TestCase):
 
     repository.writeall()
 
-    repository.targets('unclaimed').revoke("django")
-    repository.targets('unclaimed').delegate('django', [public_unclaimed_key], ['/bar*.tgz'])
+    repository.targets('unclaimed').delegate('django', [public_unclaimed_key], ['bar*.tgz'])
+    repository.targets('unclaimed').revoke('django')
     repository.writeall()
 
 

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -134,7 +134,8 @@ class TestTutorial(unittest.TestCase):
     repository.root.load_signing_key(private_root_key)
     repository.root.load_signing_key(private_root_key2)
 
-    # Patch logger to assert that it accurately logs dirty roles
+    # NOTE: The tutorial does not call dirty_roles anymore due to #964 and
+    # #958. We still call it here to see if roles are dirty as expected.
     with mock.patch("tuf.repository_tool.logger") as mock_logger:
       repository.dirty_roles()
       # Concat strings to avoid Python2/3 unicode prefix problems ('' vs. u'')
@@ -186,6 +187,8 @@ class TestTutorial(unittest.TestCase):
 
     repository.timestamp.expiration = datetime.datetime(2080, 10, 28, 12, 8)
 
+    # NOTE: The tutorial does not call dirty_roles anymore due to #964 and
+    # #958. We still call it here to see if roles are dirty as expected.
     with mock.patch("tuf.repository_tool.logger") as mock_logger:
       repository.dirty_roles()
       # Concat strings to avoid Python2/3 unicode prefix problems ('' vs. u'')
@@ -265,7 +268,8 @@ class TestTutorial(unittest.TestCase):
         'timestamp_key', 'password')
     repository.timestamp.load_signing_key(private_timestamp_key)
 
-    # Patch logger to assert that it accurately logs dirty roles
+    # NOTE: The tutorial does not call dirty_roles anymore due to #964 and
+    # #958. We still call it here to see if roles are dirty as expected.
     with mock.patch("tuf.repository_tool.logger") as mock_logger:
       repository.dirty_roles()
       # Concat strings to avoid Python2/3 unicode prefix problems ('' vs. u'')
@@ -278,6 +282,8 @@ class TestTutorial(unittest.TestCase):
     self.assertTrue(os.path.exists(os.path.join(
         'repository','targets', 'myproject', 'file4.txt')))
 
+    # NOTE: The tutorial does not call dirty_roles anymore due to #964 and
+    # #958. We still call it here to see if roles are dirty as expected.
     with mock.patch("tuf.repository_tool.logger") as mock_logger:
       repository.dirty_roles()
       # Concat strings to avoid Python2/3 unicode prefix problems ('' vs. u'')
@@ -318,7 +324,8 @@ class TestTutorial(unittest.TestCase):
         'unclaimed_key', 'password')
     repository.targets("unclaimed").load_signing_key(private_unclaimed_key)
 
-
+    # NOTE: The tutorial does not call dirty_roles anymore due to #964 and
+    # #958. We still call it here to see if roles are dirty as expected.
     with mock.patch("tuf.repository_tool.logger") as mock_logger:
       repository.dirty_roles()
       # Concat strings to avoid Python2/3 unicode prefix problems ('' vs. u'')
@@ -337,6 +344,7 @@ class TestTutorial(unittest.TestCase):
 
 
     # ----- Tutorial Section: Delegate to Hashed Bins
+    repository.targets('unclaimed').remove_target("myproject/file4.txt")
 
     targets = repository.get_filepaths_in_directory(
         os.path.join('repository', 'targets', 'myproject'), recursive_walk=True)
@@ -362,10 +370,11 @@ class TestTutorial(unittest.TestCase):
           ])
 
 
-
     for delegation in repository.targets('unclaimed').delegations:
       delegation.load_signing_key(private_unclaimed_key)
 
+    # NOTE: The tutorial does not call dirty_roles anymore due to #964 and
+    # #958. We still call it here to see if roles are dirty as expected.
     with mock.patch("tuf.repository_tool.logger") as mock_logger:
       repository.dirty_roles()
       # Concat strings to avoid Python2/3 unicode prefix problems ('' vs. u'')

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -290,6 +290,8 @@ class TestTutorial(unittest.TestCase):
 
     # ----- Tutorial Section: Consistent Snapshots
 
+    repository.root.load_signing_key(private_root_key)
+    repository.root.load_signing_key(private_root_key2)
     repository.writeall(consistent_snapshot=True)
 
 

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -237,8 +237,10 @@ class TestTutorial(unittest.TestCase):
     octal_file_permissions = oct(os.stat(target4_filepath).st_mode)[4:]
     custom_file_permissions = {'file_permissions': octal_file_permissions}
     repository.targets.add_target(target4_filepath, custom_file_permissions)
-    self.assertTrue(os.path.join(
-        'myproject', 'file4.txt') in repository.targets.target_files)
+    # Note that target filepaths specified in the repo use '/' even on Windows.
+    # (This is important to make metadata platform-independent.)
+    self.assertTrue(
+        os.path.join('myproject/file4.txt') in repository.targets.target_files)
 
 
     # Skipping user entry of password

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -181,21 +181,22 @@ class TestTutorial(unittest.TestCase):
     ## $ mkdir myproject; echo 'file4' > myproject/file4.txt
     ## $ cd ../../
 
-    with open('repository/targets/file1.txt', 'w') as fobj:
+    with open(os.path.join('repository', 'targets', 'file1.txt'), 'w') as fobj:
       fobj.write('file1')
-    with open('repository/targets/file2.txt', 'w') as fobj:
+    with open(os.path.join('repository', 'targets', 'file2.txt'), 'w') as fobj:
       fobj.write('file2')
-    with open('repository/targets/file3.txt', 'w') as fobj:
+    with open(os.path.join('repository', 'targets', 'file3.txt'), 'w') as fobj:
       fobj.write('file3')
 
-    os.mkdir('repository/targets/myproject')
-    with open('repository/targets/myproject/file4.txt', 'w') as fobj:
+    os.mkdir(os.path.join('repository', 'targets', 'myproject'))
+    with open(os.path.join('repository', 'targets', 'myproject', 'file4.txt'),
+        'w') as fobj:
       fobj.write('file4')
 
 
     repository = load_repository('repository')
     list_of_targets = repository.get_filepaths_in_directory(
-        "repository/targets/", recursive_walk=False, followlinks=True)
+        os.path.join('repository', 'targets'), recursive_walk=False, followlinks=True)
 
     self.assertEqual(sorted(list_of_targets),
         ['repository/targets/file1.txt', 'repository/targets/file2.txt',
@@ -204,7 +205,8 @@ class TestTutorial(unittest.TestCase):
 
     repository.targets.add_targets(list_of_targets)
 
-    target4_filepath = "repository/targets/myproject/file4.txt"
+    target4_filepath = os.path.abspath(os.path.join(
+        'repository', 'targets', 'myproject', 'file4.txt'))
     octal_file_permissions = oct(os.stat(target4_filepath).st_mode)[4:]
     custom_file_permissions = {'file_permissions': octal_file_permissions}
     repository.targets.add_target(target4_filepath, custom_file_permissions)
@@ -240,7 +242,8 @@ class TestTutorial(unittest.TestCase):
     repository.writeall()
 
     repository.targets.remove_target("repository/targets/file3.txt")
-    self.assertTrue(os.path.exists('repository/targets/file3.txt'))
+    self.assertTrue(os.path.exists(os.path.join(
+        'repository','targets', 'file3.txt')))
 
     repository.writeall()
 
@@ -299,7 +302,7 @@ class TestTutorial(unittest.TestCase):
     # ----- Tutorial Section: Delegate to Hashed Bins
 
     targets = repository.get_filepaths_in_directory(
-        'repository/targets/myproject', recursive_walk=True)
+        os.path.join('repository', 'targets', 'myproject'), recursive_walk=True)
 
     for delegation in repository.targets('unclaimed').delegations:
       delegation.load_signing_key(private_unclaimed_key)

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -256,9 +256,11 @@ class TestTutorial(unittest.TestCase):
 
     repository.writeall()
 
-
-    signable_content = dump_signable_metadata('targets.json')
-    append_signature(signature, 'targets.json')
+    signable_content = dump_signable_metadata(
+        os.path.join('repository', 'metadata.staged', 'targets.json'))
+    append_signature(
+        {'keyid': '99aabb', 'sig': '000000'},
+        os.path.join('repository', 'metadata.staged', 'targets.json'))
 
 
 

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -430,7 +430,7 @@ def get_dirty_roles(repository_name='default'):
     None.
 
   <Returns>
-    A list of the roles that have been modified.
+    A sorted list of the roles that have been modified.
   """
 
   # Does 'repository_name' have the correct format?  Raise
@@ -444,7 +444,7 @@ def get_dirty_roles(repository_name='default'):
     raise securesystemslib.exceptions.InvalidNameError('Repository name does'
       '  not' ' exist: ' + repository_name)
 
-  return list(_dirty_roles[repository_name])
+  return sorted(list(_dirty_roles[repository_name]))
 
 
 


### PR DESCRIPTION
Add a regression test for the tutorial instructions. Running test_tutorial.py attempts the commands replicated from TUTORIAL.md. This should help us avoid breaking the tutorial with future changes without noticing by having automated testing run the tutorial and produce helpful output.

It would be wise to add a similar test for the client use instructions.

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


