### PR TITLE
Update tested and supported Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,14 @@ matrix:
   include:
     - python: "2.7"
       env: TOXENV=py27
-    - python: "3.4"
-      env: TOXENV=py34
     - python: "3.5"
       env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
+    - python: "3.7"
+      env: TOXENV=py37
+    - python: "3.8"
+      env: TOXENV=py38
     - python: "3.6"
       env: TOXENV=with-sslib-master
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,19 @@
 environment:
   matrix:
+    - PYTHON: "C:\\Python38"
+      PYTHON_VERSION: 3.8
+      PYTHON_ARCH: 32
+
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: 3.7
+      PYTHON_ARCH: 32
+
     - PYTHON: "C:\\Python36"
       PYTHON_VERSION: 3.6
       PYTHON_ARCH: 32
 
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: 3.5
-      PYTHON_ARCH: 32
-
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: 3.4
       PYTHON_ARCH: 32
 
     - PYTHON: "C:\\Python27"

--- a/setup.py
+++ b/setup.py
@@ -103,13 +103,15 @@ setup(
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: Security',
     'Topic :: Software Development'
   ],
+  python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
   install_requires = [
     'iso8601>=0.1.12',
     'requests>=2.19.1',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py35, py36, py37, py38
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
**Fixes issue #**:
None.
Motivated by recent 3.4 build failures observed in https://github.com/theupdateframework/tuf/pull/775#issuecomment-564922719, due to an update of the transitive dependency `colorama`, which dropped Python 3.4 support in its latest version.

**Description of the changes being introduced by the pull request**:
- Drop 3.4 (due to end-of-life) and add 3.7 and 3.8 to tox, travis and appveyor configuration for automated testing.
- Adapt classifiers in setup.py accordingly.
- Add python_requires field in setup.py to reflect supported versions. This will prevent pip from trying to install tuf on a non-supported version.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


