### PR TITLE
Fix prefix file_prefix to support "" value

### DIFF
--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -190,7 +190,7 @@ class Project(Targets):
     securesystemslib.formats.NAME_SCHEMA.check_match(project_name)
     securesystemslib.formats.PATH_SCHEMA.check_match(metadata_directory)
     securesystemslib.formats.PATH_SCHEMA.check_match(targets_directory)
-    securesystemslib.formats.PATH_SCHEMA.check_match(file_prefix)
+    securesystemslib.formats.ANY_STRING_SCHEMA.check_match(file_prefix)
     securesystemslib.formats.NAME_SCHEMA.check_match(repository_name)
 
     self.metadata_directory = metadata_directory


### PR DESCRIPTION
**Fixes issue #**: None

**Description of the changes being introduced by the pull request**:
If we run the tuf unit tests with latest, not yet released,
securesyslib changes we will see that one unit test is failing
because the file_prefix argument should confront the PATH_SCHEMA
(which requires a non-empty string) but an empty string value
is passed to it.

That happens, because in tuf/developer_tool.py create_new_project
function:
https://github.com/theupdateframework/tuf/blob/b309e1befaa1df1df5afd25cd529b5fad3d4b233/tuf/developer_tool.py#L518 the "location_in_repository" arg has a default value of ''
and if not changed when creating a new object of type Project
on line 650:
https://github.com/theupdateframework/tuf/blob/b309e1befaa1df1df5afd25cd529b5fad3d4b233/tuf/developer_tool.py#L650 will cause an exception in the __init__ function
because of the file_prefix argument.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


