### PR TITLE
Fix error "[Errno 111] Connection refused" and make logs more usable

### DIFF
--- a/tests/simple_server.py
+++ b/tests/simple_server.py
@@ -71,7 +71,15 @@ class QuietHTTPRequestHandler(SimpleHTTPRequestHandler):
 if six.PY2 and platform.system() == 'Windows':
   handler = QuietHTTPRequestHandler
 else:
-  handler = SimpleHTTPRequestHandler
+  use_quiet_http_request_handler = True
+
+  if len(sys.argv) > 2:
+    use_quiet_http_request_handler = sys.argv[2]
+
+  if use_quiet_http_request_handler:
+    handler = QuietHTTPRequestHandler
+  else:
+    handler = SimpleHTTPRequestHandler
 
 httpd = six.moves.socketserver.TCPServer(('', PORT), handler)
 

--- a/tests/simple_server.py
+++ b/tests/simple_server.py
@@ -66,20 +66,19 @@ class QuietHTTPRequestHandler(SimpleHTTPRequestHandler):
 
 # NOTE: On Windows/Python2 tests that use this simple_server.py in a
 # subprocesses hang after a certain amount of requests (~68), if a PIPE is
-# passed as Popen's stderr argument. As a simple workaround we silence the
-# server on those Windows/Py2 to not fill the buffer.
-if six.PY2 and platform.system() == 'Windows':
+# passed as Popen's stderr argument. This problem doesn't emerge if
+# we silence the HTTP messages.
+# If you decide to receive the HTTP messages, then this bug
+# could reappear.
+use_quiet_http_request_handler = True
+
+if len(sys.argv) > 2:
+  use_quiet_http_request_handler = sys.argv[2]
+
+if use_quiet_http_request_handler:
   handler = QuietHTTPRequestHandler
 else:
-  use_quiet_http_request_handler = True
-
-  if len(sys.argv) > 2:
-    use_quiet_http_request_handler = sys.argv[2]
-
-  if use_quiet_http_request_handler:
-    handler = QuietHTTPRequestHandler
-  else:
-    handler = SimpleHTTPRequestHandler
+  handler = SimpleHTTPRequestHandler
 
 httpd = six.moves.socketserver.TCPServer(('', PORT), handler)
 

--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -81,7 +81,7 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
     # etc.
     cls.SERVER_PORT = random.randint(30000, 45000)
     command = ['python', 'simple_server.py', str(cls.SERVER_PORT)]
-    cls.server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
+    cls.server_process = subprocess.Popen(command)
     logger.info('Server process started.')
     logger.info('Server process id: ' + str(cls.server_process.pid))
     logger.info('Serving on port: ' + str(cls.SERVER_PORT))

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -83,7 +83,7 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
     # etc.
     cls.SERVER_PORT = random.randint(30000, 45000)
     command = ['python', 'simple_server.py', str(cls.SERVER_PORT)]
-    cls.server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
+    cls.server_process = subprocess.Popen(command)
     logger.info('Server process started.')
     logger.info('Server process id: '+str(cls.server_process.pid))
     logger.info('Serving on port: '+str(cls.SERVER_PORT))

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -87,7 +87,7 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
     # etc.
     cls.SERVER_PORT = random.randint(30000, 45000)
     command = ['python', 'simple_server.py', str(cls.SERVER_PORT)]
-    cls.server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
+    cls.server_process = subprocess.Popen(command)
     logger.info('Server process started.')
     logger.info('Server process id: '+str(cls.server_process.pid))
     logger.info('Serving on port: '+str(cls.SERVER_PORT))

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -94,7 +94,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # etc.
     cls.SERVER_PORT = random.randint(30000, 45000)
     command = ['python', 'simple_server.py', str(cls.SERVER_PORT)]
-    cls.server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
+    cls.server_process = subprocess.Popen(command)
     logger.info('Server process started.')
     logger.info('Server process id: '+str(cls.server_process.pid))
     logger.info('Serving on port: '+str(cls.SERVER_PORT))

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -83,7 +83,7 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
     # key files, etc.
     cls.SERVER_PORT = random.randint(30000, 45000)
     command = ['python', 'simple_server.py', str(cls.SERVER_PORT)]
-    cls.server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
+    cls.server_process = subprocess.Popen(command)
     logger.info('\n\tServer process started.')
     logger.info('\tServer process id: '+str(cls.server_process.pid))
     logger.info('\tServing on port: '+str(cls.SERVER_PORT))

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -88,7 +88,7 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
     # etc.
     cls.SERVER_PORT = random.randint(30000, 45000)
     command = ['python', 'simple_server.py', str(cls.SERVER_PORT)]
-    cls.server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
+    cls.server_process = subprocess.Popen(command)
     logger.info('Server process started.')
     logger.info('Server process id: '+str(cls.server_process.pid))
     logger.info('Serving on port: '+str(cls.SERVER_PORT))

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -136,14 +136,14 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
     command = ['python', SIMPLE_SERVER_PATH, str(self.SERVER_PORT)]
     command2 = ['python', SIMPLE_SERVER_PATH, str(self.SERVER_PORT2)]
 
-    self.server_process = subprocess.Popen(command, stderr=subprocess.PIPE,
+    self.server_process = subprocess.Popen(command,
         cwd=self.repository_directory)
 
     logger.debug('Server process started.')
     logger.debug('Server process id: ' + str(self.server_process.pid))
     logger.debug('Serving on port: ' + str(self.SERVER_PORT))
 
-    self.server_process2 = subprocess.Popen(command2, stderr=subprocess.PIPE,
+    self.server_process2 = subprocess.Popen(command2,
         cwd=self.repository_directory2)
 
 

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -128,8 +128,13 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
     while self.SERVER_PORT == self.SERVER_PORT2:
       self.SERVER_PORT2 = random.SystemRandom().randint(30000, 45000)
 
-    command = ['python', '-m', 'tests.simple_server', str(self.SERVER_PORT)]
-    command2 = ['python', '-m', 'tests.simple_server', str(self.SERVER_PORT2)]
+    # Needed because in some tests simple_server.py cannot be found.
+    # The reason is that the current working directory
+    # has been changed when executing a subprocess.
+    SIMPLE_SERVER_PATH = os.path.join(os.getcwd(), 'simple_server.py')
+
+    command = ['python', SIMPLE_SERVER_PATH, str(self.SERVER_PORT)]
+    command2 = ['python', SIMPLE_SERVER_PATH, str(self.SERVER_PORT2)]
 
     self.server_process = subprocess.Popen(command, stderr=subprocess.PIPE,
         cwd=self.repository_directory)

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -87,7 +87,7 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
     # etc.
     cls.SERVER_PORT = random.randint(30000, 45000)
     command = ['python', 'simple_server.py', str(cls.SERVER_PORT)]
-    cls.server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
+    cls.server_process = subprocess.Popen(command)
     logger.info('Server process started.')
     logger.info('Server process id: '+str(cls.server_process.pid))
     logger.info('Serving on port: '+str(cls.SERVER_PORT))

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -103,7 +103,7 @@ class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
     # as a delegated role 'targets/role1', three target files, five key files,
     # etc.
     command = ['python', 'slow_retrieval_server.py', str(self.SERVER_PORT), mode]
-    server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
+    server_process = subprocess.Popen(command)
     logger.info('Slow Retrieval Server process started.')
     logger.info('Server process id: '+str(server_process.pid))
     logger.info('Serving on port: '+str(self.SERVER_PORT))

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -104,7 +104,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # etc.
     cls.SERVER_PORT = random.randint(30000, 45000)
     command = ['python', cls.SIMPLE_SERVER_PATH, str(cls.SERVER_PORT)]
-    cls.server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
+    cls.server_process = subprocess.Popen(command)
     logger.info('\n\tServer process started.')
     logger.info('\tServer process id: '+str(cls.server_process.pid))
     logger.info('\tServing on port: '+str(cls.SERVER_PORT))
@@ -1097,7 +1097,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # timeout in Windows after a few tests.
     SERVER_PORT = random.randint(30000, 45000)
     command = ['python', self.SIMPLE_SERVER_PATH, str(SERVER_PORT)]
-    server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
+    server_process = subprocess.Popen(command)
 
     # NOTE: Following error is raised if a delay is not long enough:
     # <urlopen error [Errno 111] Connection refused>
@@ -1365,7 +1365,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # timeout in Windows after a few tests.
     SERVER_PORT = random.randint(30000, 45000)
     command = ['python', self.SIMPLE_SERVER_PATH, str(SERVER_PORT)]
-    server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
+    server_process = subprocess.Popen(command)
 
     # NOTE: Following error is raised if a delay is not long enough to allow
     # the server process to set up and start listening:
@@ -1497,7 +1497,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # timeout in Windows after a few tests.
     SERVER_PORT = random.randint(30000, 45000)
     command = ['python', self.SIMPLE_SERVER_PATH, str(SERVER_PORT)]
-    server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
+    server_process = subprocess.Popen(command)
 
     # NOTE: Following error is raised if a delay is not long enough to allow
     # the server process to set up and start listening:
@@ -1888,14 +1888,14 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     command = ['python', self.SIMPLE_SERVER_PATH, str(self.SERVER_PORT)]
     command2 = ['python', self.SIMPLE_SERVER_PATH, str(self.SERVER_PORT2)]
 
-    self.server_process = subprocess.Popen(command, stderr=subprocess.PIPE,
+    self.server_process = subprocess.Popen(command,
         cwd=self.repository_directory)
 
     logger.debug('Server process started.')
     logger.debug('Server process id: ' + str(self.server_process.pid))
     logger.debug('Serving on port: ' + str(self.SERVER_PORT))
 
-    self.server_process2 = subprocess.Popen(command2, stderr=subprocess.PIPE,
+    self.server_process2 = subprocess.Popen(command2,
         cwd=self.repository_directory2)
 
     logger.debug('Server process 2 started.')

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -90,6 +90,11 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # temporary files are always removed, even when exceptions occur.
     cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
 
+    # Needed because in some tests simple_server.py cannot be found.
+    # The reason is that the current working directory
+    # has been changed when executing a subprocess.
+    cls.SIMPLE_SERVER_PATH = os.path.join(os.getcwd(), 'simple_server.py')
+
     # Launch a SimpleHTTPServer (serves files in the current directory).
     # Test cases will request metadata and target files that have been
     # pre-generated in 'tuf/tests/repository_data', which will be served
@@ -98,7 +103,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # as a delegated role 'targets/role1', three target files, five key files,
     # etc.
     cls.SERVER_PORT = random.randint(30000, 45000)
-    command = ['python', '-m', 'tests.simple_server', str(cls.SERVER_PORT)]
+    command = ['python', cls.SIMPLE_SERVER_PATH, str(cls.SERVER_PORT)]
     cls.server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
     logger.info('\n\tServer process started.')
     logger.info('\tServer process id: '+str(cls.server_process.pid))
@@ -1091,7 +1096,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # The SimpleHTTPServer started in the setupclass has a tendency to
     # timeout in Windows after a few tests.
     SERVER_PORT = random.randint(30000, 45000)
-    command = ['python', '-m', 'tests.simple_server', str(SERVER_PORT)]
+    command = ['python', self.SIMPLE_SERVER_PATH, str(SERVER_PORT)]
     server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
 
     # NOTE: Following error is raised if a delay is not long enough:
@@ -1359,7 +1364,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # The SimpleHTTPServer started in the setupclass has a tendency to
     # timeout in Windows after a few tests.
     SERVER_PORT = random.randint(30000, 45000)
-    command = ['python', '-m', 'tests.simple_server', str(SERVER_PORT)]
+    command = ['python', self.SIMPLE_SERVER_PATH, str(SERVER_PORT)]
     server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
 
     # NOTE: Following error is raised if a delay is not long enough to allow
@@ -1491,7 +1496,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # The SimpleHTTPServer started in the setupclass has a tendency to
     # timeout in Windows after a few tests.
     SERVER_PORT = random.randint(30000, 45000)
-    command = ['python', '-m', 'tests.simple_server', str(SERVER_PORT)]
+    command = ['python', self.SIMPLE_SERVER_PATH, str(SERVER_PORT)]
     server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
 
     # NOTE: Following error is raised if a delay is not long enough to allow
@@ -1824,6 +1829,11 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     self.temporary_repository_root = self.make_temp_directory(directory=
         self.temporary_directory)
 
+    # Needed because in some tests simple_server.py cannot be found.
+    # The reason is that the current working directory
+    # has been changed when executing a subprocess.
+    self.SIMPLE_SERVER_PATH = os.path.join(os.getcwd(), 'simple_server.py')
+
     # The original repository, keystore, and client directories will be copied
     # for each test case.
     original_repository = os.path.join(original_repository_files, 'repository')
@@ -1875,8 +1885,8 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     self.SERVER_PORT = 30001
     self.SERVER_PORT2 = 30002
 
-    command = ['python', '-m', 'tests.simple_server', str(self.SERVER_PORT)]
-    command2 = ['python', '-m', 'tests.simple_server', str(self.SERVER_PORT2)]
+    command = ['python', self.SIMPLE_SERVER_PATH, str(self.SERVER_PORT)]
+    command2 = ['python', self.SIMPLE_SERVER_PATH, str(self.SERVER_PORT2)]
 
     self.server_process = subprocess.Popen(command, stderr=subprocess.PIPE,
         cwd=self.repository_directory)

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -90,7 +90,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # etc.
     cls.SERVER_PORT = random.randint(30000, 45000)
     command = ['python', 'simple_server.py', str(cls.SERVER_PORT)]
-    cls.server_process = subprocess.Popen(command, stderr=subprocess.PIPE)
+    cls.server_process = subprocess.Popen(command)
     logger.info('\n\tServer process started.')
     logger.info('\tServer process id: '+str(cls.server_process.pid))
     logger.info('\tServing on port: '+str(cls.SERVER_PORT))


### PR DESCRIPTION

**Fixes issue #**: #1010 

**Description of the changes being introduced by the pull request**:
When running the tests this error appears
"[Errno 111] Connection refused". After some digging Lukas
found another error "No module named tests.simple_server"
which is the root cause for error 111.

With the help of Joshua Lock, we found out that the simple_server.py
was not being found because of subprocess.Popen was being passed
a cwd kwarg which moved the current working directory
away from tuf/tests.
That's what I fix with the first commit.

In my second commit, I remove stderr=subprocess.PIPE argument from subprocess.Popen function calls and make the  QuietHTTPRequestHandler as the default HTTP handler in the `simple_server.py` script.
This change is inspired by the digging needed to discover the real problem causing issue 1010 summarized well in the @lukpueh comment https://github.com/theupdateframework/tuf/issues/1010#issuecomment-612064378.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


