### PR TITLE
Fix publishing of coverage results to coveralls.io (+ misc test config updates)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ script:
   - tox
 
 after_success:
-  - cd tests
-  - coveralls
-  - cd -
+  # Workaround to get coverage reports with relative paths.
+  # FIXME: Consider refactoring the tests to not require the test aggregation
+  # script being invoked from the `tests` directory, so that `.coverage` is
+  # written to and .coveragrc can also reside in the project root directory, as
+  # as the convention.
+  - cp tests/.coverage .
+  - coveralls --rcfile=tests/.coveragerc

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ after_success:
   # FIXME: Consider refactoring the tests to not require the test aggregation
   # script being invoked from the `tests` directory, so that `.coverage` is
   # written to and .coveragrc can also reside in the project root directory, as
-  # as the convention.
+  # is the convention.
   - cp tests/.coverage .
   - coveralls --rcfile=tests/.coveragerc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,25 @@
+dist: xenial
 language: python
-dist: trusty
-sudo: false
 cache: pip
-python: 3.6
 
-env:
-  - TOXENV=py27
-  - TOXENV=py34
-  - TOXENV=py36
+matrix:
+  include:
+    - python: "2.7"
+      env: TOXENV=py27
+    - python: "3.4"
+      env: TOXENV=py34
+    - python: "3.5"
+      env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=py36
 
-before_script:
-  - pip install pylint bandit tox coveralls
+install:
+  - pip install tox coveralls
 
 script:
-  - pylint tuf
-  - bandit -r tuf
   - tox
 
 after_success:
   - cd tests
   - coveralls
   - cd -
-
-branches:
-  only:
-    - develop
-    - pylint
-    - bandit

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - TOXENV=py36
 
 before_script:
-  - pip install pylint bandit tox
+  - pip install pylint bandit tox coveralls
 
 script:
   - pylint tuf

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,7 +1,9 @@
 securesystemslib[crypto,pynacl]
 six
 iso8601
-coverage
+requests
 pylint
 bandit
-requests
+# Pin to versions supported by `coveralls` (see .travis.yml)
+# https://github.com/coveralls-clients/coveralls-python/releases/tag/1.8.1
+coverage<5.0

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -2,6 +2,6 @@ securesystemslib[crypto,pynacl]
 six
 iso8601
 coverage
-coveralls
 pylint
+bandit
 requests

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -11,3 +11,5 @@ omit =
     # Command-line scripts.
     */tuf/scripts/client.py
     */tuf/scripts/repo.py
+    */tests/*
+    */site-packages/*

--- a/tests/.coveragerc
+++ b/tests/.coveragerc
@@ -1,15 +1,15 @@
 [run]
 branch = True
 
-[report]
-exclude_lines =
-    pragma: no cover
-    def __str__
-    if __name__ == .__main__.:
-
 omit =
     # Command-line scripts.
     */tuf/scripts/client.py
     */tuf/scripts/repo.py
     */tests/*
     */site-packages/*
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __str__
+    if __name__ == .__main__.:

--- a/tests/aggregate_tests.py
+++ b/tests/aggregate_tests.py
@@ -34,7 +34,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
-import os
 import sys
 import unittest
 import glob
@@ -91,17 +90,6 @@ for test in available_tests:
 random.shuffle(test_modules_to_run)
 
 if __name__ == '__main__':
-  # NOTE: Temporary workaround to ensure that `tuf` code from the sibling `tuf`
-  # directory is prioritized over `tuf` code installed to some system or
-  # virtualenv site-packages directory, which in turn is required for
-  # coverage/coveralls to function correctly.
-  # FIXME: Consider refactoring the tests to not require this the aggregation
-  # script being invoked from the `tests` directory. This seems to be the
-  # convention and would make use of other testing tools such as
-  # coverage/coveralls easier.
-  sys.path.insert(0,
-      os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
   suite = unittest.TestLoader().loadTestsFromNames(test_modules_to_run)
   all_tests_passed = unittest.TextTestRunner(
       verbosity=1, buffer=True).run(suite).wasSuccessful()

--- a/tests/aggregate_tests.py
+++ b/tests/aggregate_tests.py
@@ -34,6 +34,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
+import os
 import sys
 import unittest
 import glob
@@ -90,9 +91,21 @@ for test in available_tests:
 random.shuffle(test_modules_to_run)
 
 if __name__ == '__main__':
+  # NOTE: Temporary workaround to ensure that `tuf` code from the sibling `tuf`
+  # directory is prioritized over `tuf` code installed to some system or
+  # virtualenv site-packages directory, which in turn is required for
+  # coverage/coveralls to function correctly.
+  # FIXME: Consider refactoring the tests to not require this the aggregation
+  # script being invoked from the `tests` directory. This seems to be the
+  # convention and would make use of other testing tools such as
+  # coverage/coveralls easier.
+  sys.path.insert(0,
+      os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
   suite = unittest.TestLoader().loadTestsFromNames(test_modules_to_run)
   all_tests_passed = unittest.TextTestRunner(
       verbosity=1, buffer=True).run(suite).wasSuccessful()
+
   if not all_tests_passed:
     sys.exit(1)
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,12 @@
 
 [tox]
 envlist = py27, py34, py35, py36
+skipsdist = true
 
 [testenv]
+# TODO: Consider refactoring the tests to not require the aggregation script
+# being invoked from the `tests` directory. This seems to be the convention and
+# would make use of other testing tools such as coverage/coveralls easier.
 changedir = tests
 
 commands =
@@ -17,5 +21,8 @@ commands =
 
 deps =
     -r{toxinidir}/ci-requirements.txt
+    # Install TUF in editable mode, instead of tox default virtual environment
+    # installation (see `skipsdist`), to get relative paths in coverage reports
+    --editable {toxinidir}
 
 install_command = pip install --pre {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ changedir = tests
 commands =
     pylint {toxinidir}/tuf
     bandit -r {toxinidir}/tuf
-    coverage run --source tuf aggregate_tests.py
+    coverage run aggregate_tests.py
     coverage report -m --fail-under 97
 
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ envlist = py27, py34, py35, py36
 changedir = tests
 
 commands =
+    pylint {toxinidir}/tuf
+    bandit -r {toxinidir}/tuf
     coverage run --source tuf aggregate_tests.py
     coverage report -m --fail-under 97
 


### PR DESCRIPTION
**Fixes issue #**:
None

**Description of the changes being introduced by the pull request**:
Code coverage results from our Travis builds have not been published to coveralls.io in a while, due to the required `coveralls` publishing tool not being properly installed. 

Besides fixing publishing of coverage results, this PR cleans up/ updates other testing configurations:
 - Update travis to run on xenial
 - Add a build matrix to run each tox env in a corresponding travis env as per travis/tox best practices.
      https://docs.travis-ci.com/user/languages/python/#using-tox-as-the-build-script
 - Enable Python 3.5 tests, after all we claim to support Python 3.5
 - Remove "only build certain branch" restrictions
 - Use "install" instead of "before_script"  to install dependencies.
    Explicitly listing "install" prevents Travis from automatically running `pip install -r requirements.txt`, which is not necessary because most of those requirements are installed again in each  tox environment.
 - Move pylint and bandit calls to tox (pylint requires runtime dependencies to be installed).


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


