### PR TITLE
WIP: Remove the need of manually marking roles as dirty

### DIFF
--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -719,10 +719,10 @@ class TestMetadata(unittest.TestCase):
                 'consistent_snapshot': False, 'expires': expiration,
                 'partial_loaded': False}
 
-    tuf.roledb.add_role('Root', roleinfo, 'test_repository')
-    tuf.roledb.add_role('Targets', roleinfo, 'test_repository')
-    tuf.roledb.add_role('Snapshot', roleinfo, 'test_repository')
-    tuf.roledb.add_role('Timestamp', roleinfo, 'test_repository')
+    tuf.roledb.add_role('Root', roleinfo, repository_name='test_repository')
+    tuf.roledb.add_role('Targets', roleinfo, repository_name='test_repository')
+    tuf.roledb.add_role('Snapshot', roleinfo, repository_name='test_repository')
+    tuf.roledb.add_role('Timestamp', roleinfo, repository_name='test_repository')
 
     # Test for different top-level role names.
     self.metadata._rolename = 'Targets'

--- a/tests/test_roledb.py
+++ b/tests/test_roledb.py
@@ -119,7 +119,7 @@ class TestRoledb(unittest.TestCase):
     repository_name = 'example_repository'
     self.assertRaises(securesystemslib.exceptions.InvalidNameError, tuf.roledb.clear_roledb, repository_name)
     tuf.roledb.create_roledb(repository_name)
-    tuf.roledb.add_role(rolename, roleinfo, repository_name)
+    tuf.roledb.add_role(rolename, roleinfo, repository_name=repository_name)
     self.assertEqual(roleinfo['keyids'], tuf.roledb.get_role_keyids(rolename, repository_name))
     tuf.roledb.clear_roledb(repository_name)
     self.assertFalse(tuf.roledb.role_exists(rolename, repository_name))
@@ -151,7 +151,7 @@ class TestRoledb(unittest.TestCase):
     self.assertRaises(securesystemslib.exceptions.InvalidNameError, tuf.roledb.clear_roledb,
                                             repository_name)
     tuf.roledb.create_roledb(repository_name)
-    tuf.roledb.add_role(rolename, roleinfo, repository_name)
+    tuf.roledb.add_role(rolename, roleinfo, repository_name=repository_name)
     self.assertEqual(roleinfo['keyids'], tuf.roledb.get_role_keyids(rolename,
                                          repository_name))
 
@@ -166,7 +166,8 @@ class TestRoledb(unittest.TestCase):
     self.assertRaises(securesystemslib.exceptions.FormatError, tuf.roledb.add_role, rolename, None)
     self.assertRaises(securesystemslib.exceptions.FormatError, tuf.roledb.add_role, rolename, 123)
     self.assertRaises(securesystemslib.exceptions.FormatError, tuf.roledb.add_role, rolename, [''])
-    self.assertRaises(securesystemslib.exceptions.FormatError, tuf.roledb.add_role, rolename, roleinfo, 123)
+    self.assertRaises(securesystemslib.exceptions.FormatError, tuf.roledb.add_role, rolename, roleinfo, False, 123)
+    self.assertRaises(securesystemslib.exceptions.FormatError, tuf.roledb.add_role, rolename, roleinfo, [])
 
 
     # Test condition where the rolename already exists in the role database.
@@ -175,7 +176,7 @@ class TestRoledb(unittest.TestCase):
 
     # Test where the repository name does not exist in the role database.
     self.assertRaises(securesystemslib.exceptions.InvalidNameError, tuf.roledb.add_role,
-                      'new_role', roleinfo, 'non-existent')
+                      'new_role', roleinfo, repository_name='non-existent')
 
     # Test conditions for invalid rolenames.
     self.assertRaises(securesystemslib.exceptions.InvalidNameError, tuf.roledb.add_role, ' badrole ',
@@ -206,7 +207,7 @@ class TestRoledb(unittest.TestCase):
 
     tuf.roledb.create_roledb(repository_name)
     self.assertEqual(False, tuf.roledb.role_exists(rolename, repository_name))
-    tuf.roledb.add_role(rolename, roleinfo, repository_name)
+    tuf.roledb.add_role(rolename, roleinfo, repository_name=repository_name)
     self.assertTrue(tuf.roledb.role_exists(rolename, repository_name))
 
     # Reset the roledb so that subsequent tests have access to the original,
@@ -251,7 +252,7 @@ class TestRoledb(unittest.TestCase):
     self.assertRaises(securesystemslib.exceptions.InvalidNameError, tuf.roledb.remove_role, rolename, repository_name)
     tuf.roledb.create_roledb(repository_name)
 
-    tuf.roledb.add_role(rolename, roleinfo, repository_name)
+    tuf.roledb.add_role(rolename, roleinfo, repository_name=repository_name)
     self.assertEqual(roleinfo['keyids'], tuf.roledb.get_role_keyids(rolename, repository_name))
     self.assertEqual(None, tuf.roledb.remove_role(rolename, repository_name))
 
@@ -293,8 +294,8 @@ class TestRoledb(unittest.TestCase):
     repository_name = 'example_repository'
     self.assertRaises(securesystemslib.exceptions.InvalidNameError, tuf.roledb.get_rolenames, repository_name)
     tuf.roledb.create_roledb(repository_name)
-    tuf.roledb.add_role(rolename, roleinfo, repository_name)
-    tuf.roledb.add_role(rolename2, roleinfo, repository_name)
+    tuf.roledb.add_role(rolename, roleinfo, repository_name=repository_name)
+    tuf.roledb.add_role(rolename2, roleinfo, repository_name=repository_name)
 
     self.assertEqual(set(['targets', 'role1']),
                      set(tuf.roledb.get_rolenames()))
@@ -328,7 +329,7 @@ class TestRoledb(unittest.TestCase):
                                             rolename, repository_name)
 
     tuf.roledb.create_roledb(repository_name)
-    tuf.roledb.add_role(rolename, roleinfo, repository_name)
+    tuf.roledb.add_role(rolename, roleinfo, repository_name=repository_name)
     self.assertEqual(roleinfo, tuf.roledb.get_roleinfo(rolename, repository_name))
 
     # Verify that a roleinfo cannot be retrieved for a non-existent repository
@@ -368,7 +369,7 @@ class TestRoledb(unittest.TestCase):
     self.assertRaises(securesystemslib.exceptions.InvalidNameError, tuf.roledb.get_role_keyids,
                                             rolename, repository_name)
     tuf.roledb.create_roledb(repository_name)
-    tuf.roledb.add_role(rolename, roleinfo, repository_name)
+    tuf.roledb.add_role(rolename, roleinfo, repository_name=repository_name)
     self.assertEqual(['123'], tuf.roledb.get_role_keyids(rolename, repository_name))
 
     # Verify that rolekeyids cannot be retrieved from a non-existent repository
@@ -406,7 +407,7 @@ class TestRoledb(unittest.TestCase):
     self.assertRaises(securesystemslib.exceptions.InvalidNameError, tuf.roledb.get_role_threshold,
                                             rolename, repository_name)
     tuf.roledb.create_roledb(repository_name)
-    tuf.roledb.add_role(rolename, roleinfo, repository_name)
+    tuf.roledb.add_role(rolename, roleinfo, repository_name=repository_name)
     self.assertEqual(roleinfo['threshold'], tuf.roledb.get_role_threshold(rolename, repository_name))
 
     # Verify that a role's threshold cannot be retrieved from a non-existent
@@ -445,7 +446,7 @@ class TestRoledb(unittest.TestCase):
                                             rolename, repository_name)
 
     tuf.roledb.create_roledb(repository_name)
-    tuf.roledb.add_role(rolename2, roleinfo2, repository_name)
+    tuf.roledb.add_role(rolename2, roleinfo2, repository_name=repository_name)
     self.assertEqual(roleinfo2['paths'], tuf.roledb.get_role_paths(rolename2,
                                          repository_name))
 
@@ -516,7 +517,7 @@ class TestRoledb(unittest.TestCase):
     self.assertRaises(securesystemslib.exceptions.InvalidNameError, tuf.roledb.get_delegated_rolenames,
                                            rolename, repository_name)
     tuf.roledb.create_roledb(repository_name)
-    tuf.roledb.add_role(rolename, roleinfo, repository_name)
+    tuf.roledb.add_role(rolename, roleinfo, repository_name=repository_name)
     self.assertEqual(set(['django', 'tuf']),
                      set(tuf.roledb.get_delegated_rolenames(rolename, repository_name)))
 
@@ -635,7 +636,7 @@ class TestRoledb(unittest.TestCase):
     mark_role_as_dirty = True
     self.assertRaises(securesystemslib.exceptions.InvalidNameError, tuf.roledb.clear_roledb, repository_name)
     tuf.roledb.create_roledb(repository_name)
-    tuf.roledb.add_role(rolename, roleinfo, repository_name)
+    tuf.roledb.add_role(rolename, roleinfo, repository_name=repository_name)
     tuf.roledb.update_roleinfo(rolename, roleinfo, mark_role_as_dirty, repository_name)
     self.assertEqual(roleinfo['keyids'], tuf.roledb.get_role_keyids(rolename, repository_name))
 
@@ -680,7 +681,7 @@ class TestRoledb(unittest.TestCase):
     # repository.
     repository_name = 'example_repository'
     tuf.roledb.create_roledb(repository_name)
-    tuf.roledb.add_role(rolename, roleinfo1, repository_name)
+    tuf.roledb.add_role(rolename, roleinfo1, repository_name=repository_name)
     tuf.roledb.update_roleinfo(rolename, roleinfo2, mark_role_as_dirty, repository_name)
     self.assertEqual([rolename], tuf.roledb.get_dirty_roles(repository_name))
 

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -193,10 +193,11 @@ class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
     targets_private = repo_tool.import_ed25519_privatekey_from_file(key_file,
                                                                   'password')
 
-    repository.targets.load_signing_key(targets_private)
-    repository.snapshot.load_signing_key(snapshot_private)
-    repository.timestamp.load_signing_key(timestamp_private)
-
+    # Mark roles as dirty to force metadata rewrite on writeall()
+    mark_dirty = True
+    repository.targets.load_signing_key(targets_private, mark_dirty)
+    repository.snapshot.load_signing_key(snapshot_private, mark_dirty)
+    repository.timestamp.load_signing_key(timestamp_private, mark_dirty)
     repository.writeall()
 
     # Move the staged metadata to the "live" metadata.

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -284,9 +284,8 @@ class TestTutorial(unittest.TestCase):
       repository.dirty_roles()
       # Concat strings to avoid Python2/3 unicode prefix problems ('' vs. u'')
       mock_logger.info.assert_called_with(
-          "Dirty roles: " + str(['targets']))
+          "Dirty roles: " + str(['snapshot', 'targets', 'timestamp']))
 
-    repository.mark_dirty(['snapshot', 'timestamp'])
     repository.writeall()
 
 
@@ -326,9 +325,8 @@ class TestTutorial(unittest.TestCase):
       repository.dirty_roles()
       # Concat strings to avoid Python2/3 unicode prefix problems ('' vs. u'')
       mock_logger.info.assert_called_with(
-          "Dirty roles: " + str(['targets', 'unclaimed']))
+          "Dirty roles: " + str(['snapshot', 'targets', 'timestamp', 'unclaimed']))
 
-    repository.mark_dirty(["snapshot", "timestamp"])
     repository.writeall()
 
 
@@ -378,9 +376,8 @@ class TestTutorial(unittest.TestCase):
           '28-2f', '30-37', '38-3f', '40-47', '48-4f', '50-57', '58-5f',
           '60-67', '68-6f', '70-77', '78-7f', '80-87', '88-8f', '90-97',
           '98-9f', 'a0-a7', 'a8-af', 'b0-b7', 'b8-bf', 'c0-c7', 'c8-cf',
-          'd0-d7', 'd8-df', 'e0-e7', 'e8-ef', 'f0-f7', 'f8-ff', 'unclaimed']))
+          'd0-d7', 'd8-df', 'e0-e7', 'e8-ef', 'f0-f7', 'f8-ff', 'snapshot', 'timestamp', 'unclaimed']))
 
-    repository.mark_dirty(["snapshot", "timestamp"])
     repository.writeall()
 
     # ----- Tutorial Section: How to Perform an Update

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -813,7 +813,8 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     tuf.SPECIFICATION_VERSION = '0.9.0'
 
     repository = repo_tool.load_repository(self.repository_directory)
-    repository.timestamp.load_signing_key(self.role_keys['timestamp']['private'])
+    repository.timestamp.load_signing_key(
+        self.role_keys['timestamp']['private'], True)
     repository.writeall()
 
     # Move the staged metadata to the "live" metadata.
@@ -1283,10 +1284,16 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # is now being set to true (i.e., the pre-generated repository isn't set
     # to support consistent snapshots.  A new version of targets.json is needed
     # to ensure <digest>.filename target files are written to disk.
-    repository.targets.load_signing_key(self.role_keys['targets']['private'])
-    repository.root.load_signing_key(self.role_keys['root']['private'])
-    repository.snapshot.load_signing_key(self.role_keys['snapshot']['private'])
-    repository.timestamp.load_signing_key(self.role_keys['timestamp']['private'])
+    # Mark roles as dirty to force metadata rewrite on writeall()
+    mark_role_as_dirty = True
+    repository.targets.load_signing_key(self.role_keys['targets']['private'],
+        mark_role_as_dirty)
+    repository.root.load_signing_key(self.role_keys['root']['private'],
+        mark_role_as_dirty)
+    repository.snapshot.load_signing_key(self.role_keys['snapshot']['private'],
+        mark_role_as_dirty)
+    repository.timestamp.load_signing_key(self.role_keys['timestamp']['private'],
+        mark_role_as_dirty)
 
     repository.writeall(consistent_snapshot=True)
 

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -984,7 +984,7 @@ class Updater(object):
         # is None.
         rolename = roleinfo.get('name')
         logger.debug('Adding delegated role: ' + str(rolename) + '.')
-        tuf.roledb.add_role(rolename, roleinfo, self.repository_name)
+        tuf.roledb.add_role(rolename, roleinfo, repository_name=self.repository_name)
 
       except tuf.exceptions.RoleAlreadyExistsError:
         logger.warning('Role already exists: ' + rolename)

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -755,7 +755,7 @@ class Updater(object):
 
     # Load current and previous metadata.
     for metadata_set in ['current', 'previous']:
-      for metadata_role in ['root', 'targets', 'snapshot', 'timestamp']:
+      for metadata_role in tuf.roledb.TOP_LEVEL_ROLES:
         self._load_metadata_from_file(metadata_set, metadata_role)
 
     # Raise an exception if the repository is missing the required 'root'
@@ -2435,7 +2435,7 @@ class Updater(object):
     # all roles available on the repository.
     delegated_targets = []
     for role in tuf.roledb.get_rolenames(self.repository_name):
-      if role in ['root', 'snapshot', 'targets', 'timestamp']:
+      if role in tuf.roledb.TOP_LEVEL_ROLES:
         continue
 
       else:

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -293,7 +293,7 @@ class Repository(object):
     for dirty_rolename in dirty_rolenames:
 
       # Ignore top-level roles, they will be generated later in this method.
-      if dirty_rolename in ['root', 'targets', 'snapshot', 'timestamp']:
+      if dirty_rolename in tuf.roledb.TOP_LEVEL_ROLES:
         continue
 
       dirty_filename = os.path.join(self._metadata_directory,

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -815,7 +815,7 @@ class Metadata(object):
 
 
 
-  def load_signing_key(self, key):
+  def load_signing_key(self, key, mark_role_as_dirty=False):
     """
     <Purpose>
       Load the role key, which must contain the private portion, so that role
@@ -832,6 +832,12 @@ class Metadata(object):
         It must contain the private key, so that role signatures may be
         generated when writeall() or write() is eventually called to generate
         valid metadata files.
+
+      mark_role_as_dirty:
+        A boolean indicating whether the updated 'roleinfo' for 'rolename'
+        should be marked as dirty.  The caller might not want to mark
+        'rolename' as dirty if it is loading metadata from disk and only wants
+        to populate roledb.py.
 
     <Exceptions>
       securesystemslib.exceptions.FormatError, if 'key' is improperly formatted.
@@ -870,12 +876,12 @@ class Metadata(object):
     if key['keyid'] not in roleinfo['signing_keyids']:
       roleinfo['signing_keyids'].append(key['keyid'])
 
-      tuf.roledb.update_roleinfo(self.rolename, roleinfo,
+      tuf.roledb.update_roleinfo(self.rolename, roleinfo, mark_role_as_dirty,
           repository_name=self._repository_name)
 
 
 
-  def unload_signing_key(self, key):
+  def unload_signing_key(self, key, mark_role_as_dirty=False):
     """
     <Purpose>
       Remove a previously loaded role private key (i.e., load_signing_key()).
@@ -890,6 +896,12 @@ class Metadata(object):
       key:
         The role key to be unloaded, conformant to
         'securesystemslib.formats.ANYKEY_SCHEMA'.
+
+      mark_role_as_dirty:
+        A boolean indicating whether the updated 'roleinfo' for 'rolename'
+        should be marked as dirty.  The caller might not want to mark
+        'rolename' as dirty if it is loading metadata from disk and only wants
+        to populate roledb.py.
 
     <Exceptions>
       securesystemslib.exceptions.FormatError, if the 'key' argument is
@@ -920,7 +932,7 @@ class Metadata(object):
     if key['keyid'] in roleinfo['signing_keyids']:
       roleinfo['signing_keyids'].remove(key['keyid'])
 
-      tuf.roledb.update_roleinfo(self.rolename, roleinfo,
+      tuf.roledb.update_roleinfo(self.rolename, roleinfo, mark_role_as_dirty,
           repository_name=self._repository_name)
 
     else:
@@ -991,7 +1003,7 @@ class Metadata(object):
 
 
 
-  def remove_signature(self, signature):
+  def remove_signature(self, signature, mark_role_as_dirty=True):
     """
     <Purpose>
       Remove a previously loaded, or added, role 'signature'.  A role must
@@ -1005,6 +1017,12 @@ class Metadata(object):
       signature:
         The role signature to remove, conformant to
         'securesystemslib.formats.SIGNATURE_SCHEMA'.
+
+      mark_role_as_dirty:
+        A boolean indicating whether the updated 'roleinfo' for 'rolename'
+        should be marked as dirty.  The caller might not want to mark
+        'rolename' as dirty if it is loading metadata from disk and only wants
+        to populate roledb.py.
 
     <Exceptions>
       securesystemslib.exceptions.FormatError, if the 'signature' argument is
@@ -1031,7 +1049,7 @@ class Metadata(object):
     if signature in roleinfo['signatures']:
       roleinfo['signatures'].remove(signature)
 
-      tuf.roledb.update_roleinfo(self.rolename, roleinfo,
+      tuf.roledb.update_roleinfo(self.rolename, roleinfo, mark_role_as_dirty,
           repository_name=self._repository_name)
 
     else:

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -1665,7 +1665,8 @@ class Targets(Metadata):
   """
 
   def __init__(self, targets_directory, rolename='targets', roleinfo=None,
-               parent_targets_object=None, repository_name='default'):
+               parent_targets_object=None, mark_role_as_dirty=False,
+               repository_name='default'):
 
     # Do the arguments have the correct format?
     # Ensure the arguments have the appropriate number of objects and object
@@ -1708,7 +1709,7 @@ class Targets(Metadata):
 
     # Add the new role to the 'tuf.roledb'.
     try:
-      tuf.roledb.add_role(self.rolename, roleinfo,
+      tuf.roledb.add_role(self.rolename, roleinfo, mark_role_as_dirty,
           repository_name=self._repository_name)
 
     except tuf.exceptions.RoleAlreadyExistsError:
@@ -2234,6 +2235,7 @@ class Targets(Metadata):
     # The new targets object is added as an attribute to this Targets object.
     new_targets_object = Targets(self._targets_directory, rolename, roleinfo,
         parent_targets_object=self._parent_targets_object,
+        mark_role_as_dirty=True,
         repository_name=self._repository_name)
 
     return new_targets_object

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -961,10 +961,7 @@ class Metadata(object):
         A boolean indicating whether the updated 'roleinfo' for 'rolename'
         should be marked as dirty.  The caller might not want to mark
         'rolename' as dirty if it is loading metadata from disk and only wants
-        to populate roledb.py.  Likewise, add_role() would support a similar
-        boolean to allow the repository tools to successfully load roles via
-        load_repository() without needing to mark these roles as dirty (default
-        behavior).
+        to populate roledb.py.
 
     <Exceptions>
       securesystemslib.exceptions.FormatError, if the 'signature' argument is
@@ -1468,7 +1465,8 @@ class Root(Metadata):
                 'signatures': [], 'version': 0, 'consistent_snapshot': False,
                 'expires': expiration, 'partial_loaded': False}
     try:
-      tuf.roledb.add_role(self._rolename, roleinfo, self._repository_name)
+      tuf.roledb.add_role(self._rolename, roleinfo,
+          repository_name=self._repository_name)
 
     except tuf.exceptions.RoleAlreadyExistsError:
       pass
@@ -1537,7 +1535,8 @@ class Timestamp(Metadata):
                 'partial_loaded': False}
 
     try:
-      tuf.roledb.add_role(self.rolename, roleinfo, self._repository_name)
+      tuf.roledb.add_role(self.rolename, roleinfo,
+          repository_name=self._repository_name)
 
     except tuf.exceptions.RoleAlreadyExistsError:
       pass
@@ -1600,7 +1599,8 @@ class Snapshot(Metadata):
                 'partial_loaded': False}
 
     try:
-      tuf.roledb.add_role(self._rolename, roleinfo, self._repository_name)
+      tuf.roledb.add_role(self._rolename, roleinfo,
+          repository_name=self._repository_name)
 
     except tuf.exceptions.RoleAlreadyExistsError:
       pass
@@ -1708,7 +1708,8 @@ class Targets(Metadata):
 
     # Add the new role to the 'tuf.roledb'.
     try:
-      tuf.roledb.add_role(self.rolename, roleinfo, self._repository_name)
+      tuf.roledb.add_role(self.rolename, roleinfo,
+          repository_name=self._repository_name)
 
     except tuf.exceptions.RoleAlreadyExistsError:
       pass
@@ -3190,7 +3191,8 @@ def load_repository(repository_directory, repository_name='default',
       roleinfo['paths'].update({filepath: fileinfo.get('custom', {})})
     roleinfo['delegations'] = metadata_object['delegations']
 
-    tuf.roledb.add_role(metadata_name, roleinfo, repository_name)
+    tuf.roledb.add_role(metadata_name, roleinfo,
+        repository_name=repository_name)
     loaded_metadata.append(metadata_name)
 
     # Generate the Targets objects of the delegated roles of 'metadata_name'

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -88,6 +88,9 @@ _delegating_role = {'root': None,
                     'snapshot': 'root',
                     'targets': 'root'}
 
+TOP_LEVEL_ROLES = ['root', 'targets', 'snapshot', 'timestamp']
+
+
 def create_roledb_from_root_metadata(root_metadata, repository_name='default'):
   """
   <Purpose>

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -447,9 +447,6 @@ def get_dirty_roles(repository_name='default'):
   # 'securesystemslib.exceptions.FormatError' if not.
   securesystemslib.formats.NAME_SCHEMA.check_match(repository_name)
 
-  global _roledb_dict
-  global _dirty_roles
-
   if repository_name not in _roledb_dict or repository_name not in _dirty_roles:
     raise securesystemslib.exceptions.InvalidNameError('Repository name does'
       '  not' ' exist: ' + repository_name)
@@ -490,7 +487,6 @@ def mark_dirty(roles, repository_name='default'):
   securesystemslib.formats.NAMES_SCHEMA.check_match(roles)
   securesystemslib.formats.NAME_SCHEMA.check_match(repository_name)
 
-  global _roledb_dict
   global _dirty_roles
 
   if repository_name not in _roledb_dict or repository_name not in _dirty_roles:
@@ -533,7 +529,6 @@ def unmark_dirty(roles, repository_name='default'):
   securesystemslib.formats.NAMES_SCHEMA.check_match(roles)
   securesystemslib.formats.NAME_SCHEMA.check_match(repository_name)
 
-  global _roledb_dict
   global _dirty_roles
 
   if repository_name not in _roledb_dict or repository_name not in _dirty_roles:
@@ -639,7 +634,6 @@ def remove_role(rolename, repository_name='default'):
   _check_rolename(rolename, repository_name)
 
   global _roledb_dict
-  global _dirty_roles
 
   # 'rolename' was verified to exist in _check_rolename().
   # Remove 'rolename' now.
@@ -676,9 +670,6 @@ def get_rolenames(repository_name='default'):
   # Does 'repository_name' have the correct format?  Raise
   # 'securesystemslib.exceptions.FormatError' if it is improperly formatted.
   securesystemslib.formats.NAME_SCHEMA.check_match(repository_name)
-
-  global _roledb_dict
-  global _dirty_roles
 
   if repository_name not in _roledb_dict or repository_name not in _dirty_roles:
     raise securesystemslib.exceptions.InvalidNameError('Repository name does'
@@ -740,9 +731,6 @@ def get_roleinfo(rolename, repository_name='default'):
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
 
-  global _roledb_dict
-  global _dirty_roles
-
   return copy.deepcopy(_roledb_dict[repository_name][rolename])
 
 
@@ -793,9 +781,6 @@ def get_role_keyids(rolename, repository_name='default'):
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
 
-  global _roledb_dict
-  global _dirty_roles
-
   roleinfo = _roledb_dict[repository_name][rolename]
 
   return roleinfo['keyids']
@@ -845,9 +830,6 @@ def get_role_threshold(rolename, repository_name='default'):
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
 
-  global _roledb_dict
-  global _dirty_roles
-
   roleinfo = _roledb_dict[repository_name][rolename]
 
   return roleinfo['threshold']
@@ -895,9 +877,6 @@ def get_role_paths(rolename, repository_name='default'):
   # tuf.exceptions.UnknownRoleError, or
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
-
-  global _roledb_dict
-  global _dirty_roles
 
   roleinfo = _roledb_dict[repository_name][rolename]
 
@@ -955,9 +934,6 @@ def get_delegated_rolenames(rolename, repository_name='default'):
   # tuf.exceptions.UnknownRoleError, or
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
-
-  global _roledb_dict
-  global _dirty_roles
 
   # get_roleinfo() raises a 'securesystemslib.exceptions.InvalidNameError' if
   # 'repository_name' does not exist in the role database.
@@ -1044,9 +1020,6 @@ def _check_rolename(rolename, repository_name='default'):
 
   # Raises securesystemslib.exceptions.InvalidNameError.
   _validate_rolename(rolename)
-
-  global _roledb_dict
-  global _dirty_roles
 
   if repository_name not in _roledb_dict or repository_name not in _dirty_roles:
     raise securesystemslib.exceptions.InvalidNameError('Repository name does not'


### PR DESCRIPTION
**Fixes issue #**: #964 #958

**Note:** Although the best solution is undoubtedly to go for a general rework of the internal metadata representation, this pull request aims to be a short-term fix keeping the changes as close as possible to the current functionality.

I am opening it as a WIP to discuss the possible ways to handle some more complicated delegations scenarios.

**Description of the changes being introduced by the pull request**:

Remove the need of manually marking dirty all roles whose metadata needs to be (re)written on the filesystem:
- fix functions like `Metadata.load_signing_key()` that mark a role as dirty, although it shouldn't update the corresponding metadata on filesystem.
- add `mark_role_as_dirty` parameter to `roledb.add_role()` and `Targets` class which is needed to mark newly created delegated roles as dirty
- add `roledb. _propagate_dirty_roles()`  which recursively marks as dirty all roles affected by a roledb update according to the role dependencies graph e.g.:
   
```
   any update on targets:  'targets' -> 'snapshot' -> 'timestamp'
   update on targets' key: 'targets' -> 'root'
```

_Note that the dependencies is the implementation are reversed in comparison with the specification: a targets key update is performed on the Targets object which then needs to be propagated to the root metadata._

- add 'delegating_role' to role metadata dictionary. This is needed to be able to propagate an update of the delegated role to the delegating. 

` 'unclaimed' -> 'targets' -> 'snapshot' -> 'timestamp'` 

**Open for discussion:** What would be the purpose of a chain of delegations where two roles both delegate to a third?

```
   targets -> A -> C
   targets -> B -> C
```

Are both A and B delegating the same key and paths/targets to C? Is a scenario where each A and B delegates a different key to a role with the same name (C) meaningful? What should be the chain of interdependencies if C's key is updated?

While working on this I also noticed that delegating role is not updated at all when the delegated role's key is changed (check #1037).

In addition: 
- do some code cleanup and remove repetitive code from `Repository.status()` (#955 )

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


