### PR TITLE
Remove obsolete 'interposition' from docs

### DIFF
--- a/tests/repository_data/generate.py
+++ b/tests/repository_data/generate.py
@@ -153,6 +153,6 @@ if not options.dry_run:
   shutil.copytree(staged_metadata_directory, metadata_directory)
 
 # Create the client files (required directory structure and minimal metadata)
-# required by the 'tuf.interposition' and 'tuf.client.updater.py' updaters.
+# as expected by 'tuf.client.updater'.
 if not options.dry_run:
   create_tuf_client_directory('repository', os.path.join('client', 'test_repository1'))

--- a/tuf/client/README.md
+++ b/tuf/client/README.md
@@ -11,10 +11,6 @@ and set the repository mirror information.
 The **tuf.repository_tool** module can be used to create a TUF repository.  See
 [tuf/README](../README.md) for more information on creating TUF repositories.
 
-The **tuf.interposition** package can also assist in integrating TUF with a
-software updater.  See [tuf/interposition/README](../interposition/README.md)
-for more information on interposing Python urllib calls with TUF.
-
 
 ## Overview of the Update Process
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -2086,9 +2086,9 @@ def _log_status(rolename, signable, repository_name):
 def create_tuf_client_directory(repository_directory, client_directory):
   """
   <Purpose>
-    Create a client directory structure that the 'tuf.interposition' package
-    and 'tuf.client.updater' module expect of clients.  Metadata files
-    downloaded from a remote TUF repository are saved to 'client_directory'.
+    Create client directory structure as 'tuf.client.updater' expects it.
+    Metadata files downloaded from a remote TUF repository are saved to
+    'client_directory'.
     The Root file must initially exist before an update request can be
     satisfied.  create_tuf_client_directory() ensures the minimum metadata
     is copied and that required directories ('previous' and 'current') are
@@ -2164,8 +2164,8 @@ def create_tuf_client_directory(repository_directory, client_directory):
 
   # Move all  metadata to the client's 'current' and 'previous' directories.
   # The root metadata file MUST exist in '{client_metadata_directory}/current'.
-  # 'tuf.interposition' and 'tuf.client.updater.py' expect the 'current' and
-  # 'previous' directories to exist under 'metadata'.
+  # 'tuf.client.updater' expects the 'current' and 'previous' directories to
+  # exist under 'metadata'.
   client_current = os.path.join(client_metadata_directory, 'current')
   client_previous = os.path.join(client_metadata_directory, 'previous')
   shutil.copytree(metadata_directory, client_current)


### PR DESCRIPTION

**Fixes issue #**:
None. Related to #537 

**Description of the changes being introduced by the pull request**:

The `tuf.interposition` sub-package was removed in #537.
This PR removes remaining but now obsolete mentions of 'interposition' from code comments and documentation.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


