### PR TITLE
Bump version to 0.11.2-dev1 for PyPI dev release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ with open('README.md') as file_object:
 
 setup(
   name = 'tuf',
-  version = '0.11.2-alpha', # If updating version, also update it in tuf/__init__.py
+  version = '0.11.2.dev1', # If updating version, also update it in tuf/__init__.py
   description = 'A secure updater framework for Python',
   long_description = long_description,
   long_description_content_type='text/markdown',

--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -2,4 +2,4 @@
 # setup.py has it hard-coded separately.
 # Currently, when the version is changed, it must be set in both locations.
 # TODO: Single-source the version number.
-__version__ = "0.11.2-alpha"
+__version__ = "0.11.2.dev1"


### PR DESCRIPTION
Per [a request in 781](https://github.com/theupdateframework/tuf/pull/781#issuecomment-426676958), producing a dev release of this for PyPI that will use a version number that is unlikely to be installed by accident by someone trying to install a stable release. PEP 440 lays out version suffixes like 'dev0' for this sort of use.

[pip documentation](https://pip.pypa.io/en/stable/reference/pip_install/#pre-release-versions) suggests that `--pre` is required to install versions like '...-dev1'. 

This PR simply updates the version of TUF.