### PR TITLE
Fixed #243: Print expected type instead of its string representation

### DIFF
--- a/tuf/schema.py
+++ b/tuf/schema.py
@@ -514,7 +514,7 @@ class ListOf(Schema):
   
   def check_match(self, object):
     if not isinstance(object, (list, tuple)):
-      message = 'Expected '+repr(self._list_name)+' but got '+repr(object)
+      message = 'Expected '+repr(self._list_name)+' but got '+type(object)
       raise tuf.FormatError(message)
 
     # Check if all the items in the 'object' list


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #243:

**Description of the changes being introduced by the pull request**: If a user passes an object O which is a list to a Schema ListOf object, the error message will not print the string representation S of O, but its type instead (to avoid huge messages when S is large).

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature

