### PR TITLE
Bump version 0.12.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.12.1
+* Relax spec version format check for backwards compatibility (#950)
+* Update project metadata (#937, #939, #944, #947, #948, #953, #954)
+* Update misc dependencies (#936, #941, #942, #945, #956)
 
 ## v0.12.0
 * Add backwards incompatible TUF spec version checks (#842, #844, #854, #914)

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ with open('README.md') as file_object:
 
 setup(
   name = 'tuf',
-  version = '0.12.0', # If updating version, also update it in tuf/__init__.py
+  version = '0.12.1', # If updating version, also update it in tuf/__init__.py
   description = 'A secure updater framework for Python',
   long_description = long_description,
   long_description_content_type='text/markdown',

--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -2,7 +2,7 @@
 # setup.py has it hard-coded separately.
 # Currently, when the version is changed, it must be set in both locations.
 # TODO: Single-source the version number.
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 # This reference implementation produces metadata intended to conform to
 # version 1.0.0 of the TUF specification, and is expected to consume metadata


### PR DESCRIPTION
0.12.1 is a patch-release to, above all, relax the strict semver format check on metadata spec version fields, in order to re-establish backwards compatibility with pre-0.12.0 tuf metadata.

See changelog for details. 