### PR TITLE
Remove uses of keyid_hash_algorithms

### DIFF
--- a/tests/test_keydb.py
+++ b/tests/test_keydb.py
@@ -389,10 +389,16 @@ class TestKeydb(unittest.TestCase):
 
     # Ensure only 'keyid2' was added to the keydb database.  'keyid' and
     # 'keyid3' should not be stored.
+    self.maxDiff = None
     self.assertEqual(rsakey2, tuf.keydb.get_key(keyid2))
-    self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid)
+
+    test_key = rsakey2
+    test_key['keyid'] = keyid
+    self.assertEqual(test_key, tuf.keydb.get_key(keyid))
     self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid3)
+
     rsakey3['keytype'] = 'rsa'
+    rsakey2['keyid'] = keyid2
 
 
 

--- a/tests/test_keydb.py
+++ b/tests/test_keydb.py
@@ -374,11 +374,6 @@ class TestKeydb(unittest.TestCase):
     rsakey3['keytype'] = 'bad_keytype'
     keydict[keyid3] = rsakey3
 
-    # New key with a duplicate keyid
-    #rsakey4 = KEYS[1]
-    #keyid4 = KEYS[3]['keyid']
-    #keydict[keyid4] = rsakey4
-
     version = 8
     expires = '1985-10-21T01:21:00Z'
 
@@ -404,7 +399,6 @@ class TestKeydb(unittest.TestCase):
     self.assertEqual(test_key, tuf.keydb.get_key(keyid))
 
     self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid3)
-    #self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid4)
 
     # reset values
     rsakey3['keytype'] = 'rsa'

--- a/tests/test_keydb.py
+++ b/tests/test_keydb.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 # Generate the three keys to use in our test cases.
 KEYS = []
-for junk in range(3):
+for junk in range(4):
   rsa_key = securesystemslib.keys.generate_rsa_key(2048)
   rsa_key['keyid_hash_algorithms'] = securesystemslib.settings.HASH_ALGORITHMS
   KEYS.append(rsa_key)
@@ -365,6 +365,7 @@ class TestKeydb(unittest.TestCase):
     tuf.keydb.clear_keydb()
 
     # 'keyid' does not match 'rsakey2'.
+    # In this case, the key will be added to the keydb
     keydict[keyid] = rsakey2
 
     # Key with invalid keytype.
@@ -372,6 +373,12 @@ class TestKeydb(unittest.TestCase):
     keyid3 = KEYS[2]['keyid']
     rsakey3['keytype'] = 'bad_keytype'
     keydict[keyid3] = rsakey3
+
+    # New key with a duplicate keyid
+    #rsakey4 = KEYS[1]
+    #keyid4 = KEYS[3]['keyid']
+    #keydict[keyid4] = rsakey4
+
     version = 8
     expires = '1985-10-21T01:21:00Z'
 
@@ -387,16 +394,19 @@ class TestKeydb(unittest.TestCase):
 
     self.assertEqual(None, tuf.keydb.create_keydb_from_root_metadata(root_metadata))
 
-    # Ensure only 'keyid2' was added to the keydb database.  'keyid' and
-    # 'keyid3' should not be stored.
+    # Ensure only 'keyid2' and 'keyid' were added to the keydb database.
+    # 'keyid3' and 'keyid4' should not be stored.
     self.maxDiff = None
     self.assertEqual(rsakey2, tuf.keydb.get_key(keyid2))
 
     test_key = rsakey2
     test_key['keyid'] = keyid
     self.assertEqual(test_key, tuf.keydb.get_key(keyid))
-    self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid3)
 
+    self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid3)
+    #self.assertRaises(tuf.exceptions.UnknownKeyError, tuf.keydb.get_key, keyid4)
+
+    # reset values
     rsakey3['keytype'] = 'rsa'
     rsakey2['keyid'] = keyid2
 

--- a/tests/test_keydb.py
+++ b/tests/test_keydb.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 # Generate the three keys to use in our test cases.
 KEYS = []
-for junk in range(4):
+for junk in range(3):
   rsa_key = securesystemslib.keys.generate_rsa_key(2048)
   rsa_key['keyid_hash_algorithms'] = securesystemslib.settings.HASH_ALGORITHMS
   KEYS.append(rsa_key)
@@ -390,7 +390,7 @@ class TestKeydb(unittest.TestCase):
     self.assertEqual(None, tuf.keydb.create_keydb_from_root_metadata(root_metadata))
 
     # Ensure only 'keyid2' and 'keyid' were added to the keydb database.
-    # 'keyid3' and 'keyid4' should not be stored.
+    # 'keyid3' should not be stored.
     self.maxDiff = None
     self.assertEqual(rsakey2, tuf.keydb.get_key(keyid2))
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -354,7 +354,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # 'targets.json' are also loaded when the repository object is
     # instantiated.
 
-    self.assertEqual(number_of_root_keys * 2 + 2, len(tuf.keydb._keydb_dict[self.repository_name]))
+    self.assertEqual(number_of_root_keys + 1, len(tuf.keydb._keydb_dict[self.repository_name]))
 
     # Test: normal case.
     self.repository_updater._rebuild_key_and_role_db()
@@ -365,7 +365,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # _rebuild_key_and_role_db() will only rebuild the keys and roles specified
     # in the 'root.json' file, unlike __init__().  Instantiating an updater
     # object calls both _rebuild_key_and_role_db() and _import_delegations().
-    self.assertEqual(number_of_root_keys * 2, len(tuf.keydb._keydb_dict[self.repository_name]))
+    self.assertEqual(number_of_root_keys, len(tuf.keydb._keydb_dict[self.repository_name]))
 
     # Test: properly updated roledb and keydb dicts if the Root role changes.
     root_metadata = self.repository_updater.metadata['current']['root']
@@ -376,7 +376,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     root_roleinfo = tuf.roledb.get_roleinfo('root', self.repository_name)
     self.assertEqual(root_roleinfo['threshold'], 8)
-    self.assertEqual(number_of_root_keys * 2 - 2, len(tuf.keydb._keydb_dict[self.repository_name]))
+    self.assertEqual(number_of_root_keys - 1, len(tuf.keydb._keydb_dict[self.repository_name]))
 
 
 
@@ -560,7 +560,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # Take into account the number of keyids algorithms supported by default,
     # which this test condition expects to be two (sha256 and sha512).
-    self.assertEqual(4 * 2, len(tuf.keydb._keydb_dict[repository_name]))
+    self.assertEqual(4, len(tuf.keydb._keydb_dict[repository_name]))
 
     # Test: pass a role without delegations.
     self.repository_updater._import_delegations('root')
@@ -569,8 +569,8 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # checking the number of elements in the dictionaries.
     self.assertEqual(len(tuf.roledb._roledb_dict[repository_name]), 4)
     # Take into account the number of keyid hash algorithms, which this
-    # test condition expects to be two (for sha256 and sha512).
-    self.assertEqual(len(tuf.keydb._keydb_dict[repository_name]), 4 * 2)
+    # test condition expects to be one
+    self.assertEqual(len(tuf.keydb._keydb_dict[repository_name]), 4)
 
     # Test: normal case, first level delegation.
     self.repository_updater._import_delegations('targets')
@@ -578,7 +578,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     self.assertEqual(len(tuf.roledb._roledb_dict[repository_name]), 5)
     # The number of root keys (times the number of key hash algorithms) +
     # delegation's key (+1 for its sha512 keyid).
-    self.assertEqual(len(tuf.keydb._keydb_dict[repository_name]), 4 * 2 + 2)
+    self.assertEqual(len(tuf.keydb._keydb_dict[repository_name]), 4 + 1)
 
     # Verify that roledb dictionary was added.
     self.assertTrue('role1' in tuf.roledb._roledb_dict[repository_name])

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -951,18 +951,10 @@ class Updater(object):
         # We specify the keyid to ensure that it's the correct keyid
         # for the key.
         try:
+          key, keyids = securesystemslib.keys.format_metadata_to_key(keyinfo, keyid)
 
-          # The repo may have used hashing algorithms for the generated keyids
-          # that doesn't match the client's set of hash algorithms.  Make sure
-          # to only used the repo's selected hashing algorithms.
-          hash_algorithms = securesystemslib.settings.HASH_ALGORITHMS
-          securesystemslib.settings.HASH_ALGORITHMS = keyinfo['keyid_hash_algorithms']
-          key, keyids = securesystemslib.keys.format_metadata_to_key(keyinfo)
-          securesystemslib.settings.HASH_ALGORITHMS = hash_algorithms
-
-          for key_id in keyids:
-            key['keyid'] = key_id
-            tuf.keydb.add_key(key, keyid=None, repository_name=self.repository_name)
+          key['keyid'] = keyid
+          tuf.keydb.add_key(key, keyid=None, repository_name=self.repository_name)
 
         except tuf.exceptions.KeyAlreadyExistsError:
           pass

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -954,7 +954,7 @@ class Updater(object):
           key, _ = securesystemslib.keys.format_metadata_to_key(keyinfo, keyid)
 
           key['keyid'] = keyid
-          tuf.keydb.add_key(key, keyid=None, repository_name=self.repository_name)
+          tuf.keydb.add_key(key, repository_name=self.repository_name)
 
         except tuf.exceptions.KeyAlreadyExistsError:
           pass

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -951,7 +951,7 @@ class Updater(object):
         # We specify the keyid to ensure that it's the correct keyid
         # for the key.
         try:
-          key, keyids = securesystemslib.keys.format_metadata_to_key(keyinfo, keyid)
+          key, _ = securesystemslib.keys.format_metadata_to_key(keyinfo, keyid)
 
           key['keyid'] = keyid
           tuf.keydb.add_key(key, keyid=None, repository_name=self.repository_name)

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -953,7 +953,6 @@ class Updater(object):
         try:
           key, _ = securesystemslib.keys.format_metadata_to_key(keyinfo, keyid)
 
-          key['keyid'] = keyid
           tuf.keydb.add_key(key, repository_name=self.repository_name)
 
         except tuf.exceptions.KeyAlreadyExistsError:

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -122,20 +122,19 @@ def create_keydb_from_root_metadata(root_metadata, repository_name='default'):
       # format_metadata_to_key() uses the provided keyid as the default keyid.
       # All other keyids returned are ignored.
 
-      if (keyid == key_metadata['keyid']):
-        key_dict, keyids = securesystemslib.keys.format_metadata_to_key(key_metadata, keyid)
+      key_dict, keyids = securesystemslib.keys.format_metadata_to_key(key_metadata, keyid)
 
-        # Make sure to update key_dict['keyid'] to use one of the other valid
-        # keyids, otherwise add_key() will have no reference to it.
-        try:
-          key_dict['keyid'] = keyid
-          add_key(key_dict, keyid=None, repository_name=repository_name)
+      # Make sure to update key_dict['keyid'] to use one of the other valid
+      # keyids, otherwise add_key() will have no reference to it.
+      try:
+        key_dict['keyid'] = keyid
+        add_key(key_dict, keyid=None, repository_name=repository_name)
 
-        # Although keyid duplicates should *not* occur (unique dict keys), log a
-        # warning and continue.  However, 'key_dict' may have already been
-        # adding to the keydb elsewhere.
-        except tuf.exceptions.KeyAlreadyExistsError as e: # pragma: no cover
-          logger.warning(e)
+      # Although keyid duplicates should *not* occur (unique dict keys), log a
+      # warning and continue.  However, 'key_dict' may have already been
+      # adding to the keydb elsewhere.
+      except tuf.exceptions.KeyAlreadyExistsError as e: # pragma: no cover
+        logger.warning(e)
         continue
 
     else:

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -113,36 +113,29 @@ def create_keydb_from_root_metadata(root_metadata, repository_name='default'):
 
   # Iterate the keys found in 'root_metadata' by converting them to
   # 'RSAKEY_SCHEMA' if their type is 'rsa', and then adding them to the
-  # key database.
-  for junk, key_metadata in six.iteritems(root_metadata['keys']):
+  # key database using the provided keyid.
+  for keyid, key_metadata in six.iteritems(root_metadata['keys']):
     if key_metadata['keytype'] in _SUPPORTED_KEY_TYPES:
       # 'key_metadata' is stored in 'KEY_SCHEMA' format.  Call
       # create_from_metadata_format() to get the key in 'RSAKEY_SCHEMA' format,
-      # which is the format expected by 'add_key()'.  Note: The 'keyids'
-      # returned by format_metadata_to_key() include keyids in addition to the
-      # default keyid listed in 'key_dict'.  The additional keyids are
-      # generated according to securesystemslib.settings.HASH_ALGORITHMS.
+      # which is the format expected by 'add_key()'.  Note: This call to
+      # format_metadata_to_key() uses the provided keyid as the default keyid.
+      # All other keyids returned are ignored.
 
-      # The repo may have used hashing algorithms for the generated keyids that
-      # doesn't match the client's set of hash algorithms.  Make sure to only
-      # used the repo's selected hashing algorithms.
-      hash_algorithms = securesystemslib.settings.HASH_ALGORITHMS
-      securesystemslib.settings.HASH_ALGORITHMS = key_metadata['keyid_hash_algorithms']
-      key_dict, keyids = securesystemslib.keys.format_metadata_to_key(key_metadata)
-      securesystemslib.settings.HASH_ALGORITHMS = hash_algorithms
+      if (keyid == key_metadata['keyid']):
+        key_dict, keyids = securesystemslib.keys.format_metadata_to_key(key_metadata, keyid)
 
-      try:
-        for keyid in keyids:
-          # Make sure to update key_dict['keyid'] to use one of the other valid
-          # keyids, otherwise add_key() will have no reference to it.
+        # Make sure to update key_dict['keyid'] to use one of the other valid
+        # keyids, otherwise add_key() will have no reference to it.
+        try:
           key_dict['keyid'] = keyid
           add_key(key_dict, keyid=None, repository_name=repository_name)
 
-      # Although keyid duplicates should *not* occur (unique dict keys), log a
-      # warning and continue.  However, 'key_dict' may have already been
-      # adding to the keydb elsewhere.
-      except tuf.exceptions.KeyAlreadyExistsError as e: # pragma: no cover
-        logger.warning(e)
+        # Although keyid duplicates should *not* occur (unique dict keys), log a
+        # warning and continue.  However, 'key_dict' may have already been
+        # adding to the keydb elsewhere.
+        except tuf.exceptions.KeyAlreadyExistsError as e: # pragma: no cover
+          logger.warning(e)
         continue
 
     else:

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -128,7 +128,7 @@ def create_keydb_from_root_metadata(root_metadata, repository_name='default'):
       # keyids, otherwise add_key() will have no reference to it.
       try:
         key_dict['keyid'] = keyid
-        add_key(key_dict, keyid=None, repository_name=repository_name)
+        add_key(key_dict, repository_name=repository_name)
 
       # Although keyid duplicates should *not* occur (unique dict keys), log a
       # warning and continue.  However, 'key_dict' may have already been

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -122,7 +122,7 @@ def create_keydb_from_root_metadata(root_metadata, repository_name='default'):
       # format_metadata_to_key() uses the provided keyid as the default keyid.
       # All other keyids returned are ignored.
 
-      key_dict, keyids = securesystemslib.keys.format_metadata_to_key(key_metadata, keyid)
+      key_dict, _ = securesystemslib.keys.format_metadata_to_key(key_metadata, keyid)
 
       # Make sure to update key_dict['keyid'] to use one of the other valid
       # keyids, otherwise add_key() will have no reference to it.

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -127,7 +127,6 @@ def create_keydb_from_root_metadata(root_metadata, repository_name='default'):
       # Make sure to update key_dict['keyid'] to use one of the other valid
       # keyids, otherwise add_key() will have no reference to it.
       try:
-        key_dict['keyid'] = keyid
         add_key(key_dict, repository_name=repository_name)
 
       # Although keyid duplicates should *not* occur (unique dict keys), log a

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -695,7 +695,6 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
       # repository maintainer should have also been made aware of the duplicate
       # key when it was added.
       try:
-        key_object['keyid'] = keyid
         tuf.keydb.add_key(key_object, keyid=None, repository_name=repository_name)
 
       except tuf.exceptions.KeyAlreadyExistsError:

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -683,15 +683,10 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
         repository_name=repository_name)
 
     # Add the keys specified in the delegations field of the Targets role.
-    for key_metadata in six.itervalues(targets_metadata['delegations']['keys']):
+    for keyid, key_metadata in six.iteritems(targets_metadata['delegations']['keys']):
 
-      # The repo may have used hashing algorithms for the generated keyids
-      # that doesn't match the client's set of hash algorithms.  Make sure
-      # to only used the repo's selected hashing algorithms.
-      hash_algorithms = securesystemslib.settings.HASH_ALGORITHMS
-      securesystemslib.settings.HASH_ALGORITHMS = key_metadata['keyid_hash_algorithms']
-      key_object, keyids = securesystemslib.keys.format_metadata_to_key(key_metadata)
-      securesystemslib.settings.HASH_ALGORITHMS = hash_algorithms
+      # Use the keyid found in the delegation
+      key_object, keyids = securesystemslib.keys.format_metadata_to_key(key_metadata, keyid)
 
       # Add 'key_object' to the list of recognized keys.  Keys may be shared,
       # so do not raise an exception if 'key_object' has already been loaded.
@@ -700,10 +695,8 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
       # repository maintainer should have also been made aware of the duplicate
       # key when it was added.
       try:
-        for keyid in keyids: #pragma: no branch
-          key_object['keyid'] = keyid
-          tuf.keydb.add_key(key_object, keyid=None,
-              repository_name=repository_name)
+        key_object['keyid'] = keyid
+        tuf.keydb.add_key(key_object, keyid=None, repository_name=repository_name)
 
       except tuf.exceptions.KeyAlreadyExistsError:
         pass

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -686,7 +686,7 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
     for keyid, key_metadata in six.iteritems(targets_metadata['delegations']['keys']):
 
       # Use the keyid found in the delegation
-      key_object, keyids = securesystemslib.keys.format_metadata_to_key(key_metadata, keyid)
+      key_object, _ = securesystemslib.keys.format_metadata_to_key(key_metadata, keyid)
 
       # Add 'key_object' to the list of recognized keys.  Keys may be shared,
       # so do not raise an exception if 'key_object' has already been loaded.


### PR DESCRIPTION
This is a first step toward removing keyid_hash_algorithms from the reference implementation as discussed in #848. This pr removes all uses of this field during the client verification by using the keyids provided in the metadata instead of recalculating keyids using the keyid_hash_algorithms.

This pr requires changes to securesystemslib that are is a pull request at https://github.com/secure-systems-lab/securesystemslib/pull/225.