### PR TITLE
Move repository_lib.get_taget_hash back from sslib to tuf

### DIFF
--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -49,6 +49,7 @@ import tuf.log
 import tuf.settings
 
 import securesystemslib
+import securesystemslib.hash
 import securesystemslib.interface
 import iso8601
 import six
@@ -1174,6 +1175,8 @@ def get_metadata_versioninfo(rolename, repository_name):
 
 
 
+# TODO: Is this function needed? It does not seem used, also the same
+# function exists as private method in updater.Updater._get_target_hash.
 def get_target_hash(target_filepath):
   """
   <Purpose>
@@ -1198,9 +1201,20 @@ def get_target_hash(target_filepath):
 
   <Returns>
     The hash of 'target_filepath'.
-  """
 
-  return securesystemslib.util.get_target_hash(target_filepath)
+  """
+  securesystemslib.formats.RELPATH_SCHEMA.check_match(target_filepath)
+
+  # Calculate the hash of the filepath to determine which bin to find the
+  # target.  The client currently assumes the repository uses
+  # 'tuf.settings.DEFAULT_HASH_ALGORITHM' to generate hashes and 'utf-8'.
+  digest_object = securesystemslib.hash.digest(
+      tuf.settings.DEFAULT_HASH_ALGORITHM)
+  encoded_target_filepath = target_filepath.encode('utf-8')
+  digest_object.update(encoded_target_filepath)
+  target_filepath_hash = digest_object.hexdigest()
+
+  return target_filepath_hash
 
 
 

--- a/tuf/settings.py
+++ b/tuf/settings.py
@@ -97,8 +97,9 @@ CONSISTENT_METHOD = 'copy'
 
 # A setting for the instances where a default hashing algorithm is needed.
 # This setting is currently used to calculate the path hash prefixes of hashed
-# bin delegations.  The other instances (e.g., digest of files) that require a
-# hashing algorithm rely on settings in the securesystemslib external library.
+# bin delegations, and digests of targets filepaths.  The other instances
+# (e.g., digest of files) that require a hashing algorithm rely on settings in
+# the securesystemslib external library.
 DEFAULT_HASH_ALGORITHM = 'sha256'
 
 # The client's update procedure (contained within a while-loop) can potentially


### PR DESCRIPTION
**Fixes issue #**:
Related to secure-systems-lab/securesystemslib#165

**Description of the changes being introduced by the pull request**:
The function used to last be implemented in securesystemslib and repository_lib.get_taget_hash only served as wrapper.

secure-systems-lab/securesystemslib#165 drops the function as TUF-specific.

The used constant `securesystemslib.util.HASH_FUNCTION` is replaced with `tuf.settings.DEFAULT_HASH_ALGORITHM`, both of which default to 'sha256'.

NOTE: The function might be removed altogether in the future (see corresponding code comment).

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


