### PR TITLE
Use TUF specific formats as they have been removed from securesystemslib

### DIFF
--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -71,9 +71,9 @@ class TestFormats(unittest.TestCase):
 
       'SCHEME_SCHEMA': (securesystemslib.formats.SCHEME_SCHEMA, 'rsassa-pss-sha256'),
 
-      'RELPATH_SCHEMA': (securesystemslib.formats.RELPATH_SCHEMA, 'metadata/root/'),
+      'RELPATH_SCHEMA': (tuf.formats.RELPATH_SCHEMA, 'metadata/root/'),
 
-      'RELPATHS_SCHEMA': (securesystemslib.formats.RELPATHS_SCHEMA,
+      'RELPATHS_SCHEMA': (tuf.formats.RELPATHS_SCHEMA,
                           ['targets/role1/', 'targets/role2/']),
 
       'PATH_SCHEMA': (securesystemslib.formats.PATH_SCHEMA, '/home/someuser/'),
@@ -84,16 +84,16 @@ class TestFormats(unittest.TestCase):
       'URL_SCHEMA': (securesystemslib.formats.URL_SCHEMA,
                      'https://www.updateframework.com/'),
 
-      'VERSION_SCHEMA': (securesystemslib.formats.VERSION_SCHEMA,
+      'VERSION_SCHEMA': (tuf.formats.VERSION_SCHEMA,
                          {'major': 1, 'minor': 0, 'fix': 8}),
 
-      'LENGTH_SCHEMA': (securesystemslib.formats.LENGTH_SCHEMA, 8),
+      'LENGTH_SCHEMA': (tuf.formats.LENGTH_SCHEMA, 8),
 
       'NAME_SCHEMA': (securesystemslib.formats.NAME_SCHEMA, 'Marty McFly'),
 
       'BOOLEAN_SCHEMA': (securesystemslib.formats.BOOLEAN_SCHEMA, True),
 
-      'THRESHOLD_SCHEMA': (securesystemslib.formats.THRESHOLD_SCHEMA, 1),
+      'THRESHOLD_SCHEMA': (tuf.formats.THRESHOLD_SCHEMA, 1),
 
       'ROLENAME_SCHEMA': (tuf.formats.ROLENAME_SCHEMA, 'Root'),
 

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -417,7 +417,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
       '/packages/file2.txt': 'c9c4a5cdd84858dd6a23d98d7e6e6b2aec45034946c16b2200bc317c75415e92'
     }
     for filepath, target_hash in six.iteritems(expected_target_hashes):
-      self.assertTrue(securesystemslib.formats.RELPATH_SCHEMA.matches(filepath))
+      self.assertTrue(tuf.formats.RELPATH_SCHEMA.matches(filepath))
       self.assertTrue(securesystemslib.formats.HASH_SCHEMA.matches(target_hash))
       self.assertEqual(repo_lib.get_target_hash(filepath), target_hash)
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1556,7 +1556,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
       '/Jalape\xc3\xb1o': '78bfd5c314680545eb48ecad508aceb861f8d6e680f4fe1b791da45c298cda88'
     }
     for filepath, target_hash in six.iteritems(expected_target_hashes):
-      self.assertTrue(securesystemslib.formats.RELPATH_SCHEMA.matches(filepath))
+      self.assertTrue(tuf.formats.RELPATH_SCHEMA.matches(filepath))
       self.assertTrue(securesystemslib.formats.HASH_SCHEMA.matches(target_hash))
       self.assertEqual(self.repository_updater._get_target_hash(filepath), target_hash)
 

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -2627,7 +2627,7 @@ class Updater(object):
 
     # Does 'rolename' have the correct format?
     # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
-    securesystemslib.formats.RELPATH_SCHEMA.check_match(rolename)
+    tuf.formats.RELPATH_SCHEMA.check_match(rolename)
 
     # If we've been given a delegated targets role, we don't know how to
     # validate it without knowing what the delegating role is -- there could
@@ -2690,7 +2690,7 @@ class Updater(object):
 
     # Does 'target_filepath' have the correct format?
     # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
-    securesystemslib.formats.RELPATH_SCHEMA.check_match(target_filepath)
+    tuf.formats.RELPATH_SCHEMA.check_match(target_filepath)
 
     target_filepath = target_filepath.replace('\\', '/')
 

--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -694,7 +694,7 @@ def _save_project_configuration(metadata_directory, targets_directory,
   securesystemslib.formats.PATH_SCHEMA.check_match(metadata_directory)
   securesystemslib.formats.PATH_SCHEMA.check_match(prefix)
   securesystemslib.formats.PATH_SCHEMA.check_match(targets_directory)
-  securesystemslib.formats.RELPATH_SCHEMA.check_match(project_name)
+  tuf.formats.RELPATH_SCHEMA.check_match(project_name)
 
   cfg_file_directory = metadata_directory
 

--- a/tuf/download.py
+++ b/tuf/download.py
@@ -110,7 +110,7 @@ def safe_download(url, required_length):
   # Do all of the arguments have the appropriate format?
   # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
   securesystemslib.formats.URL_SCHEMA.check_match(url)
-  securesystemslib.formats.LENGTH_SCHEMA.check_match(required_length)
+  tuf.formats.LENGTH_SCHEMA.check_match(required_length)
 
   return _download_file(url, required_length, STRICT_REQUIRED_LENGTH=True)
 
@@ -161,7 +161,7 @@ def unsafe_download(url, required_length):
   # Do all of the arguments have the appropriate format?
   # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
   securesystemslib.formats.URL_SCHEMA.check_match(url)
-  securesystemslib.formats.LENGTH_SCHEMA.check_match(required_length)
+  tuf.formats.LENGTH_SCHEMA.check_match(required_length)
 
   return _download_file(url, required_length, STRICT_REQUIRED_LENGTH=False)
 
@@ -216,7 +216,7 @@ def _download_file(url, required_length, STRICT_REQUIRED_LENGTH=True):
   # Do all of the arguments have the appropriate format?
   # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
   securesystemslib.formats.URL_SCHEMA.check_match(url)
-  securesystemslib.formats.LENGTH_SCHEMA.check_match(required_length)
+  tuf.formats.LENGTH_SCHEMA.check_match(required_length)
 
   # 'url.replace('\\', '/')' is needed for compatibility with Windows-based
   # systems, because they might use back-slashes in place of forward-slashes.

--- a/tuf/mirrors.py
+++ b/tuf/mirrors.py
@@ -84,7 +84,7 @@ def get_list_of_mirrors(file_type, file_path, mirrors_dict):
   """
 
   # Checking if all the arguments have appropriate format.
-  securesystemslib.formats.RELPATH_SCHEMA.check_match(file_path)
+  tuf.formats.RELPATH_SCHEMA.check_match(file_path)
   tuf.formats.MIRRORDICT_SCHEMA.check_match(mirrors_dict)
   securesystemslib.formats.NAME_SCHEMA.check_match(file_type)
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1203,7 +1203,7 @@ def get_target_hash(target_filepath):
     The hash of 'target_filepath'.
 
   """
-  securesystemslib.formats.RELPATH_SCHEMA.check_match(target_filepath)
+  tuf.formats.RELPATH_SCHEMA.check_match(target_filepath)
 
   # Calculate the hash of the filepath to determine which bin to find the
   # target.  The client currently assumes the repository uses
@@ -1416,7 +1416,7 @@ def generate_targets_metadata(targets_directory, target_files, version,
   # types, and that all dict keys are properly named.
   # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
   securesystemslib.formats.PATH_SCHEMA.check_match(targets_directory)
-  securesystemslib.formats.PATH_FILEINFO_SCHEMA.check_match(target_files)
+  tuf.formats.PATH_FILEINFO_SCHEMA.check_match(target_files)
   tuf.formats.METADATAVERSION_SCHEMA.check_match(version)
   securesystemslib.formats.ISO8601_DATETIME_SCHEMA.check_match(expiration_date)
   securesystemslib.formats.BOOLEAN_SCHEMA.check_match(write_consistent_targets)

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -1049,7 +1049,7 @@ class Metadata(object):
     """
     <Purpose>
       A getter method that returns the role's version number, conformant to
-      'securesystemslib.formats.VERSION_SCHEMA'.
+      'tuf.formats.VERSION_SCHEMA'.
 
     <Arguments>
       None.
@@ -1062,7 +1062,7 @@ class Metadata(object):
 
     <Returns>
       The role's version number, conformant to
-      'securesystemslib.formats.VERSION_SCHEMA'.
+      'tuf.formats.VERSION_SCHEMA'.
     """
 
     roleinfo = tuf.roledb.get_roleinfo(self.rolename, self._repository_name)
@@ -1094,7 +1094,7 @@ class Metadata(object):
     <Arguments>
       version:
         The role's version number, conformant to
-        'securesystemslib.formats.VERSION_SCHEMA'.
+        'tuf.formats.VERSION_SCHEMA'.
 
     <Exceptions>
       securesystemslib.exceptions.FormatError, if the 'version' argument is
@@ -1140,7 +1140,7 @@ class Metadata(object):
 
     <Returns>
       The role's threshold value, conformant to
-      'securesystemslib.formats.THRESHOLD_SCHEMA'.
+      'tuf.formats.THRESHOLD_SCHEMA'.
     """
 
     roleinfo = tuf.roledb.get_roleinfo(self._rolename, self._repository_name)
@@ -1166,7 +1166,7 @@ class Metadata(object):
       threshold:
         An integer value that sets the role's threshold value, or the minimum
         number of signatures needed for metadata to be considered fully
-        signed.  Conformant to 'securesystemslib.formats.THRESHOLD_SCHEMA'.
+        signed.  Conformant to 'tuf.formats.THRESHOLD_SCHEMA'.
 
     <Exceptions>
       securesystemslib.exceptions.FormatError, if the 'threshold' argument is
@@ -1184,7 +1184,7 @@ class Metadata(object):
     # Ensure the arguments have the appropriate number of objects and object
     # types, and that all dict keys are properly named.  Raise
     # 'securesystemslib.exceptions.FormatError' if any are improperly formatted.
-    securesystemslib.formats.THRESHOLD_SCHEMA.check_match(threshold)
+    tuf.formats.THRESHOLD_SCHEMA.check_match(threshold)
 
     roleinfo = tuf.roledb.get_roleinfo(self._rolename, self._repository_name)
     roleinfo['previous_threshold'] = roleinfo['threshold']
@@ -1983,7 +1983,7 @@ class Targets(Metadata):
     # Ensure the arguments have the appropriate number of objects and object
     # types, and that all dict keys are properly named.
     # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
-    securesystemslib.formats.RELPATHS_SCHEMA.check_match(list_of_targets)
+    tuf.formats.RELPATHS_SCHEMA.check_match(list_of_targets)
 
     # Update the tuf.roledb entry.
     targets_directory_length = len(self._targets_directory)
@@ -2054,7 +2054,7 @@ class Targets(Metadata):
     # Ensure the arguments have the appropriate number of objects and object
     # types, and that all dict keys are properly named.  Raise
     # 'securesystemslib.exceptions.FormatError' if there is a mismatch.
-    securesystemslib.formats.RELPATH_SCHEMA.check_match(filepath)
+    tuf.formats.RELPATH_SCHEMA.check_match(filepath)
 
     # Remove 'relative_filepath', if found, and update this Targets roleinfo.
     fileinfo = tuf.roledb.get_roleinfo(self.rolename, self._repository_name)
@@ -2211,15 +2211,15 @@ class Targets(Metadata):
     # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
     tuf.formats.ROLENAME_SCHEMA.check_match(rolename)
     securesystemslib.formats.ANYKEYLIST_SCHEMA.check_match(public_keys)
-    securesystemslib.formats.RELPATHS_SCHEMA.check_match(paths)
-    securesystemslib.formats.THRESHOLD_SCHEMA.check_match(threshold)
+    tuf.formats.RELPATHS_SCHEMA.check_match(paths)
+    tuf.formats.THRESHOLD_SCHEMA.check_match(threshold)
     securesystemslib.formats.BOOLEAN_SCHEMA.check_match(terminating)
 
     if list_of_targets is not None:
-      securesystemslib.formats.RELPATHS_SCHEMA.check_match(list_of_targets)
+      tuf.formats.RELPATHS_SCHEMA.check_match(list_of_targets)
 
     if path_hash_prefixes is not None:
-      securesystemslib.formats.PATH_HASH_PREFIXES_SCHEMA.check_match(path_hash_prefixes)
+      tuf.formats.PATH_HASH_PREFIXES_SCHEMA.check_match(path_hash_prefixes)
 
     # Keep track of the valid keyids (added to the new Targets object) and
     # their keydicts (added to this Targets delegations).

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -126,7 +126,7 @@ def get_signature_status(signable, role=None, repository_name='default',
     tuf.formats.ROLENAME_SCHEMA.check_match(role)
 
   if threshold is not None:
-    securesystemslib.formats.THRESHOLD_SCHEMA.check_match(threshold)
+    tuf.formats.THRESHOLD_SCHEMA.check_match(threshold)
 
   if keyids is not None:
     securesystemslib.formats.KEYIDS_SCHEMA.check_match(keyids)


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Use TUF specific RELPATH_SCHEMA and RELPATHS_SCHEMA formats as they are removed from securesystemslib in secure-systems-lab/securesystemslib#165

Without this change we can't use tuf with the master branch of securesystemslib

Aside: is it tuf or TUF? I've seen both used and wasn't sure which to use in my commit message.