### PR TITLE
Split download timeout into connection and inter-byte timeouts

### DIFF
--- a/tuf/download.py
+++ b/tuf/download.py
@@ -274,13 +274,15 @@ def _download_file(url, required_length, STRICT_REQUIRED_LENGTH=True):
     # We will always manually close Responses, so no need for a context
     # manager.
     #
-    # Always set the timeout. This timeout value is interpreted by requests as:
+    # Initiate a request to the server, setting these timeouts on future reads:
     #  - connect timeout (max delay before first byte is received)
     #  - read (gap) timeout (max delay between bytes received)
     # These are NOT overall/total, wall-clock timeouts for any single read.
     # http://docs.python-requests.org/en/master/user/advanced/#timeouts
     response = session.get(
-        url, stream=True, timeout=tuf.settings.SOCKET_TIMEOUT)
+        url, stream=True, timeout=(
+        tuf.settings.SOCKET_CONNECT_TIMEOUT,
+        tuf.settings.SOCKET_INTERBYTE_TIMEOUT))
 
     # Check response status.
     response.raise_for_status()

--- a/tuf/settings.py
+++ b/tuf/settings.py
@@ -74,8 +74,13 @@ DEFAULT_SNAPSHOT_REQUIRED_LENGTH = 2000000 #bytes
 # download Targets metadata.
 DEFAULT_TARGETS_REQUIRED_LENGTH = 5000000 #bytes
 
-# Set a timeout value in seconds (float) for non-blocking socket operations.
-SOCKET_TIMEOUT = 4 #seconds
+# Set timeout values in seconds (float) for socket operations.
+# Requests will time out if the initial server response takes longer than
+# SOCKET_CONNECT_TIMEOUT seconds to be received, or if, while we are waiting
+# for the server to finish sending the requested data, there is a delay since
+# the last packet was received greater than SOCKET_INTERBYTE_TIMEOUT.
+SOCKET_CONNECT_TIMEOUT = 10
+SOCKET_INTERBYTE_TIMEOUT = 4
 
 # The maximum chunk of data, in bytes, we would download in every round.
 CHUNK_SIZE = 400000 #bytes


### PR DESCRIPTION
Requests accepts two kinds of timeouts: connection timeouts and
inter-byte ("read", "gap") timeouts.  Separate these so that we
can use sensible values for each.

See http://docs.python-requests.org/en/master/user/advanced/#timeouts

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


