### PR TITLE
Display sub error messages for NoWorkingMirrorError

### DIFF
--- a/tuf/exceptions.py
+++ b/tuf/exceptions.py
@@ -244,7 +244,7 @@ class NoWorkingMirrorError(Error):
       else:
         mirror_netloc = mirror_url_tokens.netloc
 
-      all_errors += '\n  ' + repr(mirror_netloc) + ': ' + repr(mirror_error)
+      all_errors += '\n  ' + repr(mirror_netloc) + ': ' + str(mirror_error)
 
     return all_errors
 


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**: #857 

**Description of the changes being introduced by the pull request**:
Use `str()` instead of `repr()` when generating error messages for `NoWorkingMirrorError`.