### PR TITLE
Explicitly encode data passed to securesystemslib.keys

### DIFF
--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -1060,8 +1060,9 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     # Append the new valid, but duplicate PSS signature, and test that
     # duplicates are removed.  create_signature() generates a key for the
     # key type of the first argument (i.e., root_rsa_key).
+    data = securesystemslib.formats.encode_canonical(root_signable['signed']).encode('utf-8')
     new_pss_signature = securesystemslib.keys.create_signature(root_rsa_key,
-        root_signable['signed'])
+        data)
     root_signable['signatures'].append(new_pss_signature)
 
     expected_number_of_signatures = len(root_signable['signatures'])

--- a/tests/test_sig.py
+++ b/tests/test_sig.py
@@ -82,8 +82,9 @@ class TestSig(unittest.TestCase):
     # Should verify we are not adding a duplicate signature
     # when doing the following action.  Here we know 'signable'
     # has only one signature so it's okay.
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
 
     tuf.keydb.add_key(KEYS[0])
 
@@ -101,9 +102,10 @@ class TestSig(unittest.TestCase):
 
   def test_get_signature_status_bad_sig(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
     signable['signed'] += 'signature no longer matches signed data'
 
     tuf.keydb.add_key(KEYS[0])
@@ -133,9 +135,10 @@ class TestSig(unittest.TestCase):
 
   def test_get_signature_status_unknown_signing_scheme(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
 
     valid_scheme = KEYS[0]['scheme']
     KEYS[0]['scheme'] = 'unknown_signing_scheme'
@@ -168,9 +171,10 @@ class TestSig(unittest.TestCase):
 
   def test_get_signature_status_single_key(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
 
     threshold = 1
 
@@ -209,9 +213,10 @@ class TestSig(unittest.TestCase):
 
   def test_get_signature_status_below_threshold(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
 
     tuf.keydb.add_key(KEYS[0])
     threshold = 2
@@ -243,12 +248,13 @@ class TestSig(unittest.TestCase):
 
   def test_get_signature_status_below_threshold_unrecognized_sigs(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     # Two keys sign it, but only one of them will be trusted.
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[2], signable['signed']))
+                                  KEYS[2], signed))
 
     tuf.keydb.add_key(KEYS[0])
     tuf.keydb.add_key(KEYS[1])
@@ -282,13 +288,13 @@ class TestSig(unittest.TestCase):
 
   def test_get_signature_status_below_threshold_unauthorized_sigs(self):
     signable = {'signed' : 'test', 'signatures' : []}
-
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
     # Two keys sign it, but one of them is only trusted for a different
     # role.
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[1], signable['signed']))
+                                  KEYS[1], signed))
 
     tuf.keydb.add_key(KEYS[0])
     tuf.keydb.add_key(KEYS[1])
@@ -334,9 +340,10 @@ class TestSig(unittest.TestCase):
 
   def test_check_signatures_no_role(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
 
     tuf.keydb.add_key(KEYS[0])
 
@@ -353,8 +360,10 @@ class TestSig(unittest.TestCase):
 
   def test_verify_single_key(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
+
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
 
     tuf.keydb.add_key(KEYS[0])
     threshold = 1
@@ -377,12 +386,13 @@ class TestSig(unittest.TestCase):
 
   def test_verify_unrecognized_sig(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     # Two keys sign it, but only one of them will be trusted.
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[2], signable['signed']))
+                                  KEYS[2], signed))
 
     tuf.keydb.add_key(KEYS[0])
     tuf.keydb.add_key(KEYS[1])
@@ -408,9 +418,10 @@ class TestSig(unittest.TestCase):
 
   def test_generate_rsa_signature(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
 
     self.assertEqual(1, len(signable['signatures']))
     signature = signable['signatures'][0]
@@ -420,7 +431,7 @@ class TestSig(unittest.TestCase):
     self.assertTrue(securesystemslib.formats.SIGNATURE_SCHEMA.matches(returned_signature))
 
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[1], signable['signed']))
+                                  KEYS[1], signed))
 
     self.assertEqual(2, len(signable['signatures']))
     signature = signable['signatures'][1]
@@ -431,9 +442,10 @@ class TestSig(unittest.TestCase):
   def test_may_need_new_keys(self):
     # One untrusted key in 'signable'.
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
 
     tuf.keydb.add_key(KEYS[1])
     threshold = 1

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -360,7 +360,7 @@ def _remove_invalid_and_duplicate_signatures(signable, repository_name):
   signature_keyids = []
 
   for signature in signable['signatures']:
-    signed = signable['signed']
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
     keyid = signature['keyid']
     key = None
 
@@ -1769,7 +1769,7 @@ def sign_metadata(metadata_object, keyids, filename, repository_name):
     # Generate the signature using the appropriate signing method.
     if key['keytype'] in SUPPORTED_KEY_TYPES:
       if 'private' in key['keyval']:
-        signed = signable['signed']
+        signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
         try:
           signature = securesystemslib.keys.create_signature(key, signed)
           signable['signatures'].append(signature)

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -157,7 +157,7 @@ def get_signature_status(signable, role=None, repository_name='default',
 
   # Extract the relevant fields from 'signable' that will allow us to identify
   # the different classes of keys (i.e., good_sigs, bad_sigs, etc.).
-  signed = signable['signed']
+  signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
   signatures = signable['signatures']
 
   # Iterate the signatures and enumerate the signature_status fields.
@@ -390,7 +390,7 @@ def generate_rsa_signature(signed, rsakey_dict):
 
   # We need 'signed' in canonical JSON format to generate
   # the 'method' and 'sig' fields of the signature.
-  signed = securesystemslib.formats.encode_canonical(signed)
+  signed = securesystemslib.formats.encode_canonical(signed).encode('utf-8')
 
   # Generate the RSA signature.
   # Raises securesystemslib.exceptions.FormatError and TypeError.


### PR DESCRIPTION
### Note: this change breaks compatibility with ssl v0.11.3 and thus should not be merged until a new release of ssl has been made and is available on PyPI.

PR https://github.com/secure-systems-lab/securesystemslib/pull/162 removed implicit encoding of data to bytes in securesystemslib.keys.[create_signature|verify_signature]

**Fixes issue #**: #913 

**Description of the changes being introduced by the pull request**: explicitly encode data we pass to `securesystemslib.keys.create_signature` and `securesystemslib.keys.verify_signature`

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


