### PR TITLE
Resolve pylint error: remove outdated exception subscript

### DIFF
--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -390,9 +390,10 @@ class Project(Targets):
             self.repository_name)
         self._log_status(self.project_name, signable, self.repository_name)
 
-      except securesystemslib.exceptions.Error as e:
-        signable = e[1]
-        self._log_status(self.project_name, signable, self.repository_name)
+      except tuf.exceptions.UnsignedMetadataError as e:
+        # This error is raised if the metadata has insufficient signatures to
+        # meet the threshold.
+        self._log_status(self.project_name, e.signable, self.repository_name)
         return
 
     finally:


### PR DESCRIPTION
Python3 does not support exception subscripting:
e.g.
```Python
except ... as e:
  e[1]       # does not work in Python3
```

This [five-year-old line of code](https://github.com/theupdateframework/tuf/blob/24618a956b05402f75a8e8fc3e5ac343b094e117/tuf/developer_tool.py#L394) was presumably not covered by testing, allowing it to persist.

I resolved with a minor change: using an error more appropriate to this particular problem, one that already includes a signable field.

In looking at this, I'm *not pleased* by how differently `developer_tool.py` and `repository_tool.py` code their `status()` functions....  That merits some attention, but it won't be here.