### PR TITLE
Load correctly the delegated Targets objects hierarchy

### DIFF
--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -201,7 +201,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
 
 
 
-  def test_get_metadata_filenames(self):
+  def test_get_top_level_metadata_filenames(self):
 
     # Test normal case.
     metadata_directory = os.path.join('metadata/')
@@ -210,7 +210,8 @@ class TestRepositoryToolFunctions(unittest.TestCase):
                  'snapshot.json': metadata_directory + 'snapshot.json',
                  'timestamp.json': metadata_directory + 'timestamp.json'}
 
-    self.assertEqual(filenames, repo_lib.get_metadata_filenames('metadata/'))
+    self.assertEqual(filenames,
+        repo_lib.get_top_level_metadata_filenames('metadata/'))
 
     # If a directory argument is not specified, the current working directory
     # is used.
@@ -219,11 +220,13 @@ class TestRepositoryToolFunctions(unittest.TestCase):
                  'targets.json': os.path.join(metadata_directory, 'targets.json'),
                  'snapshot.json': os.path.join(metadata_directory, 'snapshot.json'),
                  'timestamp.json': os.path.join(metadata_directory, 'timestamp.json')}
-    self.assertEqual(filenames, repo_lib.get_metadata_filenames(metadata_directory))
+    self.assertEqual(filenames,
+        repo_lib.get_top_level_metadata_filenames(metadata_directory))
 
 
     # Test improperly formatted argument.
-    self.assertRaises(securesystemslib.exceptions.FormatError, repo_lib.get_metadata_filenames, 3)
+    self.assertRaises(securesystemslib.exceptions.FormatError,
+        repo_lib.get_top_level_metadata_filenames, 3)
 
 
 
@@ -797,7 +800,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     storage_backend = securesystemslib.storage.FilesystemBackend()
     repo_lib.write_metadata_file(signable, root_file, 8, False, storage_backend)
 
-    filenames = repo_lib.get_metadata_filenames(metadata_directory)
+    filenames = repo_lib.get_top_level_metadata_filenames(metadata_directory)
     repository = repo_tool.create_new_repository(repository_directory, repository_name)
     repo_lib._load_top_level_metadata(repository, filenames, repository_name)
 

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -2053,6 +2053,10 @@ class TestRepositoryToolFunctions(unittest.TestCase):
 
     repository = repo_tool.load_repository(repository_directory)
     self.assertTrue(isinstance(repository, repo_tool.Repository))
+    self.assertTrue(isinstance(repository.targets('role1'),
+        repo_tool.Targets))
+    self.assertTrue(isinstance(repository.targets('role1')('role2'),
+        repo_tool.Targets))
 
     # Verify the expected roles have been loaded.  See
     # 'tuf/tests/repository_data/repository/'.

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -755,7 +755,7 @@ class Updater(object):
 
     # Load current and previous metadata.
     for metadata_set in ['current', 'previous']:
-      for metadata_role in ['root', 'targets', 'snapshot', 'timestamp']:
+      for metadata_role in tuf.roledb.TOP_LEVEL_ROLES:
         self._load_metadata_from_file(metadata_set, metadata_role)
 
     # Raise an exception if the repository is missing the required 'root'
@@ -2435,7 +2435,7 @@ class Updater(object):
     # all roles available on the repository.
     delegated_targets = []
     for role in tuf.roledb.get_rolenames(self.repository_name):
-      if role in ['root', 'snapshot', 'targets', 'timestamp']:
+      if role in tuf.roledb.TOP_LEVEL_ROLES:
         continue
 
       else:

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -812,8 +812,8 @@ def import_ed25519_privatekey_from_file(filepath, password=None):
 
 
 
-def get_delegations_filenames(metadata_directory, consistent_snapshot,
-    storage_backend=None):
+def get_delegated_roles_metadata_filenames(metadata_directory,
+    consistent_snapshot, storage_backend=None):
   """
   Return a dictionary containing all filenames in 'metadata_directory'
   except the top-level roles.
@@ -861,7 +861,7 @@ def get_delegations_filenames(metadata_directory, consistent_snapshot,
 
 
 
-def get_metadata_filenames(metadata_directory):
+def get_top_level_metadata_filenames(metadata_directory):
   """
   <Purpose>
     Return a dictionary containing the filenames of the top-level roles.
@@ -1826,7 +1826,7 @@ def _log_status_of_top_level_roles(targets_directory, metadata_directory,
 
   # The expected full filenames of the top-level roles needed to write them to
   # disk.
-  filenames = get_metadata_filenames(metadata_directory)
+  filenames = get_top_level_metadata_filenames(metadata_directory)
   root_filename = filenames[ROOT_FILENAME]
   targets_filename = filenames[TARGETS_FILENAME]
   snapshot_filename = filenames[SNAPSHOT_FILENAME]

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -175,7 +175,7 @@ def _generate_and_write_metadata(rolename, metadata_filename,
   else:
     logger.debug('Not incrementing ' + repr(rolename) + '\'s version number.')
 
-  if rolename in ['root', 'targets', 'snapshot', 'timestamp'] and not allow_partially_signed:
+  if rolename in tuf.roledb.TOP_LEVEL_ROLES and not allow_partially_signed:
     # Verify that the top-level 'rolename' is fully signed.  Only a delegated
     # role should not be written to disk without full verification of its
     # signature(s), since it can only be considered fully signed depending on
@@ -394,18 +394,15 @@ def _delete_obsolete_metadata(metadata_directory, snapshot_metadata,
     else:
       logger.debug(repr(metadata_role) + ' found in the snapshot role.')
 
-
-
     # Strip metadata extension from filename.  The role database does not
     # include the metadata extension.
     if metadata_role.endswith(METADATA_EXTENSION):
       metadata_role = metadata_role[:-len(METADATA_EXTENSION)]
-
     else:
       logger.debug(repr(metadata_role) + ' does not match'
           ' supported extension ' + repr(METADATA_EXTENSION))
 
-    if metadata_role in ['root', 'targets', 'snapshot', 'timestamp']:
+    if metadata_role in tuf.roledb.TOP_LEVEL_ROLES:
       logger.debug('Not removing top-level metadata ' + repr(metadata_role))
       return
 
@@ -850,7 +847,7 @@ def get_delegated_roles_metadata_filenames(metadata_directory,
       continue
 
     # Skip top-level roles, only interested in delegated roles.
-    if metadata_name in ['root', 'snapshot', 'targets', 'timestamp']:
+    if metadata_name in tuf.roledb.TOP_LEVEL_ROLES:
       continue
 
     # Prevent reloading duplicate versions if consistent_snapshot is True
@@ -1131,7 +1128,7 @@ def generate_root_metadata(version, expiration_date, consistent_snapshot,
   # Extract the role, threshold, and keyid information of the top-level roles,
   # which Root stores in its metadata.  The necessary role metadata is generated
   # from this information.
-  for rolename in ['root', 'targets', 'snapshot', 'timestamp']:
+  for rolename in tuf.roledb.TOP_LEVEL_ROLES:
 
     # If a top-level role is missing from 'tuf.roledb.py', raise an exception.
     if not tuf.roledb.role_exists(rolename, repository_name):
@@ -1507,7 +1504,7 @@ def generate_snapshot_metadata(metadata_directory, version, expiration_date,
       # snapshot and timestamp roles are not listed in snapshot.json, do not
       # list these roles found in the metadata directory.
       if tuf.roledb.role_exists(rolename, repository_name) and \
-          rolename not in ['root', 'snapshot', 'timestamp', 'targets']:
+          rolename not in tuf.roledb.TOP_LEVEL_ROLES:
         fileinfodict[metadata_name] = get_metadata_versioninfo(rolename,
             repository_name)
 

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -295,7 +295,7 @@ class Repository(object):
     for dirty_rolename in dirty_rolenames:
 
       # Ignore top-level roles, they will be generated later in this method.
-      if dirty_rolename in ['root', 'targets', 'snapshot', 'timestamp']:
+      if dirty_rolename in tuf.roledb.TOP_LEVEL_ROLES:
         continue
 
       dirty_filename = os.path.join(self._metadata_directory,

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -3109,8 +3109,7 @@ def load_repository(repository_directory, repository_name='default',
   # The delegated targets roles form a tree/graph which is traversed in a
   # breadth-first-search manner starting from 'targets' in order to correctly
   # load the delegations hierarchy.
-  targets_objects = {}
-  targets_objects['targets'] = repository.targets
+  parent_targets_object = repository.targets
 
   # Keep the next delegations to be loaded in a deque structure which
   # has the properties of a list but is designed to have fast appends
@@ -3176,15 +3175,14 @@ def load_repository(repository_directory, repository_name='default',
     # add it to the top-level 'targets' object and to its
     # direct delegating role object.
     new_targets_object = Targets(targets_directory, rolename,
-         roleinfo, parent_targets_object=targets_objects['targets'],
+         roleinfo, parent_targets_object=parent_targets_object,
          repository_name=repository_name)
 
-    targets_objects[rolename] = new_targets_object
-
-    targets_objects['targets'].add_delegated_role(rolename,
+    parent_targets_object.add_delegated_role(rolename,
         new_targets_object)
-    targets_objects[delegating_role].add_delegated_role(rolename,
-        new_targets_object)
+    if delegating_role != 'targets':
+      parent_targets_object(delegating_role).add_delegated_role(rolename,
+          new_targets_object)
 
     # Append the next level delegations to the deque:
     # the 'delegated' role becomes the 'delegating'

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -3090,7 +3090,7 @@ def load_repository(repository_directory, repository_name='default',
   repository = Repository(repository_directory, metadata_directory,
       targets_directory, storage_backend, repository_name)
 
-  filenames = repo_lib.get_metadata_filenames(metadata_directory)
+  filenames = repo_lib.get_top_level_metadata_filenames(metadata_directory)
 
   # The Root file is always available without a version number (a consistent
   # snapshot) attached to the filename.  Store the 'consistent_snapshot' value
@@ -3102,7 +3102,7 @@ def load_repository(repository_directory, repository_name='default',
   repository, consistent_snapshot = repo_lib._load_top_level_metadata(repository,
     filenames, repository_name)
 
-  delegated_roles_filenames = repo_lib.get_delegations_filenames(
+  delegated_roles_filenames = repo_lib.get_delegated_roles_metadata_filenames(
       metadata_directory, consistent_snapshot, storage_backend)
 
   # Load the delegated targets metadata and their fileinfo.

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2393,7 +2393,7 @@ class Targets(Metadata):
       self._parent_targets_object.add_delegated_role(rolename,
           new_targets_object)
 
-    # Add 'new_targets_object' to the 'targets' role object (this object).
+    # Add 'new_targets_object' to the delegating role object (this object).
     self.add_delegated_role(rolename, new_targets_object)
 
     # Update the 'delegations' field of the current role.
@@ -3104,45 +3104,24 @@ def load_repository(repository_directory, repository_name='default',
   # extracted fileinfo is stored in the 'meta' field of the snapshot metadata
   # object.
   targets_objects = {}
-  loaded_metadata = []
   targets_objects['targets'] = repository.targets
+  # A list of delegated-delegating role pairs
+  delegations = []
 
-  metadata_files = sorted(storage_backend.list_folder(metadata_directory),
-      reverse=True)
-  for metadata_role in metadata_files:
+  delegations_filenames = repo_lib.get_delegations_filenames(metadata_directory,
+        consistent_snapshot, storage_backend)
 
-    metadata_path = os.path.join(metadata_directory, metadata_role)
-    metadata_name = \
-      metadata_path[len(metadata_directory):].lstrip(os.path.sep)
+  # Top-level roles are already loaded, fetch targets and get its delegations.
+  # Collect a list of delegated-delegating role pairs, starting from the
+  # top-level targets: [('role1', 'targets'), ('role2', 'targets'), ... ]
+  roleinfo = tuf.roledb.get_roleinfo('targets', repository_name)
+  for role in roleinfo['delegations']['roles']:
+    delegations.append([role['name'], 'targets'])
 
-    # Strip the version number if 'consistent_snapshot' is True,
-    # or if 'metadata_role' is Root.
-    # Example:  '10.django.json' --> 'django.json'
-    consistent_snapshot = \
-      metadata_role.endswith('root.json') or consistent_snapshot == True
-    metadata_name, junk = repo_lib._strip_version_number(metadata_name,
-      consistent_snapshot)
-
-    if metadata_name.endswith(METADATA_EXTENSION):
-      extension_length = len(METADATA_EXTENSION)
-      metadata_name = metadata_name[:-extension_length]
-
-    else:
-      logger.debug('Skipping file with unsupported metadata'
-          ' extension: ' + repr(metadata_path))
-      continue
-
-    # Skip top-level roles, only interested in delegated roles now that the
-    # top-level roles have already been loaded.
-    if metadata_name in ['root', 'snapshot', 'targets', 'timestamp']:
-      continue
-
-    # Keep a store of metadata previously loaded metadata to prevent re-loading
-    # duplicate versions.  Duplicate versions may occur with
-    # 'consistent_snapshot', where the same metadata may be available in
-    # multiples files (the different hash is included in each filename.
-    if metadata_name in loaded_metadata:
-      continue
+  # Load the delegated roles by starting from 'targets' and continuously
+  # appending the next level delegations to the list
+  for rolename, delegating_role in delegations:
+    metadata_path = delegations_filenames[rolename]
 
     signable = None
 
@@ -3156,9 +3135,9 @@ def load_repository(repository_directory, repository_name='default',
 
     metadata_object = signable['signed']
 
-    # Extract the metadata attributes of 'metadata_name' and update its
+    # Extract the metadata attributes of 'metadata_object' and update its
     # corresponding roleinfo.
-    roleinfo = {'name': metadata_name,
+    roleinfo = {'name': rolename,
                 'signing_keyids': [],
                 'signatures': [],
                 'partial_loaded': False
@@ -3170,18 +3149,26 @@ def load_repository(repository_directory, repository_name='default',
     roleinfo['paths'] = metadata_object['targets']
     roleinfo['delegations'] = metadata_object['delegations']
 
-    tuf.roledb.add_role(metadata_name, roleinfo, repository_name)
-    loaded_metadata.append(metadata_name)
+    tuf.roledb.add_role(rolename, roleinfo, repository_name)
 
-    # Generate the Targets objects of the delegated roles of 'metadata_name'
-    # and add it to the top-level 'targets' object.
-    new_targets_object = Targets(targets_directory, metadata_name, roleinfo,
-        repository_name=repository_name)
-    targets_object = targets_objects['targets']
-    targets_objects[metadata_name] = new_targets_object
+    # Generate the Targets object of the delegated role,
+    # add it to the top-level 'targets' object and to its
+    # direct delegating role object.
+    new_targets_object = Targets(targets_directory, rolename,
+         roleinfo, parent_targets_object=targets_objects['targets'],
+         repository_name=repository_name)
 
-    targets_object._delegated_roles[(os.path.basename(metadata_name))] = \
-        new_targets_object
+    targets_objects[rolename] = new_targets_object
+
+    targets_objects['targets'].add_delegated_role(rolename,
+        new_targets_object)
+    targets_objects[delegating_role].add_delegated_role(rolename,
+        new_targets_object)
+
+    # Append the next level delegations to the list:
+    # the 'delegated' role becomes the 'delegating'
+    for delegation in metadata_object['delegations']['roles']:
+      delegations.append([delegation['name'], rolename])
 
     # Extract the keys specified in the delegations field of the Targets
     # role.  Add 'key_object' to the list of recognized keys.  Keys may be
@@ -3196,8 +3183,10 @@ def load_repository(repository_directory, repository_name='default',
       # that doesn't match the client's set of hash algorithms.  Make sure
       # to only used the repo's selected hashing algorithms.
       hash_algorithms = securesystemslib.settings.HASH_ALGORITHMS
-      securesystemslib.settings.HASH_ALGORITHMS = key_metadata['keyid_hash_algorithms']
-      key_object, keyids = securesystemslib.keys.format_metadata_to_key(key_metadata)
+      securesystemslib.settings.HASH_ALGORITHMS = \
+          key_metadata['keyid_hash_algorithms']
+      key_object, keyids = \
+          securesystemslib.keys.format_metadata_to_key(key_metadata)
       securesystemslib.settings.HASH_ALGORITHMS = hash_algorithms
       try:
         for keyid in keyids: # pragma: no branch

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -73,6 +73,9 @@ _dirty_roles = {}
 _dirty_roles['default'] = set()
 
 
+TOP_LEVEL_ROLES = ['root', 'targets', 'snapshot', 'timestamp']
+
+
 def create_roledb_from_root_metadata(root_metadata, repository_name='default'):
   """
   <Purpose>


### PR DESCRIPTION

**Fixes issue #**: #1045 

**Description of the changes being introduced by the pull request**:
- Update `load_repository()` function to load the delegations metadata starting from 'targets' and traversing downwards the delegated roles in order to load correctly the delegations hierarchy.
- Improve readability by extracting the loading of `metadata_directory` files in a separate function `get_delegations_filenames()` in a similar way in which top level metadata files are loaded by `get_metadata_filenames()`.
- Update `test_load_repository`.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


