### PR TITLE
Remove uses of securesystemslib.util.TempFile

### DIFF
--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -111,9 +111,11 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     download_file = download.safe_download
 
     temp_fileobj = download_file(self.url, self.target_data_length)
-    self.assertEqual(self.target_data, temp_fileobj.read().decode('utf-8'))
-    self.assertEqual(self.target_data_length, len(temp_fileobj.read()))
-    temp_fileobj.close_temp_file()
+    temp_fileobj.seek(0)
+    temp_file_data = temp_fileobj.read().decode('utf-8')
+    self.assertEqual(self.target_data, temp_file_data)
+    self.assertEqual(self.target_data_length, len(temp_file_data))
+    temp_fileobj.close()
 
 
 
@@ -158,7 +160,7 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
 
     self.assertEqual(self.target_data, temp_fileobj.read())
     self.assertEqual(self.target_data_length, len(temp_fileobj.read()))
-    temp_fileobj.close_temp_file()
+    temp_fileobj.close()
 
     print "Performance cpu time: "+str(end_cpu - star_cpu)
     print "Performance real time: "+str(end_real - star_real)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1568,7 +1568,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
   def test_10__hard_check_file_length(self):
     # Test for exception if file object is not equal to trusted file length.
-    temp_file_object = securesystemslib.util.TempFile()
+    temp_file_object = tempfile.TemporaryFile()
     temp_file_object.write(b'X')
     temp_file_object.seek(0)
     self.assertRaises(tuf.exceptions.DownloadLengthMismatchError,
@@ -1581,7 +1581,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
   def test_10__soft_check_file_length(self):
     # Test for exception if file object is not equal to trusted file length.
-    temp_file_object = securesystemslib.util.TempFile()
+    temp_file_object = tempfile.TemporaryFile()
     temp_file_object.write(b'XXX')
     temp_file_object.seek(0)
     self.assertRaises(tuf.exceptions.DownloadLengthMismatchError,
@@ -1704,7 +1704,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
   def test_11__verify_uncompressed_metadata_file(self):
     # Test for invalid metadata content.
-    metadata_file_object = securesystemslib.util.TempFile()
+    metadata_file_object = tempfile.TemporaryFile()
     metadata_file_object.write(b'X')
     metadata_file_object.seek(0)
 

--- a/tuf/download.py
+++ b/tuf/download.py
@@ -20,10 +20,7 @@
 <Purpose>
   Download metadata and target files and check their validity.  The hash and
   length of a downloaded file has to match the hash and length supplied by the
-  metadata of that file.  The downloaded file is technically a  file-like
-  object that will automatically destroys itself once closed.  Note that the
-  file-like object, 'securesystemslib.util.TempFile', is returned by the
-  '_download_file()' function.
+  metadata of that file.
 """
 
 # Help with Python 3 compatibility, where the print statement is a function, an
@@ -37,6 +34,7 @@ from __future__ import unicode_literals
 import logging
 import time
 import timeit
+import tempfile
 
 import tuf
 import requests
@@ -76,11 +74,6 @@ def safe_download(url, required_length):
     tuf.download.unsafe_download() may be called if an upper download limit is
     preferred.
 
-    'securesystemslib.util.TempFile', the file-like object returned, is used
-    instead of regular tempfile object because of additional functionality
-    provided, such as handling compressed metadata and automatically closing
-    files after moving to final destination.
-
   <Arguments>
     url:
       A URL string that represents the location of the file.
@@ -90,8 +83,7 @@ def safe_download(url, required_length):
       limit.
 
   <Side Effects>
-    A 'securesystemslib.util.TempFile' object is created on disk to store the
-    contents of 'url'.
+    A file object is created on disk to store the contents of 'url'.
 
   <Exceptions>
     tuf.ssl_commons.exceptions.DownloadLengthMismatchError, if there was a
@@ -103,8 +95,7 @@ def safe_download(url, required_length):
     Any other unforeseen runtime exception.
 
   <Returns>
-    A 'securesystemslib.util.TempFile' file-like object that points to the
-    contents of 'url'.
+    A file object that points to the contents of 'url'.
   """
 
   # Do all of the arguments have the appropriate format?
@@ -127,11 +118,6 @@ def unsafe_download(url, required_length):
     tuf.download.safe_download() may be called if an exact download limit is
     preferred.
 
-    'securesystemslib.util.TempFile', the file-like object returned, is used
-    instead of regular tempfile object because of additional functionality
-    provided, such as handling compressed metadata and automatically closing
-    files after moving to final destination.
-
   <Arguments>
     url:
       A URL string that represents the location of the file.
@@ -141,8 +127,7 @@ def unsafe_download(url, required_length):
       limit.
 
   <Side Effects>
-    A 'securesystemslib.util.TempFile' object is created on disk to store the
-    contents of 'url'.
+    A file object is created on disk to store the contents of 'url'.
 
   <Exceptions>
     tuf.ssl_commons.exceptions.DownloadLengthMismatchError, if there was a
@@ -154,8 +139,7 @@ def unsafe_download(url, required_length):
     Any other unforeseen runtime exception.
 
   <Returns>
-    A 'securesystemslib.util.TempFile' file-like object that points to the
-    contents of 'url'.
+    A file object that points to the contents of 'url'.
   """
 
   # Do all of the arguments have the appropriate format?
@@ -178,10 +162,6 @@ def _download_file(url, required_length, STRICT_REQUIRED_LENGTH=True):
     the file's length is not checked and a slow retrieval exception is raised
     if the downloaded rate falls below the acceptable rate).
 
-    securesystemslib.util.TempFile is used instead of regular tempfile object
-    because of additional functionality provided by
-    'securesystemslib.util.TempFile'.
-
   <Arguments>
     url:
       A URL string that represents the location of the file.
@@ -196,8 +176,7 @@ def _download_file(url, required_length, STRICT_REQUIRED_LENGTH=True):
       timestamp metadata, which has no signed required_length.
 
   <Side Effects>
-    A 'securesystemslib.util.TempFile' object is created on disk to store the
-    contents of 'url'.
+    A file object is created on disk to store the contents of 'url'.
 
   <Exceptions>
     tuf.exceptions.DownloadLengthMismatchError, if there was a
@@ -209,8 +188,7 @@ def _download_file(url, required_length, STRICT_REQUIRED_LENGTH=True):
     Any other unforeseen runtime exception.
 
   <Returns>
-    A 'securesystemslib.util.TempFile' file-like object that points to the
-    contents of 'url'.
+    A file object that points to the contents of 'url'.
   """
 
   # Do all of the arguments have the appropriate format?
@@ -228,7 +206,7 @@ def _download_file(url, required_length, STRICT_REQUIRED_LENGTH=True):
 
   # This is the temporary file that we will return to contain the contents of
   # the downloaded file.
-  temp_file = securesystemslib.util.TempFile()
+  temp_file = tempfile.TemporaryFile()
 
   try:
     # Use a different requests.Session per schema+hostname combination, to
@@ -304,7 +282,7 @@ def _download_file(url, required_length, STRICT_REQUIRED_LENGTH=True):
 
   except Exception:
     # Close 'temp_file'.  Any written data is lost.
-    temp_file.close_temp_file()
+    temp_file.close()
     logger.exception('Could not download URL: ' + repr(url))
     raise
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -38,6 +38,7 @@ import logging
 import shutil
 import json
 import platform
+import tempfile
 
 import tuf
 import tuf.formats
@@ -51,6 +52,7 @@ import tuf.settings
 import securesystemslib
 import securesystemslib.hash
 import securesystemslib.interface
+import securesystemslib.util
 import iso8601
 import six
 
@@ -1860,12 +1862,11 @@ def write_metadata_file(metadata, filename, version_number, consistent_snapshot)
   # The 'metadata' object is written to 'file_object'.  To avoid partial
   # metadata from being written, 'metadata' is first written to a temporary
   # location (i.e., 'file_object') and then moved to 'filename'.
-  file_object = securesystemslib.util.TempFile()
+  file_object = tempfile.TemporaryFile()
 
   # Serialize 'metadata' to the file-like object and then write 'file_object'
   # to disk.  The dictionary keys of 'metadata' are sorted and indentation is
-  # used.  The 'securesystemslib.util.TempFile' file-like object is automically
-  # closed after the final move.
+  # used.
   file_object.write(file_content)
 
   if consistent_snapshot:
@@ -1880,7 +1881,7 @@ def write_metadata_file(metadata, filename, version_number, consistent_snapshot)
     # the consistent snapshot and point 'written_filename' to it.
     logger.debug('Creating a consistent file for ' + repr(written_filename))
     logger.debug('Saving ' + repr(written_consistent_filename))
-    file_object.move(written_consistent_filename)
+    securesystemslib.util.persist_temp_file(file_object, written_consistent_filename)
 
     # For GitHub issue #374 https://github.com/theupdateframework/tuf/issues/374
     # We provide the option of either (1) creating a link via os.link() to the
@@ -1912,7 +1913,7 @@ def write_metadata_file(metadata, filename, version_number, consistent_snapshot)
   else:
     logger.debug('Not creating a consistent snapshot for ' + repr(written_filename))
     logger.debug('Saving ' + repr(written_filename))
-    file_object.move(written_filename)
+    securesystemslib.util.persist_temp_file(file_object, written_filename)
 
   return written_filename
 

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -50,6 +50,7 @@ import tuf.repository_lib as repo_lib
 
 import securesystemslib.keys
 import securesystemslib.formats
+import securesystemslib.util
 import iso8601
 import six
 
@@ -3144,13 +3145,13 @@ def append_signature(signature, metadata_filepath):
 
   signable['signatures'].append(signature)
 
-  file_object = securesystemslib.util.TempFile()
+  file_object = tempfile.TemporaryFile()
 
   written_metadata_content = json.dumps(signable, indent=1,
       separators=(',', ': '), sort_keys=True).encode('utf-8')
 
   file_object.write(written_metadata_content)
-  file_object.move(metadata_filepath)
+  securesystemslib.util.persist_temp_file(file_object, metadata_filepath)
 
 
 # Wrapper functions that we wish to make available here from securesystemslib.


### PR DESCRIPTION
### Note: this change breaks compatibility with ssl v0.11.3 and thus should not be merged until a new release of ssl has been made and is available on PyPI.

**Description of the changes being introduced by the pull request**: remove use of `securesystemslib.util.TempFile` in favour of `tempfile.TemporaryFile` from the Python standard library. SSL's `TempFile` included features which are no longer used by TUF or in-toto and had API which was inconsistent with normal Python file objects, and thus was removed.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


