### PR TITLE
Update deprecated links in docs

### DIFF
--- a/docs/CONTRIBUTORS.rst
+++ b/docs/CONTRIBUTORS.rst
@@ -98,7 +98,7 @@ Fedora-based distributions can install these libraries with dnf.
 
     $ dnf install libffi-devel redhat-rpm-config openssl-devel
 
-OS X users can install these header libraries with the `Homebrew <http://brew.sh/>`_ package manager.
+OS X users can install these header libraries with the `Homebrew <https://brew.sh/>`_ package manager.
 ::
 
     $ brew install python

--- a/docs/OVERVIEW.rst
+++ b/docs/OVERVIEW.rst
@@ -27,7 +27,7 @@ Our Approach
 
 There are literally thousands of different software update systems in
 common use today. (In fact the average Windows user has about `two
-dozen <http://secunia.com/gfx/pdf/Secunia_RSA_Software_Portfolio_Security_Exposure.pdf>`_
+dozen <https://secuniaresearch.flexerasoftware.com/gfx/pdf/Secunia_RSA_Software_Portfolio_Security_Exposure.pdf>`_
 different software updaters on their machine!)
 
 We are building a library that can be universally (and in most cases


### PR DESCRIPTION
This PR replaces deprecated HTTP links in docs by correct, secure HTTPS links.


