### PR TITLE
test: Remove port collison chance and lengthen delays for AppVeyor

### DIFF
--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -261,10 +261,11 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     #    generation method used for the next two, in case it comes to matter)
     # 3: run with an HTTPS certificate with an unexpected hostname
     # 4: run with an HTTPS certificate that is expired
-    port1 = str(random.randint(30000, 45000))
-    port2 = str(int(port1) + 1)
-    port3 = str(int(port1) + 2)
-    port4 = str(int(port1) + 3)
+    # Be sure to offset from the port used in setUp to avoid collision.
+    port1 = str(self.PORT + 1)
+    port2 = str(self.PORT + 2)
+    port3 = str(self.PORT + 3)
+    port4 = str(self.PORT + 4)
     good_https_server_proc = popen_python(
         ['simple_https_server.py', port1, good_cert_fname])
     good2_https_server_proc = popen_python(
@@ -274,13 +275,12 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     expd_https_server_proc = popen_python(
         ['simple_https_server.py', port4, expired_cert_fname])
 
-    # Provide a delay long enough to allow the HTTPS servers to start.
-    # Encountered an error on one test system at delay value of 0.2s, so
-    # increasing to 0.5s.  Further increasing to 2s due to occasional failures
-    # in other tests in similar circumstances on AppVeyor.
+    # Provide a delay long enough to allow the four HTTPS servers to start.
+    # Have encountered errors at 0.2s, 0.5s, and 2s, primarily on AppVeyor.
+    # Increasing to 4s for this test.
     # Expect to see "Connection refused" if this delay is not long enough
     # (though other issues could cause that).
-    time.sleep(2)
+    time.sleep(3)
 
     relative_target_fpath = os.path.basename(target_filepath)
     good_https_url = 'https://localhost:' + port1 + '/' + relative_target_fpath

--- a/tests/test_proxy_use.py
+++ b/tests/test_proxy_use.py
@@ -123,8 +123,9 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
     # start listening before allowing tests to begin, lest we get "Connection
     # refused" errors. On the first test system. 0.1s was too short and 0.15s
     # was long enough. Use 0.5s to be safe, and if issues arise, increase it.
-    # Observed some occasional AppVeyor failures, so increasing this to 1s.
-    time.sleep(2)
+    # Observed occasional failures at 0.1s, 0.15s, 0.5s, and 2s, primarily on
+    # AppVeyor.  Increasing to 4s.  This setup runs once for the module.
+    time.sleep(4)
 
 
 


### PR DESCRIPTION
As predicted by #799...

Delay more when spawning test servers to avoid rare failures
on AppVeyor during automatic testing.

The Windows test systems run on AppVeyor were occasionally laggy
enough that spawning a separate server process didn't happen fast
enough for the included delays, so connection attempts in the tests
occasionally failed.

This also removes the chance of a random port collision for one of the five servers spawned in `test_download.py` by making sure that the other chosen ports are all in sequence with it.