### PR TITLE
Bump version 0.12.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+
+## v0.12.0
+* Add backwards incompatible TUF spec version checks (#842, #844, #854, #914)
+* Adopt securesystemslib v0.12.0 update (#909, #910, #855, #912, #934)
+* Fix multi-root rotation (#885, #930)
+* Fix duplicate schema definitions (#929)
+* Refactor metadata generation (#836)
+* Refactor securesystemslib interface (#919)
+* Update implementation roadmap (#833)
+* Improve tests and testing infrastructure (#825, #839, #890, #915, #892, #923)
+* Improve documentation (#824, #849, #852, #853, #893, #924, #928, et al.)
+* Update misc dependencies (#850, #851, #916, #922, #926, #931)
+
 ## v0.11.1
 
 * Prevent persistent freeze attack (pr [#737](https://github.com/theupdateframework/tuf/pull/737)).

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ with open('README.md') as file_object:
 
 setup(
   name = 'tuf',
-  version = '0.11.2.dev3', # If updating version, also update it in tuf/__init__.py
+  version = '0.12.0', # If updating version, also update it in tuf/__init__.py
   description = 'A secure updater framework for Python',
   long_description = long_description,
   long_description_content_type='text/markdown',

--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -2,7 +2,7 @@
 # setup.py has it hard-coded separately.
 # Currently, when the version is changed, it must be set in both locations.
 # TODO: Single-source the version number.
-__version__ = "0.11.2.dev3"
+__version__ = "0.12.0"
 
 # This reference implementation produces metadata intended to conform to
 # version 1.0.0 of the TUF specification, and is expected to consume metadata


### PR DESCRIPTION
**TODO**
1. Wait for securesystemslib 0.12.0 to be released on PyPI
1. Merge #917 and #918 to adapt to breaking changes in securesystemslib
1. Rebase this release PR onto develop
1. Release tuf 0.12.0-dev0
*Alternatively, and if preferred, release as 1.0.0-dev0 instead (requires changing the version numbers in `CHANGELOG.md`, `setup.py` and `__init__.py`)*

