### PR TITLE
Add colorama to dependencies installed in the tutorial

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -15,7 +15,7 @@ how TUF works, however.  It will serve as a very basic update system.
 
 Make sure that TUF is installed, along with some of the optional cryptographic
 libraries and C extensions.  Try this command to do that:
-`pip install securesystemslib[crypto,pynacl] tuf`
+`pip install securesystemslib[colors,crypto,pynacl] tuf`
 
 If you run into errors during that pip command, please consult the more
 detailed [TUF Installation Instructions](INSTALLATION.rst).  (There are some


### PR DESCRIPTION
colorama is now an optional dependency for securesystemslib, and so isn't
installed by default. However, the repo script uses colorama and doesn't
handle its absence.

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**:

**Description of the changes being introduced by the pull request**:
* adds colorama to the packages installed at the start of the tutorial in `docs/QUICKSTART.md`

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


