### PR TITLE
Improve the way specification version is checked in metadata

### DIFF
--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -166,11 +166,6 @@ logger = logging.getLogger('tuf.client.updater')
 iso8601_logger = logging.getLogger('iso8601')
 iso8601_logger.disabled = True
 
-# Metadata includes the specification version number that it follows.
-# All downloaded metadata must be equal to our supported major version of 1.
-# For example, "1.4.3" and "1.0.0" are supported.  "2.0.0" is not supported.
-SUPPORTED_MAJOR_VERSION = 1
-
 
 class MultiRepoUpdater(object):
   """
@@ -1497,11 +1492,15 @@ class Updater(object):
         # version number of new metadata equals our expected major version
         # number, the new metadata is safe to parse.
         try:
-          spec_version_parsed = metadata_signable['signed']['spec_version'].split('.')
-          if int(spec_version_parsed[0]) != SUPPORTED_MAJOR_VERSION:
-            raise securesystemslib.exceptions.BadVersionNumberError('Downloaded'
-              ' metadata that specifies an unsupported spec_version.  Supported'
-              ' major version number: ' + repr(SUPPORTED_MAJOR_VERSION))
+          metadata_spec_version = metadata_signable['signed']['spec_version']
+          spec_major_version = int(metadata_spec_version.split('.')[0])
+          if spec_major_version != tuf.formats.SUPPORTED_MAJOR_VERSION:
+            raise tuf.exceptions.UnsupportedSpecificationError(
+                'Downloaded metadata that specifies an unsupported '
+                'spec_version.  This code supports major version number: ' +
+                repr(tuf.formats.SUPPORTED_MAJOR_VERSION) + '; however, the '
+                'obtained metadata lists version number: ' +
+                str(metadata_spec_version))
 
         except (ValueError, TypeError):
           raise securesystemslib.exceptions.FormatError('Improperly'

--- a/tuf/exceptions.py
+++ b/tuf/exceptions.py
@@ -40,6 +40,12 @@ class Error(Exception):
   """Indicate a generic error."""
 
 
+class UnsupportedSpecificationError(Error):
+  """
+  Metadata received claims to conform to a version of the specification that is
+  not supported by this client.
+  """
+
 class FormatError(Error):
   """Indicate an error while validating an object's format."""
 

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -90,7 +90,12 @@ import six
 # TUF specification version.  The constant should be updated when the version
 # number of the specification changes.  All metadata should list this version
 # number.
+# Metadata includes the specification version number that it follows.
+# All downloaded metadata must be equal to our supported major version of 1.
+# For example, "1.4.3" and "1.0.0" are supported.  "2.0.0" is not supported.
 TUF_VERSION_NUMBER = '1.0'
+SUPPORTED_MAJOR_VERSION = int(TUF_VERSION_NUMBER.split('.')[0])
+
 SPECIFICATION_VERSION_SCHEMA = SCHEMA.AnyString()
 
 # A datetime in 'YYYY-MM-DDTHH:MM:SSZ' ISO 8601 format.  The "Z" zone designator


### PR DESCRIPTION
Improve the way specification version is checked in metadata
and generate more friendly errors.  Prior to this, a test in
test_updater.py was written in such a way to not actually be
testing whether or not specification version checking was
working correctly -- the error updater.py raised if a specification
version number was not supported was the same as would be raised
if a role version was not the expected version, and, amusingly,
the test could not distinguish between these two scenarios and
was providing the wrong role version......

Specification version mismatch now raises a particular error:
UnsupportedSpecificationError.

The specification version supported by this code is now also all
in one place, tuf.formats rather than tuf.updater.

Related error messages and testing were improved (with some
edge cases closed).

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
