### PR TITLE
Update targets delegations in generate_targets_metadata 

### DIFF
--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -310,11 +310,6 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     # securesystemslib.exceptions.Error exception is raised for duplicate keyids.
     tuf.keydb._keydb_dict['default'][root_keyids[0]]['keytype'] = 'rsa'
 
-    # Add duplicate keyid to root's roleinfo.
-    tuf.roledb._roledb_dict['default']['root']['keyids'].append(root_keyids[0])
-    self.assertRaises(securesystemslib.exceptions.Error, repo_lib.generate_root_metadata, 1,
-                      expires, consistent_snapshot=False)
-
     # Test improperly formatted arguments.
     self.assertRaises(securesystemslib.exceptions.FormatError, repo_lib.generate_root_metadata,
                       '3', expires, False)
@@ -349,27 +344,13 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     file_permissions = oct(os.stat(file1_path).st_mode)[4:]
     target_files = {'file.txt': {'custom': {'file_permission': file_permissions}}}
 
-    delegations = {"keys": {
-      "a394c28384648328b16731f81440d72243c77bb44c07c040be99347f0df7d7bf": {
-       "keytype": "ed25519",
-       "keyval": {
-        "public": "3eb81026ded5af2c61fb3d4b272ac53cd1049a810ee88f4df1fc35cdaf918157"
-       }
-      }
-     },
-     "roles": [
-      {
-       "keyids": [
-        "a394c28384648328b16731f81440d72243c77bb44c07c040be99347f0df7d7bf"
-       ],
-       "name": "targets/warehouse",
-       "paths": [
-        "/file1.txt", "/README.txt", '/warehouse/'
-       ],
-       "threshold": 1
-      }
-     ]
-    }
+    # Delegations data must be loaded into roledb since
+    # generate_targets_metadata tries to update delegations keyids
+    # and threshold
+    repository_path = os.path.join('repository_data', 'repository')
+    repository = repo_tool.load_repository(repository_path)
+    roleinfo = tuf.roledb.get_roleinfo('targets')
+    delegations = roleinfo['delegations']
 
     targets_metadata = \
       repo_lib.generate_targets_metadata(targets_directory, target_files,
@@ -957,6 +938,21 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     filenames = repo_lib.get_top_level_metadata_filenames(metadata_directory)
     repository = repo_tool.create_new_repository(repository_directory, repository_name)
     repo_lib._load_top_level_metadata(repository, filenames, repository_name)
+
+    # Manually add targets delegations to roledb since
+    # repository.write('targets') will try to update its delegations
+    targets_filepath = os.path.join('repository_data', 'repository',
+                                 'metadata', 'targets.json')
+    targets_signable = securesystemslib.util.load_json_file(targets_filepath)
+    delegations = targets_signable['signed']['delegations']
+
+    roleinfo = {}
+    roleinfo['name'] = delegations['roles'][0]['name']
+    roleinfo['keyids'] = delegations['roles'][0]['keyids']
+    roleinfo['threshold'] = delegations['roles'][0]['threshold']
+    roleinfo['version'] = 1
+    tuf.roledb.add_role('role1', roleinfo, repository_name)
+
 
     # Partially write all top-level roles (we increase the threshold of each
     # top-level role so that they are flagged as partially written.

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -2288,7 +2288,7 @@ def keys_to_keydict(keys):
 
 if __name__ == '__main__':
   # The interactive sessions of the documentation strings can
-  # be tested by running repository_tool.py as a standalone module:
+  # be tested by running repository_lib.py as a standalone module:
   # $ python repository_lib.py.
   import doctest
   doctest.testmod()

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2377,7 +2377,7 @@ class Targets(Metadata):
 
     # Keep track of the valid keyids (added to the new Targets object) and
     # their keydicts (added to this Targets delegations).
-    keyids, keydict = _keys_to_keydict(public_keys)
+    keyids, keydict = repo_lib.keys_to_keydict(public_keys)
 
     # Ensure the paths of 'list_of_targets' are located in the repository's
     # targets directory.
@@ -2612,7 +2612,7 @@ class Targets(Metadata):
       hash_prefix = repo_lib.get_target_hash(target_path)[:prefix_length]
       ordered_roles[int(hash_prefix, 16) // bin_size]["target_paths"].append(target_path)
 
-    keyids, keydict = _keys_to_keydict(keys_of_hashed_bins)
+    keyids, keydict = repo_lib.keys_to_keydict(keys_of_hashed_bins)
 
     # A queue of roleinfo's that need to be updated in the roledb
     delegated_roleinfos = []
@@ -2853,30 +2853,6 @@ class Targets(Metadata):
       raise tuf.exceptions.InvalidNameError('Path ' + repr(pathname)
           + ' starts with a directory separator. All paths should be relative'
           '  to targets directory.')
-
-
-
-
-
-def _keys_to_keydict(keys):
-  """
-  Iterate over a list of keys and return a list of keyids and a dict mapping
-  keyid to key metadata
-  """
-  keyids = []
-  keydict = {}
-
-  for key in keys:
-    keyid = key['keyid']
-    key_metadata_format = securesystemslib.keys.format_keyval_to_metadata(
-        key['keytype'], key['scheme'], key['keyval'])
-
-    new_keydict = {keyid: key_metadata_format}
-    keydict.update(new_keydict)
-    keyids.append(keyid)
-
-  return keyids, keydict
-
 
 
 


### PR DESCRIPTION

**Fixes issue #**: #1037

**Description of the changes being introduced by the pull request**:
- Collect keys and threshold of delegated roles and update delegations in `generate_targets_metadata() `in a similar manner as `generate_root_metadata()` does for top-level roles.
- Move key dictionary generation from `generate_root_metadata()` to a helper function` _add_keys_to_keydict()` 
- Update tests

Fixing this issue was partially blocked by #574: after loading the repository the delegated roles' 'keyids' and 'threshold' are lost which leads to throwing "missing key" exceptions while trying to update the delegations.

I suggest a short-term solution of #574 by using the recently added logic of hierarchically loading the delegations in `load_reposiroty()`. This makes it possible to get the delegated roles `keyids` and `threshold` from its delegating role metadata.
Clearly this won't work if more than one delegation to the same role exists but ... this is not supported correctly anyway in the current implementation so lets cover the simplest use case here?

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


