### PR TITLE
Update docs on crypto details

### DIFF
--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -65,15 +65,17 @@ updates.
 The repository tool supports multiple public-key algorithms, such as
 [RSA](https://en.wikipedia.org/wiki/RSA_%28cryptosystem%29) and
 [Ed25519](https://ed25519.cr.yp.to/), and multiple cryptography libraries.
-Which cryptography library to use is determined by the default, or user modified,
-settings in [settings.py](../tuf/settings.py).
 
 Using [RSA-PSS](https://tools.ietf.org/html/rfc8017#section-8.1) or
 [ECDSA](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm)
 signatures requires the [cryptography](https://cryptography.io/) library. If
 generation of Ed25519 signatures is needed
-[PyNaCl](https://github.com/pyca/pynacl) library should be installed.
-Ed25519 and ECDSA keys are stored in JSON format and RSA keys are stored in PEM
+[PyNaCl](https://github.com/pyca/pynacl) library should be installed. This
+tutorial assumes both dependencies are installed: refer to
+[Installation Instructions](INSTALLATION.rst#install-with-more-cryptographic-flexibility)
+for details.
+
+The Ed25519 and ECDSA keys are stored in JSON format and RSA keys are stored in PEM
 format. Private keys are encrypted and passphrase-protected (strengthened with
 PBKDF2-HMAC-SHA256.)  Generating, importing, and loading cryptographic key
 files can be done with functions available in the repository tool.
@@ -81,7 +83,6 @@ files can be done with functions available in the repository tool.
 To start, a public and private RSA key pair is generated with the
 `generate_and_write_rsa_keypair()` function.  The keys generated next are
 needed to sign the repository metadata files created in upcoming sub-sections.
-
 
 Note:  In the instructions below, lines that start with `>>>` denote commands
 that should be entered by the reader, `#` begins the start of a comment, and

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -68,14 +68,13 @@ The repository tool supports multiple public-key algorithms, such as
 Which cryptography library to use is determined by the default, or user modified,
 settings in [settings.py](../tuf/settings.py).
 
-The [PyCrypto](https://www.dlitz.net/software/pycrypto/) library may be
-selected to generate RSA keys and
-[RSA-PSS](https://en.wikipedia.org/wiki/RSA-PSS) signatures.  If generation of
-Ed25519 signatures is needed, the [PyNaCl](https://github.com/pyca/pynacl)
-library setting should be enabled.  PyNaCl is a Python binding to the
-Networking and Cryptography Library.  For key storage, RSA keys may be stored
-in PEM or JSON format, and Ed25519 keys in JSON format.  Private keys, for both
-RSA and Ed25519, are encrypted and passphrase-protected (strengthened with
+Using [RSA-PSS](https://tools.ietf.org/html/rfc8017#section-8.1) or
+[ECDSA](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm)
+signatures requires the [cryptography](https://cryptography.io/) library. If
+generation of Ed25519 signatures is needed
+[PyNaCl](https://github.com/pyca/pynacl) library should be installed.
+Ed25519 and ECDSA keys are stored in JSON format and RSA keys are stored in PEM
+format. Private keys are encrypted and passphrase-protected (strengthened with
 PBKDF2-HMAC-SHA256.)  Generating, importing, and loading cryptographic key
 files can be done with functions available in the repository tool.
 

--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,9 @@
   $ pip install .
 
   # Installing optional requirements (i.e., after installing tuf).
-  # The 'tools' optional requirement is currently supported, which enables
-  # fast and secure ed25519 key generation, and signature verification
-  # computations with PyNaCl+libsodium.  General-purpose cryptography is also
-  # provided.  'tools' is needed by the TUF repository tools.  Clients that
-  # require verification of RSASSA-PSS signatures must also install tuf[tools].
-  $ pip install tuf[tools]
+  # Support for creation of Ed25519 signatures and support for RSA and ECDSA
+  # signatures in general requires optional dependencies:
+  $ pip install securesystemslib[crypto,pynacl]
 
 
   Alternate installation options:


### PR DESCRIPTION
The specifics on crypto dependencies are out of date in a few places: fix setup.py comments and Tutorial.

Obviously this PR reflects my understanding of the situation -- and I'm a newbie here so I may have misunderstood. Review is welcome.

There's a potential additional fix in the Tutorial section that I'm not sure about:

> Which cryptography library to use is determined by the default, or user modified, settings in settings.py

This seems false or misleading -- only hash algorithms can be selected in settings and the signature algorithm selection is done when keys are generated, right?