### PR TITLE
Adjust to removals from securesystemslib

### DIFF
--- a/tests/test_developer_tool.py
+++ b/tests/test_developer_tool.py
@@ -170,7 +170,7 @@ class TestProject(unittest.TestCase):
       developer_tool.create_new_project(project_name, metadata_directory,
           location_in_repository, targets_directory, project_key)
 
-    except (OSError, securesystemslib.exceptions.RepositoryError):
+    except (OSError, tuf.exceptions.RepositoryError):
       pass
 
     developer_tool.METADATA_DIRECTORY_NAME = valid_metadata_directory_name

--- a/tests/test_keydb.py
+++ b/tests/test_keydb.py
@@ -132,12 +132,12 @@ class TestKeydb(unittest.TestCase):
     keyid = KEYS[0]['keyid']
     repository_name = 'example_repository'
     tuf.keydb.create_keydb(repository_name)
-    self.assertRaises(securesystemslib.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid, repository_name)
+    self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid, repository_name)
     tuf.keydb.add_key(rsakey, keyid, repository_name)
     self.assertEqual(rsakey, tuf.keydb.get_key(keyid, repository_name))
 
     tuf.keydb.clear_keydb(repository_name)
-    self.assertRaises(securesystemslib.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid, repository_name)
+    self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid, repository_name)
 
     # Remove 'repository_name' from the key database to revert it back to its
     # original, default state (i.e., only the 'default' repository exists).
@@ -169,7 +169,7 @@ class TestKeydb(unittest.TestCase):
 
     # Test condition using a 'keyid' that has not been added yet.
     keyid3 = KEYS[2]['keyid']
-    self.assertRaises(securesystemslib.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid3)
+    self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid3)
 
     # Test condition for a key added to a non-default repository.
     repository_name = 'example_repository'
@@ -183,7 +183,7 @@ class TestKeydb(unittest.TestCase):
 
     # Verify that 'rsakey3' is added to the expected repository name.
     # If not supplied, the 'default' repository name is searched.
-    self.assertRaises(securesystemslib.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid3)
+    self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid3)
     self.assertEqual(rsakey3, tuf.keydb.get_key(keyid3, repository_name))
 
     # Remove the 'example_repository' so that other test functions have access
@@ -231,15 +231,15 @@ class TestKeydb(unittest.TestCase):
     # Test conditions using keyids that have already been added.
     tuf.keydb.add_key(rsakey, keyid)
     tuf.keydb.add_key(rsakey2, keyid2)
-    self.assertRaises(securesystemslib.exceptions.KeyAlreadyExistsError, tuf.keydb.add_key, rsakey)
-    self.assertRaises(securesystemslib.exceptions.KeyAlreadyExistsError, tuf.keydb.add_key, rsakey2)
+    self.assertRaises(tuf.exceptions.KeyAlreadyExistsError, tuf.keydb.add_key, rsakey)
+    self.assertRaises(tuf.exceptions.KeyAlreadyExistsError, tuf.keydb.add_key, rsakey2)
 
     # Test condition for key added to the keydb of a non-default repository.
     repository_name = 'example_repository'
     tuf.keydb.create_keydb(repository_name)
-    self.assertRaises(securesystemslib.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid3, repository_name)
+    self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid3, repository_name)
     tuf.keydb.add_key(rsakey3, keyid3, repository_name)
-    self.assertRaises(securesystemslib.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid3)
+    self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid3)
     self.assertEqual(rsakey3, tuf.keydb.get_key(keyid3, repository_name))
 
     # Test condition for key added to the keydb of a non-existent repository.
@@ -268,14 +268,14 @@ class TestKeydb(unittest.TestCase):
     self.assertEqual(None, tuf.keydb.remove_key(keyid2))
 
     # Ensure the keys were actually removed.
-    self.assertRaises(securesystemslib.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid)
-    self.assertRaises(securesystemslib.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid2)
+    self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid)
+    self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid2)
 
     # Test for 'keyid' not in keydb.
-    self.assertRaises(securesystemslib.exceptions.UnknownKeyError, tuf.keydb.remove_key, keyid)
+    self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.remove_key, keyid)
 
     # Test condition for unknown key argument.
-    self.assertRaises(securesystemslib.exceptions.UnknownKeyError, tuf.keydb.remove_key, '1')
+    self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.remove_key, '1')
 
     # Test condition for removal of keys from a non-default repository.
     repository_name = 'example_repository'
@@ -283,7 +283,7 @@ class TestKeydb(unittest.TestCase):
     tuf.keydb.add_key(rsakey, keyid, repository_name)
     self.assertRaises(securesystemslib.exceptions.InvalidNameError, tuf.keydb.remove_key, keyid, 'non-existent')
     tuf.keydb.remove_key(keyid, repository_name)
-    self.assertRaises(securesystemslib.exceptions.UnknownKeyError, tuf.keydb.remove_key, keyid, repository_name)
+    self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.remove_key, keyid, repository_name)
 
     # Reset the keydb so that subsequent tests have access to the original,
     # default keydb.
@@ -390,8 +390,8 @@ class TestKeydb(unittest.TestCase):
     # Ensure only 'keyid2' was added to the keydb database.  'keyid' and
     # 'keyid3' should not be stored.
     self.assertEqual(rsakey2, tuf.keydb.get_key(keyid2))
-    self.assertRaises(securesystemslib.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid)
-    self.assertRaises(securesystemslib.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid3)
+    self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid)
+    self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid3)
     rsakey3['keytype'] = 'rsa'
 
 

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -240,7 +240,7 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
       self.repository_updater.targets_of_role('role1')
 
     # Verify that the specific
-    # 'securesystemslib.exceptions.BadVersionNumberError' exception is raised by
+    # 'tuf.exceptions.BadVersionNumberError' exception is raised by
     # each mirror.
     except tuf.exceptions.NoWorkingMirrorError as exception:
       for mirror_url, mirror_error in six.iteritems(exception.mirror_errors):
@@ -249,8 +249,8 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
 
         # Verify that 'role1.json' is the culprit.
         self.assertEqual(url_file.replace('\\', '/'), mirror_url)
-        self.assertTrue(isinstance(mirror_error,
-                        securesystemslib.exceptions.BadVersionNumberError))
+        self.assertTrue(isinstance(
+            mirror_error, tuf.exceptions.BadVersionNumberError))
 
     else:
       self.fail('TUF did not prevent a mix-and-match attack.')

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -866,7 +866,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
 
 
     # Test invalid argument (i.e., client directory already exists.)
-    self.assertRaises(securesystemslib.exceptions.RepositoryError,
+    self.assertRaises(tuf.exceptions.RepositoryError,
         repo_lib.create_tuf_client_directory, repository_directory,
         client_directory)
 
@@ -882,7 +882,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     # Creation of the '/' directory is forbidden on all supported OSs.  The '/'
     # argument to create_tuf_client_directory should cause it to re-raise a
     # non-errno.EEXIST exception.
-    self.assertRaises((OSError, securesystemslib.exceptions.RepositoryError),
+    self.assertRaises((OSError, tuf.exceptions.RepositoryError),
         repo_lib.create_tuf_client_directory, repository_directory, '/')
 
     # Restore the metadata directory name in repo_lib.
@@ -1035,7 +1035,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
 
     # Remove the required Root file and verify that an exception is raised.
     os.remove(os.path.join(metadata_directory, 'root.json'))
-    self.assertRaises(securesystemslib.exceptions.RepositoryError,
+    self.assertRaises(tuf.exceptions.RepositoryError,
         repo_lib._load_top_level_metadata, repository, filenames,
         repository_name)
 

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -250,7 +250,7 @@ class TestRepository(unittest.TestCase):
     repository.status()
 
     # Verify that status() does not raise
-    # 'securesystemslib.exceptions.InsufficientKeysError' if a top-level role
+    # 'tuf.exceptions.InsufficientKeysError' if a top-level role
     # does not contain a threshold of keys.
     targets_roleinfo = tuf.roledb.get_roleinfo('targets', repository_name)
     old_threshold = targets_roleinfo['threshold']
@@ -266,7 +266,7 @@ class TestRepository(unittest.TestCase):
         repository_name=repository_name)
 
     # Verify that status() does not raise
-    # 'securesystemslib.exceptions.InsufficientKeysError' if a delegated role
+    # 'tuf.exceptions.InsufficientKeysError' if a delegated role
     # does not contain a threshold of keys.
     role1_roleinfo = tuf.roledb.get_roleinfo('role1', repository_name)
     old_role1_threshold = role1_roleinfo['threshold']
@@ -971,7 +971,7 @@ class TestTargets(unittest.TestCase):
     self.assertTrue(isinstance(targets_object('role1'), repo_tool.Targets))
 
     # Test invalid (i.e., non-delegated) rolename argument.
-    self.assertRaises(securesystemslib.exceptions.UnknownRoleError, targets_object, 'unknown_role')
+    self.assertRaises(tuf.exceptions.UnknownRoleError, targets_object, 'unknown_role')
 
     # Test improperly formatted argument.
     self.assertRaises(securesystemslib.exceptions.FormatError, targets_object, 1)
@@ -1741,7 +1741,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     root_filepath = os.path.join(repository_directory,
         repo_tool.METADATA_STAGED_DIRECTORY_NAME, 'root.json')
     os.remove(root_filepath)
-    self.assertRaises(securesystemslib.exceptions.RepositoryError,
+    self.assertRaises(tuf.exceptions.RepositoryError,
         repo_tool.load_repository, repository_directory)
 
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -719,7 +719,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     except tuf.exceptions.NoWorkingMirrorError as e:
       for mirror_error in six.itervalues(e.mirror_errors):
-        assert isinstance(mirror_error, securesystemslib.exceptions.BadVersionNumberError)
+        assert isinstance(mirror_error, tuf.exceptions.BadVersionNumberError)
 
     else:
       self.fail(
@@ -727,7 +727,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # Verify that the specific exception raised is correct for the previous
     # case.  The version number is checked, so the specific error in
-    # this case should be 'securesystemslib.exceptions.BadVersionNumberError'.
+    # this case should be 'tuf.exceptions.BadVersionNumberError'.
     try:
       self.repository_updater._update_metadata('targets',
                                                DEFAULT_TARGETS_FILELENGTH,
@@ -735,7 +735,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     except tuf.exceptions.NoWorkingMirrorError as e:
       for mirror_error in six.itervalues(e.mirror_errors):
-        assert isinstance(mirror_error, securesystemslib.exceptions.BadVersionNumberError)
+        assert isinstance(mirror_error, tuf.exceptions.BadVersionNumberError)
 
     else:
       self.fail(

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -963,7 +963,7 @@ class Updater(object):
             key['keyid'] = key_id
             tuf.keydb.add_key(key, keyid=None, repository_name=self.repository_name)
 
-        except securesystemslib.exceptions.KeyAlreadyExistsError:
+        except tuf.exceptions.KeyAlreadyExistsError:
           pass
 
         except (securesystemslib.exceptions.FormatError, securesystemslib.exceptions.Error):
@@ -1530,7 +1530,7 @@ class Updater(object):
           # Verify that the downloaded version matches the version expected by
           # the caller.
           if version_downloaded != expected_version:
-            raise securesystemslib.exceptions.BadVersionNumberError('Downloaded'
+            raise tuf.exceptions.BadVersionNumberError('Downloaded'
               ' version number: ' + repr(version_downloaded) + '.  Version'
               ' number MUST be: ' + repr(expected_version))
 

--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -351,7 +351,7 @@ class Project(Targets):
         try:
           _check_role_keys(delegated_role, self.repository_name)
 
-        except securesystemslib.exceptions.InsufficientKeysError:
+        except tuf.exceptions.InsufficientKeysError:
           insufficient_keys.append(delegated_role)
           continue
 
@@ -380,7 +380,7 @@ class Project(Targets):
       try:
         _check_role_keys(self.rolename, self.repository_name)
 
-      except securesystemslib.exceptions.InsufficientKeysError as e:
+      except tuf.exceptions.InsufficientKeysError as e:
         logger.info(str(e))
         return
 
@@ -944,7 +944,7 @@ def load_project(project_directory, prefix='', new_targets_location=None,
         try:
           tuf.keydb.add_key(key_object, repository_name=repository_name)
 
-        except securesystemslib.exceptions.KeyAlreadyExistsError:
+        except tuf.exceptions.KeyAlreadyExistsError:
           pass
 
       for role in metadata_object['delegations']['roles']:

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -141,7 +141,7 @@ def create_keydb_from_root_metadata(root_metadata, repository_name='default'):
       # Although keyid duplicates should *not* occur (unique dict keys), log a
       # warning and continue.  Howerver, 'key_dict' may have already been
       # adding to the keydb elsewhere.
-      except securesystemslib.exceptions.KeyAlreadyExistsError as e: # pragma: no cover
+      except tuf.exceptions.KeyAlreadyExistsError as e: # pragma: no cover
         logger.warning(e)
         continue
 
@@ -256,7 +256,7 @@ def add_key(key_dict, keyid=None, repository_name='default'):
 
     securesystemslib.exceptions.Error, if 'keyid' does not match the keyid for 'rsakey_dict'.
 
-    securesystemslib.exceptions.KeyAlreadyExistsError, if 'rsakey_dict' is found in the key database.
+    tuf.exceptions.KeyAlreadyExistsError, if 'rsakey_dict' is found in the key database.
 
     securesystemslib.exceptions.InvalidNameError, if 'repository_name' does not exist in the key
     database.
@@ -295,7 +295,7 @@ def add_key(key_dict, keyid=None, repository_name='default'):
   # available in the key database before returning.
   keyid = key_dict['keyid']
   if keyid in _keydb_dict[repository_name]:
-    raise securesystemslib.exceptions.KeyAlreadyExistsError('Key: ' + keyid)
+    raise tuf.exceptions.KeyAlreadyExistsError('Key: ' + keyid)
 
   _keydb_dict[repository_name][keyid] = copy.deepcopy(key_dict)
 
@@ -320,7 +320,7 @@ def get_key(keyid, repository_name='default'):
   <Exceptions>
     securesystemslib.exceptions.FormatError, if the arguments do not have the correct format.
 
-    securesystemslib.exceptions.UnknownKeyError, if 'keyid' is not found in the keydb database.
+    tuf.exceptions.UnknownKeyError, if 'keyid' is not found in the keydb database.
 
     securesystemslib.exceptions.InvalidNameError, if 'repository_name' does not exist in the key
     database.
@@ -351,7 +351,7 @@ def get_key(keyid, repository_name='default'):
     return copy.deepcopy(_keydb_dict[repository_name][keyid])
 
   except KeyError:
-    raise securesystemslib.exceptions.UnknownKeyError('Key: ' + keyid)
+    raise tuf.exceptions.UnknownKeyError('Key: ' + keyid)
 
 
 
@@ -374,7 +374,7 @@ def remove_key(keyid, repository_name='default'):
   <Exceptions>
     securesystemslib.exceptions.FormatError, if the arguments do not have the correct format.
 
-    securesystemslib.exceptions.UnknownKeyError, if 'keyid' is not found in key database.
+    tuf.exceptions.UnknownKeyError, if 'keyid' is not found in key database.
 
     securesystemslib.exceptions.InvalidNameError, if 'repository_name' does not exist in the key
     database.
@@ -404,7 +404,7 @@ def remove_key(keyid, repository_name='default'):
     del _keydb_dict[repository_name][keyid]
 
   else:
-    raise securesystemslib.exceptions.UnknownKeyError('Key: ' + keyid)
+    raise tuf.exceptions.UnknownKeyError('Key: ' + keyid)
 
 
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -333,12 +333,12 @@ def _check_role_keys(rolename, repository_name):
 
   # Raise an exception for an invalid threshold of public keys.
   if total_keyids < threshold:
-    raise securesystemslib.exceptions.InsufficientKeysError(repr(rolename) + ' role contains'
+    raise tuf.exceptions.InsufficientKeysError(repr(rolename) + ' role contains'
       ' ' + repr(total_keyids) + ' / ' + repr(threshold) + ' public keys.')
 
   # Raise an exception for an invalid threshold of signing keys.
   if total_signatures == 0 and total_signing_keys < threshold:
-    raise securesystemslib.exceptions.InsufficientKeysError(repr(rolename) + ' role contains'
+    raise tuf.exceptions.InsufficientKeysError(repr(rolename) + ' role contains'
       ' ' + repr(total_signing_keys) + ' / ' + repr(threshold) + ' signing keys.')
 
 
@@ -369,7 +369,7 @@ def _remove_invalid_and_duplicate_signatures(signable, repository_name):
     try:
       key = tuf.keydb.get_key(keyid, repository_name=repository_name)
 
-    except securesystemslib.exceptions.UnknownKeyError:
+    except tuf.exceptions.UnknownKeyError:
       signable['signatures'].remove(signature)
       continue
 
@@ -580,7 +580,7 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
     consistent_snapshot = root_metadata['consistent_snapshot']
 
   else:
-    raise securesystemslib.exceptions.RepositoryError('Cannot load the required'
+    raise tuf.exceptions.RepositoryError('Cannot load the required'
       ' root file: ' + repr(root_filename))
 
   # Load 'timestamp.json'.  A Timestamp role file without a version number is
@@ -708,7 +708,7 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
           tuf.keydb.add_key(key_object, keyid=None,
               repository_name=repository_name)
 
-      except securesystemslib.exceptions.KeyAlreadyExistsError:
+      except tuf.exceptions.KeyAlreadyExistsError:
         pass
 
   else:
@@ -1141,7 +1141,7 @@ def get_metadata_versioninfo(rolename, repository_name):
   <Arguments>
     rolename:
       The metadata role whose versioninfo is needed.  It must exist, otherwise
-      a 'securesystemslib.exceptions.UnknownRoleError' exception is raised.
+      a 'tuf.exceptions.UnknownRoleError' exception is raised.
 
     repository_name:
       The name of the repository.  If not supplied, 'rolename' is added to the
@@ -1151,7 +1151,7 @@ def get_metadata_versioninfo(rolename, repository_name):
     securesystemslib.exceptions.FormatError, if 'rolename' is improperly
     formatted.
 
-    securesystemslib.exceptions.UnknownRoleError, if 'rolename' does not exist.
+    tuf.exceptions.UnknownRoleError, if 'rolename' does not exist.
 
   <Side Effects>
     None.
@@ -1955,7 +1955,7 @@ def _log_status_of_top_level_roles(targets_directory, metadata_directory,
     try:
       _check_role_keys(rolename, repository_name)
 
-    except securesystemslib.exceptions.InsufficientKeysError as e:
+    except tuf.exceptions.InsufficientKeysError as e:
       logger.info(str(e))
 
   # Do the top-level roles contain a valid threshold of signatures?  Top-level
@@ -2112,7 +2112,7 @@ def create_tuf_client_directory(repository_directory, client_directory):
     securesystemslib.exceptions.FormatError, if the arguments are improperly
     formatted.
 
-    securesystemslib.exceptions.RepositoryError, if the metadata directory in
+    tuf.exceptions.RepositoryError, if the metadata directory in
     'client_directory' already exists.
 
   <Side Effects>
@@ -2153,7 +2153,7 @@ def create_tuf_client_directory(repository_directory, client_directory):
     if e.errno == errno.EEXIST:
       message = 'Cannot create a fresh client metadata directory: ' +\
         repr(client_metadata_directory) + '.  Already exists.'
-      raise securesystemslib.exceptions.RepositoryError(message)
+      raise tuf.exceptions.RepositoryError(message)
 
     # Testing of non-errno.EEXIST exceptions have been verified on all
     # supported OSs.  An unexpected exception (the '/' directory exists, rather

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -665,7 +665,7 @@ class Metadata(object):
     try:
       tuf.keydb.add_key(key, repository_name=self._repository_name)
 
-    except securesystemslib.exceptions.KeyAlreadyExistsError:
+    except tuf.exceptions.KeyAlreadyExistsError:
       logger.warning('Adding a verification key that has already been used.')
 
     keyid = key['keyid']
@@ -783,7 +783,7 @@ class Metadata(object):
     try:
       tuf.keydb.add_key(key, repository_name=self._repository_name)
 
-    except securesystemslib.exceptions.KeyAlreadyExistsError:
+    except tuf.exceptions.KeyAlreadyExistsError:
       tuf.keydb.remove_key(key['keyid'], self._repository_name)
       tuf.keydb.add_key(key, repository_name=self._repository_name)
 
@@ -1635,7 +1635,7 @@ class Targets(Metadata):
       securesystemslib.exceptions.FormatError, if the arguments are improperly
       formatted.
 
-      securesystemslib.exceptions.UnknownRoleError, if 'rolename' has not been
+      tuf.exceptions.UnknownRoleError, if 'rolename' has not been
       delegated by this Targets object.
 
     <Side Effects>
@@ -1655,7 +1655,7 @@ class Targets(Metadata):
       return self._delegated_roles[rolename]
 
     else:
-      raise securesystemslib.exceptions.UnknownRoleError(repr(rolename) + ' has'
+      raise tuf.exceptions.UnknownRoleError(repr(rolename) + ' has'
           ' not been delegated by ' + repr(self.rolename))
 
 
@@ -2168,11 +2168,11 @@ class Targets(Metadata):
         continue searching for targets (target files it is trusted to list but
         has not yet specified) in other delegations.  If 'terminating' is True
         and 'updater.target()' does not find 'example_target.tar.gz' in this
-        role, a 'securesystemslib.exceptions.UnknownTargetError' exception
-        should be raised.  If 'terminating' is False (default), and
-        'target/other_role' is also trusted with 'example_target.tar.gz' and
-        has listed it, updater.target() should backtrack and return the target
-        file specified by 'target/other_role'.
+        role, a 'tuf.exceptions.UnknownTargetError' exception should be raised.
+        If 'terminating' is False (default), and 'target/other_role' is also
+        trusted with 'example_target.tar.gz' and has listed it,
+        updater.target() should backtrack and return the target file specified
+        by 'target/other_role'.
 
       list_of_targets:
         A list of target filepaths that are added to 'rolename'.
@@ -2754,7 +2754,7 @@ class Targets(Metadata):
       None.
 
     <Exceptions>
-      securesystemslib.exceptions.UnknownRoleError, if this Targets' rolename
+      tuf.exceptions.UnknownRoleError, if this Targets' rolename
       does not exist in 'tuf.roledb'.
 
     <Side Effects>
@@ -2893,7 +2893,7 @@ def load_repository(repository_directory, repository_name='default'):
     securesystemslib.exceptions.FormatError, if 'repository_directory' or any of
     the metadata files are improperly formatted.
 
-    securesystemslib.exceptions.RepositoryError, if the Root role cannot be
+    tuf.exceptions.RepositoryError, if the Root role cannot be
     found.  At a minimum, a repository must contain 'root.json'
 
   <Side Effects>
@@ -3037,7 +3037,7 @@ def load_repository(repository_directory, repository_name='default'):
           tuf.keydb.add_key(key_object, keyid=None,
               repository_name=repository_name)
 
-      except securesystemslib.exceptions.KeyAlreadyExistsError:
+      except tuf.exceptions.KeyAlreadyExistsError:
         pass
 
   return repository

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -359,7 +359,7 @@ def update_roleinfo(rolename, roleinfo, mark_role_as_dirty=True, repository_name
     securesystemslib.exceptions.FormatError, if 'rolename' or 'roleinfo' does
     not have the correct object format.
 
-    securesystemslib.exceptions.UnknownRoleError, if 'rolename' cannot be found
+    tuf.exceptions.UnknownRoleError, if 'rolename' cannot be found
     in the role database.
 
     securesystemslib.exceptions.InvalidNameError, if 'rolename' is improperly
@@ -606,7 +606,7 @@ def remove_role(rolename, repository_name='default'):
     securesystemslib.exceptions.FormatError, if 'rolename' does not have the
     correct object format.
 
-    securesystemslib.exceptions.UnknownRoleError, if 'rolename' cannot be found
+    tuf.exceptions.UnknownRoleError, if 'rolename' cannot be found
     in the role database.
 
     securesystemslib.exceptions.InvalidNameError, if 'rolename' is incorrectly
@@ -624,7 +624,7 @@ def remove_role(rolename, repository_name='default'):
   securesystemslib.formats.NAME_SCHEMA.check_match(repository_name)
 
   # Raises securesystemslib.exceptions.FormatError,
-  # securesystemslib.exceptions.UnknownRoleError, or
+  # tuf.exceptions.UnknownRoleError, or
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
 
@@ -708,7 +708,7 @@ def get_roleinfo(rolename, repository_name='default'):
     securesystemslib.exceptions.FormatError, if the arguments are improperly
     formatted.
 
-    securesystemslib.exceptions.UnknownRoleError, if 'rolename' does not exist.
+    tuf.exceptions.UnknownRoleError, if 'rolename' does not exist.
 
     securesystemslib.exceptions.InvalidNameError, if 'rolename' is incorrectly
     formatted, or 'repository_name' does not exist in the role database.
@@ -726,7 +726,7 @@ def get_roleinfo(rolename, repository_name='default'):
   securesystemslib.formats.NAME_SCHEMA.check_match(repository_name)
 
   # Raises securesystemslib.exceptions.FormatError,
-  # securesystemslib.exceptions.UnknownRoleError, or
+  # tuf.exceptions.UnknownRoleError, or
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
 
@@ -761,7 +761,7 @@ def get_role_keyids(rolename, repository_name='default'):
     securesystemslib.exceptions.FormatError, if the arguments do not have the
     correct object format.
 
-    securesystemslib.exceptions.UnknownRoleError, if 'rolename' cannot be found
+    tuf.exceptions.UnknownRoleError, if 'rolename' cannot be found
     in the role database.
 
     securesystemslib.exceptions.InvalidNameError, if 'rolename' is incorrectly
@@ -779,7 +779,7 @@ def get_role_keyids(rolename, repository_name='default'):
   securesystemslib.formats.NAME_SCHEMA.check_match(repository_name)
 
   # Raises securesystemslib.exceptions.FormatError,
-  # securesystemslib.exceptions.UnknownRoleError, or
+  # tuf.exceptions.UnknownRoleError, or
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
 
@@ -831,7 +831,7 @@ def get_role_threshold(rolename, repository_name='default'):
   securesystemslib.formats.NAME_SCHEMA.check_match(repository_name)
 
   # Raises securesystemslib.exceptions.FormatError,
-  # securesystemslib.exceptions.UnknownRoleError, or
+  # tuf.exceptions.UnknownRoleError, or
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
 
@@ -864,7 +864,7 @@ def get_role_paths(rolename, repository_name='default'):
     securesystemslib.exceptions.FormatError, if the arguments do not have the
     correct object format.
 
-    securesystemslib.exceptions.UnknownRoleError, if 'rolename' cannot be found
+    tuf.exceptions.UnknownRoleError, if 'rolename' cannot be found
     in the role database.
 
     securesystemslib.exceptions.InvalidNameError, if 'rolename' is incorrectly
@@ -882,7 +882,7 @@ def get_role_paths(rolename, repository_name='default'):
   securesystemslib.formats.NAME_SCHEMA.check_match(repository_name)
 
   # Raises securesystemslib.exceptions.FormatError,
-  # securesystemslib.exceptions.UnknownRoleError, or
+  # tuf.exceptions.UnknownRoleError, or
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
 
@@ -922,7 +922,7 @@ def get_delegated_rolenames(rolename, repository_name='default'):
     securesystemslib.exceptions.FormatError, if the arguments do not have the
     correct object format.
 
-    securesystemslib.exceptions.UnknownRoleError, if 'rolename' cannot be found
+    tuf.exceptions.UnknownRoleError, if 'rolename' cannot be found
     in the role database.
 
     securesystemslib.exceptions.InvalidNameError, if 'rolename' is incorrectly
@@ -942,7 +942,7 @@ def get_delegated_rolenames(rolename, repository_name='default'):
   securesystemslib.formats.NAME_SCHEMA.check_match(repository_name)
 
   # Raises securesystemslib.exceptions.FormatError,
-  # securesystemslib.exceptions.UnknownRoleError, or
+  # tuf.exceptions.UnknownRoleError, or
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
 
@@ -1019,7 +1019,7 @@ def clear_roledb(repository_name='default', clear_all=False):
 def _check_rolename(rolename, repository_name='default'):
   """ Raise securesystemslib.exceptions.FormatError if 'rolename' does not match
   'tuf.formats.ROLENAME_SCHEMA',
-  securesystemslib.exceptions.UnknownRoleError if 'rolename' is not found in the
+  tuf.exceptions.UnknownRoleError if 'rolename' is not found in the
   role database, or securesystemslib.exceptions.InvalidNameError if
   'repository_name' does not exist in the role database.
   """

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -169,7 +169,7 @@ def get_signature_status(signable, role=None, repository_name='default',
     try:
       key = tuf.keydb.get_key(keyid, repository_name)
 
-    except securesystemslib.exceptions.UnknownKeyError:
+    except tuf.exceptions.UnknownKeyError:
       unknown_sigs.append(keyid)
       continue
 
@@ -208,8 +208,7 @@ def get_signature_status(signable, role=None, repository_name='default',
       bad_sigs.append(keyid)
 
   # Retrieve the threshold value for 'role'.  Raise
-  # securesystemslib.exceptions.UnknownRoleError if we were given an invalid
-  # role.
+  # tuf.exceptions.UnknownRoleError if we were given an invalid role.
   if role is not None:
     if threshold is None:
       # Note that if the role is not known, tuf.exceptions.UnknownRoleError is
@@ -267,7 +266,7 @@ def verify(signable, role, repository_name='default', threshold=None,
       in tuf.roledb.py for 'role'.
 
   <Exceptions>
-    securesystemslib.exceptions.UnknownRoleError, if 'role' is not recognized.
+    tuf.exceptions.UnknownRoleError, if 'role' is not recognized.
 
     securesystemslib.exceptions.FormatError, if 'signable' is not formatted
     correctly.
@@ -288,7 +287,7 @@ def verify(signable, role, repository_name='default', threshold=None,
   securesystemslib.formats.NAME_SCHEMA.check_match(repository_name)
 
   # Retrieve the signature status.  tuf.sig.get_signature_status() raises:
-  # securesystemslib.exceptions.UnknownRoleError
+  # tuf.exceptions.UnknownRoleError
   # securesystemslib.exceptions.FormatError.  'threshold' and 'keyids' are also
   # validated.
   status = get_signature_status(signable, role, repository_name, threshold, keyids)


### PR DESCRIPTION
Removal of securesystemslib exceptions that are TUF-specific occurs in [securesystemslib PR #165](https://github.com/secure-systems-lab/securesystemslib/pull/165).

This PR adapts to those changes.  Exceptions that are specific to TUF should be in TUF and not in securesystemslib.  This commit uses those already-existing TUF exceptions instead of pointing to securesystemslib exceptions that will be removed.

For example, securesystemslib has no notion of repositories, so it's clearly wrong to have a `RepositoryError` in securesystemslib and clearly wrong for TUF to use `securesystemslib.exceptions.RepositoryError`.

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


