### PR TITLE
tuf/repository_tool: Return delegated bin_name during modifications

### DIFF
--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1495,10 +1495,10 @@ class TestTargets(unittest.TestCase):
 
     # Add 'target1_filepath' and verify that the relative path of
     # 'target1_filepath' is added to the correct bin.
-    self.targets_object.add_target_to_bin(target1_filepath, 16)
+    rolename = self.targets_object.add_target_to_bin(target1_filepath, 16)
 
     for delegation in self.targets_object.delegations:
-      if delegation.rolename == '5':
+      if delegation.rolename == rolename:
         self.assertTrue('file1.txt' in delegation.target_files)
 
       else:
@@ -1513,7 +1513,7 @@ class TestTargets(unittest.TestCase):
                       target1_filepath, 16)
 
     # Test for a required hashed bin that does not exist.
-    self.targets_object.revoke('5')
+    self.targets_object.revoke(rolename)
     self.assertRaises(securesystemslib.exceptions.Error,
                       self.targets_object.add_target_to_bin,
                       target1_filepath, 16)
@@ -1523,10 +1523,11 @@ class TestTargets(unittest.TestCase):
     target2_fileinfo = tuf.formats.make_fileinfo(37, target2_hashes)
     target2_filepath = 'file2.txt'
 
-    self.targets_object.add_target_to_bin(target2_filepath, 16, fileinfo=target2_fileinfo)
+    rolename = self.targets_object.add_target_to_bin(target2_filepath, 16,
+        fileinfo=target2_fileinfo)
 
     for delegation in self.targets_object.delegations:
-      if delegation.rolename == '0':
+      if delegation.rolename == rolename:
         self.assertTrue(target2_filepath in delegation.target_files)
 
       else:

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1562,10 +1562,10 @@ class TestTargets(unittest.TestCase):
 
     # Add 'target1_filepath' and verify that the relative path of
     # 'target1_filepath' is added to the correct bin.
-    self.targets_object.add_target_to_bin(target1_filepath, 16)
+    added_rolename = self.targets_object.add_target_to_bin(target1_filepath, 16)
 
     for delegation in self.targets_object.delegations:
-      if delegation.rolename == '5':
+      if delegation.rolename == added_rolename:
         self.assertTrue('file1.txt' in delegation.target_files)
         self.assertTrue(len(delegation.target_files) == 1)
       else:
@@ -1573,7 +1573,8 @@ class TestTargets(unittest.TestCase):
 
     # Test the remove_target_from_bin() method.  Verify that 'target1_filepath'
     # has been removed.
-    self.targets_object.remove_target_from_bin(target1_filepath, 16)
+    removed_rolename = self.targets_object.remove_target_from_bin(target1_filepath, 16)
+    self.assertEqual(added_rolename, removed_rolename)
 
     for delegation in self.targets_object.delegations:
       self.assertTrue(target1_filepath not in delegation.target_files)
@@ -1609,17 +1610,19 @@ class TestTargets(unittest.TestCase):
 
     # Add 'target1_filepath' and verify that the relative path of
     # 'target1_filepath' is added to the correct bin.
-    self.targets_object.add_target_to_bin(os.path.basename(target1_filepath))
+    added_rolename = self.targets_object.add_target_to_bin(os.path.basename(target1_filepath))
 
     for delegation in self.targets_object.delegations:
-      if delegation.rolename == '558-55b':
+      if delegation.rolename == added_rolename:
         self.assertTrue('file1.txt' in delegation.target_files)
 
       else:
         self.assertFalse('file1.txt' in delegation.target_files)
 
     # Remove target1_filepath and verify that all bins are now empty
-    self.targets_object.remove_target_from_bin(os.path.basename(target1_filepath))
+    removed_rolename = self.targets_object.remove_target_from_bin(
+        os.path.basename(target1_filepath))
+    self.assertEqual(added_rolename, removed_rolename)
 
     for delegation in self.targets_object.delegations:
       self.assertEqual(delegation.target_files, {})

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2666,7 +2666,7 @@ class Targets(Metadata):
       object.
 
     <Returns>
-      None.
+      The name of the hashed bin that the target was added to.
     """
 
     # Do the arguments have the correct format?
@@ -2689,6 +2689,7 @@ class Targets(Metadata):
     self._delegated_roles[bin_name].add_target(target_filepath,
         fileinfo=fileinfo)
 
+    return bin_name
 
 
 
@@ -2727,7 +2728,7 @@ class Targets(Metadata):
       Targets object.
 
     <Returns>
-      None.
+      The name of the hashed bin that the target was added to.
     """
 
     # Do the arguments have the correct format?
@@ -2749,7 +2750,7 @@ class Targets(Metadata):
 
     self._delegated_roles[bin_name].remove_target(target_filepath)
 
-
+    return bin_name
 
 
   @property


### PR DESCRIPTION

**Fixes issue #**: None (raised on chat).

**Description of the changes being introduced by the pull request**:

This makes it easier for consumers of `repository_tool` to mark the
appropriate delegated bin as dirty when using delegated targets.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature

I wasn't sure how to go about adding tests for this; I can look into the `test_repository_tool.py` tests to see what can be done.
