### PR TITLE
test_repository_tool: Add missing clear_all flag

### DIFF
--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -81,9 +81,6 @@ class TestRepository(unittest.TestCase):
 
 
   def setUp(self):
-    tuf.roledb.clear_roledb(clear_all=True)
-    tuf.keydb.clear_keydb(clear_all=True)
-
     tuf.roledb.create_roledb('test_repository')
     tuf.keydb.create_keydb('test_repository')
 
@@ -1110,8 +1107,8 @@ class TestTimestamp(unittest.TestCase):
 
 
   def tearDown(self):
-    tuf.roledb.clear_roledb()
-    tuf.keydb.clear_keydb()
+    tuf.roledb.clear_roledb(clear_all=True)
+    tuf.keydb.clear_keydb(clear_all=True)
 
 
 


### PR DESCRIPTION
Without this the next create_*db() call will fail meaning
   pytest test_repository_tool.py
fails on every test after this one.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>
