### PR TITLE
Minor error message clarifications and greater testing for generating targets metadata with existing fileinfo

### DIFF
--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -435,6 +435,39 @@ class TestRepositoryToolFunctions(unittest.TestCase):
                       expiration_date)
 
 
+    # Test use of an existing fileinfo structures
+    target1_hashes = {'sha256': 'c2986576f5fdfd43944e2b19e775453b96748ec4fe2638a6d2f32f1310967095'}
+    target2_hashes = {'sha256': '517c0ce943e7274a2431fa5751e17cfd5225accd23e479bfaad13007751e87ef'}
+
+    # Test missing expected field, hashes, when use_existing_fileinfo
+    target_files = {'file.txt': {'length': 555}}
+    self.assertRaises(securesystemslib.exceptions.Error, repo_lib.generate_targets_metadata,
+                      targets_directory, target_files, version, expiration_date,
+                      use_existing_fileinfo=True)
+
+    # Test missing expected field, length, when use_existing_fileinfo
+    target_files = {'file.txt': {'hashes': target1_hashes}}
+    self.assertRaises(securesystemslib.exceptions.Error, repo_lib.generate_targets_metadata,
+                      targets_directory, target_files, version, expiration_date,
+                      use_existing_fileinfo=True)
+
+    # Test missing both expected fields when use_existing_fileinfo
+    target_files = {'file.txt': {}}
+    self.assertRaises(securesystemslib.exceptions.Error, repo_lib.generate_targets_metadata,
+                      targets_directory, target_files, version, expiration_date,
+                      use_existing_fileinfo=True)
+
+    target_files = {'file1.txt': {'custom': {'meta': 'foo'},
+                                  'hashes': target1_hashes,
+                                  'length': 555},
+                    'file2.txt': {'custom': {'meta': 'bar'},
+                                  'hashes': target2_hashes,
+                                  'length': 42}}
+    targets_metadata = \
+      repo_lib.generate_targets_metadata(targets_directory, target_files,
+                                         version, expiration_date, delegations,
+                                         False, use_existing_fileinfo=True)
+
 
   def test_generate_snapshot_metadata(self):
     # Test normal case.

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1416,13 +1416,13 @@ def generate_targets_metadata(targets_directory, target_files, version,
 
       # Ensure all fileinfo entries in target_files have a non-empty hashes dict
       if not fileinfo.get('hashes', None):
-        raise securesystemslib.exceptions.Error('use_existing_hashes option set'
-            ' but no hashes exist in roledb for ' + repr(target))
+        raise securesystemslib.exceptions.Error('use_existing_fileinfo option'
+            ' set but no hashes exist in fileinfo for ' + repr(target))
 
       # and a non-empty length
       if fileinfo.get('length', -1) < 0:
-        raise securesystemslib.exceptions.Error('use_existing_hashes option set'
-            ' but fileinfo\'s length is not set')
+        raise securesystemslib.exceptions.Error('use_existing_fileinfo option'
+            ' set but no length exists in fileinfo for ' + repr(target))
 
       filedict[target] = fileinfo
 


### PR DESCRIPTION
**Fixes issue #**: N/A

**Description of the changes being introduced by the pull request**:
* Fix the error reporting to use the correct parameter name and be clearer as to the cause of the error when `generate_targets_metadata` is called with `use_existing_fileinfo` and incomplete metadata exists in the provided fileinfo
* Add additional, more granular, testing of `generate_targets_metadata` with `use_existing_fileinfo`

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


