### PR TITLE
Fix failing builds due to pylint 2.4.0 update

### DIFF
--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1728,7 +1728,6 @@ class Updater(object):
     # Construct the metadata filename as expected by the download/mirror
     # modules.
     metadata_filename = metadata_role + '.json'
-    metadata_filename = metadata_filename
 
     # Attempt a file download from each mirror until the file is downloaded and
     # verified.  If the signature of the downloaded file is valid, proceed,

--- a/tuf/log.py
+++ b/tuf/log.py
@@ -173,7 +173,7 @@ class ConsoleFilter(logging.Filter):
       # file logging handler, the user may always consult the file log for the
       # original exception traceback. The exc_info is explained here:
       # http://docs.python.org/2/library/sys.html#sys.exc_info
-      exc_type, junk, junk = record.exc_info
+      exc_type, _, _ = record.exc_info
 
       # Simply set the class name as the exception text.
       record.exc_text = exc_type.__name__


### PR DESCRIPTION
**Fixes issue #**:
None. 

**Description of the changes being introduced by the pull request**:
Pylint was updated to 2.4.0 a few minutes ago. The new versions now emits the following warnings:
```
py35 run-test: commands[0] | pylint tuf
************* Module tuf.log
tuf/log.py:176:6: W0128: Redeclared variable 'junk' in assignment (redeclared-assigned-name)
************* Module tuf.client.updater
tuf/client/updater.py:1731:4: W0127: Assigning the same variable 'metadata_filename' to itself (self-assigning-variable)
```
This PR fixes the issues. See commit messages for details.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


