### PR TITLE
Clarify generate_targets_metadata()

### DIFF
--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1251,9 +1251,12 @@ def generate_targets_metadata(targets_directory, target_files, version,
   securesystemslib.formats.BOOLEAN_SCHEMA.check_match(write_consistent_targets)
   securesystemslib.formats.BOOLEAN_SCHEMA.check_match(use_existing_fileinfo)
 
+  # If the caller requested consistent targets *and* supplied their own fileinfo
+  # consistent versions of the targets can not be created, because target
+  # files and their storage are not accessed when using existing fileinfo.
   if write_consistent_targets and use_existing_fileinfo:
-    raise securesystemslib.exceptions.Error('Cannot support writing consistent'
-        ' targets and using existing fileinfo.')
+    logger.info('Consistent targets will not be created because targets '
+        'metadata is being generated from existing fileinfo.')
 
   if delegations is not None:
     tuf.formats.DELEGATIONS_SCHEMA.check_match(delegations)


### PR DESCRIPTION
**Fixes issue #**: N/A

**Description of the changes being introduced by the pull request**:
* Improve documentation for `generate_targets_metadata()`, in the docstring and code comments, to make the `use_existing_fileinfo` and `write_consistent_targets` arguments, and their interactions, clearer.
* Fix `generate_targets_metadata()` so that both `use_existing_fileinfo` and `write_consistent_fileinfo` can be used together, as required by Warehouse for PEP 458

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


