### PR TITLE
Do not immediately verify latest root when rotating

### DIFF
--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1128,7 +1128,7 @@ class Updater(object):
     # Retrieve the latest, remote root.json *WITHOUT* verifying it just yet.
     # We will verify it soon if all goes well.
     latest_root_metadata_file = self._get_file(
-        'root.json', lambda f: f, 'meta', DEFAULT_ROOT_UPPERLENGTH,
+        'root.json', lambda f: True, 'meta', DEFAULT_ROOT_UPPERLENGTH,
         download_safely=False)
 
     latest_root_metadata = securesystemslib.util.load_json_string(
@@ -1149,6 +1149,16 @@ class Updater(object):
       # _update_metadata().
       self.consistent_snapshot = True
       self._update_metadata('root', DEFAULT_ROOT_UPPERLENGTH, version=version)
+      # Ensure that the role and key information of the top-level roles is the
+      # latest.  We do this whether or not Root needed to be updated, in order
+      # to ensure that, e.g., the entries in roledb for top-level roles are
+      # populated with expected keyid info so that roles can be validated.  In
+      # certain circumstances, top-level metadata might be missing because it
+      # was marked obsolete and deleted after a failed attempt, and thus we
+      # should refresh them here as a protective measure.  See Issue #736.
+      self._rebuild_key_and_role_db()
+      self.consistent_snapshot = \
+          self.metadata['current']['root']['consistent_snapshot']
 
 
 

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1125,9 +1125,11 @@ class Updater(object):
       None.
     """
 
-    # Retrieve the latest, remote root.json.
-    latest_root_metadata_file = self._get_metadata_file(
-        'root', 'root.json', DEFAULT_ROOT_UPPERLENGTH, None)
+    # Retrieve the latest, remote root.json *WITHOUT* verifying it just yet.
+    # We will verify it soon if all goes well.
+    latest_root_metadata_file = self._get_file(
+        'root.json', lambda f: f, 'meta', DEFAULT_ROOT_UPPERLENGTH,
+        download_safely=False)
 
     latest_root_metadata = securesystemslib.util.load_json_string(
         latest_root_metadata_file.read().decode('utf-8'))

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1148,7 +1148,7 @@ class Updater(object):
         # Thoroughly verify it.
         self._update_metadata('root', DEFAULT_ROOT_UPPERLENGTH,
             version=next_version)
-      # When we run into HTTP 403 /404 error from ALL mirrors, break out of
+      # When we run into HTTP 403/404 error from ALL mirrors, break out of
       # loop, because the next root metadata file is most likely missing.
       except tuf.exceptions.NoWorkingMirrorError as exception:
         for mirror_error in exception.mirror_errors.values():

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1127,14 +1127,14 @@ class Updater(object):
     """
 
     def neither_403_nor_404(mirror_error):
+      WHITELIST = {403, 404}
       if isinstance(mirror_error, six.moves.urllib.error.HTTPError):
-        if mirror_error.code in {403, 404}:
+        if mirror_error.code in WHITELIST:
           return False
       elif isinstance(mirror_error, requests.exceptions.HTTPError):
-        if mirror_error.response.status_code in {403, 404}:
+        if mirror_error.response.status_code in WHITELIST:
           return False
-      else:
-        return True
+      return True
 
     # Temporarily set consistent snapshot. Will be updated to whatever is set
     # in the latest root.json after running through the intermediates with

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1128,7 +1128,7 @@ class Updater(object):
     # Retrieve the latest, remote root.json *WITHOUT* verifying it just yet.
     # We will verify it soon if all goes well.
     latest_root_metadata_file = self._get_file(
-        'root.json', lambda f: True, 'meta', DEFAULT_ROOT_UPPERLENGTH,
+        'root.json', lambda f: None, 'meta', DEFAULT_ROOT_UPPERLENGTH,
         download_safely=False)
 
     latest_root_metadata = securesystemslib.util.load_json_string(
@@ -1143,11 +1143,13 @@ class Updater(object):
     # current = version 1
     # latest = version 3
     # update from 1.root.json to 3.root.json.
+
+    # Temporarily set consistent snapshot. Will be updated to whatever is set
+    # in the latest root.json after running through the intermediates with
+    # _update_metadata().
+    self.consistent_snapshot = True
+
     for version in range(next_version, latest_version + 1):
-      # Temporarily set consistent snapshot. Will be updated to whatever is set
-      # in the latest root.json after running through the intermediates with
-      # _update_metadata().
-      self.consistent_snapshot = True
       self._update_metadata('root', DEFAULT_ROOT_UPPERLENGTH, version=version)
       # Ensure that the role and key information of the top-level roles is the
       # latest.  We do this whether or not Root needed to be updated, in order
@@ -1157,8 +1159,10 @@ class Updater(object):
       # was marked obsolete and deleted after a failed attempt, and thus we
       # should refresh them here as a protective measure.  See Issue #736.
       self._rebuild_key_and_role_db()
-      self.consistent_snapshot = \
-          self.metadata['current']['root']['consistent_snapshot']
+
+    # Set our consistent snapshot property to what the latest root has said.
+    self.consistent_snapshot = \
+        self.metadata['current']['root']['consistent_snapshot']
 
 
 

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1127,12 +1127,8 @@ class Updater(object):
     """
 
     def neither_403_nor_404(mirror_error):
-      WHITELIST = {403, 404}
-      if isinstance(mirror_error, six.moves.urllib.error.HTTPError):
-        if mirror_error.code in WHITELIST:
-          return False
-      elif isinstance(mirror_error, requests.exceptions.HTTPError):
-        if mirror_error.response.status_code in WHITELIST:
+      if isinstance(mirror_error, requests.exceptions.HTTPError):
+        if mirror_error.response.status_code in {403, 404}:
           return False
       return True
 

--- a/tuf/settings.py
+++ b/tuf/settings.py
@@ -106,3 +106,7 @@ DEFAULT_HASH_ALGORITHM = 'sha256'
 # to suspend execution for a specified amount of time.  See
 # theupdateframework/tuf/issue#338.
 SLEEP_BEFORE_ROUND = None
+
+# Maximum number of root metadata file rotations we should perform in order to
+# prevent a denial-of-service (DoS) attack.
+MAX_NUMBER_ROOT_ROTATIONS = 2**10

--- a/tuf/settings.py
+++ b/tuf/settings.py
@@ -109,4 +109,4 @@ SLEEP_BEFORE_ROUND = None
 
 # Maximum number of root metadata file rotations we should perform in order to
 # prevent a denial-of-service (DoS) attack.
-MAX_NUMBER_ROOT_ROTATIONS = 2**10
+MAX_NUMBER_ROOT_ROTATIONS = 2**5


### PR DESCRIPTION
**Fixes issue #**:

N/A

**Description of the changes being introduced by the pull request**:

When rotating the root (say from v2 to v3, then v3 to v4), the reference implementation currently immediately _verifies_ signatures on the latest root (say, v4). This will fail when v4 is signed using v3's but not v2's keys. This PR changes the implementation so that signatures on the latest root is _not_ immediately verified.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


