### PR TITLE
Enhancements for hashed bin delegation

### DIFF
--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -335,7 +335,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     datetime_object = datetime.datetime(2030, 1, 1, 12, 0)
     expiration_date = datetime_object.isoformat() + 'Z'
     file_permissions = oct(os.stat(file1_path).st_mode)[4:]
-    target_files = {'file.txt': {'file_permission': file_permissions}}
+    target_files = {'file.txt': {'custom': {'file_permission': file_permissions}}}
 
     delegations = {"keys": {
       "a394c28384648328b16731f81440d72243c77bb44c07c040be99347f0df7d7bf": {

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1374,10 +1374,13 @@ class TestTargets(unittest.TestCase):
     def check_prefixes_match_range():
       roleinfo = tuf.roledb.get_roleinfo(self.targets_object.rolename,
           'test_repository')
+      have_prefixes = False
+
       for delegated_role in roleinfo['delegations']['roles']:
         if len(delegated_role['path_hash_prefixes']) > 0:
           rolename = delegated_role['name']
           prefixes = delegated_role['path_hash_prefixes']
+          have_prefixes = True
 
           if len(prefixes) > 1:
             prefix_range = "{}-{}".format(prefixes[0], prefixes[-1])
@@ -1386,6 +1389,8 @@ class TestTargets(unittest.TestCase):
 
           self.assertEqual(rolename, prefix_range)
 
+      # We expect at least one delegation with some path_hash_prefixes
+      self.assertTrue(have_prefixes)
 
 
     # Test delegate_hashed_bins() and verify that 16 hashed bins have

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1076,14 +1076,14 @@ class TestTargets(unittest.TestCase):
 
     self.assertEqual(len(self.targets_object.target_files), 2)
     self.assertTrue('file2.txt' in self.targets_object.target_files)
-    self.assertEqual(self.targets_object.target_files['file2.txt'],
+    self.assertEqual(self.targets_object.target_files['file2.txt']['custom'],
                      custom_file_permissions)
 
     # Attempt to replace target that has already been added.
     octal_file_permissions2 = oct(os.stat(target_filepath).st_mode)[4:]
     custom_file_permissions2 = {'file_permissions': octal_file_permissions}
     self.targets_object.add_target(target2_filepath, custom_file_permissions2)
-    self.assertEqual(self.targets_object.target_files['file2.txt'],
+    self.assertEqual(self.targets_object.target_files['file2.txt']['custom'],
     custom_file_permissions2)
 
     # Test improperly formatted arguments.

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1094,18 +1094,6 @@ class TestTargets(unittest.TestCase):
                       target_filepath, 3)
 
 
-    # Test invalid filepath argument (i.e., non-existent or invalid file.)
-    self.assertRaises(securesystemslib.exceptions.Error, self.targets_object.add_target,
-                      'non-existent.txt')
-
-    # Not under the repository's targets directory.
-    self.assertRaises(securesystemslib.exceptions.Error, self.targets_object.add_target,
-                      self.temporary_directory)
-
-    # Not a file (i.e., a valid path, but a directory.)
-    test_directory = os.path.join(self.targets_directory, 'test_directory')
-    os.mkdir(test_directory)
-    self.assertRaises(securesystemslib.exceptions.Error, self.targets_object.add_target, test_directory)
 
 
 
@@ -1134,17 +1122,6 @@ class TestTargets(unittest.TestCase):
     # Test improperly formatted arguments.
     self.assertRaises(securesystemslib.exceptions.FormatError, self.targets_object.add_targets, 3)
 
-    # Test invalid filepath argument (i.e., non-existent or invalid file.)
-    self.assertRaises(securesystemslib.exceptions.Error, self.targets_object.add_targets,
-                      ['non-existent.txt'])
-    self.assertRaises(securesystemslib.exceptions.Error, self.targets_object.add_targets,
-                      [target1_filepath, target2_filepath, 'non-existent.txt'])
-    self.assertRaises(securesystemslib.exceptions.Error, self.targets_object.add_targets,
-                      [self.temporary_directory])
-    temp_directory = os.path.join(self.targets_directory, 'temp')
-    os.mkdir(temp_directory)
-    self.assertRaises(securesystemslib.exceptions.Error, self.targets_object.add_targets,
-                      [temp_directory])
 
 
 
@@ -1404,10 +1381,6 @@ class TestTargets(unittest.TestCase):
     # Test improperly formatted argument.
     self.assertRaises(securesystemslib.exceptions.FormatError,
                       self.targets_object.add_target_to_bin, 3, 'foo')
-
-    # Invalid target file path argument.
-    self.assertRaises(securesystemslib.exceptions.Error,
-                      self.targets_object.add_target_to_bin, '/non-existent', 16)
 
 
 

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1365,17 +1365,16 @@ class TestTargets(unittest.TestCase):
 
     # Set needed arguments by delegate_hashed_bins().
     public_keys = [public_key]
-    list_of_targets = [target1_filepath]
 
     # Delegate to hashed bins.  The target filepath to be tested is expected
     # to contain a hash prefix of 'e', and should be available at:
     # repository.targets('e').
-    self.targets_object.delegate_hashed_bins(list_of_targets, public_keys,
+    self.targets_object.delegate_hashed_bins([], public_keys,
         number_of_bins=16)
 
     # Ensure each hashed bin initially contains zero targets.
     for delegation in self.targets_object.delegations:
-      self.assertTrue(target1_filepath not in delegation.target_files)
+      self.assertEqual(delegation.target_files, {})
 
     # Add 'target1_filepath' and verify that the relative path of
     # 'target1_filepath' is added to the correct bin.
@@ -1450,17 +1449,16 @@ class TestTargets(unittest.TestCase):
 
     # Set needed arguments by delegate_hashed_bins().
     public_keys = [public_key]
-    list_of_targets = [os.path.basename(target1_filepath)]
 
     # Delegate to hashed bins.  The target filepath to be tested is expected
     # to contain a hash prefix of 'e', and can be accessed as:
     # repository.targets('e').
-    self.targets_object.delegate_hashed_bins(list_of_targets, public_keys,
+    self.targets_object.delegate_hashed_bins([], public_keys,
                                              number_of_bins=16)
 
     # Ensure each hashed bin initially contains zero targets.
     for delegation in self.targets_object.delegations:
-      self.assertTrue(os.path.basename(target1_filepath) not in delegation.target_files)
+      self.assertEqual(delegation.target_files, {})
 
     # Add 'target1_filepath' and verify that the relative path of
     # 'target1_filepath' is added to the correct bin.

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1301,7 +1301,7 @@ class TestTargets(unittest.TestCase):
           prefixes = delegated_role['path_hash_prefixes']
 
           if len(prefixes) > 1:
-            prefix_range = "{}-{}".format(prefixes[0], prefixes[1])
+            prefix_range = "{}-{}".format(prefixes[0], prefixes[-1])
           else:
             prefix_range = prefixes[0]
 

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1485,6 +1485,20 @@ class TestTargets(unittest.TestCase):
                       self.targets_object.add_target_to_bin,
                       os.path.basename(target1_filepath), 16)
 
+    # Test adding a target with fileinfo
+    target2_hashes = {'sha256': '517c0ce943e7274a2431fa5751e17cfd5225accd23e479bfaad13007751e87ef'}
+    target2_fileinfo = tuf.formats.make_fileinfo(37, target2_hashes)
+    target2_filepath = os.path.join(self.targets_directory, 'file2.txt')
+
+    self.targets_object.add_target_to_bin(os.path.basename(target2_filepath), 16, fileinfo=target2_fileinfo)
+
+    for delegation in self.targets_object.delegations:
+      if delegation.rolename == '0':
+        self.assertTrue('file2.txt' in delegation.target_files)
+
+      else:
+        self.assertFalse('file2.txt' in delegation.target_files)
+
     # Test improperly formatted argument.
     self.assertRaises(securesystemslib.exceptions.FormatError,
                       self.targets_object.add_target_to_bin, 3, 'foo')

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1378,7 +1378,7 @@ class TestTargets(unittest.TestCase):
 
     # Add 'target1_filepath' and verify that the relative path of
     # 'target1_filepath' is added to the correct bin.
-    self.targets_object.add_target_to_bin(os.path.basename(target1_filepath))
+    self.targets_object.add_target_to_bin(os.path.basename(target1_filepath), 16)
 
     for delegation in self.targets_object.delegations:
       if delegation.rolename == '5':
@@ -1387,55 +1387,27 @@ class TestTargets(unittest.TestCase):
       else:
         self.assertFalse('file1.txt' in delegation.target_files)
 
-    # Verify that 'path_hash_prefixes' must exist for hashed bin delegations.
-
-    roleinfo = tuf.roledb.get_roleinfo(self.targets_object.rolename,
-        repository_name)
-
-    for delegated_role in roleinfo['delegations']['roles']:
-      delegated_role['path_hash_prefixes'] = []
-
-    tuf.roledb.update_roleinfo(self.targets_object.rolename, roleinfo,
-        repository_name=repository_name)
-    self.assertRaises(securesystemslib.exceptions.Error,
-                      self.targets_object.add_target_to_bin, target1_filepath)
-
-    # Verify that an exception is raised if a target does not match with
-    # any of the 'path_hash_prefixes'.
-    roleinfo = tuf.roledb.get_roleinfo(self.targets_object.rolename,
-        repository_name)
-    delegated_role = roleinfo['delegations']['roles'][0]
-    delegated_role['path_hash_prefixes'] = ['faac']
-    delegated_roles = list()
-    delegated_roles.append(delegated_role)
-    roleinfo['delegations']['roles'] = delegated_roles
-    tuf.roledb.update_roleinfo(self.targets_object.rolename, roleinfo,
-        repository_name=repository_name)
-
-    self.assertRaises(securesystemslib.exceptions.Error,
-                      self.targets_object.add_target_to_bin, target1_filepath)
-
     # Test for non-existent delegations and hashed bins.
     empty_targets_role = repo_tool.Targets(self.targets_directory, 'empty',
         repository_name=repository_name)
 
     self.assertRaises(securesystemslib.exceptions.Error,
                       empty_targets_role.add_target_to_bin,
-                      target1_filepath)
+                      os.path.basename(target1_filepath), 16)
 
     # Test for a required hashed bin that does not exist.
-    self.targets_object.revoke('e')
+    self.targets_object.revoke('5')
     self.assertRaises(securesystemslib.exceptions.Error,
                       self.targets_object.add_target_to_bin,
-                      target1_filepath)
+                      os.path.basename(target1_filepath), 16)
 
     # Test improperly formatted argument.
     self.assertRaises(securesystemslib.exceptions.FormatError,
-                      self.targets_object.add_target_to_bin, 3)
+                      self.targets_object.add_target_to_bin, 3, 'foo')
 
     # Invalid target file path argument.
     self.assertRaises(securesystemslib.exceptions.Error,
-                      self.targets_object.add_target_to_bin, '/non-existent')
+                      self.targets_object.add_target_to_bin, '/non-existent', 16)
 
 
 
@@ -1462,34 +1434,30 @@ class TestTargets(unittest.TestCase):
 
     # Add 'target1_filepath' and verify that the relative path of
     # 'target1_filepath' is added to the correct bin.
-    self.targets_object.add_target_to_bin(os.path.basename(target1_filepath))
+    self.targets_object.add_target_to_bin(os.path.basename(target1_filepath), 16)
 
     for delegation in self.targets_object.delegations:
       if delegation.rolename == '5':
         self.assertTrue('file1.txt' in delegation.target_files)
-
+        self.assertTrue(len(delegation.target_files) == 1)
       else:
         self.assertTrue('file1.txt' not in delegation.target_files)
 
     # Test the remove_target_from_bin() method.  Verify that 'target1_filepath'
     # has been removed.
-    self.targets_object.remove_target_from_bin(os.path.basename(target1_filepath))
+    self.targets_object.remove_target_from_bin(os.path.basename(target1_filepath), 16)
 
     for delegation in self.targets_object.delegations:
-      if delegation.rolename == 'e':
-        self.assertTrue('file1.txt' not in delegation.target_files)
-
-      else:
-        self.assertTrue('file1.txt' not in delegation.target_files)
+      self.assertTrue('file1.txt' not in delegation.target_files)
 
 
     # Test improperly formatted argument.
     self.assertRaises(securesystemslib.exceptions.FormatError,
-                      self.targets_object.remove_target_from_bin, 3)
+        self.targets_object.remove_target_from_bin, 3, 'foo')
 
     # Invalid target file path argument.
     self.assertRaises(securesystemslib.exceptions.Error,
-        self.targets_object.remove_target_from_bin, '/non-existent')
+        self.targets_object.remove_target_from_bin, '/non-existent', 16)
 
 
 

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -358,10 +358,10 @@ class TestTutorial(unittest.TestCase):
           targets, [public_unclaimed_key], 32)
 
       self.assertListEqual([
-            "Creating hashed bin delegations.",
-            "1 total targets.",
-            "32 hashed bins.",
-            "256 total hash prefixes.",
+            "Creating hashed bin delegations.\n"
+            "1 total targets.\n"
+            "32 hashed bins.\n"
+            "256 total hash prefixes.\n"
             "Each bin ranges over 8 hash prefixes."
           ] + ["Adding a verification key that has already been used."] * 32,
           [

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -298,13 +298,20 @@ DELEGATIONS_SCHEMA = SCHEMA.Object(
 NUMBINS_SCHEMA = SCHEMA.Integer(lo=1)
 
 # The fileinfo format of targets specified in the repository and
-# developer tools.  The second element of this list holds custom data about the
-# target, such as file permissions, author(s), last modified, etc.
+# developer tools.  The fields match that of FILEINFO_SCHEMA, only all
+# fields are optional.
 CUSTOM_SCHEMA = SCHEMA.Object()
+LOOSE_FILEINFO_SCHEMA = SCHEMA.Object(
+  object_name = "LOOSE_FILEINFO_SCHEMA",
+  length = SCHEMA.Optional(LENGTH_SCHEMA),
+  hashes = SCHEMA.Optional(HASHDICT_SCHEMA),
+  version = SCHEMA.Optional(METADATAVERSION_SCHEMA),
+  custom = SCHEMA.Optional(SCHEMA.Object())
+)
 
 PATH_FILEINFO_SCHEMA = SCHEMA.DictOf(
   key_schema = RELPATH_SCHEMA,
-  value_schema = CUSTOM_SCHEMA)
+  value_schema = LOOSE_FILEINFO_SCHEMA)
 
 # TUF roledb
 ROLEDB_SCHEMA = SCHEMA.Object(

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -662,7 +662,7 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
     # Update 'targets.json' in 'tuf.roledb.py'
     roleinfo = tuf.roledb.get_roleinfo('targets', repository_name)
     for filepath, fileinfo in six.iteritems(targets_metadata['targets']):
-      roleinfo['paths'].update({filepath: fileinfo.get('custom', {})})
+      roleinfo['paths'].update({filepath: fileinfo})
     roleinfo['version'] = targets_metadata['version']
     roleinfo['expires'] = targets_metadata['expires']
     roleinfo['delegations'] = targets_metadata['delegations']
@@ -1287,7 +1287,7 @@ def generate_targets_metadata(targets_directory, target_files, version,
   targets_directory = _check_directory(targets_directory)
 
   # Generate the fileinfo of all the target files listed in 'target_files'.
-  for target, custom in six.iteritems(target_files):
+  for target, fileinfo in six.iteritems(target_files):
 
     # The root-most folder of the targets directory should not be included in
     # target paths listed in targets metadata.
@@ -1307,9 +1307,7 @@ def generate_targets_metadata(targets_directory, target_files, version,
     # Add 'custom' if it has been provided.  Custom data about the target is
     # optional and will only be included in metadata (i.e., a 'custom' field in
     # the target's fileinfo dictionary) if specified here.
-    custom_data = None
-    if len(custom):
-      custom_data = custom
+    custom_data = fileinfo.get('custom', None)
 
     filedict[relative_targetpath.replace('\\', '/').lstrip('/')] = \
       get_metadata_fileinfo(target_path, custom_data)

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2802,6 +2802,29 @@ class Targets(Metadata):
 
 
 
+def _get_hash(target_filepath):
+  """
+  <Purpose>
+    Generate a hash of target_filepath, a path to a file (not the file
+    itself), using HASH_FUNCTION
+
+  <Arguments>
+    target_filepath:
+      A path to a targetfile, relative to the targets directory
+
+  <Returns>
+    The hexdigest hash of the filepath.
+  """
+
+  # TODO: ensure target_filepath is relative to targets_directory?
+  digest_object = securesystemslib.hash.digest(algorithm=HASH_FUNCTION)
+  digest_object.update(target_filepath.encode('utf-8'))
+  return digest_object.hexdigest()
+
+
+
+
+
 
 def create_new_repository(repository_directory, repository_name='default'):
   """

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2512,11 +2512,11 @@ class Targets(Metadata):
       raise securesystemslib.exceptions.Error('The "number_of_bins" argument'
           ' must be a power of 2.')
 
-    logger.info('Creating hashed bin delegations.')
-    logger.info(repr(len(list_of_targets)) + ' total targets.')
-    logger.info(repr(number_of_bins) + ' hashed bins.')
-    logger.info(repr(total_hash_prefixes) + ' total hash prefixes.')
-    logger.info('Each bin ranges over ' + repr(bin_size) + ' hash prefixes.')
+    logger.info('Creating hashed bin delegations.\n' +
+        repr(len(list_of_targets)) + ' total targets.\n' +
+        repr(number_of_bins) + ' hashed bins.\n' +
+        repr(total_hash_prefixes) + ' total hash prefixes.\n' +
+        'Each bin ranges over ' + repr(bin_size) + ' hash prefixes.')
 
     # Generate a list of bin names, the range of prefixes to be delegated to
     # that bin, along with the corresponding full list of target prefixes

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2556,8 +2556,7 @@ class Targets(Metadata):
 
 
 
-  def add_target_to_bin(self, target_filepath, number_of_bins, custom=None,
-      fileinfo=None):
+  def add_target_to_bin(self, target_filepath, number_of_bins, fileinfo=None):
     """
     <Purpose>
       Add the fileinfo of 'target_filepath' to the expected hashed bin, if the
@@ -2578,9 +2577,6 @@ class Targets(Metadata):
         The number of delegated roles, or hashed bins, in use by the repository.
         Note: 'number_of_bins' must be a power of 2.
 
-      custom:
-        An optional object providing additional information about the file.
-
       fileinfo:
         An optional fileinfo object, conforming to tuf.formats.FILEINFO_SCHEMA,
         providing full information about the file.
@@ -2588,9 +2584,6 @@ class Targets(Metadata):
     <Exceptions>
       securesystemslib.exceptions.FormatError, if 'target_filepath' is
       improperly formatted.
-
-      securesystemslib.exceptions.Error, if both 'custom' and 'fileinfo' are
-      passed.
 
       securesystemslib.exceptions.Error, if 'target_filepath' cannot be added to
       a hashed bin (e.g., an invalid target filepath, or the expected hashed
@@ -2621,8 +2614,8 @@ class Targets(Metadata):
       raise securesystemslib.exceptions.Error(self.rolename + ' does not have'
           ' a delegated role ' + bin_name)
 
-    self._delegated_roles[bin_name].add_target(target_filepath, custom,
-        fileinfo)
+    self._delegated_roles[bin_name].add_target(target_filepath,
+        fileinfo=fileinfo)
 
 
 

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2027,10 +2027,10 @@ class Targets(Metadata):
     for relative_target in relative_list_of_targets:
       if relative_target not in roleinfo['paths']:
         logger.debug('Adding new target: ' + repr(relative_target))
-        roleinfo['paths'].update({relative_target: {}})
 
       else:
         logger.debug('Replacing target: ' + repr(relative_target))
+      roleinfo['paths'].update({relative_target: {}})
 
     tuf.roledb.update_roleinfo(self.rolename, roleinfo,
         repository_name=self._repository_name)

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -217,7 +217,7 @@ class Repository(object):
 
 
 
-  def writeall(self, consistent_snapshot=False):
+  def writeall(self, consistent_snapshot=False, use_existing_fileinfo=False):
     """
     <Purpose>
       Write all the JSON Metadata objects to their corresponding files for
@@ -232,6 +232,11 @@ class Repository(object):
         include a version number in the filename (i.e.,
         <version_number>.root.json, <version_number>.README.json
         Example: 13.root.json'
+
+      use_existing_fileinfo:
+        Boolean indicating whether the fileinfo dicts in the roledb should be
+        written as-is (True) or whether hashes should be generated (False,
+        requires access to the targets files on-disk).
 
     <Exceptions>
       tuf.exceptions.UnsignedMetadataError, if any of the top-level
@@ -278,7 +283,8 @@ class Repository(object):
       repo_lib._generate_and_write_metadata(dirty_rolename, dirty_filename,
           self._targets_directory, self._metadata_directory,
           consistent_snapshot, filenames,
-          repository_name=self._repository_name)
+          repository_name=self._repository_name,
+          use_existing_fileinfo=use_existing_fileinfo)
 
     # Metadata should be written in (delegated targets -> root -> targets ->
     # snapshot -> timestamp) order.  Begin by generating the 'root.json'
@@ -298,7 +304,8 @@ class Repository(object):
       repo_lib._generate_and_write_metadata('targets', filenames['targets'],
           self._targets_directory, self._metadata_directory,
           consistent_snapshot,
-          repository_name=self._repository_name)
+          repository_name=self._repository_name,
+          use_existing_fileinfo=use_existing_fileinfo)
 
     # Generate the 'snapshot.json' metadata file.
     if 'snapshot' in dirty_rolenames:
@@ -325,7 +332,8 @@ class Repository(object):
 
 
 
-  def write(self, rolename, consistent_snapshot=False, increment_version_number=True):
+  def write(self, rolename, consistent_snapshot=False, increment_version_number=True,
+      use_existing_fileinfo=False):
     """
     <Purpose>
       Write the JSON metadata for 'rolename' to its corresponding file on disk.
@@ -345,6 +353,11 @@ class Repository(object):
       increment_version_number:
         Boolean indicating whether the version number of 'rolename' should be
         automatically incremented.
+
+      use_existing_fileinfo:
+        Boolean indicating whether the fileinfo dicts in the roledb should be
+        written as-is (True) or whether hashes should be generated (False,
+        requires access to the targets files on-disk).
 
     <Exceptions>
       None.
@@ -368,7 +381,8 @@ class Repository(object):
         self._targets_directory, self._metadata_directory, consistent_snapshot,
         filenames=filenames, allow_partially_signed=True,
         increment_version_number=increment_version_number,
-        repository_name=self._repository_name)
+        repository_name=self._repository_name,
+        use_existing_fileinfo=use_existing_fileinfo)
 
     # Ensure 'rolename' is no longer marked as dirty after the successful write().
     tuf.roledb.unmark_dirty([rolename], self._repository_name)

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -1922,9 +1922,6 @@ class Targets(Metadata):
       securesystemslib.exceptions.FormatError, if 'filepath' is improperly
       formatted.
 
-      securesystemslib.exceptions.Error, if 'filepath' is not located in the
-      repository's targets directory.
-
     <Side Effects>
       Adds 'filepath' to this role's list of targets.  This role's
       'tuf.roledb.py' entry is also updated.
@@ -1953,31 +1950,25 @@ class Targets(Metadata):
     # freedom to add targets and parent restrictions in any order, minimize the
     # number of times these checks are performed, and allow any role to
     # delegate trust of packages to this Targes role.
-    if os.path.isfile(filepath):
 
-      # Update the role's 'tuf.roledb.py' entry and avoid duplicates.  Make
-      # sure to exclude the path separator when calculating the length of the
-      # targets directory.
-      targets_directory_length = len(self._targets_directory) + 1
-      roleinfo = tuf.roledb.get_roleinfo(self._rolename, self._repository_name)
-      relative_path = filepath[targets_directory_length:].replace('\\', '/')
+    # Update the role's 'tuf.roledb.py' entry and avoid duplicates.  Make
+    # sure to exclude the path separator when calculating the length of the
+    # targets directory.
+    targets_directory_length = len(self._targets_directory) + 1
+    roleinfo = tuf.roledb.get_roleinfo(self._rolename, self._repository_name)
+    relative_path = filepath[targets_directory_length:].replace('\\', '/')
 
-      if relative_path not in roleinfo['paths']:
-        logger.debug('Adding new target: ' + repr(relative_path))
-        roleinfo['paths'].update({relative_path: custom})
-
-      else:
-        logger.debug('Replacing target: ' + repr(relative_path))
-        roleinfo['paths'].update({relative_path: custom})
-
-
-      tuf.roledb.update_roleinfo(self._rolename, roleinfo,
-          repository_name=self._repository_name)
+    if relative_path not in roleinfo['paths']:
+      logger.debug('Adding new target: ' + repr(relative_path))
 
     else:
-      raise securesystemslib.exceptions.Error(repr(filepath) + ' is not'
-          ' a valid file in the repository\'s targets'
-          ' directory: ' + repr(self._targets_directory))
+      logger.debug('Replacing target: ' + repr(relative_path))
+
+    roleinfo['paths'].update({relative_path: custom})
+
+    tuf.roledb.update_roleinfo(self._rolename, roleinfo,
+        repository_name=self._repository_name)
+
 
 
 
@@ -2000,10 +1991,6 @@ class Targets(Metadata):
     <Exceptions>
       securesystemslib.exceptions.FormatError, if the arguments are improperly
       formatted.
-
-      securesystemslib.exceptions.Error, if any of the paths listed in
-      'list_of_targets' is not located in the repository's targets directory or
-      is invalid.
 
     <Side Effects>
       This Targets' roleinfo is updated with the paths in 'list_of_targets'.
@@ -2031,13 +2018,9 @@ class Targets(Metadata):
     for target in list_of_targets:
       filepath = os.path.join(self._targets_directory, target)
 
-      if os.path.isfile(filepath):
-        relative_list_of_targets.append(
-            filepath[targets_directory_length + 1:].replace('\\', '/'))
+      relative_list_of_targets.append(
+          filepath[targets_directory_length + 1:].replace('\\', '/'))
 
-      else:
-        raise securesystemslib.exceptions.Error(repr(filepath) + ' is not'
-          ' a valid file.')
 
     # Update this Targets 'tuf.roledb.py' entry.
     roleinfo = tuf.roledb.get_roleinfo(self._rolename, self._repository_name)

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2824,6 +2824,61 @@ def _get_hash(target_filepath):
 
 
 
+def _create_bin_name(low, high, prefix_len):
+  """
+  <Purpose>
+    Create a string name of a delegated hash bin, where name will be a range of
+    zero-padded (up to prefix_len) strings i.e. for low=00, high=07,
+    prefix_len=3 the returned name would be '000-007'.
+
+  """
+  if low == high:
+    return "{low:0{len}x}".format(low=low, len=prefix_len)
+
+  return "{low:0{len}x}-{high:0{len}x}".format(low=low, high=high,
+      len=prefix_len)
+
+
+
+
+
+def _find_bin_for_hash(path_hash, number_of_bins):
+  """
+  <Purpose>
+    For a given hashed filename, path_hash, calculate the name of a hashed bin
+    into which this file would be delegated given number_of_bins bins are in
+    use.
+
+  <Arguments>
+    path_hash:
+      The hash of the target file's path
+
+    number_of_bins:
+      The number of hashed_bins in use
+
+  <Returns>
+    The name of the hashed bin path_hash would be binned into.
+  """
+
+  prefix_len = len("{:x}".format(number_of_bins - 1))
+  prefix_count = 16 ** prefix_len
+
+  if prefix_count % number_of_bins != 0:
+    # Note: doesn't guarantee a power of two for any x and y, but does work
+    # due to the relationship between nuber_of_bins and prefix_count
+    raise securesystemslib.exceptions.Error('The "number_of_bins" argument'
+        ' must be a power of 2.')
+
+  bin_size = prefix_count // number_of_bins
+  prefix = int(path_hash[:prefix_len], 16)
+
+  low = prefix - (prefix % bin_size)
+  high = (low + bin_size - 1)
+
+  return _create_bin_name(low, high, prefix_len)
+
+
+
 
 
 def create_new_repository(repository_directory, repository_name='default'):

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2530,10 +2530,9 @@ class Targets(Metadata):
     for target_path in list_of_targets:
 
       # Determine the hash prefix of 'target_path' by computing the digest of
-      # its path relative to the targets directory.  Example:
-      # '{repository_root}/targets/file1.txt' -> 'file1.txt'.
-      #relative_path = target_path[len(self._targets_directory):]
-      hash_prefix = _get_hash(target_path)[:prefix_length]
+      # its path relative to the targets directory.
+      # We must hash a target path as it appears in the metadata
+      hash_prefix = _get_hash(target_path.replace('\\', '/').lstrip('/'))[:prefix_length]
       ordered_roles[int(hash_prefix, 16) // bin_size]["target_paths"].append(target_path)
 
     for bin_rolename in ordered_roles:


### PR DESCRIPTION
**Fixes issue #**: #994, #995, #1003, #1004

**Description of the changes being introduced by the pull request**:

__Note__: This is the first PR addressing changes required by the PEP 458 implementation.

* Make tests around hashed bins simpler and more robust
* Add various helper functions for common functionality around hashed bins:
  * `_get_hash()` to hash a filepath string
  * `_create_bin_name()` to create the string name of a delegated hash bin (mostly to consolidate the instances where we do non-trivial string formatting)
  * `_find_bin_for_hash()` to calculate the bin a hashed file string would be allocated to
* Refactor `add_target_to_bin()` and `remove_target_from_bin()` to remove the dispatcher and simplify the code as well as allowing `add_target_to_bin()` to take a custom argument, the same as `add_target()`
* Refactor `delegate_hashed_bins()` to simplify the code
* Ensure file paths are hashed as they appear in the targets metadata
* Enable passing a fileinfo to `add_target()` and `add_target_to_bin()`
* Add `use_existing_fileinfo` argument to `write()` and `writeall()` to allow writing metadata without access to targets files

**Please verify and check that the pull request fulfils the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature

cc @woodruffw
