### PR TITLE
Port to securesystemslib with abstract files and directories (securesystemslib PR 232)

### DIFF
--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -11,7 +11,7 @@ pycparser==2.20           # via cffi
 pynacl==1.3.0             # via securesystemslib
 python-dateutil==2.8.1    # via securesystemslib
 requests==2.23.0
-securesystemslib[colors,crypto,pynacl]==0.14.2
+securesystemslib[colors,crypto,pynacl]==0.15.0
 six==1.14.0
 subprocess32==3.5.4       ; python_version < '3' # via securesystemslib
 urllib3==1.25.9           # via requests

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ setup(
     'iso8601>=0.1.12',
     'requests>=2.19.1',
     'six>=1.11.0',
-    'securesystemslib>=0.12.0'
+    'securesystemslib>=0.15.0'
   ],
   tests_require = [
     'mock; python_version < "3.3"'

--- a/tests/repository_data/generate_project_data.py
+++ b/tests/repository_data/generate_project_data.py
@@ -104,10 +104,6 @@ project('role1').load_signing_key(delegation_private)
 project.expiration = datetime.datetime(2030, 1, 1, 0, 0)
 project('role1').expiration = datetime.datetime(2030, 1, 1, 0, 0)
 
-# Compress the project role metadata so that the unit tests have a pre-generated
-# example of compressed metadata.
-project.compressions = ['gz']
-
 # Create the actual metadata files, which are saved to 'metadata.staged'.
 if not options.dry_run:
   project.write()

--- a/tests/test_developer_tool.py
+++ b/tests/test_developer_tool.py
@@ -38,6 +38,7 @@ import tuf.developer_tool as developer_tool
 import tuf.exceptions
 
 import securesystemslib
+import securesystemslib.exceptions
 
 from tuf.developer_tool import METADATA_DIRECTORY_NAME
 from tuf.developer_tool import TARGETS_DIRECTORY_NAME
@@ -188,7 +189,8 @@ class TestProject(unittest.TestCase):
 
     # Test non-existent project filepath.
     nonexistent_path = os.path.join(local_tmp, 'nonexistent')
-    self.assertRaises(IOError, developer_tool.load_project, nonexistent_path)
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+        developer_tool.load_project, nonexistent_path)
 
     # Copy the pregenerated metadata.
     project_data_filepath = os.path.join('repository_data', 'project')

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -245,17 +245,23 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     fileinfo = {'length': file_length, 'hashes': file_hashes}
     self.assertTrue(tuf.formats.FILEINFO_SCHEMA.matches(fileinfo))
 
-    self.assertEqual(fileinfo, repo_lib.get_metadata_fileinfo(test_filepath))
+    storage_backend = securesystemslib.storage.FilesystemBackend()
+
+    self.assertEqual(fileinfo, repo_lib.get_metadata_fileinfo(test_filepath,
+                                                              storage_backend))
 
 
     # Test improperly formatted argument.
-    self.assertRaises(securesystemslib.exceptions.FormatError, repo_lib.get_metadata_fileinfo, 3)
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+                      repo_lib.get_metadata_fileinfo, 3,
+                      storage_backend)
 
 
     # Test non-existent file.
     nonexistent_filepath = os.path.join(temporary_directory, 'oops.txt')
-    self.assertRaises(securesystemslib.exceptions.Error, repo_lib.get_metadata_fileinfo,
-                      nonexistent_filepath)
+    self.assertRaises(securesystemslib.exceptions.Error,
+                      repo_lib.get_metadata_fileinfo,
+                      nonexistent_filepath, storage_backend)
 
 
 
@@ -674,13 +680,6 @@ class TestRepositoryToolFunctions(unittest.TestCase):
 
     # Restore the metadata directory name in repo_lib.
     repo_lib.METADATA_DIRECTORY_NAME = metadata_directory_name
-
-
-
-  def test__check_directory(self):
-    # Test for non-existent directory.
-    self.assertRaises(securesystemslib.exceptions.Error,
-        repo_lib._check_directory, 'non-existent')
 
 
 

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -819,7 +819,9 @@ class TestRepositoryToolFunctions(unittest.TestCase):
       if role_file.endswith('.json') and not role_file.startswith('root'):
         role_filename = os.path.join(metadata_directory, role_file)
         os.remove(role_filename)
-    repo_lib._load_top_level_metadata(repository, filenames, repository_name)
+    self.assertRaises(tuf.exceptions.RepositoryError,
+        repo_lib._load_top_level_metadata, repository, filenames,
+        repository_name)
 
     # Remove the required Root file and verify that an exception is raised.
     os.remove(os.path.join(metadata_directory, 'root.json'))

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -845,11 +845,6 @@ class TestRepositoryToolFunctions(unittest.TestCase):
 
     repo_lib.write_metadata_file(signable, root_file, 8, False)
 
-    # Attempt to load a repository that contains a compressed Root file.
-    repository = repo_tool.create_new_repository(repository_directory, repository_name)
-    filenames = repo_lib.get_metadata_filenames(metadata_directory)
-    repo_lib._load_top_level_metadata(repository, filenames, repository_name)
-
     filenames = repo_lib.get_metadata_filenames(metadata_directory)
     repository = repo_tool.create_new_repository(repository_directory, repository_name)
     repo_lib._load_top_level_metadata(repository, filenames, repository_name)

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -52,8 +52,10 @@ import tuf.repository_lib as repo_lib
 import tuf.repository_tool as repo_tool
 
 import securesystemslib
+import securesystemslib.exceptions
 import securesystemslib.rsa_keys
 import securesystemslib.interface
+import securesystemslib.storage
 import six
 
 logger = logging.getLogger(__name__)
@@ -126,8 +128,9 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     # Non-existent key file.
     nonexistent_keypath = os.path.join(temporary_directory,
                                        'nonexistent_keypath')
-    self.assertRaises(IOError, repo_lib.import_rsa_privatekey_from_file,
-                      nonexistent_keypath, 'pw')
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+        repo_lib.import_rsa_privatekey_from_file,
+        nonexistent_keypath, 'pw')
 
     # Invalid key file argument.
     invalid_keyfile = os.path.join(temporary_directory, 'invalid_keyfile')
@@ -160,7 +163,8 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     # Non-existent key file.
     nonexistent_keypath = os.path.join(temporary_directory,
                                        'nonexistent_keypath')
-    self.assertRaises(IOError, repo_lib.import_ed25519_privatekey_from_file,
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+                      repo_lib.import_ed25519_privatekey_from_file,
                       nonexistent_keypath, 'pw')
 
     # Invalid key file argument.
@@ -215,7 +219,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
                  'targets.json': os.path.join(metadata_directory, 'targets.json'),
                  'snapshot.json': os.path.join(metadata_directory, 'snapshot.json'),
                  'timestamp.json': os.path.join(metadata_directory, 'timestamp.json')}
-    self.assertEqual(filenames, repo_lib.get_metadata_filenames())
+    self.assertEqual(filenames, repo_lib.get_metadata_filenames(metadata_directory))
 
 
     # Test improperly formatted argument.
@@ -440,8 +444,9 @@ class TestRepositoryToolFunctions(unittest.TestCase):
 
     # Load a valid repository so that top-level roles exist in roledb and
     # generate_snapshot_metadata() has roles to specify in snapshot metadata.
+    storage_backend = securesystemslib.storage.FilesystemBackend()
     repository = repo_tool.Repository(repository_directory, metadata_directory,
-                                      targets_directory)
+                                      targets_directory, storage_backend)
 
     repository_junk = repo_tool.load_repository(repository_directory)
 
@@ -458,6 +463,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
       repo_lib.generate_snapshot_metadata(metadata_directory, version,
                                           expiration_date,
                                           targets_filename,
+                                          storage_backend,
                                           consistent_snapshot=False)
     self.assertTrue(tuf.formats.SNAPSHOT_SCHEMA.matches(snapshot_metadata))
 
@@ -465,19 +471,19 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     # Test improperly formatted arguments.
     self.assertRaises(securesystemslib.exceptions.FormatError, repo_lib.generate_snapshot_metadata,
                       3, version, expiration_date,
-                      targets_filename, consistent_snapshot=False)
+                      targets_filename, consistent_snapshot=False, storage_backend=storage_backend)
     self.assertRaises(securesystemslib.exceptions.FormatError, repo_lib.generate_snapshot_metadata,
                       metadata_directory, '3', expiration_date,
-                      targets_filename, consistent_snapshot=False)
+                      targets_filename, storage_backend, consistent_snapshot=False)
     self.assertRaises(securesystemslib.exceptions.FormatError, repo_lib.generate_snapshot_metadata,
                       metadata_directory, version, '3',
-                      targets_filename, consistent_snapshot=False)
+                      targets_filename, storage_backend, consistent_snapshot=False)
     self.assertRaises(securesystemslib.exceptions.FormatError, repo_lib.generate_snapshot_metadata,
                       metadata_directory, version, expiration_date,
-                      3, consistent_snapshot=False)
+                      3, storage_backend, consistent_snapshot=False)
     self.assertRaises(securesystemslib.exceptions.FormatError, repo_lib.generate_snapshot_metadata,
                       metadata_directory, version, expiration_date,
-                      targets_filename, 3)
+                      targets_filename, 3, storage_backend)
 
 
 
@@ -599,85 +605,25 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     version_number = root_signable['signed']['version'] + 1
 
     self.assertFalse(os.path.exists(output_filename))
+    storage_backend = securesystemslib.storage.FilesystemBackend()
     repo_lib.write_metadata_file(root_signable, output_filename, version_number,
-        consistent_snapshot=False)
+        consistent_snapshot=False, storage_backend=storage_backend)
     self.assertTrue(os.path.exists(output_filename))
 
     # Attempt to over-write the previously written metadata file.  An exception
     # is not raised in this case, only a debug message is logged.
     repo_lib.write_metadata_file(root_signable, output_filename, version_number,
-        consistent_snapshot=False)
-
-    # Try to write a consistent metadate file. An exception is not raised in
-    # this case.  For testing purposes, root.json should be a hard link to the
-    # consistent metadata file.  We should verify that root.json points to
-    # the latest consistent files.
-    tuf.settings.CONSISTENT_METHOD = 'hard_link'
-    repo_lib.write_metadata_file(root_signable, output_filename, version_number,
-        consistent_snapshot=True)
-
-    # Test if the consistent files are properly named
-    # Filename format of a consistent file: <version number>.rolename.json
-    version_and_filename = str(version_number) + '.' + 'root.json'
-    first_version_output_file = os.path.join(temporary_directory, version_and_filename)
-    self.assertTrue(os.path.exists(first_version_output_file))
-
-    # Verify that the consistent file content is equal to 'output_filename'.
-    self.assertEqual(
-        securesystemslib.util.get_file_details(output_filename),
-        securesystemslib.util.get_file_details(first_version_output_file))
-
-    # Try to add more consistent metadata files.
-    version_number += 1
-    root_signable['signed']['version'] = version_number
-    repo_lib.write_metadata_file(root_signable, output_filename,
-        version_number, consistent_snapshot=True)
-
-    # Test if the latest root.json points to the expected consistent file
-    # and consistent metadata do not all point to the same root.json
-    version_and_filename = str(version_number) + '.' + 'root.json'
-    second_version_output_file = os.path.join(temporary_directory, version_and_filename)
-    self.assertTrue(os.path.exists(second_version_output_file))
-
-    # Verify that the second version is equal to the second output file, and
-    # that the second output filename differs from the first.
-    self.assertEqual(securesystemslib.util.get_file_details(output_filename),
-        securesystemslib.util.get_file_details(second_version_output_file))
-    self.assertNotEqual(securesystemslib.util.get_file_details(output_filename),
-        securesystemslib.util.get_file_details(first_version_output_file))
-
-    # Test for an improper settings.CONSISTENT_METHOD string value.
-    tuf.settings.CONSISTENT_METHOD = 'somebadidea'
-
-    # Test for invalid consistent methods on systems other than Windows,
-    # which always uses the copy method.
-    if platform.system() == 'Windows':
-      pass
-
-    else:
-      self.assertRaises(securesystemslib.exceptions.InvalidConfigurationError,
-          repo_lib.write_metadata_file, root_signable, output_filename,
-          version_number, consistent_snapshot=True)
-
-    # Try to create a link to root.json when root.json doesn't exist locally.
-    # repository_lib should log a message if this is the case.
-    tuf.settings.CONSISTENT_METHOD = 'hard_link'
-    os.remove(output_filename)
-    repo_lib.write_metadata_file(root_signable, output_filename, version_number,
-        consistent_snapshot=True)
-
-    # Reset CONSISTENT_METHOD so that subsequent tests work as expected.
-    tuf.settings.CONSISTENT_METHOD = 'copy'
+        consistent_snapshot=False, storage_backend=storage_backend)
 
     # Test improperly formatted arguments.
     self.assertRaises(securesystemslib.exceptions.FormatError, repo_lib.write_metadata_file,
-        3, output_filename, version_number, False)
+        3, output_filename, version_number, False, storage_backend)
     self.assertRaises(securesystemslib.exceptions.FormatError, repo_lib.write_metadata_file,
-        root_signable, 3, version_number, False)
+        root_signable, 3, version_number, False, storage_backend)
     self.assertRaises(securesystemslib.exceptions.FormatError, repo_lib.write_metadata_file,
-        root_signable, output_filename, '3', False)
+        root_signable, output_filename, '3', False, storage_backend)
     self.assertRaises(securesystemslib.exceptions.FormatError, repo_lib.write_metadata_file,
-        root_signable, output_filename, version_number, 3)
+        root_signable, output_filename, storage_backend, version_number, 3)
 
 
 
@@ -774,9 +720,11 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     tuf.roledb.add_role('obsolete_role', targets_roleinfo,
         repository_name=repository_name)
 
+    storage_backend = securesystemslib.storage.FilesystemBackend()
     repo_lib._generate_and_write_metadata('obsolete_role', obsolete_metadata,
-        targets_directory, metadata_directory, consistent_snapshot=False,
-        filenames=None, repository_name=repository_name)
+        targets_directory, metadata_directory, storage_backend,
+        consistent_snapshot=False, filenames=None,
+        repository_name=repository_name)
 
     snapshot_filepath = os.path.join('repository_data', 'repository',
                                      'metadata', 'snapshot.json')
@@ -785,7 +733,8 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     self.assertTrue(os.path.exists(os.path.join(metadata_directory,
                                                 'obsolete_role.json')))
     tuf.repository_lib._delete_obsolete_metadata(metadata_directory,
-        snapshot_signable['signed'], False, repository_name)
+        snapshot_signable['signed'], False, repository_name,
+        storage_backend)
     self.assertFalse(os.path.exists(metadata_directory + 'obsolete_role.json'))
     shutil.copyfile(targets_metadata, obsolete_metadata)
 
@@ -801,6 +750,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     snapshot_filepath = os.path.join('repository_data', 'repository',
         'metadata', 'snapshot.json')
     snapshot_signable = securesystemslib.util.load_json_file(snapshot_filepath)
+    storage_backend = securesystemslib.storage.FilesystemBackend()
 
     # Create role metadata that should not exist in snapshot.json.
     role1_filepath = os.path.join('repository_data', 'repository', 'metadata',
@@ -808,20 +758,21 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     shutil.copyfile(role1_filepath, os.path.join(metadata_directory, 'role2.json'))
 
     repo_lib._delete_obsolete_metadata(metadata_directory,
-        snapshot_signable['signed'], True, repository_name)
+        snapshot_signable['signed'], True, repository_name, storage_backend)
 
     # _delete_obsolete_metadata should never delete root.json.
     root_filepath = os.path.join('repository_data', 'repository', 'metadata',
         'root.json')
     shutil.copyfile(root_filepath, os.path.join(metadata_directory, 'root.json'))
     repo_lib._delete_obsolete_metadata(metadata_directory,
-        snapshot_signable['signed'], True, repository_name)
+        snapshot_signable['signed'], True, repository_name, storage_backend)
     self.assertTrue(os.path.exists(os.path.join(metadata_directory, 'root.json')))
 
     # Verify what happens for a non-existent metadata directory (a debug
     # message is logged).
-    repo_lib._delete_obsolete_metadata('non-existent',
-        snapshot_signable['signed'], True, repository_name)
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+        repo_lib._delete_obsolete_metadata, 'non-existent',
+        snapshot_signable['signed'], True, repository_name, storage_backend)
 
 
   def test__load_top_level_metadata(self):
@@ -843,7 +794,8 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     signable = securesystemslib.util.load_json_file(os.path.join(metadata_directory, 'root.json'))
     signable['signatures'].append(signable['signatures'][0])
 
-    repo_lib.write_metadata_file(signable, root_file, 8, False)
+    storage_backend = securesystemslib.storage.FilesystemBackend()
+    repo_lib.write_metadata_file(signable, root_file, 8, False, storage_backend)
 
     filenames = repo_lib.get_metadata_filenames(metadata_directory)
     repository = repo_tool.create_new_repository(repository_directory, repository_name)

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -343,12 +343,15 @@ class TestRepository(unittest.TestCase):
     # loaded before writing consistent snapshot.
     repository.root.load_signing_key(root_privkey)
     repository.snapshot.load_signing_key(snapshot_privkey)
+    # Must also load targets signing key, because targets is re-signed when
+    # updating 'role1'.
+    repository.targets.load_signing_key(targets_privkey)
     repository.targets('role1').load_signing_key(role1_privkey)
 
     # Verify that a consistent snapshot can be written and loaded.  The roles
     # above must be marked as dirty, otherwise writeall() will not create a
     # consistent snapshot for them.
-    repository.mark_dirty(['role1', 'root', 'snapshot', 'timestamp'])
+    repository.mark_dirty(['role1', 'targets', 'root', 'snapshot', 'timestamp'])
     repository.writeall(consistent_snapshot=True)
 
     # Verify that the newly written consistent snapshot can be loaded

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -48,6 +48,7 @@ import tuf.repository_tool as repo_tool
 import securesystemslib.exceptions
 
 import securesystemslib
+import securesystemslib.storage
 import six
 
 logger = logging.getLogger(__name__)
@@ -96,20 +97,22 @@ class TestRepository(unittest.TestCase):
   def test_init(self):
     # Test normal case.
     repository_name = 'test_repository'
+    storage_backend = securesystemslib.storage.FilesystemBackend()
     repository = repo_tool.Repository('repository_directory/',
-        'metadata_directory/', 'targets_directory/', repository_name)
+        'metadata_directory/', 'targets_directory/', storage_backend,
+        repository_name)
     self.assertTrue(isinstance(repository.root, repo_tool.Root))
     self.assertTrue(isinstance(repository.snapshot, repo_tool.Snapshot))
     self.assertTrue(isinstance(repository.timestamp, repo_tool.Timestamp))
     self.assertTrue(isinstance(repository.targets, repo_tool.Targets))
 
     # Test improperly formatted arguments.
-    self.assertRaises(securesystemslib.exceptions.FormatError, repo_tool.Repository, 3,
-                      'metadata_directory/', 'targets_directory')
     self.assertRaises(securesystemslib.exceptions.FormatError, repo_tool.Repository,
-                      'repository_directory', 3, 'targets_directory')
+                      storage_backend, 3, 'metadata_directory/', 'targets_directory')
     self.assertRaises(securesystemslib.exceptions.FormatError, repo_tool.Repository,
-                      'repository_directory', 'metadata_directory', 3)
+                      'repository_directory', storage_backend, 3, 'targets_directory')
+    self.assertRaises(securesystemslib.exceptions.FormatError, repo_tool.Repository,
+                      'repository_directory', 'metadata_directory', 3, storage_backend)
 
 
 
@@ -1818,14 +1821,9 @@ class TestRepositoryToolFunctions(unittest.TestCase):
         repo_tool.create_new_repository, 3, repository_name)
 
     # For testing purposes, try to create a repository directory that
-    # fails due to a non-errno.EEXIST exception raised.  create_new_repository()
-    # should only pass for OSError (errno.EEXIST).
-    try:
-      repo_tool.create_new_repository('bad' * 2000, repository_name)
-
-    except OSError as e:
-      # errno.ENOENT is raised in Windows.
-      self.assertTrue(e.errno == errno.ENAMETOOLONG or e.errno == errno.ENOENT)
+    # fails due to a non-errno.EEXIST exception raised.
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+        repo_tool.create_new_repository, 'bad' * 2000, repository_name)
 
     # Reset the 'repository_directory' so that the metadata and targets
     # directories can be tested likewise.
@@ -1836,12 +1834,8 @@ class TestRepositoryToolFunctions(unittest.TestCase):
       tuf.repository_tool.METADATA_STAGED_DIRECTORY_NAME
     tuf.repository_tool.METADATA_STAGED_DIRECTORY_NAME = 'bad' * 2000
 
-    try:
-      repo_tool.create_new_repository(repository_directory, repository_name)
-
-    except OSError as e:
-      # errno.ENOENT is raised in Windows.
-      self.assertTrue(e.errno == errno.ENAMETOOLONG or e.errno == errno.ENOENT)
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+        repo_tool.create_new_repository, repository_directory, repository_name)
 
     # Reset metadata staged directory so that the targets directory can be
     # tested...
@@ -1851,12 +1845,8 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     original_targets_directory = tuf.repository_tool.TARGETS_DIRECTORY_NAME
     tuf.repository_tool.TARGETS_DIRECTORY_NAME = 'bad' * 2000
 
-    try:
-      repo_tool.create_new_repository(repository_directory, repository_name)
-
-    except OSError as e:
-      # errno.ENOENT is raised in Windows.
-      self.assertTrue(e.errno == errno.ENAMETOOLONG or e.errno == errno.ENOENT)
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+         repo_tool.create_new_repository, repository_directory, repository_name)
 
     tuf.repository_tool.TARGETS_DIRECTORY_NAME = \
       original_targets_directory
@@ -1943,8 +1933,10 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     metadata_content = repo_tool.dump_signable_metadata(targets_metadata_file)
 
     # Test for an invalid targets metadata file..
-    self.assertRaises(securesystemslib.exceptions.FormatError, repo_tool.dump_signable_metadata, 1)
-    self.assertRaises(IOError, repo_tool.dump_signable_metadata, 'bad file path')
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+        repo_tool.dump_signable_metadata, 1)
+    self.assertRaises(securesystemslib.exceptions.StorageError,
+        repo_tool.dump_signable_metadata, 'bad file path')
 
 
 

--- a/tests/test_root_versioning_integration.py
+++ b/tests/test_root_versioning_integration.py
@@ -41,6 +41,7 @@ import tuf.keydb
 import tuf.repository_tool as repo_tool
 
 import securesystemslib
+import securesystemslib.storage
 
 logger = logging.getLogger(__name__)
 
@@ -63,9 +64,11 @@ class TestRepository(unittest.TestCase):
 
   def test_init(self):
     # Test normal case.
+    storage_backend = securesystemslib.storage.FilesystemBackend()
     repository = repo_tool.Repository('repository_directory/',
                                       'metadata_directory/',
-                                      'targets_directory/')
+                                      'targets_directory/',
+                                      storage_backend)
     self.assertTrue(isinstance(repository.root, repo_tool.Root))
     self.assertTrue(isinstance(repository.snapshot, repo_tool.Snapshot))
     self.assertTrue(isinstance(repository.timestamp, repo_tool.Timestamp))
@@ -73,11 +76,11 @@ class TestRepository(unittest.TestCase):
 
     # Test improperly formatted arguments.
     self.assertRaises(securesystemslib.exceptions.FormatError, repo_tool.Repository, 3,
-                      'metadata_directory/', 'targets_directory')
+                      'metadata_directory/', 'targets_directory', storage_backend)
     self.assertRaises(securesystemslib.exceptions.FormatError, repo_tool.Repository,
-                      'repository_directory', 3, 'targets_directory')
+                      'repository_directory', 3, 'targets_directory', storage_backend)
     self.assertRaises(securesystemslib.exceptions.FormatError, repo_tool.Repository,
-                      'repository_directory', 'metadata_directory', 3)
+                      'repository_directory', 'metadata_directory', storage_backend, 3)
 
 
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -436,6 +436,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     repository.root.threshold = 2
     repository.root.load_signing_key(self.role_keys['root']['private'])
 
+    storage_backend = securesystemslib.storage.FilesystemBackend()
     # The client uses the threshold from the previous root file to verify the
     # new root. Thus we need to make two updates so that the threshold used for
     # verification becomes 2. I.e. we bump the version, sign twice with the
@@ -455,7 +456,8 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
       # catch the unmet threshold.
       # We also skip writing to 'metadata.staged' and copying to 'metadata' and
       # instead write directly to 'metadata'
-      repo_lib.write_metadata_file(signed_metadata, live_root_path, info["version"], True)
+      repo_lib.write_metadata_file(signed_metadata, live_root_path,
+          info["version"], True, storage_backend)
 
 
     # Update from current '1.root.json' to '3.root.json' on client and assert

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -140,6 +140,7 @@ import tuf.roledb
 import tuf.sig
 import tuf.exceptions
 
+import securesystemslib.exceptions
 import securesystemslib.hash
 import securesystemslib.keys
 import securesystemslib.util
@@ -211,7 +212,7 @@ class MultiRepoUpdater(object):
       # The map file dictionary that associates targets with repositories.
       self.map_file = securesystemslib.util.load_json_file(map_file)
 
-    except (securesystemslib.exceptions.Error, IOError) as e:
+    except (securesystemslib.exceptions.Error) as e:
       raise tuf.exceptions.Error('Cannot load the map file: ' + str(e))
 
     # Raise securesystemslib.exceptions.FormatError if the map file is
@@ -3174,7 +3175,7 @@ class Updater(object):
             algorithm=algorithm)
 
         # This exception would occur if the target does not exist locally.
-        except IOError:
+        except securesystemslib.exceptions.StorageError:
           updated_targets.append(target)
           updated_targetpaths.append(target_filepath)
           break

--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -501,8 +501,9 @@ def _generate_and_write_metadata(rolename, metadata_filename, write_partial,
 
   if tuf.sig.verify(signable, rolename, repository_name) or write_partial:
     repo_lib._remove_invalid_and_duplicate_signatures(signable, repository_name)
+    storage_backend = securesystemslib.storage.FilesystemBackend()
     filename = repo_lib.write_metadata_file(signable, metadata_filename,
-        metadata['version'], False)
+        metadata['version'], False, storage_backend)
 
   # 'signable' contains an invalid threshold of signatures.
   else:

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -598,7 +598,8 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
         repository_name=repository_name)
 
   except securesystemslib.exceptions.StorageError:
-    logger.debug('Cannot load the Timestamp  file: ' + repr(timestamp_filename))
+    raise tuf.exceptions.RepositoryError('Cannot load the Timestamp file: '
+        + repr(timestamp_filename))
 
   # Load 'snapshot.json'.  A consistent snapshot.json must be calculated if
   # 'consistent_snapshot' is True.
@@ -637,7 +638,8 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
         repository_name=repository_name)
 
   except securesystemslib.exceptions.StorageError:
-    logger.debug('The Snapshot file cannot be loaded: ' + repr(snapshot_filename))
+    raise tuf.exceptions.RepositoryError('The Snapshot file cannot be loaded: '
+        + repr(snapshot_filename))
 
   # Load 'targets.json'.  A consistent snapshot of the Targets role must be
   # calculated if 'consistent_snapshot' is True.
@@ -701,7 +703,8 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
         pass
 
   except securesystemslib.exceptions.StorageError:
-    logger.debug('The Targets file can not be loaded: ' + repr(targets_filename))
+    raise tuf.exceptions.RepositoryError('The Targets file can not be loaded: '
+        + repr(targets_filename))
 
   return repository, consistent_snapshot
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1481,11 +1481,6 @@ def generate_snapshot_metadata(metadata_directory, version, expiration_date,
   fileinfodict[TARGETS_FILENAME] = get_metadata_versioninfo(targets_filename,
       repository_name)
 
-  # We previously also stored the compressed versions of roles in
-  # snapshot.json, however, this is no longer needed as their hashes and
-  # lengths are not used and their version numbers match the uncompressed role
-  # files.
-
   # Search the metadata directory and generate the versioninfo of all the role
   # files found there.  This information is stored in the 'meta' field of
   # 'snapshot.json'.
@@ -1585,11 +1580,6 @@ def generate_timestamp_metadata(snapshot_filename, version, expiration_date,
   snapshot_version = get_metadata_versioninfo('snapshot', repository_name)
   snapshot_fileinfo[SNAPSHOT_FILENAME] = \
     tuf.formats.make_fileinfo(length, hashes, version=snapshot_version['version'])
-
-  # We previously saved the versioninfo of the compressed versions of
-  # 'snapshot.json' in 'versioninfo'.  Since version numbers are now stored,
-  # the version numbers of compressed roles do not change and can thus be
-  # excluded.
 
   # Generate the timestamp metadata object.
   # Use generalized build_dict_conforming_to_schema func to produce a dict that

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -530,8 +530,7 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
 
   # Load 'root.json'.  A Root role file without a version number is always
   # written.
-  if os.path.exists(root_filename):
-
+  try:
     # Initialize the key and role metadata of the top-level roles.
     signable = securesystemslib.util.load_json_file(root_filename)
     tuf.formats.check_signable_object_format(signable)
@@ -569,13 +568,13 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
     # Ensure the 'consistent_snapshot' field is extracted.
     consistent_snapshot = root_metadata['consistent_snapshot']
 
-  else:
+  except securesystemslib.exceptions.StorageError:
     raise tuf.exceptions.RepositoryError('Cannot load the required'
-      ' root file: ' + repr(root_filename))
+        ' root file: ' + repr(root_filename))
 
   # Load 'timestamp.json'.  A Timestamp role file without a version number is
   # always written.
-  if os.path.exists(timestamp_filename):
+  try:
     signable = securesystemslib.util.load_json_file(timestamp_filename)
     timestamp_metadata = signable['signed']
     for signature in signable['signatures']:
@@ -598,7 +597,7 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
     tuf.roledb.update_roleinfo('timestamp', roleinfo, mark_role_as_dirty=False,
         repository_name=repository_name)
 
-  else:
+  except securesystemslib.exceptions.StorageError:
     logger.debug('Cannot load the Timestamp  file: ' + repr(timestamp_filename))
 
   # Load 'snapshot.json'.  A consistent snapshot.json must be calculated if
@@ -612,7 +611,7 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
     snapshot_filename = os.path.join(dirname,
         str(snapshot_version) + '.' + basename + METADATA_EXTENSION)
 
-  if os.path.exists(snapshot_filename):
+  try:
     signable = securesystemslib.util.load_json_file(snapshot_filename)
     tuf.formats.check_signable_object_format(signable)
     snapshot_metadata = signable['signed']
@@ -637,7 +636,7 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
     tuf.roledb.update_roleinfo('snapshot', roleinfo, mark_role_as_dirty=False,
         repository_name=repository_name)
 
-  else:
+  except securesystemslib.exceptions.StorageError:
     logger.debug('The Snapshot file cannot be loaded: ' + repr(snapshot_filename))
 
   # Load 'targets.json'.  A consistent snapshot of the Targets role must be
@@ -647,7 +646,7 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
     dirname, basename = os.path.split(targets_filename)
     targets_filename = os.path.join(dirname, str(targets_version) + '.' + basename)
 
-  if os.path.exists(targets_filename):
+  try:
     signable = securesystemslib.util.load_json_file(targets_filename)
     tuf.formats.check_signable_object_format(signable)
     targets_metadata = signable['signed']
@@ -701,8 +700,8 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
       except tuf.exceptions.KeyAlreadyExistsError:
         pass
 
-  else:
-    logger.debug('The Targets file cannot be loaded: ' + repr(targets_filename))
+  except securesystemslib.exceptions.StorageError:
+    logger.debug('The Targets file can not be loaded: ' + repr(targets_filename))
 
   return repository, consistent_snapshot
 

--- a/tuf/settings.py
+++ b/tuf/settings.py
@@ -87,14 +87,6 @@ MIN_AVERAGE_DOWNLOAD_SPEED = 50 #bytes/second
 # By default, limit number of delegatees we visit for any target.
 MAX_NUMBER_OF_DELEGATIONS = 2**5
 
-# This configuration is for indicating how consistent files should be created.
-# There are two options: "copy" and "hard_link".  For "copy", the consistent
-# file with be a copy of root.json.  This approach will require the most disk
-# space out of the two options.  For "hard_link", the latest root.json will be
-# a hard link to 2.root.json (for example).  This approach is more efficient in
-# terms of disk space usage.  By default, we use 'copy'.
-CONSISTENT_METHOD = 'copy'
-
 # A setting for the instances where a default hashing algorithm is needed.
 # This setting is currently used to calculate the path hash prefixes of hashed
 # bin delegations, and digests of targets filepaths.  The other instances


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**: this PR encapsulates step three of #1009

**Description of the changes being introduced by the pull request**:
* port to securesystemslib with abstract filesystem backend
  * Update TUF repository code to create a new or load an existing TUF repository, to obtain hashes and sizes of metadata files, and to persist metadata files, all using a customizable file backend
* Drop support for `tuf.settings.CONSISTENT_METHOD`

**NOTE**: this change shouldn't land until we've merged secure-systems-lab/securesystemslib#232 and made a release.

**UPDATE**: prior to this PR `_delete_obsolete_metadata()` would `os.walk()` the metadata directory, thus picking up any metadata files in subdirectories of the metadata directory. The change in this PR to use `list_folder()` from the `StorageBackendInterface` means that _should_ there be any sub-directories of the metadata directory which contain metadata, the metadata in those directories would not be removed by the changed version of `_delete_obsolete_metadata()`. 
This should not be a problem because, by default, all metadata files exist as children of the metadata directory, rather than in subdirectories.

**Please verify and check that the pull request fulfils the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


