### PR TITLE
Fix signature threshold

### DIFF
--- a/tests/test_sig.py
+++ b/tests/test_sig.py
@@ -388,6 +388,9 @@ class TestSig(unittest.TestCase):
 
   def test_verify_must_not_count_duplicate_keyids_towards_threshold(self):
     # Create and sign dummy metadata twice with same key
+    # Note that we use the non-deterministic rsassa-pss signing scheme, so
+    # creating the signature twice shows that we don't only detect duplicate
+    # signatures but also different signatures from the same key.
     signable = {"signed" : "test", "signatures" : []}
     signed = securesystemslib.formats.encode_canonical(
         signable["signed"]).encode("utf-8")

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -78,7 +78,8 @@ def get_signature_status(signable, role=None, repository_name='default',
     * good -- Valid signature from key that is available in 'tuf.keydb', and is
       authorized for the passed role as per 'tuf.roledb' (authorization may be
       overwritten by passed 'keyids').
-    * unknown -- Signature from key that is not available in 'tuf.keydb'.
+    * unknown -- Signature from key that is not available in 'tuf.keydb', or if
+      'role' is None.
     * unknown signing schemes -- Signature from key with unknown signing
       scheme.
     * untrusted -- Valid signature from key that is available in 'tuf.keydb',


### PR DESCRIPTION
**Fixes issue #**:
None

**Description of the changes being introduced by the pull request**:
Prior to this PR metadadata signature verification as provided by `tuf.sig.verify()` and used e.g. in `tuf.client.updater` counted multiple signatures with identical authorized keyids each separately towards the threshold.

This PR changes this to count identical authorized keyids only once towards the threshold.
It further clarifies the behavior of the relevant functions in the `sig` module, i.e. `get_signature_status` and `verify` in their respective docstrings. And adds tests for those functions and also for the client updater.

An alternative fix is outlined in the commit message of a0397c7 (including a patch).


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


