### PR TITLE
Adopt a consistent behavior when adding targets and paths

### DIFF
--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -352,15 +352,8 @@ the target filepaths to metadata.
 # in targets metadata.
 >>> repository = load_repository('repository')
 
-# get_filepaths_in_directory() returns a list of file paths in a directory. It
-# can also return files in sub-directories if 'recursive_walk' is True.
->>> list_of_targets = repository.get_filepaths_in_directory(
-...     "repository/targets/", recursive_walk=False, followlinks=True)
-
-# Note: Since we set the 'recursive_walk' argument to false, the 'myproject'
-# sub-directory is excluded from 'list_of_targets'.
->>> list_of_targets
-['/path/to/repository/targets/file2.txt', '/path/to/repository/targets/file1.txt', '/path/to/repository/targets/file3.txt']
+# Create a list of all targets in the directory.
+>>> list_of_targets = ['file1.txt', 'file2.txt', 'file3.txt']
 
 # Add the list of target paths to the metadata of the top-level Targets role.
 # Any target file paths that might already exist are NOT replaced, and
@@ -376,10 +369,12 @@ the target filepaths to metadata.
 # (octal number specifying file access for owner, group, others e.g., 0755) is
 # added alongside the default fileinfo.  All target objects in metadata include
 # the target's filepath, hash, and length.
+# Note: target path passed to add_target() method has to be relative
+# to the targets directory or an exception is raised.
 >>> target4_filepath = os.path.abspath("repository/targets/myproject/file4.txt")
 >>> octal_file_permissions = oct(os.stat(target4_filepath).st_mode)[4:]
 >>> custom_file_permissions = {'file_permissions': octal_file_permissions}
->>> repository.targets.add_target(target4_filepath, custom_file_permissions)
+>>> repository.targets.add_target('myproject/file4.txt', custom_file_permissions)
 ```
 
 The private keys of roles affected by the changes above must now be imported and
@@ -498,7 +493,6 @@ targets and generate signed metadata.
 
 # Make a delegation (delegate trust of 'myproject/*.txt' files) from "targets"
 # to "unclaimed", where "unclaimed" initially contains zero targets.
-# NOTE: Please ignore the warning about the path pattern's location (see #963)
 >>> repository.targets.delegate('unclaimed', [public_unclaimed_key], ['myproject/*.txt'])
 
 # Thereafter, we can access the delegated role by its name to e.g. add target
@@ -635,8 +629,7 @@ to some role.
 >>> repository.targets('unclaimed').remove_target("myproject/file4.txt")
 
 # Get a list of target paths for the hashed bins.
->>> targets = repository.get_filepaths_in_directory(
-...     'repository/targets/myproject', recursive_walk=True)
+>>> targets = ['myproject/file4.txt']
 
 # Delegate trust to 32 hashed bin roles. Each role is responsible for the set
 # of target files, determined by the path hash prefix. TUF evenly distributes

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -371,10 +371,11 @@ the target filepaths to metadata.
 # the target's filepath, hash, and length.
 # Note: target path passed to add_target() method has to be relative
 # to the targets directory or an exception is raised.
->>> target4_filepath = os.path.abspath("repository/targets/myproject/file4.txt")
->>> octal_file_permissions = oct(os.stat(target4_filepath).st_mode)[4:]
+>>> target4_filepath = 'myproject/file4.txt'
+>>> target4_abspath = os.path.abspath(os.path.join('repository', 'targets', target4_filepath))
+>>> octal_file_permissions = oct(os.stat(target4_abspath).st_mode)[4:]
 >>> custom_file_permissions = {'file_permissions': octal_file_permissions}
->>> repository.targets.add_target('myproject/file4.txt', custom_file_permissions)
+>>> repository.targets.add_target(target4_filepath, custom_file_permissions)
 ```
 
 The private keys of roles affected by the changes above must now be imported and

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -218,7 +218,7 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
     # new version is generated.
     with open(file3_path, 'wt') as file_object:
       file_object.write('This is role2\'s target file.')
-    repository.targets('role1').add_target(file3_path)
+    repository.targets('role1').add_target(os.path.basename(file3_path))
 
     repository.writeall()
 

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1452,13 +1452,18 @@ class TestTargets(unittest.TestCase):
                       list_of_targets, public_keys, number_of_bins=3)
 
     # Invalid 'list_of_targets'.
-    # TODO
-    """
-    invalid_targets = ['/non-existent']
-    self.assertRaises(securesystemslib.exceptions.Error,
+    # A path or target starting with a directory separator
+    self.assertRaises(tuf.exceptions.InvalidNameError,
                       self.targets_object.delegate_hashed_bins,
-                      invalid_targets, public_keys, number_of_bins=16)
-    """
+                      ['/file1.txt'], public_keys,
+                      number_of_bins=2)
+
+    # A path or target using '\' as a directory separator
+    self.assertRaises(tuf.exceptions.InvalidNameError,
+                      self.targets_object.delegate_hashed_bins,
+                      ['subpath\\file1.txt'], public_keys,
+                      number_of_bins=2)
+
 
   def test_add_target_to_bin(self):
     # Test normal case.

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1677,10 +1677,6 @@ class TestTargets(unittest.TestCase):
     # paths, which it previously did.
     self.targets_object.add_paths(['non-existent'], 'tuf')
 
-    # add_paths() should not raise an exception for paths that
-    # are not located in the repository's targets directory
-    repository_directory = os.path.join('repository_data', 'repository')
-    self.targets_object.add_paths([repository_directory], 'tuf')
 
 
 
@@ -1724,11 +1720,16 @@ class TestTargets(unittest.TestCase):
     self.assertRaises(securesystemslib.exceptions.FormatError,
         self.targets_object._check_path, 3)
 
-    # Test invalid pathname - starting with os separator
+    # Test invalid pathname
+    # Starting with os separator
     self.assertRaises(tuf.exceptions.InvalidNameError,
         self.targets_object._check_path, '/file1.txt')
 
-    # Test invalid pathname - using '\' as os separator
+    # Starting with Windows-style separator
+    self.assertRaises(tuf.exceptions.InvalidNameError,
+        self.targets_object._check_path, '\\file1.txt')
+
+    # Using Windows-style separator ('\')
     self.assertRaises(tuf.exceptions.InvalidNameError,
         self.targets_object._check_path, 'subdir\\non-existent')
 

--- a/tests/test_root_versioning_integration.py
+++ b/tests/test_root_versioning_integration.py
@@ -165,15 +165,15 @@ class TestRepository(unittest.TestCase):
     repository.timestamp.load_signing_key(timestamp_privkey)
 
     # (4) Add target files.
-    target1 = os.path.join(targets_directory, 'file1.txt')
-    target2 = os.path.join(targets_directory, 'file2.txt')
-    target3 = os.path.join(targets_directory, 'file3.txt')
+    target1 = 'file1.txt'
+    target2 = 'file2.txt'
+    target3 = 'file3.txt'
     repository.targets.add_target(target1)
     repository.targets.add_target(target2)
 
 
     # (5) Perform delegation.
-    repository.targets.delegate('role1', [role1_pubkey], [os.path.basename(target3)])
+    repository.targets.delegate('role1', [role1_pubkey], [target3])
     repository.targets('role1').load_signing_key(role1_privkey)
 
     # (6) Write repository.

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -223,13 +223,10 @@ class TestTutorial(unittest.TestCase):
 
 
     repository = load_repository('repository')
-    list_of_targets = repository.get_filepaths_in_directory(
-        os.path.join('repository', 'targets'), recursive_walk=False, followlinks=True)
 
-    self.assertListEqual(sorted(list_of_targets), [
-        os.path.abspath(os.path.join('repository', 'targets', 'file1.txt')),
-        os.path.abspath(os.path.join('repository', 'targets', 'file2.txt')),
-        os.path.abspath(os.path.join('repository', 'targets', 'file3.txt'))])
+    # List of targets is hardcoded since get_filepaths_in_directory()
+    # returns absolute paths and add_targets() raises an exception.
+    list_of_targets = ['file1.txt', 'file2.txt', 'file3.txt']
 
 
     repository.targets.add_targets(list_of_targets)
@@ -243,7 +240,7 @@ class TestTutorial(unittest.TestCase):
         'repository', 'targets', 'myproject', 'file4.txt'))
     octal_file_permissions = oct(os.stat(target4_filepath).st_mode)[4:]
     custom_file_permissions = {'file_permissions': octal_file_permissions}
-    repository.targets.add_target(target4_filepath, custom_file_permissions)
+    repository.targets.add_target('myproject/file4.txt', custom_file_permissions)
     # Note that target filepaths specified in the repo use '/' even on Windows.
     # (This is important to make metadata platform-independent.)
     self.assertTrue(
@@ -346,8 +343,7 @@ class TestTutorial(unittest.TestCase):
     # ----- Tutorial Section: Delegate to Hashed Bins
     repository.targets('unclaimed').remove_target("myproject/file4.txt")
 
-    targets = repository.get_filepaths_in_directory(
-        os.path.join('repository', 'targets', 'myproject'), recursive_walk=True)
+    targets = ['myproject/file4.txt']
 
     # Patch logger to assert that it accurately logs the output of hashed bin
     # delegation. The logger is called multiple times, first with info level

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -224,10 +224,9 @@ class TestTutorial(unittest.TestCase):
 
     repository = load_repository('repository')
 
-    # List of targets is hardcoded since get_filepaths_in_directory()
-    # returns absolute paths and add_targets() raises an exception.
+    # TODO: replace the hard-coded list of targets with a helper
+    # method that returns a list of normalized relative target paths
     list_of_targets = ['file1.txt', 'file2.txt', 'file3.txt']
-
 
     repository.targets.add_targets(list_of_targets)
 
@@ -235,16 +234,16 @@ class TestTutorial(unittest.TestCase):
     self.assertTrue('file2.txt' in repository.targets.target_files)
     self.assertTrue('file3.txt' in repository.targets.target_files)
 
-
-    target4_filepath = os.path.abspath(os.path.join(
-        'repository', 'targets', 'myproject', 'file4.txt'))
-    octal_file_permissions = oct(os.stat(target4_filepath).st_mode)[4:]
+    target4_filepath = 'myproject/file4.txt'
+    target4_abspath = os.path.abspath(os.path.join(
+        'repository', 'targets', target4_filepath))
+    octal_file_permissions = oct(os.stat(target4_abspath).st_mode)[4:]
     custom_file_permissions = {'file_permissions': octal_file_permissions}
-    repository.targets.add_target('myproject/file4.txt', custom_file_permissions)
+    repository.targets.add_target(target4_filepath, custom_file_permissions)
     # Note that target filepaths specified in the repo use '/' even on Windows.
     # (This is important to make metadata platform-independent.)
     self.assertTrue(
-        os.path.join('myproject/file4.txt') in repository.targets.target_files)
+        os.path.join(target4_filepath) in repository.targets.target_files)
 
 
     # Skipping user entry of password

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -863,7 +863,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # Modify one target file on the remote repository.
     repository = repo_tool.load_repository(self.repository_directory)
-    target3 = os.path.join(self.repository_directory, 'targets', 'file3.txt')
+    target3 = 'file3.txt'
 
     repository.targets.add_target(target3)
     repository.root.version = repository.root.version + 1
@@ -936,7 +936,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
                       unsafely_update_root_if_necessary=False)
 
     repository = repo_tool.load_repository(self.repository_directory)
-    target3 = os.path.join(self.repository_directory, 'targets', 'file3.txt')
+    target3 = 'file3.txt'
 
     repository.targets.add_target(target3)
     repository.targets.load_signing_key(self.role_keys['targets']['private'])
@@ -969,8 +969,6 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # Verify that the client's metadata was updated.
     targets_metadata = self.repository_updater.metadata['current']['targets']
-    targets_directory = os.path.join(self.repository_directory, 'targets')
-    target3 = target3[len(targets_directory) + 1:]
     self.assertTrue(target3 in targets_metadata['targets'])
 
     # Verify the expected version numbers of the updated roles.
@@ -1142,12 +1140,13 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # Test updater.get_one_valid_targetinfo() backtracking behavior (enabled by
     # default.)
     targets_directory = os.path.join(self.repository_directory, 'targets')
-    foo_directory = os.path.join(targets_directory, 'foo')
-    foo_pattern = 'foo/foo*.tar.gz'
-    os.makedirs(foo_directory)
+    os.makedirs(os.path.join(targets_directory, 'foo'))
 
-    foo_package = os.path.join(foo_directory, 'foo1.1.tar.gz')
-    with open(foo_package, 'wb') as file_object:
+    foo_package = 'foo/foo1.1.tar.gz'
+    foo_pattern = 'foo/foo*.tar.gz'
+
+    foo_fullpath = os.path.join(targets_directory, foo_package)
+    with open(foo_fullpath, 'wb') as file_object:
       file_object.write(b'new release')
 
     # Modify delegations on the remote repository to test backtracking behavior.
@@ -1452,7 +1451,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     length, hashes = securesystemslib.util.get_file_details(target1)
 
-    repository.targets.add_target(target1)
+    repository.targets.add_target(os.path.basename(target1))
     repository.targets.load_signing_key(self.role_keys['targets']['private'])
     repository.snapshot.load_signing_key(self.role_keys['snapshot']['private'])
 
@@ -1461,7 +1460,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     length, hashes = securesystemslib.util.get_file_details(target1)
 
-    repository.targets.add_target(target1)
+    repository.targets.add_target(os.path.basename(target1))
     repository.targets.load_signing_key(self.role_keys['targets']['private'])
     repository.snapshot.load_signing_key(self.role_keys['snapshot']['private'])
     repository.timestamp.load_signing_key(self.role_keys['timestamp']['private'])
@@ -2065,7 +2064,7 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     repository.targets.remove_target(os.path.basename(target1))
 
     custom_field = {"custom": "my_custom_data"}
-    repository.targets.add_target(target1, custom_field)
+    repository.targets.add_target(os.path.basename(target1), custom_field)
     repository.targets.load_signing_key(self.role_keys['targets']['private'])
     repository.snapshot.load_signing_key(self.role_keys['snapshot']['private'])
     repository.timestamp.load_signing_key(self.role_keys['timestamp']['private'])
@@ -2091,7 +2090,7 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
 
     repository.targets.remove_target(os.path.basename(target1))
 
-    repository.targets.add_target(target1)
+    repository.targets.add_target(os.path.basename(target1))
     repository.targets.load_signing_key(self.role_keys['targets']['private'])
     repository.snapshot.load_signing_key(self.role_keys['snapshot']['private'])
     repository.timestamp.load_signing_key(self.role_keys['timestamp']['private'])

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1319,7 +1319,7 @@ def generate_targets_metadata(targets_directory, target_files, version,
         raise securesystemslib.exceptions.Error('use_existing_hashes option set'
             ' but fileinfo\'s length is not set')
 
-      filedict[target.replace('\\', '/').lstrip('/')] = fileinfo
+      filedict[target] = fileinfo
 
   else:
     filedict = _generate_targets_fileinfo(target_files, targets_directory,
@@ -1393,7 +1393,7 @@ def _generate_targets_fileinfo(target_files, targets_directory,
     # the target's fileinfo dictionary) if specified here.
     custom_data = fileinfo.get('custom', None)
 
-    filedict[relative_targetpath.replace('\\', '/').lstrip('/')] = \
+    filedict[relative_targetpath] = \
         get_metadata_fileinfo(target_path, custom_data)
 
     # Copy 'target_path' to 'digest_target' if consistent hashing is enabled.

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -1854,7 +1854,8 @@ class Targets(Metadata):
       securesystemslib.exceptions.Error, if 'child_rolename' has not been
       delegated yet.
 
-      tuf.exceptions.InvalidNameError, if 'pathname' does not match pattern.
+      tuf.exceptions.InvalidNameError, if any path in 'paths' does not match
+      pattern.
 
     <Side Effects>
       Modifies this Targets' delegations field.
@@ -1870,10 +1871,6 @@ class Targets(Metadata):
     securesystemslib.formats.PATHS_SCHEMA.check_match(paths)
     tuf.formats.ROLENAME_SCHEMA.check_match(child_rolename)
 
-    # A list of relative and verified paths or glob patterns to be added to the
-    # child role's entry in the parent's delegations field.
-    relative_paths = []
-
     # Ensure that 'child_rolename' exists, otherwise it will not have an entry
     # in the parent role's delegations field.
     if not tuf.roledb.role_exists(child_rolename, self._repository_name):
@@ -1886,7 +1883,6 @@ class Targets(Metadata):
       # on the file system is not verified. If the path is incorrect,
       # the targetfile won't be matched successfully during a client update.
       self._check_path(path)
-      relative_paths.append(path)
 
     # Get the current role's roleinfo, so that its delegations field can be
     # updated.
@@ -1895,7 +1891,7 @@ class Targets(Metadata):
     # Update the delegated paths of 'child_rolename' to add relative paths.
     for role in roleinfo['delegations']['roles']:
       if role['name'] == child_rolename:
-        for relative_path in relative_paths:
+        for relative_path in paths:
           if relative_path not in role['paths']:
             role['paths'].append(relative_path)
 
@@ -1944,7 +1940,7 @@ class Targets(Metadata):
       securesystemslib.exceptions.FormatError, if 'filepath' is improperly
       formatted.
 
-      tuf.exceptions.InvalidNameError, if 'pathname' does not match pattern.
+      tuf.exceptions.InvalidNameError, if 'filepath' does not match pattern.
 
     <Side Effects>
       Adds 'filepath' to this role's list of targets.  This role's
@@ -2024,7 +2020,8 @@ class Targets(Metadata):
       securesystemslib.exceptions.FormatError, if the arguments are improperly
       formatted.
 
-      tuf.exceptions.InvalidNameError, if 'pathname' does not match pattern.
+      tuf.exceptions.InvalidNameError, if any target in 'list_of_targets'
+      does not match pattern.
 
     <Side Effects>
       This Targets' roleinfo is updated with the paths in 'list_of_targets'.
@@ -2039,9 +2036,6 @@ class Targets(Metadata):
     # Raise 'securesystemslib.exceptions.FormatError' if there is a mismatch.
     tuf.formats.RELPATHS_SCHEMA.check_match(list_of_targets)
 
-    # Update the tuf.roledb entry.
-    relative_list_of_targets = []
-
     # Ensure the paths in 'list_of_targets' are relative and use forward slash
     # as a separator or raise an exception. The paths of 'list_of_targets'
     # will be verified as existing and allowed paths according to this Targets
@@ -2050,14 +2044,12 @@ class Targets(Metadata):
     # in any order and minimize the number of times these checks are performed.
     for target in list_of_targets:
       self._check_path(target)
-      relative_list_of_targets.append(target)
 
     # Update this Targets 'tuf.roledb.py' entry.
     roleinfo = tuf.roledb.get_roleinfo(self._rolename, self._repository_name)
-    for relative_target in relative_list_of_targets:
+    for relative_target in list_of_targets:
       if relative_target not in roleinfo['paths']:
         logger.debug('Adding new target: ' + repr(relative_target))
-
       else:
         logger.debug('Replacing target: ' + repr(relative_target))
       roleinfo['paths'].update({relative_target: {}})
@@ -2285,7 +2277,8 @@ class Targets(Metadata):
 
       securesystemslib.exceptions.Error, if the delegated role already exists.
 
-      tuf.exceptions.InvalidNameError, if 'pathname' does not match pattern.
+      tuf.exceptions.InvalidNameError, if any path in 'paths' or target in
+      'list_of_targets' does not match pattern.
 
     <Side Effects>
       A new Target object is created for 'rolename' that is accessible to the
@@ -2490,7 +2483,8 @@ class Targets(Metadata):
       2, or one of the targets in 'list_of_targets' is not relative to the
       repository's targets directory.
 
-      tuf.exceptions.InvalidNameError, if 'pathname' does not match pattern.
+      tuf.exceptions.InvalidNameError, if any target in 'list_of_targets'
+      does not match pattern.
 
     <Side Effects>
       Delegates multiple target roles from the current parent role.

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2784,7 +2784,7 @@ class Targets(Metadata):
       raise tuf.exceptions.InvalidNameError('Path ' + repr(pathname)
           + ' does not use the forward slash (/) as directory separator.')
 
-    if pathname.startswith(os.sep):
+    if pathname.startswith('/'):
       raise tuf.exceptions.InvalidNameError('Path ' + repr(pathname)
           + ' starts with a directory separator. All paths should be relative'
           '  to targets directory.')


### PR DESCRIPTION

**Fixes issue #** : #957, #963 

**Description of the changes being introduced by the pull request**:

As described in the issues above, the methods of Targets class use inconsistent checks when adding target files and delegated paths. As a result of this plus the need to avoid access to the file system in certain cases, this pull request suggests:

- Adopt the strict behavior of accepting only relative paths (all absolute paths raise an error, even existing ones)
- Assume that relative paths are relative to the targets directory and targets directory is not included in the path/target name
- Perform the checks only on the path/target name, without accessing the file system
- If the added target file does not exist relative to the targets dir, an error is raised at a later stage, during the hash calculation in `write()` or `writeall()`
- If the path/pattern added to a delegated role does not exist relative to the targets dir, target file won't be matched during a client update (same as current behavior) 

Code changes:

- Add `_check_relpath()` method to Targets class 
- Modify all methods adding paths (`add_paths()`, `delegate()`) to utilise `_check_relpath()`
- Modify all methods adding targets (`add_target(s)()`, `delegate()`, `delegate_hashed_bins()`, `_locate_and_update_target_in_bin`) to utilise `_check_relpath()`

**Note**: Tests, delegation section in tutorial as well as `get_filepaths_in_directory()` helper also need updating but I am sharing the PR sooner as it includes changes needed by PEP 458 implementation. I will be updating them accordingly either in the PR or as a follow on it. 

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


