### PR TITLE
Improve error message and docstring for custom parameter in `add_target()`

### DIFF
--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -300,7 +300,10 @@ NUMBINS_SCHEMA = SCHEMA.Integer(lo=1)
 # The fileinfo format of targets specified in the repository and
 # developer tools.  The fields match that of FILEINFO_SCHEMA, only all
 # fields are optional.
-CUSTOM_SCHEMA = SCHEMA.Object()
+CUSTOM_SCHEMA = SCHEMA.DictOf(
+  key_schema = SCHEMA.AnyString(),
+  value_schema = SCHEMA.Any()
+)
 LOOSE_FILEINFO_SCHEMA = SCHEMA.Object(
   object_name = "LOOSE_FILEINFO_SCHEMA",
   length = SCHEMA.Optional(LENGTH_SCHEMA),

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -1929,12 +1929,6 @@ class Targets(Metadata):
       Add a filepath (must be relative to the repository's targets directory)
       to the Targets object.
 
-      This method does not access the file system. 'filepath' must already
-      exist on the file system.
-
-      If 'filepath' does not exist the file will still be added to 'roleinfo'.
-      Only later calls to write() and writeall() will fail.
-
       If 'filepath' has already been added, it will be replaced with any new
       file or 'custom' information.
 
@@ -1948,11 +1942,21 @@ class Targets(Metadata):
         targets directory.
 
       custom:
-        An optional object providing additional information about the file.
+        An optional dictionary providing additional information about the file.
+        NOTE: if a custom value is passed, the fileinfo parameter must be None.
+        This parameter will be deprecated in a future release of tuf, use of
+        the fileinfo parameter is preferred.
 
       fileinfo:
-        An optional fileinfo object, conforming to tuf.formats.FILEINFO_SCHEMA,
-        providing full information about the file.
+        An optional fileinfo dictionary, conforming to
+        tuf.formats.FILEINFO_SCHEMA, providing full information about the
+        file, i.e:
+          { 'length': 101,
+            'hashes': { 'sha256': '123EDF...' },
+            'version': 2, # optional
+            'custom': { 'permissions': '600'} # optional
+          }
+        NOTE: if a custom value is passed, the fileinfo parameter must be None.
 
     <Exceptions>
       securesystemslib.exceptions.FormatError, if 'filepath' is improperly


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Fixes issue #**: N/A

**Description of the changes being introduced by the pull request**:
* Change the definition of CUSTOM_SCHEMA to better match the usage, it's a dictionary not an object. cc @SantiagoTorres 
* Update the docstring of `add_target()` to make the use of _custom_ and _fileinfo_, that they are mutually exclusive and that we intend to deprecate _custom_ much clearer.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


