### PR TITLE
Silence the log messages during a test run

### DIFF
--- a/tests/slow_retrieval_server.py
+++ b/tests/slow_retrieval_server.py
@@ -83,6 +83,9 @@ class Handler(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):
     except IOError as e:
       self.send_error(404, 'File Not Found!')
 
+  # Override log_request
+  def log_request(self, code='-', size='-'):
+    pass
 
 
 def get_random_port():

--- a/tuf/log.py
+++ b/tuf/log.py
@@ -375,8 +375,6 @@ def remove_console_handler():
     console_handler = None
     logger.debug('Removed a console handler.')
 
-  else:
-    logger.warning('We do not have a console handler.')
 
 
 


### PR DESCRIPTION
**Fixes issue #**: https://github.com/theupdateframework/tuf/issues/1039

**Description of the changes being introduced by the pull request**:

1. Filter the `GET` request messages from `tests/slow_retrieval.py`:
![image](https://user-images.githubusercontent.com/16246778/83541406-4424c700-a502-11ea-98d2-88737c013fe4.png)

2. Filter the `code 404, message File not found` error messages:
![image](https://user-images.githubusercontent.com/16246778/83541512-66b6e000-a502-11ea-86f1-d9cdaa3e41bb.png)

3. Remove `We do not have a console handler` warnings.


**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


