### PR TITLE
Satisfy new pylint version by removing 'pass' in class defs...

### DIFF
--- a/tuf/exceptions.py
+++ b/tuf/exceptions.py
@@ -38,12 +38,10 @@ logger = logging.getLogger('tuf.exceptions')
 
 class Error(Exception):
   """Indicate a generic error."""
-  pass
 
 
 class FormatError(Error):
   """Indicate an error while validating an object's format."""
-  pass
 
 
 class InvalidMetadataJSONError(FormatError):
@@ -62,7 +60,6 @@ class InvalidMetadataJSONError(FormatError):
 
 class UnsupportedAlgorithmError(Error):
   """Indicate an error while trying to identify a user-specified algorithm."""
-  pass
 
 
 class BadHashError(Error):
@@ -85,32 +82,26 @@ class BadVersionNumberError(Error):
 
 class BadPasswordError(Error):
   """Indicate an error after encountering an invalid password."""
-  pass
 
 
 class UnknownKeyError(Error):
   """Indicate an error while verifying key-like objects (e.g., keyids)."""
-  pass
 
 
 class RepositoryError(Error):
   """Indicate an error with a repository's state, such as a missing file."""
-  pass
 
 
 class InsufficientKeysError(Error):
   """Indicate that metadata role lacks a threshold of pubic or private keys."""
-  pass
 
 
 class ForbiddenTargetError(RepositoryError):
   """Indicate that a role signed for a target that it was not delegated to."""
-  pass
 
 
 class ExpiredMetadataError(Error):
   """Indicate that a TUF Metadata file has expired."""
-  pass
 
 
 class ReplayedMetadataError(RepositoryError):
@@ -132,7 +123,6 @@ class ReplayedMetadataError(RepositoryError):
 
 class CryptoError(Error):
   """Indicate any cryptography-related errors."""
-  pass
 
 
 class BadSignatureError(CryptoError):
@@ -149,17 +139,14 @@ class BadSignatureError(CryptoError):
 
 class UnknownMethodError(CryptoError):
   """Indicate that a user-specified cryptograpthic method is unknown."""
-  pass
 
 
 class UnsupportedLibraryError(Error):
   """Indicate that a supported library could not be located or imported."""
-  pass
 
 
 class DownloadError(Error):
   """Indicate an error occurred while attempting to download a file."""
-  pass
 
 
 class DownloadLengthMismatchError(DownloadError):
@@ -191,27 +178,22 @@ class SlowRetrievalError(DownloadError):
 
 class KeyAlreadyExistsError(Error):
   """Indicate that a key already exists and cannot be added."""
-  pass
 
 
 class RoleAlreadyExistsError(Error):
   """Indicate that a role already exists and cannot be added."""
-  pass
 
 
 class UnknownRoleError(Error):
   """Indicate an error trying to locate or identify a specified TUF role."""
-  pass
 
 
 class UnknownTargetError(Error):
   """Indicate an error trying to locate or identify a specified target."""
-  pass
 
 
 class InvalidNameError(Error):
   """Indicate an error while trying to validate any type of named object."""
-  pass
 
 
 class UnsignedMetadataError(Error):
@@ -263,19 +245,15 @@ class NoWorkingMirrorError(Error):
 
 class NotFoundError(Error):
   """If a required configuration or resource is not found."""
-  pass
 
 
 class URLMatchesNoPatternError(Error):
   """If a URL does not match a user-specified regular expression."""
-  pass
 
 class URLParsingError(Error):
   """If we are unable to parse a URL -- for example, if a hostname element
   cannot be isoalted."""
-  pass
 
 class InvalidConfigurationError(Error):
   """If a configuration object does not match the expected format."""
-  pass
 


### PR DESCRIPTION
Satisfy new pylint version by removing `pass` in class definitions in tuf/exceptions.py, since those class definitions have docstrings, and that is apparently sufficient in a class definition to make a `pass` statement unnecessary.  pylint version 2.2.0 complains about unnecessary `pass` statements in this situation, so this resolves that.  (See build in #806.)

While the code is prettier and shorter, I am just slightly uncomfortable with comments changing code semantics....