### PR TITLE
Support loading external signing keys

### DIFF
--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -291,6 +291,10 @@ PATH_FILEINFO_SCHEMA = SCHEMA.DictOf(
   key_schema = RELPATH_SCHEMA,
   value_schema = CUSTOM_SCHEMA)
 
+EXTERNAL_SIGNERS_SCHEMA = SCHEMA.DictOf(
+  key_schema = KEYID_SCHEMA,
+  value_schema = SCHEMA.Any())
+
 # TUF roledb
 ROLEDB_SCHEMA = SCHEMA.Object(
   object_name = 'ROLEDB_SCHEMA',
@@ -305,7 +309,8 @@ ROLEDB_SCHEMA = SCHEMA.Object(
   paths = SCHEMA.Optional(SCHEMA.OneOf([RELPATHS_SCHEMA, PATH_FILEINFO_SCHEMA])),
   path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA),
   delegations = SCHEMA.Optional(DELEGATIONS_SCHEMA),
-  partial_loaded = SCHEMA.Optional(BOOLEAN_SCHEMA))
+  partial_loaded = SCHEMA.Optional(BOOLEAN_SCHEMA),
+  external_signers = SCHEMA.Optional(EXTERNAL_SIGNERS_SCHEMA))
 
 # A signable object.  Holds the signing role and its associated signatures.
 SIGNABLE_SCHEMA = SCHEMA.Object(


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**: -

**Description of the changes being introduced by the pull request**:

This PR shows our general idea on how to provide signatures for _TUF metadata_ files externally. This implementation does not break any current behavior, just allows us to generate signatures on write-only hardware devices (which does not allow exporting private keys) and store them in metadata files. Signatures need to be generated with the same algorithms that are used by TUF. 

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


