### PR TITLE
repo.py: Decode key bytes for SHA key as well

### DIFF
--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -439,15 +439,13 @@ def import_privatekey_from_file(keypath, password=None):
   encrypted_key = None
 
   with open(keypath, 'rb') as file_object:
-    encrypted_key = file_object.read()
+    encrypted_key = file_object.read().decode('utf-8')
 
   # Decrypt the loaded key file, calling the 'cryptography' library to generate
   # the derived encryption key from 'password'.  Raise
   # 'securesystemslib.exceptions.CryptoError' if the decryption fails.
   try:
-
-    key_object = securesystemslib.keys.decrypt_key(encrypted_key.decode('utf-8'),
-        password)
+    key_object = securesystemslib.keys.decrypt_key(encrypted_key, password)
 
   except securesystemslib.exceptions.CryptoError:
     try:


### PR DESCRIPTION
key bytes were decoded as utf-8 for the JSON keys. Do the same for SHA
key bytes.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

---

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature -- repo.py isn't tested: I don't think I'm adding tests just for this


