### PR TITLE
WIP: minor: fix bug in test_developer_tool

### DIFF
--- a/tests/test_developer_tool.py
+++ b/tests/test_developer_tool.py
@@ -173,6 +173,9 @@ class TestProject(unittest.TestCase):
     except (OSError, tuf.exceptions.RepositoryError):
       pass
 
+    else:
+      self.fail('Expected RepositoryError exception not raised.')
+
     developer_tool.METADATA_DIRECTORY_NAME = valid_metadata_directory_name
 
 


### PR DESCRIPTION
The PR corrects a hole in one test's logic in `test_developer_tool`.  It's another instance of a test not failing if an expected error is not raised, due to flawed try/except/else construction.