### PR TITLE
Avoid unnecessary delegated role downloads

### DIFF
--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -2349,6 +2349,12 @@ class Updater(object):
   def all_targets(self):
     """
     <Purpose>
+
+      NOTE: This function is deprecated.  Its behavior with regard to which
+      delegating Targets roles are trusted to determine how to validate a
+      delegated Targets role is NOT WELL DEFINED.  Please transition to use of
+      get_one_valid_targetinfo()!
+
       Get a list of the target information for all the trusted targets on the
       repository.  This list also includes all the targets of delegated roles.
       Targets of the list returned are ordered according the trusted order of
@@ -2558,6 +2564,12 @@ class Updater(object):
   def targets_of_role(self, rolename='targets'):
     """
     <Purpose>
+
+      NOTE: This function is deprecated.  Use with rolename 'targets' is secure
+      and the behavior well-defined, but use with any delegated targets role is
+      not. Please transition use for delegated targets roles to
+      get_one_valid_targetinfo().  More information is below.
+
       Return a list of trusted targets directly specified by 'rolename'.
       The returned information is a list conformant to
       'tuf.formats.TARGETINFOS_SCHEMA', and has the form:
@@ -2603,7 +2615,24 @@ class Updater(object):
     # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
     securesystemslib.formats.RELPATH_SCHEMA.check_match(rolename)
 
+    # If we've been given a delegated targets role, we don't know how to
+    # validate it without knowing what the delegating role is -- there could
+    # be several roles that delegate to the given role.  Behavior of this
+    # function for roles other than Targets is not well defined as a result.
+    # This function is deprecated, but:
+    #   - Usage of this function or a future successor makes sense when the
+    #     role of interest is Targets, since we always know exactly how to
+    #     validate Targets (We use root.).
+    #   - Until it's removed (hopefully soon), we'll try to provide what it has
+    #     always provided.  To do this, we fetch and "validate" all delegated
+    #     roles listed by snapshot.  For delegated roles only, the order of the
+    #     validation impacts the security of the validation -- the most-
+    #     recently-validated role delegating to a role you are currently
+    #     validating determines the expected keyids and threshold of the role
+    #     you are currently validating.  That is NOT GOOD.  Again, please switch
+    #     to get_one_valid_targetinfo, which is well-defined and secure.
     self._refresh_targets_metadata(refresh_all_delegated_roles=True)
+
 
     if not tuf.roledb.role_exists(rolename, self.repository_name):
       raise tuf.exceptions.UnknownRoleError(rolename)

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -2631,7 +2631,8 @@ class Updater(object):
     #     validating determines the expected keyids and threshold of the role
     #     you are currently validating.  That is NOT GOOD.  Again, please switch
     #     to get_one_valid_targetinfo, which is well-defined and secure.
-    self._refresh_targets_metadata(refresh_all_delegated_roles=True)
+    if rolename != 'targets':
+      self._refresh_targets_metadata(refresh_all_delegated_roles=True)
 
 
     if not tuf.roledb.role_exists(rolename, self.repository_name):


### PR DESCRIPTION
Using deprecated function [`Updater.targets_of_role()`](https://github.com/theupdateframework/tuf/blob/d910c0865a83fda735b4cdd595c711e69c837974/tuf/client/updater.py#L2486) to fetch the targets listed by the top-level Targets role previously led to the unneeded download of all delegated targets roles.  This PR fixes that specifically for calls to `targets_of_role('targets')` (which is the only well-defined and secure use of the deprecated function `targets_of_role`).

All delegated targets continue to be downloaded if `targets_of_role` is called on a delegated targets role.  This provides something like what we think users who might do this expect (It's not clear there are any people doing this.), refreshing all delegated targets roles to avoid use of outdated delegation information, and essentially hoping that the most-recently-validated delegation to the role of interest is what the user would expect that role to have been validated by.....

`targets_of_role` will be removed or replaced, so this is a fix for the sole reasonable use case until then.

The PR also adds some explanatory comments and warnings to the code.


- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


