### PR TITLE
Streamline TUFs crypto interface 

### DIFF
--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -53,14 +53,34 @@ import securesystemslib.keys
 
 import six
 
-# These imports provide the interface for 'developer_tool.py', since the
-# imports are made there.
-from securesystemslib.keys import format_keyval_to_metadata
-
 from tuf.repository_tool import Targets
 from tuf.repository_lib import _check_role_keys
-from tuf.repository_lib import generate_targets_metadata
 from tuf.repository_lib import _metadata_is_partially_loaded
+
+
+# Copy API
+# pylint: disable=unused-import
+
+# Copy generic repository API functions to be used via `developer_tool`
+from tuf.repository_lib import (
+    generate_targets_metadata,
+    create_tuf_client_directory,
+    disable_console_log_messages)
+
+# Copy key-related API functions to be used via `developer_tool`
+from tuf.repository_lib import (
+    import_rsa_privatekey_from_file)
+
+from securesystemslib.keys import (
+    format_keyval_to_metadata)
+
+from securesystemslib.interface import (
+    generate_and_write_rsa_keypair,
+    generate_and_write_ed25519_keypair,
+    import_rsa_publickey_from_file,
+    import_ed25519_publickey_from_file,
+    import_ed25519_privatekey_from_file)
+
 
 # See 'log.py' to learn how logging is handled in TUF.
 logger = logging.getLogger('tuf.developer_tool')
@@ -984,35 +1004,6 @@ def _strip_prefix_from_targets_metadata(targets_metadata, prefix):
 
   return targets_metadata
 
-
-
-# Wrapper functions that we wish to make available here from repository_lib.py.
-# Users are expected to call functions provided by repository_tool.py.  We opt
-# for this approach, as opposed to using import statements to achieve the
-# equivalent, to avoid linter warnings for unused imports.
-def generate_and_write_rsa_keypair(filepath, bits, password):
-  return repo_lib.generate_and_write_rsa_keypair(filepath, bits, password)
-
-def generate_and_write_ed25519_keypair(filepath, password):
-  return repo_lib.generate_and_write_ed25519_keypair(filepath, password)
-
-def import_rsa_publickey_from_file(filepath):
-  return repo_lib.import_rsa_publickey_from_file(filepath)
-
-def import_ed25519_publickey_from_file(filepath):
-  return repo_lib.import_ed25519_publickey_from_file(filepath)
-
-def import_rsa_privatekey_from_file(filepath, password):
-  return repo_lib.import_rsa_privatekey_from_file(filepath, password)
-
-def import_ed25519_privatekey_from_file(filepath, password):
-  return repo_lib.import_ed25519_privatekey_from_file(filepath, password)
-
-def create_tuf_client_directory(repository_directory, client_directory):
-  return repo_lib.create_tuf_client_directory(repository_directory, client_directory)
-
-def disable_console_log_messages():
-  return repo_lib.disable_console_log_messages()
 
 
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -63,13 +63,6 @@ logger = logging.getLogger('tuf.repository_lib')
 iso8601_logger = logging.getLogger('iso8601')
 iso8601_logger.disabled = True
 
-# Recommended RSA key sizes:
-# http://www.emc.com/emc-plus/rsa-labs/historical/twirl-and-rsa-key-size.htm#table1
-# According to the document above, revised May 6, 2003, RSA keys of
-# size 3072 provide security through 2031 and beyond. 2048-bit keys
-# are the recommended minimum and are good from the present through 2030.
-DEFAULT_RSA_KEY_BITS = 3072
-
 # The extension of TUF metadata.
 METADATA_EXTENSION = '.json'
 
@@ -752,42 +745,6 @@ def _log_warning_if_expires_soon(rolename, expires_iso8601_timestamp,
 
 
 
-def generate_and_write_rsa_keypair(filepath, bits=DEFAULT_RSA_KEY_BITS,
-    password=None):
-  """
-  <Purpose>
-    Generate an RSA key file, create an encrypted PEM string (using 'password'
-    as the pass phrase), and store it in 'filepath'.  The public key portion of
-    the generated RSA key is stored in <'filepath'>.pub.
-
-  <Arguments>
-    filepath:
-      The public and private key files are saved to <filepath>.pub, <filepath>,
-      respectively.
-
-    bits:
-      The number of bits of the generated RSA key.
-
-    password:
-      The password used to encrypt 'filepath'.
-
-  <Exceptions>
-    securesystemslib.exceptions.FormatError, if the arguments are improperly
-    formatted.
-
-  <Side Effects>
-    Writes key files to '<filepath>' and '<filepath>.pub'.
-
-  <Returns>
-    None.
-  """
-
-  securesystemslib.interface.generate_and_write_rsa_keypair(
-      filepath, bits, password)
-
-
-
-
 def import_rsa_privatekey_from_file(filepath, password=None):
   """
   <Purpose>
@@ -837,111 +794,6 @@ def import_rsa_privatekey_from_file(filepath, password=None):
   return private_key
 
 
-
-
-
-def import_rsa_publickey_from_file(filepath):
-  """
-  <Purpose>
-    Import the RSA key stored in 'filepath'.  The key object returned is a TUF
-    key, specifically 'securesystemslib.RSAKEY_SCHEMA'.  If the RSA PEM
-    in 'filepath' contains a private key, it is discarded.
-
-  <Arguments>
-    filepath:
-      <filepath>.pub file, an RSA PEM file.
-
-  <Exceptions>
-    securesystemslib.exceptions.FormatError, if 'filepath' is improperly formatted.
-
-    securesystemslib.exceptions.Error, if a valid RSA key object cannot be
-    generated.  This may be caused by an improperly formatted PEM file.
-
-  <Side Effects>
-    'filepath' is read and its contents extracted.
-
-  <Returns>
-    An RSA key object conformant to 'securesystemslib.RSAKEY_SCHEMA'.
-  """
-
-  return securesystemslib.interface.import_rsa_publickey_from_file(filepath)
-
-
-
-
-
-def generate_and_write_ed25519_keypair(filepath, password=None):
-  """
-  <Purpose>
-    Generate an Ed25519 key file, create an encrypted TUF key (using 'password'
-    as the pass phrase), and store it in 'filepath'.  The public key portion of
-    the generated ED25519 key is stored in <'filepath'>.pub.  Which cryptography
-    library performs the cryptographic decryption is determined by the string
-    set in 'settings.ED25519_CRYPTO_LIBRARY'.
-
-    The Ed25519 private key is encrypted with AES-256 and CTR the mode of
-    operation.  The password is strengthened with PBKDF2-HMAC-SHA256.
-
-  <Arguments>
-    filepath:
-      The public and private key files are saved to <filepath>.pub and
-      <filepath>, respectively.
-
-    password:
-      The password, or passphrase, to encrypt the private portion of the
-      generated ed25519 key.  A symmetric encryption key is derived from
-      'password', so it is not directly used.
-
-  <Exceptions>
-    securesystemslib.exceptions.FormatError, if the arguments are improperly
-    formatted.
-
-    securesystemslib.exceptions.CryptoError, if 'filepath' cannot be encrypted.
-
-    securesystemslib.exceptions.UnsupportedLibraryError, if 'filepath' cannot be
-    encrypted due to an invalid configuration setting (i.e., invalid
-    'tuf.settings.py' setting).
-
-  <Side Effects>
-    Writes key files to '<filepath>' and '<filepath>.pub'.
-
-  <Returns>
-    None.
-  """
-
-  securesystemslib.interface.generate_and_write_ed25519_keypair(
-      filepath, password)
-
-
-
-
-
-def import_ed25519_publickey_from_file(filepath):
-  """
-  <Purpose>
-    Load the ED25519 public key object (conformant to
-    'securesystemslib.KEY_SCHEMA') stored in 'filepath'.  Return
-    'filepath' in securesystemslib.ED25519KEY_SCHEMA format.
-
-    If the TUF key object in 'filepath' contains a private key, it is discarded.
-
-  <Arguments>
-    filepath:
-      <filepath>.pub file, a TUF public key file.
-
-  <Exceptions>
-    securesystemslib.exceptions.FormatError, if 'filepath' is improperly
-    formatted or is an unexpected key type.
-
-  <Side Effects>
-    The contents of 'filepath' is read and saved.
-
-  <Returns>
-    An ED25519 key object conformant to
-    'securesystemslib.ED25519KEY_SCHEMA'.
-  """
-
-  return securesystemslib.interface.import_ed25519_publickey_from_file(filepath)
 
 
 

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -54,6 +54,37 @@ import iso8601
 import six
 
 
+# Copy API
+# pylint: disable=unused-import
+
+# Copy generic repository API functions to be used via `repository_tool`
+from tuf.repository_lib import (
+    create_tuf_client_directory,
+    disable_console_log_messages)
+
+
+# Copy key-related API functions to be used via `repository_tool`
+from tuf.repository_lib import (
+    import_rsa_privatekey_from_file,
+    import_ed25519_privatekey_from_file)
+
+from securesystemslib.interface import (
+    generate_and_write_rsa_keypair,
+    generate_and_write_ecdsa_keypair,
+    generate_and_write_ed25519_keypair,
+    import_rsa_publickey_from_file,
+    import_ecdsa_publickey_from_file,
+    import_ed25519_publickey_from_file,
+    import_ecdsa_privatekey_from_file)
+
+from securesystemslib.keys import (
+    generate_rsa_key,
+    generate_ecdsa_key,
+    generate_ed25519_key,
+    import_rsakey_from_pem,
+    import_ecdsakey_from_pem)
+
+
 # See 'log.py' to learn how logging is handled in TUF.
 logger = logging.getLogger('tuf.repository_tool')
 
@@ -3153,63 +3184,6 @@ def append_signature(signature, metadata_filepath):
   file_object.move(metadata_filepath)
 
 
-# Wrapper functions that we wish to make available here from securesystemslib.
-# Users are expected to call functions provided by repository_tool.py.  We opt
-# for wrapper functions, instead of using the import statements to achieve the
-# equivalent, to avoid linter warnings for unused imports.
-def generate_and_write_ed25519_keypair(filepath=None, password=None):
-  return repo_lib.generate_and_write_ed25519_keypair(filepath, password)
-
-def generate_ed25519_key(scheme='ed25519'):
-  return securesystemslib.keys.generate_ed25519_key(scheme)
-
-def import_ed25519_publickey_from_file(filepath):
-  return repo_lib.import_ed25519_publickey_from_file(filepath)
-
-def import_ed25519_privatekey_from_file(filepath, password=None):
-  return repo_lib.import_ed25519_privatekey_from_file(filepath, password)
-
-# NOTE: securesystemslib cannot presently import an Ed25519 key from PEM.
-
-def generate_and_write_rsa_keypair(filepath=None,
-    bits=repo_lib.DEFAULT_RSA_KEY_BITS, password=None):
-  return repo_lib.generate_and_write_rsa_keypair(filepath, bits, password)
-
-def generate_rsa_key(bits=DEFAULT_RSA_KEY_BITS, scheme='rsassa-pss-sha256'):
-  return securesystemslib.keys.generate_rsa_key(bits, scheme)
-
-def import_rsa_publickey_from_file(filepath):
-  return repo_lib.import_rsa_publickey_from_file(filepath)
-
-def import_rsa_privatekey_from_file(filepath, password=None):
-  return repo_lib.import_rsa_privatekey_from_file(filepath, password)
-
-def import_rsakey_from_pem(pem, scheme='rsassa-pss-sha256'):
-  return securesystemslib.keys.import_rsakey_from_pem(pem, scheme)
-
-def generate_and_write_ecdsa_keypair(filepath=None, password=None):
-  return securesystemslib.interface.generate_and_write_ecdsa_keypair(
-      filepath, password)
-
-def generate_ecdsa_key(scheme='ecdsa-sha2-nistp256'):
-  return securesystemslib.keys.generate_ecdsa_key(scheme)
-
-def import_ecdsa_privatekey_from_file(filepath, password=None):
-  return securesystemslib.interface.import_ecdsa_privatekey_from_file(
-      filepath, password)
-
-def import_ecdsa_publickey_from_file(filepath):
-  return securesystemslib.interface.import_ecdsa_publickey_from_file(filepath)
-
-def import_ecdsakey_from_pem(pem, scheme='ecdsa-sha2-nistp256'):
-  return securesystemslib.keys.import_ecdsakey_from_pem(pem, scheme)
-
-def create_tuf_client_directory(repository_directory, client_directory):
-  return repo_lib.create_tuf_client_directory(
-      repository_directory, client_directory)
-
-def disable_console_log_messages():
-  return repo_lib.disable_console_log_messages()
 
 
 


### PR DESCRIPTION
**Fixes issue #**:
Closes #656
Supersedes #804
Paves the way for #840 

**Description of the changes being introduced by the pull request**:

- Remove `securesystemslib`-wrappers  in `repository_lib` that don't add any new functionality. Also remove corresponding tests that already exist in `securesystemslib`.
This means the functions are no longer available via `repository_lib`, which should be fine, because `repository_lib` does not seem to be a public interface.

- Replace `securesystemslib`-  and `repository_lib`-wrappers, in `repository_tool` and `developer_tool` with direct imports.
This means, the functions are still available via the `repository_tool` (or `developer_tool`), which they should be (see e.g. TUTORIAL.md), but internally the modules get slimmer. 

See commit messages for more details.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


