### PR TITLE
Specification version support code cleanup

### DIFF
--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -3,3 +3,11 @@
 # Currently, when the version is changed, it must be set in both locations.
 # TODO: Single-source the version number.
 __version__ = "0.11.2.dev3"
+
+# This reference implementation produces metadata intended to conform to
+# version 1.0 of the TUF specification, and is expected to consume metadata
+# conforming to version 1.0 of the TUF specification.
+# All downloaded metadata must be equal to our supported major version of 1.
+# For example, "1.4.3" and "1.0.0" are supported.  "2.0.0" is not supported.
+# See https://github.com/theupdateframework/specification
+SPECIFICATION_VERSION = '1.0'

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1493,14 +1493,15 @@ class Updater(object):
         # number, the new metadata is safe to parse.
         try:
           metadata_spec_version = metadata_signable['signed']['spec_version']
-          spec_major_version = int(metadata_spec_version.split('.')[0])
-          if spec_major_version != tuf.formats.SUPPORTED_MAJOR_VERSION:
+          metadata_spec_major_version = int(metadata_spec_version.split('.')[0])
+          code_spec_major_version = int(tuf.SPECIFICATION_VERSION.split('.')[0])
+
+          if metadata_spec_major_version != code_spec_major_version:
             raise tuf.exceptions.UnsupportedSpecificationError(
                 'Downloaded metadata that specifies an unsupported '
                 'spec_version.  This code supports major version number: ' +
-                repr(tuf.formats.SUPPORTED_MAJOR_VERSION) + '; however, the '
-                'obtained metadata lists version number: ' +
-                str(metadata_spec_version))
+                repr(code_spec_major_version) + '; however, the obtained '
+                'metadata lists version number: ' + str(metadata_spec_version))
 
         except (ValueError, TypeError):
           raise securesystemslib.exceptions.FormatError('Improperly'

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -87,15 +87,6 @@ import securesystemslib.schema as SCHEMA
 import six
 
 
-# TUF specification version.  The constant should be updated when the version
-# number of the specification changes.  All metadata should list this version
-# number.
-# Metadata includes the specification version number that it follows.
-# All downloaded metadata must be equal to our supported major version of 1.
-# For example, "1.4.3" and "1.0.0" are supported.  "2.0.0" is not supported.
-TUF_VERSION_NUMBER = '1.0'
-SUPPORTED_MAJOR_VERSION = int(TUF_VERSION_NUMBER.split('.')[0])
-
 SPECIFICATION_VERSION_SCHEMA = SCHEMA.AnyString()
 
 # A datetime in 'YYYY-MM-DDTHH:MM:SSZ' ISO 8601 format.  The "Z" zone designator
@@ -543,7 +534,7 @@ class TimestampFile(MetaFile):
   @staticmethod
   def make_metadata(version, expiration_date, filedict):
     result = {'_type' : 'timestamp'}
-    result['spec_version'] = TUF_VERSION_NUMBER
+    result['spec_version'] = tuf.SPECIFICATION_VERSION
     result['version'] = version
     result['expires'] = expiration_date
     result['meta'] = filedict
@@ -583,7 +574,7 @@ class RootFile(MetaFile):
   @staticmethod
   def make_metadata(version, expiration_date, keydict, roledict, consistent_snapshot):
     result = {'_type' : 'root'}
-    result['spec_version'] = TUF_VERSION_NUMBER
+    result['spec_version'] = tuf.SPECIFICATION_VERSION
     result['version'] = version
     result['expires'] = expiration_date
     result['keys'] = keydict
@@ -623,7 +614,7 @@ class SnapshotFile(MetaFile):
   @staticmethod
   def make_metadata(version, expiration_date, versiondict):
     result = {'_type' : 'snapshot'}
-    result['spec_version'] = TUF_VERSION_NUMBER
+    result['spec_version'] = tuf.SPECIFICATION_VERSION
     result['version'] = version
     result['expires'] = expiration_date
     result['meta'] = versiondict
@@ -671,7 +662,7 @@ class TargetsFile(MetaFile):
         ' empty targets metadata.')
 
     result = {'_type' : 'targets'}
-    result['spec_version'] = TUF_VERSION_NUMBER
+    result['spec_version'] = tuf.SPECIFICATION_VERSION
     result['version'] = version
     result['expires'] = expiration_date
     result['targets'] = {}


### PR DESCRIPTION
Corrects and finishes the task of PR #842.

Specification version now only lives in tuf/__init__.py, and will only be derived from there.

Specification version info is no longer in tuf.formats, where it was previously moved from tuf.updater, since this was redundant.

Also finally corrects spec version testing in test_updater.py.

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


