### PR TITLE
Reduce test spam by using unittest output buffering

### DIFF
--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -303,4 +303,4 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_developer_tool.py
+++ b/tests/test_developer_tool.py
@@ -424,4 +424,4 @@ class TestProject(unittest.TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -404,4 +404,4 @@ def popen_python(command_arg_list):
 
 # Run unit test.
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -291,4 +291,4 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -56,4 +56,4 @@ class TestExceptions(unittest.TestCase):
 
 # Run the unit tests.
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -235,4 +235,4 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -768,4 +768,4 @@ class TestFormats(unittest.TestCase):
 
 # Run unit test.
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -508,4 +508,4 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -72,4 +72,4 @@ class TestInit(unittest.TestCase):
 
 # Run the unit tests.
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -516,4 +516,4 @@ def _load_role_keys(keystore_directory):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_keydb.py
+++ b/tests/test_keydb.py
@@ -382,4 +382,4 @@ class TestKeydb(unittest.TestCase):
 
 # Run unit test.
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -195,4 +195,4 @@ class TestLog(unittest.TestCase):
 
 # Run unit test.
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_mirrors.py
+++ b/tests/test_mirrors.py
@@ -112,4 +112,4 @@ class TestMirrors(unittest_toolbox.Modified_TestCase):
 
 # Run the unittests
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -257,4 +257,4 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -304,4 +304,4 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_proxy_use.py
+++ b/tests/test_proxy_use.py
@@ -382,4 +382,4 @@ def popen_python(command_arg_list):
 
 # Run unit test.
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -340,4 +340,4 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -1091,4 +1091,4 @@ class TestRepositoryToolFunctions(unittest.TestCase):
 
 # Run the test cases.
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1800,4 +1800,4 @@ class TestRepositoryToolFunctions(unittest.TestCase):
 
 # Run the test cases.
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_roledb.py
+++ b/tests/test_roledb.py
@@ -771,4 +771,4 @@ def tearDownModule():
 
 # Run the unit tests.
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_root_versioning_integration.py
+++ b/tests/test_root_versioning_integration.py
@@ -225,4 +225,4 @@ class TestRepository(unittest.TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_sig.py
+++ b/tests/test_sig.py
@@ -445,4 +445,4 @@ class TestSig(unittest.TestCase):
 
 # Run unit test.
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -324,4 +324,4 @@ class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_unittest_toolbox.py
+++ b/tests/test_unittest_toolbox.py
@@ -55,4 +55,4 @@ class TestUnittestToolbox(unittest_toolbox.Modified_TestCase):
 
 # Run the unit tests.
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -2120,4 +2120,4 @@ def _load_role_keys(keystore_directory):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -383,4 +383,4 @@ def _load_role_keys(keystore_directory):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(buffer=True)


### PR DESCRIPTION
After merge, stdout should only appear if a test has failed.  This functionality is provided by `unittest.main` argument `buffer=True`.  This functions like the `--buffer` command line argument listed [here](https://docs.python.org/2/library/unittest.html#command-line-options).  std out is discarded if a test succeeds.