### PR TITLE
Fix consistent snapshot handling in `repository_lib.get_delegated_roles_metadata()`

### DIFF
--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -836,10 +836,10 @@ def get_delegated_roles_metadata_filenames(metadata_directory,
     # Strip the version number if 'consistent_snapshot' is True,
     # or if 'metadata_role' is Root.
     # Example:  '10.django.json' --> 'django.json'
-    consistent_snapshot = \
+    consistent = \
       metadata_role.endswith('root.json') or consistent_snapshot == True
     metadata_name, junk = _strip_version_number(metadata_role,
-      consistent_snapshot)
+      consistent)
 
     if metadata_name.endswith(METADATA_EXTENSION):
       extension_length = len(METADATA_EXTENSION)


### PR DESCRIPTION
**Fixes issue #**: #1069 

**Description of the changes being introduced by the pull request**:
Fix consistent snapshot handling in `repository_lib.get_delegated_roles_metadata()`. Using the same variable name for a function argument and an internal state tracking variable resulting in incorrect state handling during the loop.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


