### PR TITLE
Relax semver for spec version in 0.12.MINOR

### DIFF
--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -79,11 +79,17 @@ import six
 # As per TUF spec 1.0.0 the spec version field must follow the Semantic
 # Versioning 2.0.0 (semver) format. The regex pattern is provided by semver.
 # https://semver.org/spec/v2.0.0.html#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-SPECIFICATION_VERSION_SCHEMA = SCHEMA.RegularExpression(
-  r'(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)'
-  r'(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)'
-  r'(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?'
-  r'(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?')
+SEMVER_2_0_0_SCHEMA = SCHEMA.RegularExpression(
+    r'(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)'
+    r'(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)'
+    r'(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?'
+    r'(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?'
+)
+SPECIFICATION_VERSION_SCHEMA = SCHEMA.OneOf([
+    # However, temporarily allow "1.0" for backwards-compatibility in tuf-0.12.PATCH.
+    SCHEMA.String("1.0"),
+    SEMVER_2_0_0_SCHEMA
+])
 
 # A datetime in 'YYYY-MM-DDTHH:MM:SSZ' ISO 8601 format.  The "Z" zone designator
 # for the zero UTC offset is always used (i.e., a numerical offset is not


### PR DESCRIPTION
**Fixes issue #**:

#949 

**Description of the changes being introduced by the pull request**:

Allow one of two version scehemes (the fixed string "1.0" or SemVer) for `spec_version`, so that 0.12 can at least _load_ repositories written with 0.11.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


