### PR TITLE
Use consistent default value for num of hashed bins

### DIFF
--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1555,6 +1555,42 @@ class TestTargets(unittest.TestCase):
 
 
 
+  def test_default_bin_num(self):
+    # Test creating, adding to and removing from hashed bins with the default
+    # number of bins
+    keystore_directory = os.path.join('repository_data', 'keystore')
+    public_keypath = os.path.join(keystore_directory, 'snapshot_key.pub')
+    public_key = repo_tool.import_ed25519_publickey_from_file(public_keypath)
+    target1_filepath = os.path.join(self.targets_directory, 'file1.txt')
+
+    # Set needed arguments by delegate_hashed_bins().
+    public_keys = [public_key]
+
+    # Test default parameters for number_of_bins
+    self.targets_object.delegate_hashed_bins([], public_keys)
+
+    # Ensure each hashed bin initially contains zero targets.
+    for delegation in self.targets_object.delegations:
+      self.assertEqual(delegation.target_files, {})
+
+    # Add 'target1_filepath' and verify that the relative path of
+    # 'target1_filepath' is added to the correct bin.
+    self.targets_object.add_target_to_bin(os.path.basename(target1_filepath))
+
+    for delegation in self.targets_object.delegations:
+      if delegation.rolename == '558-55b':
+        self.assertTrue('file1.txt' in delegation.target_files)
+
+      else:
+        self.assertFalse('file1.txt' in delegation.target_files)
+
+    # Remove target1_filepath and verify that all bins are now empty
+    self.targets_object.remove_target_from_bin(os.path.basename(target1_filepath))
+
+    for delegation in self.targets_object.delegations:
+      self.assertEqual(delegation.target_files, {})
+
+
   def test_add_paths(self):
     # Test normal case.
     # Perform a delegation so that add_paths() has a child role to delegate a

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -104,6 +104,9 @@ DEFAULT_RSA_KEY_BITS=3072
 # of hashed bin delegations.  Please see delegate_hashed_bins()
 HASH_FUNCTION = tuf.settings.DEFAULT_HASH_ALGORITHM
 
+# The default number of hashed bin delegations
+DEFAULT_NUM_BINS=1024
+
 # The targets and metadata directory names.  Metadata files are written
 # to the staged metadata directory instead of the "live" one.
 METADATA_STAGED_DIRECTORY_NAME = 'metadata.staged'
@@ -2429,7 +2432,7 @@ class Targets(Metadata):
 
 
   def delegate_hashed_bins(self, list_of_targets, keys_of_hashed_bins,
-      number_of_bins=1024):
+      number_of_bins=DEFAULT_NUM_BINS):
     """
     <Purpose>
       Distribute a large number of target files over multiple delegated roles
@@ -2540,7 +2543,8 @@ class Targets(Metadata):
 
 
 
-  def add_target_to_bin(self, target_filepath, number_of_bins, fileinfo=None):
+  def add_target_to_bin(self, target_filepath, number_of_bins=DEFAULT_NUM_BINS,
+      fileinfo=None):
     """
     <Purpose>
       Add the fileinfo of 'target_filepath' to the expected hashed bin, if the
@@ -2604,7 +2608,8 @@ class Targets(Metadata):
 
 
 
-  def remove_target_from_bin(self, target_filepath, number_of_bins):
+  def remove_target_from_bin(self, target_filepath,
+      number_of_bins=DEFAULT_NUM_BINS):
     """
     <Purpose>
       Remove the fileinfo of 'target_filepath' from the expected hashed bin, if


### PR DESCRIPTION
**Fixes issue #**: N/A

**Description of the changes being introduced by the pull request**:
I realised that `delegate_hashed_bins()` has a number_of_bins parameter which defaults to 1024, whereas `add_target_to_bin()` and `remove_target_from_bin()` both have a number_of_bins parameter with no default. 

In order to be consistent and following the principle of least surprise, add default values for number_of_bins to `add_target_to_bin()` and `remove_target_from_bin()`

**Please verify and check that the pull request fulfils the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


