### PR TITLE
Load full target file info for delegated targets metadata

### DIFF
--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -2073,6 +2073,22 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     self.assertTrue('file2.txt' in repository.targets.target_files)
     self.assertTrue('file3.txt' in repository.targets('role1').target_files)
 
+    # Test if targets file info is loaded correctly: read the JSON metadata
+    # files separately and then compare with the loaded repository data.
+    targets_path = os.path.join(metadata_directory, 'targets.json')
+    role1_path = os.path.join(metadata_directory, 'role1.json')
+
+    targets_object = securesystemslib.util.load_json_file(targets_path)
+    role1_object = securesystemslib.util.load_json_file(role1_path)
+
+    targets_fileinfo = targets_object['signed']['targets']
+    role1_fileinfo = role1_object['signed']['targets']
+
+    repository = repo_tool.load_repository(repository_directory)
+
+    self.assertEqual(targets_fileinfo, repository.targets.target_files)
+    self.assertEqual(role1_fileinfo, repository.targets('role1').target_files)
+
     # Test for a non-default repository name.
     repository = repo_tool.load_repository(repository_directory, 'my-repo')
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -614,8 +614,7 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
 
     # Update 'targets.json' in 'tuf.roledb.py'
     roleinfo = tuf.roledb.get_roleinfo('targets', repository_name)
-    for filepath, fileinfo in six.iteritems(targets_metadata['targets']):
-      roleinfo['paths'].update({filepath: fileinfo})
+    roleinfo['paths'] = targets_metadata['targets']
     roleinfo['version'] = targets_metadata['version']
     roleinfo['expires'] = targets_metadata['expires']
     roleinfo['delegations'] = targets_metadata['delegations']

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -3161,16 +3161,13 @@ def load_repository(repository_directory, repository_name='default',
     roleinfo = {'name': metadata_name,
                 'signing_keyids': [],
                 'signatures': [],
-                'partial_loaded': False,
-                'paths': {},
+                'partial_loaded': False
                }
 
     roleinfo['signatures'].extend(signable['signatures'])
     roleinfo['version'] = metadata_object['version']
     roleinfo['expires'] = metadata_object['expires']
-
-    for filepath, fileinfo in six.iteritems(metadata_object['targets']):
-      roleinfo['paths'].update({filepath: fileinfo.get('custom', {})})
+    roleinfo['paths'] = metadata_object['targets']
     roleinfo['delegations'] = metadata_object['delegations']
 
     tuf.roledb.add_role(metadata_name, roleinfo, repository_name)


### PR DESCRIPTION

**Fixes issue #**: #1046

**Description of the changes being introduced by the pull request**:

- Fix `load_repository()` to actually load the full targets file info from file system for delegated targets.
- Update `_load_top_level_metadata()` to load targets and delegated targets metadata in a consistent way.
- Add a test case checking if targets file info is loaded correctly.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature
