### PR TITLE
Update securesystemslib to 0.12.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -42,7 +42,7 @@ pylint==1.9.3 ; python_version < "3.0" # pyup: ignore
 pynacl==1.3.0
 pyyaml==5.1.2
 requests==2.22.0
-securesystemslib[crypto,pynacl]==0.11.3
+securesystemslib[crypto,pynacl]==0.12.0
 singledispatch==3.4.0.3
 six==1.12.0
 smmap2==2.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -119,7 +119,7 @@ pynacl==1.3.0 \
 requests==2.22.0 \
     --hash=sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4 \
     --hash=sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31
-securesystemslib==0.11.3 \
+securesystemslib==0.12.0 \
     --hash=sha256:368ef6f6cc40d3636e271485c7adb21c53c22200bab44a2fe8af62886a01c3d5 \
     --hash=sha256:cbd1f7f1af2f2921be33b9fd17384705f5f4147d3a8b5d95b33ec3ce2213f176
 six==1.12.0 \

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(
     'iso8601>=0.1.12',
     'requests>=2.19.1',
     'six>=1.11.0',
-    'securesystemslib>=0.11.3'
+    'securesystemslib>=0.12.0'
   ],
   packages = find_packages(exclude=['tests']),
   scripts = [

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -111,9 +111,11 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     download_file = download.safe_download
 
     temp_fileobj = download_file(self.url, self.target_data_length)
-    self.assertEqual(self.target_data, temp_fileobj.read().decode('utf-8'))
-    self.assertEqual(self.target_data_length, len(temp_fileobj.read()))
-    temp_fileobj.close_temp_file()
+    temp_fileobj.seek(0)
+    temp_file_data = temp_fileobj.read().decode('utf-8')
+    self.assertEqual(self.target_data, temp_file_data)
+    self.assertEqual(self.target_data_length, len(temp_file_data))
+    temp_fileobj.close()
 
 
 
@@ -158,7 +160,7 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
 
     self.assertEqual(self.target_data, temp_fileobj.read())
     self.assertEqual(self.target_data_length, len(temp_fileobj.read()))
-    temp_fileobj.close_temp_file()
+    temp_fileobj.close()
 
     print "Performance cpu time: "+str(end_cpu - star_cpu)
     print "Performance real time: "+str(end_real - star_real)

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -906,8 +906,9 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     # Append the new valid, but duplicate PSS signature, and test that
     # duplicates are removed.  create_signature() generates a key for the
     # key type of the first argument (i.e., root_rsa_key).
+    data = securesystemslib.formats.encode_canonical(root_signable['signed']).encode('utf-8')
     new_pss_signature = securesystemslib.keys.create_signature(root_rsa_key,
-        root_signable['signed'])
+        data)
     root_signable['signatures'].append(new_pss_signature)
 
     expected_number_of_signatures = len(root_signable['signatures'])

--- a/tests/test_sig.py
+++ b/tests/test_sig.py
@@ -82,8 +82,9 @@ class TestSig(unittest.TestCase):
     # Should verify we are not adding a duplicate signature
     # when doing the following action.  Here we know 'signable'
     # has only one signature so it's okay.
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
 
     tuf.keydb.add_key(KEYS[0])
 
@@ -101,9 +102,10 @@ class TestSig(unittest.TestCase):
 
   def test_get_signature_status_bad_sig(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
     signable['signed'] += 'signature no longer matches signed data'
 
     tuf.keydb.add_key(KEYS[0])
@@ -133,9 +135,10 @@ class TestSig(unittest.TestCase):
 
   def test_get_signature_status_unknown_signing_scheme(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
 
     valid_scheme = KEYS[0]['scheme']
     KEYS[0]['scheme'] = 'unknown_signing_scheme'
@@ -168,9 +171,10 @@ class TestSig(unittest.TestCase):
 
   def test_get_signature_status_single_key(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
 
     threshold = 1
 
@@ -209,9 +213,10 @@ class TestSig(unittest.TestCase):
 
   def test_get_signature_status_below_threshold(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
 
     tuf.keydb.add_key(KEYS[0])
     threshold = 2
@@ -243,12 +248,13 @@ class TestSig(unittest.TestCase):
 
   def test_get_signature_status_below_threshold_unrecognized_sigs(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     # Two keys sign it, but only one of them will be trusted.
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[2], signable['signed']))
+                                  KEYS[2], signed))
 
     tuf.keydb.add_key(KEYS[0])
     tuf.keydb.add_key(KEYS[1])
@@ -282,13 +288,13 @@ class TestSig(unittest.TestCase):
 
   def test_get_signature_status_below_threshold_unauthorized_sigs(self):
     signable = {'signed' : 'test', 'signatures' : []}
-
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
     # Two keys sign it, but one of them is only trusted for a different
     # role.
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[1], signable['signed']))
+                                  KEYS[1], signed))
 
     tuf.keydb.add_key(KEYS[0])
     tuf.keydb.add_key(KEYS[1])
@@ -334,9 +340,10 @@ class TestSig(unittest.TestCase):
 
   def test_check_signatures_no_role(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
 
     tuf.keydb.add_key(KEYS[0])
 
@@ -353,8 +360,10 @@ class TestSig(unittest.TestCase):
 
   def test_verify_single_key(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
+
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
 
     tuf.keydb.add_key(KEYS[0])
     threshold = 1
@@ -377,12 +386,13 @@ class TestSig(unittest.TestCase):
 
   def test_verify_unrecognized_sig(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     # Two keys sign it, but only one of them will be trusted.
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[2], signable['signed']))
+                                  KEYS[2], signed))
 
     tuf.keydb.add_key(KEYS[0])
     tuf.keydb.add_key(KEYS[1])
@@ -408,9 +418,10 @@ class TestSig(unittest.TestCase):
 
   def test_generate_rsa_signature(self):
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
 
     self.assertEqual(1, len(signable['signatures']))
     signature = signable['signatures'][0]
@@ -420,7 +431,7 @@ class TestSig(unittest.TestCase):
     self.assertTrue(securesystemslib.formats.SIGNATURE_SCHEMA.matches(returned_signature))
 
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[1], signable['signed']))
+                                  KEYS[1], signed))
 
     self.assertEqual(2, len(signable['signatures']))
     signature = signable['signatures'][1]
@@ -431,9 +442,10 @@ class TestSig(unittest.TestCase):
   def test_may_need_new_keys(self):
     # One untrusted key in 'signable'.
     signable = {'signed' : 'test', 'signatures' : []}
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
 
     signable['signatures'].append(securesystemslib.keys.create_signature(
-                                  KEYS[0], signable['signed']))
+                                  KEYS[0], signed))
 
     tuf.keydb.add_key(KEYS[1])
     threshold = 1

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1568,7 +1568,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
   def test_10__hard_check_file_length(self):
     # Test for exception if file object is not equal to trusted file length.
-    temp_file_object = securesystemslib.util.TempFile()
+    temp_file_object = tempfile.TemporaryFile()
     temp_file_object.write(b'X')
     temp_file_object.seek(0)
     self.assertRaises(tuf.exceptions.DownloadLengthMismatchError,
@@ -1581,7 +1581,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
   def test_10__soft_check_file_length(self):
     # Test for exception if file object is not equal to trusted file length.
-    temp_file_object = securesystemslib.util.TempFile()
+    temp_file_object = tempfile.TemporaryFile()
     temp_file_object.write(b'XXX')
     temp_file_object.seek(0)
     self.assertRaises(tuf.exceptions.DownloadLengthMismatchError,
@@ -1704,7 +1704,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
   def test_11__verify_uncompressed_metadata_file(self):
     # Test for invalid metadata content.
-    metadata_file_object = securesystemslib.util.TempFile()
+    metadata_file_object = tempfile.TemporaryFile()
     metadata_file_object.write(b'X')
     metadata_file_object.seek(0)
 

--- a/tuf/download.py
+++ b/tuf/download.py
@@ -20,10 +20,7 @@
 <Purpose>
   Download metadata and target files and check their validity.  The hash and
   length of a downloaded file has to match the hash and length supplied by the
-  metadata of that file.  The downloaded file is technically a  file-like
-  object that will automatically destroys itself once closed.  Note that the
-  file-like object, 'securesystemslib.util.TempFile', is returned by the
-  '_download_file()' function.
+  metadata of that file.
 """
 
 # Help with Python 3 compatibility, where the print statement is a function, an
@@ -37,6 +34,7 @@ from __future__ import unicode_literals
 import logging
 import time
 import timeit
+import tempfile
 
 import tuf
 import requests
@@ -76,11 +74,6 @@ def safe_download(url, required_length):
     tuf.download.unsafe_download() may be called if an upper download limit is
     preferred.
 
-    'securesystemslib.util.TempFile', the file-like object returned, is used
-    instead of regular tempfile object because of additional functionality
-    provided, such as handling compressed metadata and automatically closing
-    files after moving to final destination.
-
   <Arguments>
     url:
       A URL string that represents the location of the file.
@@ -90,8 +83,7 @@ def safe_download(url, required_length):
       limit.
 
   <Side Effects>
-    A 'securesystemslib.util.TempFile' object is created on disk to store the
-    contents of 'url'.
+    A file object is created on disk to store the contents of 'url'.
 
   <Exceptions>
     tuf.ssl_commons.exceptions.DownloadLengthMismatchError, if there was a
@@ -103,8 +95,7 @@ def safe_download(url, required_length):
     Any other unforeseen runtime exception.
 
   <Returns>
-    A 'securesystemslib.util.TempFile' file-like object that points to the
-    contents of 'url'.
+    A file object that points to the contents of 'url'.
   """
 
   # Do all of the arguments have the appropriate format?
@@ -127,11 +118,6 @@ def unsafe_download(url, required_length):
     tuf.download.safe_download() may be called if an exact download limit is
     preferred.
 
-    'securesystemslib.util.TempFile', the file-like object returned, is used
-    instead of regular tempfile object because of additional functionality
-    provided, such as handling compressed metadata and automatically closing
-    files after moving to final destination.
-
   <Arguments>
     url:
       A URL string that represents the location of the file.
@@ -141,8 +127,7 @@ def unsafe_download(url, required_length):
       limit.
 
   <Side Effects>
-    A 'securesystemslib.util.TempFile' object is created on disk to store the
-    contents of 'url'.
+    A file object is created on disk to store the contents of 'url'.
 
   <Exceptions>
     tuf.ssl_commons.exceptions.DownloadLengthMismatchError, if there was a
@@ -154,8 +139,7 @@ def unsafe_download(url, required_length):
     Any other unforeseen runtime exception.
 
   <Returns>
-    A 'securesystemslib.util.TempFile' file-like object that points to the
-    contents of 'url'.
+    A file object that points to the contents of 'url'.
   """
 
   # Do all of the arguments have the appropriate format?
@@ -178,10 +162,6 @@ def _download_file(url, required_length, STRICT_REQUIRED_LENGTH=True):
     the file's length is not checked and a slow retrieval exception is raised
     if the downloaded rate falls below the acceptable rate).
 
-    securesystemslib.util.TempFile is used instead of regular tempfile object
-    because of additional functionality provided by
-    'securesystemslib.util.TempFile'.
-
   <Arguments>
     url:
       A URL string that represents the location of the file.
@@ -196,8 +176,7 @@ def _download_file(url, required_length, STRICT_REQUIRED_LENGTH=True):
       timestamp metadata, which has no signed required_length.
 
   <Side Effects>
-    A 'securesystemslib.util.TempFile' object is created on disk to store the
-    contents of 'url'.
+    A file object is created on disk to store the contents of 'url'.
 
   <Exceptions>
     tuf.exceptions.DownloadLengthMismatchError, if there was a
@@ -209,8 +188,7 @@ def _download_file(url, required_length, STRICT_REQUIRED_LENGTH=True):
     Any other unforeseen runtime exception.
 
   <Returns>
-    A 'securesystemslib.util.TempFile' file-like object that points to the
-    contents of 'url'.
+    A file object that points to the contents of 'url'.
   """
 
   # Do all of the arguments have the appropriate format?
@@ -228,7 +206,7 @@ def _download_file(url, required_length, STRICT_REQUIRED_LENGTH=True):
 
   # This is the temporary file that we will return to contain the contents of
   # the downloaded file.
-  temp_file = securesystemslib.util.TempFile()
+  temp_file = tempfile.TemporaryFile()
 
   try:
     # Use a different requests.Session per schema+hostname combination, to
@@ -304,7 +282,7 @@ def _download_file(url, required_length, STRICT_REQUIRED_LENGTH=True):
 
   except Exception:
     # Close 'temp_file'.  Any written data is lost.
-    temp_file.close_temp_file()
+    temp_file.close()
     logger.exception('Could not download URL: ' + repr(url))
     raise
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -38,6 +38,7 @@ import logging
 import shutil
 import json
 import platform
+import tempfile
 
 import tuf
 import tuf.formats
@@ -51,6 +52,7 @@ import tuf.settings
 import securesystemslib
 import securesystemslib.hash
 import securesystemslib.interface
+import securesystemslib.util
 import iso8601
 import six
 
@@ -1712,12 +1714,11 @@ def write_metadata_file(metadata, filename, version_number, consistent_snapshot)
   # The 'metadata' object is written to 'file_object'.  To avoid partial
   # metadata from being written, 'metadata' is first written to a temporary
   # location (i.e., 'file_object') and then moved to 'filename'.
-  file_object = securesystemslib.util.TempFile()
+  file_object = tempfile.TemporaryFile()
 
   # Serialize 'metadata' to the file-like object and then write 'file_object'
   # to disk.  The dictionary keys of 'metadata' are sorted and indentation is
-  # used.  The 'securesystemslib.util.TempFile' file-like object is automically
-  # closed after the final move.
+  # used.
   file_object.write(file_content)
 
   if consistent_snapshot:
@@ -1732,7 +1733,7 @@ def write_metadata_file(metadata, filename, version_number, consistent_snapshot)
     # the consistent snapshot and point 'written_filename' to it.
     logger.debug('Creating a consistent file for ' + repr(written_filename))
     logger.debug('Saving ' + repr(written_consistent_filename))
-    file_object.move(written_consistent_filename)
+    securesystemslib.util.persist_temp_file(file_object, written_consistent_filename)
 
     # For GitHub issue #374 https://github.com/theupdateframework/tuf/issues/374
     # We provide the option of either (1) creating a link via os.link() to the
@@ -1764,7 +1765,7 @@ def write_metadata_file(metadata, filename, version_number, consistent_snapshot)
   else:
     logger.debug('Not creating a consistent snapshot for ' + repr(written_filename))
     logger.debug('Saving ' + repr(written_filename))
-    file_object.move(written_filename)
+    securesystemslib.util.persist_temp_file(file_object, written_filename)
 
   return written_filename
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -353,7 +353,7 @@ def _remove_invalid_and_duplicate_signatures(signable, repository_name):
   signature_keyids = []
 
   for signature in signable['signatures']:
-    signed = signable['signed']
+    signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
     keyid = signature['keyid']
     key = None
 
@@ -1621,7 +1621,7 @@ def sign_metadata(metadata_object, keyids, filename, repository_name):
     # Generate the signature using the appropriate signing method.
     if key['keytype'] in SUPPORTED_KEY_TYPES:
       if 'private' in key['keyval']:
-        signed = signable['signed']
+        signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
         try:
           signature = securesystemslib.keys.create_signature(key, signed)
           signable['signatures'].append(signature)

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -50,6 +50,7 @@ import tuf.repository_lib as repo_lib
 
 import securesystemslib.keys
 import securesystemslib.formats
+import securesystemslib.util
 import iso8601
 import six
 
@@ -3175,13 +3176,13 @@ def append_signature(signature, metadata_filepath):
 
   signable['signatures'].append(signature)
 
-  file_object = securesystemslib.util.TempFile()
+  file_object = tempfile.TemporaryFile()
 
   written_metadata_content = json.dumps(signable, indent=1,
       separators=(',', ': '), sort_keys=True).encode('utf-8')
 
   file_object.write(written_metadata_content)
-  file_object.move(metadata_filepath)
+  securesystemslib.util.persist_temp_file(file_object, metadata_filepath)
 
 
 

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -157,7 +157,7 @@ def get_signature_status(signable, role=None, repository_name='default',
 
   # Extract the relevant fields from 'signable' that will allow us to identify
   # the different classes of keys (i.e., good_sigs, bad_sigs, etc.).
-  signed = signable['signed']
+  signed = securesystemslib.formats.encode_canonical(signable['signed']).encode('utf-8')
   signatures = signable['signatures']
 
   # Iterate the signatures and enumerate the signature_status fields.
@@ -389,7 +389,7 @@ def generate_rsa_signature(signed, rsakey_dict):
 
   # We need 'signed' in canonical JSON format to generate
   # the 'method' and 'sig' fields of the signature.
-  signed = securesystemslib.formats.encode_canonical(signed)
+  signed = securesystemslib.formats.encode_canonical(signed).encode('utf-8')
 
   # Generate the RSA signature.
   # Raises securesystemslib.exceptions.FormatError and TypeError.


### PR DESCRIPTION
**Fixes issue #**:
Closes #28.
Supersedes #917 and #918.

**Description of the changes being introduced by the pull request**:

Updates pinned version  of `securesystemslib` dependency in `*requirements.txt` and `setup.py` to latest 0.12.0.

The update requires a few adjustments due to breaking changes in securesystemslib 0.12.0, which were kindly provided by @joshuagl in #917 and #918:
- explicitly encode data we pass to `securesystemslib.keys.create_signature` and `securesystemslib.keys.verify_signature`
- remove use of `securesystemslib.util.TempFile` in favour of `tempfile.TemporaryFile` from the Python standard library

These changes are incorporated with this PR, fixing minor merge conflicts due to #885.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


