### PR TITLE
Reduce test spam by using unittest output buffering

### DIFF
--- a/tests/aggregate_tests.py
+++ b/tests/aggregate_tests.py
@@ -91,7 +91,8 @@ random.shuffle(test_modules_to_run)
 
 if __name__ == '__main__':
   suite = unittest.TestLoader().loadTestsFromNames(test_modules_to_run)
-  all_tests_passed = unittest.TextTestRunner(verbosity=1).run(suite).wasSuccessful()
+  all_tests_passed = unittest.TextTestRunner(
+      verbosity=1, buffer=True).run(suite).wasSuccessful()
   if not all_tests_passed:
     sys.exit(1)
 


### PR DESCRIPTION
Thanks go to @lukpueh for this helpful tip.

This is a succinct replacement for PR #819.

After merge, stdout from the code being tested should only appear if the test has failed or errored out.

This functionality is provided by `unittest.TextTestRunner` argument `buffer=True`.
This functions like the `--buffer` command line argument listed [here](https://docs.python.org/3/library/unittest.html#command-line-options)