### PR TITLE
Each key applies to signature threshold once

### DIFF
--- a/tests/test_sig.py
+++ b/tests/test_sig.py
@@ -436,9 +436,9 @@ class TestSig(unittest.TestCase):
     tuf.keydb.add_key(key_sha256)
     tuf.keydb.add_key(key_sha512)
 
-    # Assert that both keys count towards threshold although its the same key
+    # Assert that the key only counts toward the threshold once
     keyids = [key_sha256["keyid"], key_sha512["keyid"]]
-    self.assertTrue(
+    self.assertFalse(
         tuf.sig.verify(signable, "root", keyids=keyids, threshold=2))
 
     # Clean-up keydb

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -245,8 +245,7 @@ def verify(signable, role, repository_name='default', threshold=None,
     NOTE:
     - Signatures with identical authorized keyids only count towards the
       threshold once.
-    - Signatures with different authorized keyids each count towards the
-      threshold, even if the keyids identify the same key.
+    - Signatures with the same key only count toward the threshold once.
 
   <Arguments>
     signable:
@@ -307,7 +306,12 @@ def verify(signable, role, repository_name='default', threshold=None,
   if threshold is None or threshold <= 0: #pragma: no cover
     raise securesystemslib.exceptions.Error("Invalid threshold: " + repr(threshold))
 
-  return len(set(good_sigs)) >= threshold
+  unique_keys = set()
+  for keyid in good_sigs:
+    key = tuf.keydb.get_key(keyid, repository_name)
+    unique_keys.add(key['keyval']['public'])
+
+  return len(unique_keys) >= threshold
 
 
 


### PR DESCRIPTION
This addresses part 2 of #1084.

This pr ensures that each key will only count toward the signature threshold once, even if the keys have different keyids. This will be especially important when repositories are allowed to define their own keyids as part of TAP 12.

The solution is based on @lukpueh's [commit for threshold verification](https://github.com/theupdateframework/tuf/commit/a0397c7c820ec1c30ebc793cc9469b61c8d3f50e)
