### PR TITLE
Add TUF-specific schemas removed in sslib

### DIFF
--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -145,7 +145,7 @@ class TestFormats(unittest.TestCase):
                            {'keyid': '123abc',
                             'sig': 'A4582BCF323BCEF'}),
 
-      'SIGNATURESTATUS_SCHEMA': (securesystemslib.formats.SIGNATURESTATUS_SCHEMA,
+      'SIGNATURESTATUS_SCHEMA': (tuf.formats.SIGNATURESTATUS_SCHEMA,
                                  {'threshold': 1,
                                   'good_sigs': ['123abc'],
                                   'bad_sigs': ['123abc'],
@@ -164,7 +164,7 @@ class TestFormats(unittest.TestCase):
                                      'keyval': {'public': 'pubkey',
                                                 'private': 'privkey'}}}),
 
-      'KEYDB_SCHEMA': (securesystemslib.formats.KEYDB_SCHEMA,
+      'KEYDB_SCHEMA': (tuf.formats.KEYDB_SCHEMA,
                        {'123abc': {'keytype': 'rsa',
                                    'scheme': 'rsassa-pss-sha256',
                                    'keyid': '123456789abcdef',
@@ -738,7 +738,7 @@ class TestFormats(unittest.TestCase):
     version_number = 8
     versioninfo = {'version': version_number}
 
-    VERSIONINFO_SCHEMA = securesystemslib.formats.VERSIONINFO_SCHEMA
+    VERSIONINFO_SCHEMA = tuf.formats.VERSIONINFO_SCHEMA
     make_versioninfo = tuf.formats.make_versioninfo
     self.assertTrue(VERSIONINFO_SCHEMA.matches(make_versioninfo(version_number)))
 

--- a/tests/test_sig.py
+++ b/tests/test_sig.py
@@ -66,7 +66,7 @@ class TestSig(unittest.TestCase):
 
     # A valid, but empty signature status.
     sig_status = tuf.sig.get_signature_status(signable)
-    self.assertTrue(securesystemslib.formats.SIGNATURESTATUS_SCHEMA.matches(sig_status))
+    self.assertTrue(tuf.formats.SIGNATURESTATUS_SCHEMA.matches(sig_status))
 
     self.assertEqual(0, sig_status['threshold'])
     self.assertEqual([], sig_status['good_sigs'])

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1973,7 +1973,7 @@ class Updater(object):
         A dict object representing the new file information for
         'metadata_filename'.  'new_versioninfo' may be 'None' when
         updating 'root' without having 'snapshot' available.  This
-        dict conforms to 'securesystemslib.formats.VERSIONINFO_SCHEMA' and has
+        dict conforms to 'tuf.formats.VERSIONINFO_SCHEMA' and has
         the form:
 
         {'version': 288}

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -85,12 +85,20 @@ SPECIFICATION_VERSION_SCHEMA = SCHEMA.AnyString()
 # check, and an ISO8601 string should be fully verified when it is parsed.
 ISO8601_DATETIME_SCHEMA = SCHEMA.RegularExpression(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z')
 
+# An integer representing the numbered version of a metadata file.
+# Must be 1, or greater.
+METADATAVERSION_SCHEMA = SCHEMA.Integer(lo=0)
+
+VERSIONINFO_SCHEMA = SCHEMA.Object(
+  object_name = 'VERSIONINFO_SCHEMA',
+  version = METADATAVERSION_SCHEMA)
+
 # A dict holding the version or file information for a particular metadata
 # role.  The dict keys hold the relative file paths, and the dict values the
 # corresponding version numbers and/or file information.
 FILEINFODICT_SCHEMA = SCHEMA.DictOf(
   key_schema = securesystemslib.formats.RELPATH_SCHEMA,
-  value_schema = SCHEMA.OneOf([securesystemslib.formats.VERSIONINFO_SCHEMA,
+  value_schema = SCHEMA.OneOf([VERSIONINFO_SCHEMA,
                               securesystemslib.formats.FILEINFO_SCHEMA]))
 
 # A string representing a role's name.
@@ -136,10 +144,6 @@ VERSION_SCHEMA = SCHEMA.Object(
   minor = SCHEMA.Integer(lo=0),
   fix = SCHEMA.Integer(lo=0))
 
-# An integer representing the numbered version of a metadata file.
-# Must be 1, or greater.
-METADATAVERSION_SCHEMA = SCHEMA.Integer(lo=0)
-
 # A value that is either True or False, on or off, etc.
 BOOLEAN_SCHEMA = SCHEMA.Boolean()
 
@@ -183,6 +187,26 @@ KEY_SCHEMA = SCHEMA.Object(
 KEYDICT_SCHEMA = SCHEMA.DictOf(
   key_schema = KEYID_SCHEMA,
   value_schema = KEY_SCHEMA)
+
+# The format used by the key database to store keys.  The dict keys hold a key
+# identifier and the dict values any object.  The key database should store
+# key objects in the values (e.g., 'RSAKEY_SCHEMA', 'DSAKEY_SCHEMA').
+KEYDB_SCHEMA = SCHEMA.DictOf(
+  key_schema = KEYID_SCHEMA,
+  value_schema = SCHEMA.Any())
+
+# A schema holding the result of checking the signatures of a particular
+# 'SIGNABLE_SCHEMA' role.
+# For example, how many of the signatures for the 'Target' role are
+# valid?  This SCHEMA holds this information.  See 'sig.py' for
+# more information.
+SIGNATURESTATUS_SCHEMA = SCHEMA.Object(
+  object_name = 'SIGNATURESTATUS_SCHEMA',
+  threshold = SCHEMA.Integer(),
+  good_sigs = KEYIDS_SCHEMA,
+  bad_sigs = KEYIDS_SCHEMA,
+  unknown_sigs = KEYIDS_SCHEMA,
+  untrusted_sigs = KEYIDS_SCHEMA)
 
 
 # A relative file path (e.g., 'metadata/root/').
@@ -811,7 +835,7 @@ def make_versioninfo(version_number):
 
   # Raise 'securesystemslib.exceptions.FormatError' if 'versioninfo' is
   # improperly formatted.
-  securesystemslib.formats.VERSIONINFO_SCHEMA.check_match(versioninfo)
+  VERSIONINFO_SCHEMA.check_match(versioninfo)
 
   return versioninfo
 

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -65,7 +65,7 @@ def create_keydb_from_root_metadata(root_metadata, repository_name='default'):
   <Purpose>
     Populate the key database with the unique keys found in 'root_metadata'.
     The database dictionary will conform to
-    'securesystemslib.formats.KEYDB_SCHEMA' and have the form: {keyid: key,
+    'tuf.formats.KEYDB_SCHEMA' and have the form: {keyid: key,
     ...}.  The 'keyid' conforms to 'securesystemslib.formats.KEYID_SCHEMA' and
     'key' to its respective type.  In the case of RSA keys, this object would
     match 'RSAKEY_SCHEMA'.

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1131,7 +1131,7 @@ def get_metadata_versioninfo(rolename, repository_name):
   """
   <Purpose>
     Retrieve the version information of 'rolename'.  The object returned
-    conforms to 'securesystemslib.VERSIONINFO_SCHEMA'.  The information
+    conforms to 'tuf.formats.VERSIONINFO_SCHEMA'.  The information
     generated for 'rolename' is stored in 'snapshot.json'.
     The versioninfo object returned has the form:
 
@@ -1156,7 +1156,7 @@ def get_metadata_versioninfo(rolename, repository_name):
     None.
 
   <Returns>
-    A dictionary conformant to 'securesystemslib.VERSIONINFO_SCHEMA'.
+    A dictionary conformant to 'tuf.formats.VERSIONINFO_SCHEMA'.
     This dictionary contains the version  number of 'rolename'.
   """
 

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -336,7 +336,7 @@ def may_need_new_keys(signature_status):
   # This check will ensure 'signature_status' has the appropriate number
   # of objects and object types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if the check fails.
-  securesystemslib.formats.SIGNATURESTATUS_SCHEMA.check_match(signature_status)
+  tuf.formats.SIGNATURESTATUS_SCHEMA.check_match(signature_status)
 
   unknown = signature_status['unknown_sigs']
   untrusted = signature_status['untrusted_sigs']


### PR DESCRIPTION
**Fixes issue #**:
Related to secure-systems-lab/securesystemslib#165

**Description of the changes being introduced by the pull request**:
Add schemas `KEYDB_SCHEMA`, `SIGNATURESTATUS_SCHEMA` and `VERSIONINFO_SCHEMA`, removed in secure-systems-lab/securesystemslib#165 as TUF specific, and adopt usage accordingly.

NOTE: The usefulness of these schemas may be assessed in a different PR.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


