### PR TITLE
[WIP] Use separate keydb for delegated targets

### DIFF
--- a/tests/test_developer_tool.py
+++ b/tests/test_developer_tool.py
@@ -375,7 +375,7 @@ class TestProject(unittest.TestCase):
 
 
     # Load_signing_keys.
-    project('delegation').load_signing_key(delegation_private_key)
+    project('delegation').load_signing_key(delegation_private_key, 'targets')
 
     project.status()
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -2120,7 +2120,6 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     # verify that get_valid_targetinfo() raises an UnknownTargetError
     # despite both repos signing for file1.txt.
     multi_repo_updater.map_file['mapping'][0]['threshold'] = 2
-    print(multi_repo_updater.get_valid_targetinfo('file1.txt'))
     self.assertRaises(tuf.exceptions.UnknownTargetError,
         multi_repo_updater.get_valid_targetinfo, 'file1.txt')
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1171,8 +1171,8 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     repository.targets('role4').add_target(foo_package)
 
     repository.targets.load_signing_key(self.role_keys['targets']['private'])
-    repository.targets('role3').load_signing_key(self.role_keys['targets']['private'])
-    repository.targets('role4').load_signing_key(self.role_keys['targets']['private'])
+    repository.targets('role3').load_signing_key(self.role_keys['targets']['private'], 'targets')
+    repository.targets('role4').load_signing_key(self.role_keys['targets']['private'], 'targets')
     repository.snapshot.load_signing_key(self.role_keys['snapshot']['private'])
     repository.timestamp.load_signing_key(self.role_keys['timestamp']['private'])
     repository.writeall()

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -940,7 +940,6 @@ class Updater(object):
       return
 
     # This could be quite slow with a large number of delegations.
-    keys_info = current_parent_metadata['delegations'].get('keys', {})
     roles_info = current_parent_metadata['delegations'].get('roles', [])
 
     logger.debug('Adding roles delegated from ' + repr(parent_role) + '.')
@@ -2501,7 +2500,7 @@ class Updater(object):
       roleinfo = tuf.roledb.get_roleinfo(rolename, self.repository_name)
       try:
         delegating_rolename = roleinfo['parent_role']
-      except:
+      except KeyError:
         delegating_rolename = 'root'
       self._update_metadata_if_changed(rolename,
             delegating_rolename=delegating_rolename)

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -962,7 +962,8 @@ class Updater(object):
         # is None.
         rolename = roleinfo.get('name')
         logger.debug('Adding delegated role: ' + str(rolename) + '.')
-        tuf.roledb.add_role(rolename, roleinfo, self.repository_name, parent_role)
+        roleinfo['parent_role'] = parent_role
+        tuf.roledb.add_role(rolename, roleinfo, self.repository_name)
 
       except tuf.exceptions.RoleAlreadyExistsError:
         logger.warning('Role already exists: ' + rolename)

--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -259,7 +259,7 @@ class Project(Targets):
       roleinfo = tuf.roledb.get_roleinfo(delegated_rolename, self.repository_name)
       try:
         delegating_rolename = roleinfo['parent_role']
-      except:
+      except KeyError:
         delegating_rolename = 'root'
 
       # Ensure the parent directories of 'metadata_filepath' exist, otherwise an
@@ -384,7 +384,7 @@ class Project(Targets):
         roleinfo = tuf.roledb.get_roleinfo(delegated_role, self.repository_name)
         try:
           delegating_rolename = roleinfo['parent_role']
-        except:
+        except KeyError:
           delegating_rolename = 'root'
 
         try:

--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -898,7 +898,7 @@ def load_project(project_directory, prefix='', new_targets_location=None,
       repository_name=repository_name)
 
   tuf.keydb.create_keydb_from_targets_metadata(targets_metadata['delegations'],
-      repository_name, 'Targets')
+      repository_name, 'targets')
 
   for role in targets_metadata['delegations']['roles']:
     rolename = role['name']
@@ -906,7 +906,7 @@ def load_project(project_directory, prefix='', new_targets_location=None,
                 'threshold': role['threshold'],
                 'signing_keyids': [], 'signatures': [], 'partial_loaded':False,
                 'delegations': {'keys':{}, 'roles':[]},
-                'parent_role': 'Targets'
+                'parent_role': 'targets'
                 }
     tuf.roledb.add_role(rolename, roleinfo, repository_name=repository_name)
 

--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -289,7 +289,7 @@ class Project(Targets):
 
 
 
-  def add_verification_key(self, key, expires=None):
+  def add_verification_key(self, key, expires=None, delegating_rolename='root'):
     """
       <Purpose>
         Function as a thin wrapper call for the project._targets call
@@ -322,7 +322,7 @@ class Project(Targets):
     if len(self.keys) > 0:
       raise securesystemslib.exceptions.Error("This project already contains a key.")
 
-    super(Project, self).add_verification_key(key, expires)
+    super(Project, self).add_verification_key(key, expires, delegating_rolename)
 
 
 

--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -897,7 +897,8 @@ def load_project(project_directory, prefix='', new_targets_location=None,
     roleinfo = {'name': role['name'], 'keyids': role['keyids'],
                 'threshold': role['threshold'],
                 'signing_keyids': [], 'signatures': [], 'partial_loaded':False,
-                'delegations': {'keys':{}, 'roles':[]}
+                'delegations': {'keys':{}, 'roles':[]},
+                'parent_role': targets_metadata['name']
                 }
     tuf.roledb.add_role(rolename, roleinfo, repository_name=repository_name)
 
@@ -980,7 +981,8 @@ def load_project(project_directory, prefix='', new_targets_location=None,
                     'signing_keyids': [], 'signatures': [],
                     'partial_loaded': False,
                     'delegations': {'keys': {},
-                                    'roles': []}}
+                                    'roles': []},
+                    'parent_role' : metadata_object['name']}
         tuf.roledb.add_role(rolename, roleinfo, repository_name=repository_name)
 
   if new_prefix:

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -137,7 +137,8 @@ ROLE_SCHEMA = SCHEMA.Object(
   threshold = THRESHOLD_SCHEMA,
   terminating = SCHEMA.Optional(securesystemslib.formats.BOOLEAN_SCHEMA),
   paths = SCHEMA.Optional(RELPATHS_SCHEMA),
-  path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA))
+  path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA),
+  parent_role = SCHEMA.Optional(ROLENAME_SCHEMA))
 
 # A dict of roles where the dict keys are role names and the dict values holding
 # the role data/information.

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -444,7 +444,7 @@ def get_key(keyid, repository_name='default', delegating_rolename='root'):
       ' ' + repr(repository_name))
 
   # Return the key belonging to 'keyid', if found in the key database.
-  if delegating_rolename is not 'root':
+  if delegating_rolename != 'root':
     repository_name = repository_name + ' ' + delegating_rolename
   try:
     return copy.deepcopy(_keydb_dict[repository_name][keyid])

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -152,7 +152,8 @@ def create_keydb_from_root_metadata(root_metadata, repository_name='default'):
 
 
 
-def create_keydb_from_targets_metadata(delegations_metadata, repository_name):
+def create_keydb_from_targets_metadata(delegations_metadata, repository_name,
+      delegating_rolename):
   """
   <Purpose>
     Populate the key database with the unique keys found in 'delegations_metadata'.
@@ -194,6 +195,8 @@ def create_keydb_from_targets_metadata(delegations_metadata, repository_name):
 
   # Does 'repository_name' have the correct format?
   securesystemslib.formats.NAME_SCHEMA.check_match(repository_name)
+
+  repository_name = repository_name + ' ' + delegating_rolename
 
   # Clear the key database for 'repository_name', or create it if non-existent.
   if repository_name in _keydb_dict:

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -659,7 +659,7 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
     # Create a keydb for the keys specified in the delegations field of the Targets
     # role. This keydb will be used for all delegations from the Target role.
     tuf.keydb.create_keydb_from_targets_metadata(targets_metadata['delegations'],
-        repository_name, 'Targets')
+        repository_name, 'targets')
 
   except securesystemslib.exceptions.StorageError:
     raise tuf.exceptions.RepositoryError('The Targets file can not be loaded: '
@@ -1837,7 +1837,7 @@ def sign_metadata(metadata_object, keyids, filename, repository_name,
   # keyid of 'keyids'.
   signable = tuf.formats.make_signable(metadata_object)
 
-  if delegating_rolename is not 'root':
+  if delegating_rolename != 'root':
     repository_name = repository_name + ' ' + delegating_rolename
 
   # Sign the metadata with each keyid in 'keyids'.  'signable' should have

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -196,7 +196,7 @@ def _generate_and_write_metadata(rolename, metadata_filename,
     roleinfo = tuf.roledb.get_roleinfo(rolename, repository_name)
     try:
       delegating_rolename = roleinfo['parent_role']
-    except:
+    except KeyError:
       delegating_rolename = 'root'
     signable = sign_metadata(metadata, signing_keyids, metadata_filename,
         repository_name, delegating_rolename=delegating_rolename)
@@ -247,7 +247,7 @@ def _generate_and_write_metadata(rolename, metadata_filename,
     roleinfo = tuf.roledb.get_roleinfo(rolename, repository_name)
     try:
       delegating_rolename = roleinfo['parent_role']
-    except:
+    except KeyError:
       delegating_rolename = 'root'
     signable = sign_metadata(metadata, signing_keyids, metadata_filename,
         repository_name, delegating_rolename=delegating_rolename)

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -3182,25 +3182,11 @@ def load_repository(repository_directory, repository_name='default',
     # log a warning here as there may be many such duplicate key warnings.
     # The repository maintainer should have also been made aware of the
     # duplicate key when it was added.
-    for key_metadata in six.itervalues(metadata_object['delegations']['keys']):
-
-      # The repo may have used hashing algorithms for the generated keyids
-      # that doesn't match the client's set of hash algorithms.  Make sure
-      # to only used the repo's selected hashing algorithms.
-      hash_algorithms = securesystemslib.settings.HASH_ALGORITHMS
-      securesystemslib.settings.HASH_ALGORITHMS = \
-          key_metadata['keyid_hash_algorithms']
-      key_object, keyids = \
-          securesystemslib.keys.format_metadata_to_key(key_metadata)
-      securesystemslib.settings.HASH_ALGORITHMS = hash_algorithms
-      try:
-        for keyid in keyids: # pragma: no branch
-          key_object['keyid'] = keyid
-          tuf.keydb.add_key(key_object, keyid=None,
-              repository_name=repository_name)
-
-      except tuf.exceptions.KeyAlreadyExistsError:
-        pass
+    try:
+      tuf.keydb.create_keydb_from_targets_metadata(metadata_object['delegations'],
+          repository_name + ' ' + rolename)
+    except tuf.exceptions.KeyAlreadyExistsError:
+      pass
 
   return repository
 

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2412,7 +2412,8 @@ class Targets(Metadata):
                 'keyids': keyids,
                 'threshold': threshold,
                 'terminating': terminating,
-                'paths': list(relative_targetpaths.keys())}
+                'paths': list(relative_targetpaths.keys()),
+                'parent_role' : self._rolename}
 
     if paths:
       roleinfo['paths'] = paths

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -3184,7 +3184,7 @@ def load_repository(repository_directory, repository_name='default',
     # duplicate key when it was added.
     try:
       tuf.keydb.create_keydb_from_targets_metadata(metadata_object['delegations'],
-          repository_name + ' ' + rolename)
+          repository_name, rolename)
     except tuf.exceptions.KeyAlreadyExistsError:
       pass
 

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -54,7 +54,6 @@ import securesystemslib.keys
 import securesystemslib.formats
 import securesystemslib.util
 import iso8601
-import six
 
 import securesystemslib.storage
 

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -853,7 +853,7 @@ class Metadata(object):
 
 
 
-  def load_signing_key(self, key):
+  def load_signing_key(self, key, delegating_rolename='root'):
     """
     <Purpose>
       Load the role key, which must contain the private portion, so that role
@@ -897,11 +897,15 @@ class Metadata(object):
     # Has the key, with the private portion included, been added to the keydb?
     # The public version of the key may have been previously added.
     try:
-      tuf.keydb.add_key(key, repository_name=self._repository_name)
+      if delegating_rolename != 'root':
+        repository_name = self._repository_name + ' ' + delegating_rolename
+      else:
+        repository_name = self._repository_name
+      tuf.keydb.add_key(key, repository_name=repository_name)
 
     except tuf.exceptions.KeyAlreadyExistsError:
-      tuf.keydb.remove_key(key['keyid'], self._repository_name)
-      tuf.keydb.add_key(key, repository_name=self._repository_name)
+      tuf.keydb.remove_key(key['keyid'], repository_name)
+      tuf.keydb.add_key(key, repository_name=repository_name)
 
     # Update the role's 'signing_keys' field in 'tuf.roledb.py'.
     roleinfo = tuf.roledb.get_roleinfo(self.rolename, self._repository_name)

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -35,10 +35,11 @@
           'signatures': ['abcd3452...'],
           'paths': ['role.json'],
           'path_hash_prefixes': ['ab34df13'],
-          'delegations': {'keys': {}, 'roles': {}}}
+          'delegations': {'keys': {}, 'roles': {},
+          'parent_role': 'parent_rolename'}}
 
-  The 'name', 'paths', 'path_hash_prefixes', and 'delegations' dict keys are
-  optional.
+  The 'name', 'paths', 'path_hash_prefixes', 'delegations', and 'parent_role'
+  dict keys are optional.
 """
 
 # Help with Python 3 compatibility, where the print statement is a function, an
@@ -263,9 +264,10 @@ def add_role(rolename, roleinfo, repository_name='default'):
        'paths': ['path/to/target1', 'path/to/target2', ...],
        'path_hash_prefixes': ['a324fcd...', ...],
        'delegations': {'keys': }
+       'parent_role' " 'parent_rolename'}
 
-      The 'paths', 'path_hash_prefixes', and 'delegations' dict keys are
-      optional.
+      The 'paths', 'path_hash_prefixes', 'delegations', and 'parent_role'
+      dict keys are optional.
 
       The 'target' role has an additional 'paths' key.  Its value is a list of
       strings representing the path of the target file(s).
@@ -693,10 +695,11 @@ def get_roleinfo(rolename, repository_name='default'):
      'signatures': ['ab453bdf...', ...],
      'paths': ['path/to/target1', 'path/to/target2', ...],
      'path_hash_prefixes': ['a324fcd...', ...],
-     'delegations': {'keys': {}, 'roles': []}}
+     'delegations': {'keys': {}, 'roles': []}
+     'parent_role' : 'parent_rolename'}
 
-    The 'signatures', 'paths', 'path_hash_prefixes', and 'delegations' dict keys
-    are optional.
+    The 'signatures', 'paths', 'path_hash_prefixes', 'delegations', and
+    'parent_role' dict keys are optional.
 
   <Arguments>
     rolename:

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -309,7 +309,7 @@ def verify(signable, role, repository_name='default', threshold=None,
 
   unique_keys = set()
   for keyid in good_sigs:
-    key = tuf.keydb.get_key(keyid, repository_name)
+    key = tuf.keydb.get_key(keyid, repository_name, delegating_rolename)
     unique_keys.add(key['keyval']['public'])
 
   return len(unique_keys) >= threshold

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -67,7 +67,7 @@ iso8601_logger.disabled = True
 
 
 def get_signature_status(signable, role=None, repository_name='default',
-    threshold=None, keyids=None):
+    threshold=None, keyids=None, delegating_rolename='root'):
   """
   <Purpose>
     Return a dictionary representing the status of the signatures listed in
@@ -163,7 +163,7 @@ def get_signature_status(signable, role=None, repository_name='default',
 
     # Does the signature use an unrecognized key?
     try:
-      key = tuf.keydb.get_key(keyid, repository_name)
+      key = tuf.keydb.get_key(keyid, repository_name, delegating_rolename)
 
     except tuf.exceptions.UnknownKeyError:
       unknown_sigs.append(keyid)
@@ -233,7 +233,7 @@ def get_signature_status(signable, role=None, repository_name='default',
 
 
 def verify(signable, role, repository_name='default', threshold=None,
-    keyids=None):
+    keyids=None, delegating_rolename='root'):
   """
   <Purpose>
     Verify that 'signable' has a valid threshold of authorized signatures
@@ -293,7 +293,8 @@ def verify(signable, role, repository_name='default', threshold=None,
   # tuf.exceptions.UnknownRoleError
   # securesystemslib.exceptions.FormatError.  'threshold' and 'keyids' are also
   # validated.
-  status = get_signature_status(signable, role, repository_name, threshold, keyids)
+  status = get_signature_status(signable, role, repository_name, threshold, keyids,
+      delegating_rolename)
 
   # Retrieve the role's threshold and the authorized keys of 'status'
   threshold = status['threshold']


### PR DESCRIPTION
Fixes issue: part 3 of #1084

To implement TAP 12, this pr adds separate keydbs for each delegating instance. This means that the roles delegated to by root will use one keydb, the roles delegated to by targets will use a different one, and so on.

To do so, this pr introduces keydb.create_keydb_from_targets_metadata to make a new keydb for all roles delegated to by a targets metadata file and adds a `parent_role` field to the roledb to keep track of what keydb should be used when verifying a role.
