### PR TITLE
Test performance and reliability fixes

### DIFF
--- a/tests/proxy_server.py
+++ b/tests/proxy_server.py
@@ -466,7 +466,7 @@ def test(HandlerClass=ProxyRequestHandler, ServerClass=ThreadingHTTPServer, prot
         port = int(sys.argv[1])
     else:
         port = 8080
-    server_address = ('127.0.0.1', port) # MODIFIED: changed from '::1'
+    server_address = ('localhost', port)
 
     # MODIFIED: Argument added, conditional below added to control INTERCEPT
     # setting.

--- a/tests/simple_server.py
+++ b/tests/simple_server.py
@@ -80,6 +80,9 @@ if use_quiet_http_request_handler:
 else:
   handler = SimpleHTTPRequestHandler
 
+# Allow re-use so you can re-run tests as often as you want even if the
+# tests re-use ports. Otherwise TCP TIME-WAIT prevents reuse for ~1 minute
+six.moves.socketserver.TCPServer.allow_reuse_address = True
 httpd = six.moves.socketserver.TCPServer(('', PORT), handler)
 
 httpd.serve_forever()

--- a/tests/simple_server.py
+++ b/tests/simple_server.py
@@ -35,7 +35,6 @@ from __future__ import unicode_literals
 
 import sys
 import random
-import platform
 
 import six
 from six.moves.SimpleHTTPServer import SimpleHTTPRequestHandler

--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -39,12 +39,10 @@ from __future__ import unicode_literals
 import os
 import tempfile
 import random
-import time
 import shutil
 import json
 import subprocess
 import logging
-import sys
 import unittest
 
 import tuf

--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -55,6 +55,8 @@ import tuf.log
 import tuf.client.updater as updater
 import tuf.unittest_toolbox as unittest_toolbox
 
+import utils
+
 import securesystemslib
 import six
 
@@ -87,9 +89,7 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
     logger.info('Serving on port: ' + str(cls.SERVER_PORT))
     cls.url = 'http://localhost:' + str(cls.SERVER_PORT) + os.path.sep
 
-    # NOTE: Following error is raised if a delay is not applied:
-    # <urlopen error [Errno 111] Connection refused>
-    time.sleep(1)
+    utils.wait_for_server('localhost', cls.SERVER_PORT)
 
 
 

--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -106,6 +106,7 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
     if cls.server_process.returncode is None:
       logger.info('Server process ' + str(cls.server_process.pid) + ' terminated.')
       cls.server_process.kill()
+      cls.server_process.wait()
 
 
 

--- a/tests/test_developer_tool.py
+++ b/tests/test_developer_tool.py
@@ -22,13 +22,10 @@
 """
 
 import os
-import time
-import datetime
 import unittest
 import logging
 import tempfile
 import shutil
-import unittest
 
 import tuf
 import tuf.log

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -308,13 +308,13 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
       # trusting the good certs (trusting the bad cert instead). Expect failure
       # because even though the server's cert file is otherwise OK, we don't
       # trust it.
-      print('Trying HTTPS download of target file: ' + good_https_url)
+      logger.info('Trying HTTPS download of target file: ' + good_https_url)
       with self.assertRaises(requests.exceptions.SSLError):
         download.safe_download(good_https_url, target_data_length)
       with self.assertRaises(requests.exceptions.SSLError):
         download.unsafe_download(good_https_url, target_data_length)
 
-      print('Trying HTTPS download of target file: ' + good2_https_url)
+      logger.info('Trying HTTPS download of target file: ' + good2_https_url)
       with self.assertRaises(requests.exceptions.SSLError):
         download.safe_download(good2_https_url, target_data_length)
       with self.assertRaises(requests.exceptions.SSLError):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -127,8 +127,8 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     # the server-reported length of the file does not match the
     # required_length.  'updater.py' *does* verify the hashes of downloaded
     # content.
-    download.safe_download(self.url, self.target_data_length - 4)
-    download.unsafe_download(self.url, self.target_data_length - 4)
+    download.safe_download(self.url, self.target_data_length - 4).close()
+    download.unsafe_download(self.url, self.target_data_length - 4).close()
 
     # We catch 'tuf.exceptions.DownloadLengthMismatchError' for safe_download()
     # because it will not download more bytes than requested (in this case, a
@@ -138,7 +138,7 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
 
     # Calling unsafe_download() with a mismatched length should not raise an
     # exception.
-    download.unsafe_download(self.url, self.target_data_length + 1)
+    download.unsafe_download(self.url, self.target_data_length + 1).close()
 
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -39,7 +39,6 @@ import os
 import random
 import subprocess
 import sys
-import time
 import unittest
 
 import tuf
@@ -53,7 +52,6 @@ import utils
 import requests.exceptions
 
 import securesystemslib
-import six
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -102,6 +102,8 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     if self.server_proc.returncode is None:
       logger.info('\tServer process '+str(self.server_proc.pid)+' terminated.')
       self.server_proc.kill()
+      # Drop return values of communicate()
+      self.server_proc.communicate()
     self.target_fileobj.close()
 
 
@@ -372,6 +374,8 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
         if proc.returncode is None:
           logger.info('Terminating server process ' + str(proc.pid))
           proc.kill()
+          # drop return values
+          proc.communicate()
 
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -48,6 +48,8 @@ import tuf.log
 import tuf.unittest_toolbox as unittest_toolbox
 import tuf.exceptions
 
+import utils
+
 import requests.exceptions
 
 import securesystemslib
@@ -81,13 +83,7 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     junk, rel_target_filepath = os.path.split(target_filepath)
     self.url = 'http://localhost:'+str(self.PORT)+'/'+rel_target_filepath
 
-    # Provide a delay long enough to allow the HTTPS servers to start.
-    # Encountered an error on one test system at delay value of 0.2s, so
-    # increasing to 0.5s.  Further increasing to 2s due to occasional failures
-    # in other tests in similar circumstances on AppVeyor.
-    # Expect to see "Connection refused" if this delay is not long enough
-    # (though other issues could cause that).
-    time.sleep(2)
+    utils.wait_for_server('localhost', self.PORT)
 
     # Computing hash of target file data.
     m = hashlib.md5()
@@ -279,12 +275,8 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     expd_https_server_proc = popen_python(
         ['simple_https_server.py', port4, expired_cert_fname])
 
-    # Provide a delay long enough to allow the four HTTPS servers to start.
-    # Have encountered errors at 0.2s, 0.5s, and 2s, primarily on AppVeyor.
-    # Increasing to 4s for this test.
-    # Expect to see "Connection refused" if this delay is not long enough
-    # (though other issues could cause that).
-    time.sleep(3)
+    for port in range(self.PORT + 1, self.PORT + 5):
+      utils.wait_for_server('localhost', port)
 
     relative_target_fpath = os.path.basename(target_filepath)
     good_https_url = 'https://localhost:' + port1 + '/' + relative_target_fpath

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -108,6 +108,7 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
     if cls.server_process.returncode is None:
       logger.info('Server process '+str(cls.server_process.pid)+' terminated.')
       cls.server_process.kill()
+      cls.server_process.wait()
 
 
 

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -57,6 +57,8 @@ import tuf.client.updater as updater
 import tuf.unittest_toolbox as unittest_toolbox
 import tuf.roledb
 
+import utils
+
 import securesystemslib
 import six
 
@@ -89,9 +91,7 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
     logger.info('Serving on port: '+str(cls.SERVER_PORT))
     cls.url = 'http://localhost:'+str(cls.SERVER_PORT) + os.path.sep
 
-    # NOTE: Following error is raised if a delay is not applied:
-    # <urlopen error [Errno 111] Connection refused>
-    time.sleep(.8)
+    utils.wait_for_server('localhost', cls.SERVER_PORT)
 
 
 

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -42,12 +42,10 @@ from __future__ import unicode_literals
 import os
 import tempfile
 import random
-import time
 import shutil
 import json
 import subprocess
 import logging
-import sys
 import unittest
 
 import tuf

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -60,6 +60,8 @@ import tuf.roledb
 import tuf.keydb
 import tuf.unittest_toolbox as unittest_toolbox
 
+import utils
+
 import securesystemslib
 import six
 
@@ -93,9 +95,7 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
     logger.info('Serving on port: '+str(cls.SERVER_PORT))
     cls.url = 'http://localhost:'+str(cls.SERVER_PORT) + os.path.sep
 
-    # NOTE: Following error is raised if a delay is not applied:
-    # <urlopen error [Errno 111] Connection refused>
-    time.sleep(.7)
+    utils.wait_for_server('localhost', cls.SERVER_PORT)
 
 
 

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -112,6 +112,7 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
     if cls.server_process.returncode is None:
       logger.info('Server process '+str(cls.server_process.pid)+' terminated.')
       cls.server_process.kill()
+      cls.server_process.wait()
 
 
 

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -45,12 +45,10 @@ from __future__ import unicode_literals
 import os
 import tempfile
 import random
-import time
 import shutil
 import json
 import subprocess
 import logging
-import sys
 import unittest
 
 import tuf.formats

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -123,6 +123,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     if cls.server_process.returncode is None:
       logger.info('Server process '+str(cls.server_process.pid)+' terminated.')
       cls.server_process.kill()
+      cls.server_process.wait()
 
 
 

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -64,6 +64,8 @@ import tuf.roledb
 import tuf.keydb
 import tuf.exceptions
 
+import utils
+
 import securesystemslib
 import six
 
@@ -100,13 +102,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     logger.info('Serving on port: '+str(cls.SERVER_PORT))
     cls.url = 'http://localhost:'+str(cls.SERVER_PORT) + os.path.sep
 
-    # Provide a delay long enough to allow the HTTP server to start.
-    # Encountered an error on one test system at delay value of 0.2s, so
-    # increasing to 0.5s.  Further increasing to 2s due to occasional failures
-    # in other tests in similar circumstances on AppVeyor.
-    # Expect to see "Connection refused" if this delay is not long enough
-    # (though other issues could cause that).
-    time.sleep(2)
+    utils.wait_for_server('localhost', cls.SERVER_PORT)
 
 
 

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -52,7 +52,6 @@ import shutil
 import json
 import subprocess
 import logging
-import sys
 import unittest
 
 import tuf.formats

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -56,6 +56,8 @@ import tuf.repository_tool as repo_tool
 import tuf.unittest_toolbox as unittest_toolbox
 import tuf.client.updater as updater
 
+import utils
+
 import securesystemslib
 import six
 
@@ -89,9 +91,7 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
     logger.info('\tServing on port: '+str(cls.SERVER_PORT))
     cls.url = 'http://localhost:'+str(cls.SERVER_PORT) + os.path.sep
 
-    # NOTE: Following error is raised if a delay is not applied:
-    # <urlopen error [Errno 111] Connection refused>
-    time.sleep(1)
+    utils.wait_for_server('localhost', cls.SERVER_PORT)
 
 
 

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -108,6 +108,7 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
     if cls.server_process.returncode is None:
       logger.info('\tServer process '+str(cls.server_process.pid)+' terminated.')
       cls.server_process.kill()
+      cls.server_process.wait()
 
 
 

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -38,14 +38,11 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import os
-import time
 import shutil
-import copy
 import tempfile
 import logging
 import random
 import subprocess
-import sys
 import unittest
 
 import tuf

--- a/tests/test_mirrors.py
+++ b/tests/test_mirrors.py
@@ -30,7 +30,6 @@ from __future__ import unicode_literals
 
 import unittest
 
-import tuf
 import tuf.mirrors as mirrors
 import tuf.unittest_toolbox as unittest_toolbox
 

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -41,12 +41,9 @@ from __future__ import unicode_literals
 import os
 import tempfile
 import random
-import time
 import shutil
-import json
 import subprocess
 import logging
-import sys
 import unittest
 
 import tuf.exceptions
@@ -59,7 +56,6 @@ import tuf.keydb
 
 import utils
 
-import securesystemslib
 import six
 
 # The repository tool is imported and logs console messages by default.

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -113,6 +113,8 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
     if cls.server_process.returncode is None:
       logger.info('Server process '+str(cls.server_process.pid)+' terminated.')
       cls.server_process.kill()
+      cls.server_process.wait()
+
 
 
 

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -57,6 +57,8 @@ import tuf.unittest_toolbox as unittest_toolbox
 import tuf.roledb
 import tuf.keydb
 
+import utils
+
 import securesystemslib
 import six
 
@@ -94,9 +96,7 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
     logger.info('Serving on port: '+str(cls.SERVER_PORT))
     cls.url = 'http://localhost:'+str(cls.SERVER_PORT) + os.path.sep
 
-    # NOTE: Following error is raised if a delay is not applied:
-    # <urlopen error [Errno 111] Connection refused>
-    time.sleep(.8)
+    utils.wait_for_server('localhost', cls.SERVER_PORT)
 
 
 

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -30,12 +30,10 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import os
-import sys
 import tempfile
 import random
 import subprocess
 import logging
-import time
 import shutil
 import unittest
 import json
@@ -45,7 +43,6 @@ import tuf.log
 import tuf.roledb
 import tuf.client.updater as updater
 import tuf.settings
-import securesystemslib
 import tuf.unittest_toolbox as unittest_toolbox
 import tuf.repository_tool as repo_tool
 

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -191,19 +191,17 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
     if self.server_process.returncode is None:
       logger.info('Server process ' + str(self.server_process.pid) + ' terminated.')
       self.server_process.kill()
+      self.server_process.wait()
 
     if self.server_process2.returncode is None:
       logger.info('Server 2 process ' + str(self.server_process2.pid) + ' terminated.')
       self.server_process2.kill()
+      self.server_process2.wait()
 
     # updater.Updater() populates the roledb with the name "test_repository1"
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated of all the test cases.
-    # sleep for a bit to allow the kill'd server processes to terminate.
-    time.sleep(.3)
     shutil.rmtree(self.temporary_directory)
 
 

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -49,6 +49,8 @@ import securesystemslib
 import tuf.unittest_toolbox as unittest_toolbox
 import tuf.repository_tool as repo_tool
 
+import utils
+
 import six
 import securesystemslib
 
@@ -153,13 +155,8 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
     self.url = 'http://localhost:' + str(self.SERVER_PORT) + os.path.sep
     self.url2 = 'http://localhost:' + str(self.SERVER_PORT2) + os.path.sep
 
-    # NOTE: Following error is raised if a delay is not long enough:
-    # <urlopen error [Errno 111] Connection refused>
-    # or, on Windows:
-    # Failed to establish a new connection: [Errno 111] Connection refused'
-    # 0.3s led to occasional failures in automated builds, primarily on
-    # AppVeyor, so increasing this to 2s, sadly.
-    time.sleep(2)
+    utils.wait_for_server('localhost', self.SERVER_PORT)
+    utils.wait_for_server('localhost', self.SERVER_PORT2)
 
     url_prefix = 'http://localhost:' + str(self.SERVER_PORT)
     url_prefix2 = 'http://localhost:' + str(self.SERVER_PORT2)

--- a/tests/test_proxy_use.py
+++ b/tests/test_proxy_use.py
@@ -148,6 +148,8 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
       if proc.returncode is None:
         logger.info('\tTerminating process ' + str(proc.pid) + ' in cleanup.')
         proc.kill()
+        # Drop return values of communicate()
+        proc.communicate()
 
 
 

--- a/tests/test_proxy_use.py
+++ b/tests/test_proxy_use.py
@@ -50,6 +50,8 @@ import tuf.log
 import tuf.unittest_toolbox as unittest_toolbox
 import tuf.exceptions
 
+import utils
+
 import requests.exceptions
 
 import securesystemslib
@@ -118,15 +120,10 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
     # the type of connection used with the target server.
     cls.https_proxy_addr = 'https://127.0.0.1:' + str(cls.https_proxy_port)
 
-    # Give the HTTP server and proxy server processes a little bit of time to
-    # start listening before allowing tests to begin, lest we get "Connection
-    # refused" errors. On the first test system. 0.1s was too short and 0.15s
-    # was long enough. Use 0.5s to be safe, and if issues arise, increase it.
-    # Observed occasional failures at 0.1s, 0.15s, 0.5s, and 2s, primarily on
-    # AppVeyor.  Increasing to 4s.  This setup runs once for the module.
-    time.sleep(4)
-
-
+    utils.wait_for_server('127.0.0.1', cls.http_port)
+    utils.wait_for_server('127.0.0.1', cls.https_port)
+    utils.wait_for_server('127.0.0.1', cls.http_proxy_port)
+    utils.wait_for_server('127.0.0.1', cls.https_proxy_port)
 
 
 

--- a/tests/test_proxy_use.py
+++ b/tests/test_proxy_use.py
@@ -35,13 +35,11 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
-import hashlib
 import logging
 import os
 import random
 import subprocess
 import sys
-import time
 import unittest
 
 import tuf
@@ -52,9 +50,6 @@ import tuf.exceptions
 
 import utils
 
-import requests.exceptions
-
-import securesystemslib
 import six
 
 logger = logging.getLogger(__name__)

--- a/tests/test_proxy_use.py
+++ b/tests/test_proxy_use.py
@@ -118,12 +118,12 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
         os.path.join('ssl_certs', 'ssl_cert.crt')])
     # Note that the HTTPS proxy server's address uses https://, regardless of
     # the type of connection used with the target server.
-    cls.https_proxy_addr = 'https://127.0.0.1:' + str(cls.https_proxy_port)
+    cls.https_proxy_addr = 'https://localhost:' + str(cls.https_proxy_port)
 
-    utils.wait_for_server('127.0.0.1', cls.http_port)
-    utils.wait_for_server('127.0.0.1', cls.https_port)
-    utils.wait_for_server('127.0.0.1', cls.http_proxy_port)
-    utils.wait_for_server('127.0.0.1', cls.https_proxy_port)
+    utils.wait_for_server('localhost', cls.http_port)
+    utils.wait_for_server('localhost', cls.https_port)
+    utils.wait_for_server('localhost', cls.http_proxy_port)
+    utils.wait_for_server('localhost', cls.https_proxy_port)
 
 
 

--- a/tests/test_proxy_use.py
+++ b/tests/test_proxy_use.py
@@ -78,6 +78,10 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
 
     unittest_toolbox.Modified_TestCase.setUpClass()
 
+    if not six.PY2:
+      raise NotImplementedError("TestWithProxies only works with Python 2"
+                                " (proxy_server.py is Python2 only)")
+
     # Launch a simple HTTP server (serves files in the current dir).
     cls.http_port = random.randint(30000, 45000)
     cls.http_server_proc = popen_python(

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -112,6 +112,7 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
     if cls.server_process.returncode is None:
       logger.info('Server process '+str(cls.server_process.pid)+' terminated.')
       cls.server_process.kill()
+      cls.server_process.wait()
 
 
 

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -41,13 +41,10 @@ from __future__ import unicode_literals
 import os
 import tempfile
 import random
-import time
 import datetime
 import shutil
-import json
 import subprocess
 import logging
-import sys
 import unittest
 
 import tuf.formats

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -56,6 +56,8 @@ import tuf.client.updater as updater
 import tuf.repository_tool as repo_tool
 import tuf.unittest_toolbox as unittest_toolbox
 
+import utils
+
 import securesystemslib
 import six
 
@@ -93,9 +95,7 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
     logger.info('Serving on port: '+str(cls.SERVER_PORT))
     cls.url = 'http://localhost:'+str(cls.SERVER_PORT) + os.path.sep
 
-    # NOTE: Following error is raised if a delay is not applied:
-    # <urlopen error [Errno 111] Connection refused>
-    time.sleep(.8)
+    utils.wait_for_server('localhost', cls.SERVER_PORT)
 
 
 

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -35,10 +35,7 @@ import logging
 import tempfile
 import json
 import shutil
-import stat
-import sys
 import unittest
-import platform
 
 import tuf
 import tuf.formats

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -35,8 +35,6 @@ import unittest
 import logging
 import tempfile
 import shutil
-import sys
-import errno
 
 import tuf
 import tuf.log
@@ -49,7 +47,6 @@ import securesystemslib.exceptions
 
 import securesystemslib
 import securesystemslib.storage
-import six
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_root_versioning_integration.py
+++ b/tests/test_root_versioning_integration.py
@@ -29,7 +29,6 @@ import os
 import logging
 import tempfile
 import shutil
-import sys
 import unittest
 
 import tuf

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -123,6 +123,7 @@ class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
     if server_process.returncode is None:
       logger.info('Server process '+str(server_process.pid)+' terminated.')
       server_process.kill()
+      server_process.wait()
 
 
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -57,7 +57,6 @@ import tempfile
 import logging
 import random
 import subprocess
-import sys
 import errno
 import unittest
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -72,6 +72,8 @@ import tuf.repository_lib as repo_lib
 import tuf.unittest_toolbox as unittest_toolbox
 import tuf.client.updater as updater
 
+import utils
+
 import securesystemslib
 import six
 
@@ -110,14 +112,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     logger.info('\tServing on port: '+str(cls.SERVER_PORT))
     cls.url = 'http://localhost:'+str(cls.SERVER_PORT) + os.path.sep
 
-    # NOTE: Following error is raised if a delay is not long enough to allow
-    # the server process to set up and start listening:
-    #     <urlopen error [Errno 111] Connection refused>
-    # or, on Windows:
-    #     Failed to establish a new connection: [Errno 111] Connection refused'
-    # While 0.3s has consistently worked on Travis and local builds, it led to
-    # occasional failures in AppVeyor builds, so increasing this to 2s, sadly.
-    time.sleep(2)
+    utils.wait_for_server('localhost', cls.SERVER_PORT)
 
 
 
@@ -1100,13 +1095,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     command = ['python', self.SIMPLE_SERVER_PATH, str(SERVER_PORT)]
     server_process = subprocess.Popen(command)
 
-    # NOTE: Following error is raised if a delay is not long enough:
-    # <urlopen error [Errno 111] Connection refused>
-    # or, on Windows:
-    # Failed to establish a new connection: [Errno 111] Connection refused'
-    # While 0.3s has consistently worked on Travis and local builds, it led to
-    # occasional failures in AppVeyor builds, so increasing this to 2s, sadly.
-    time.sleep(2)
+    utils.wait_for_server('localhost', SERVER_PORT)
 
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
@@ -1368,15 +1357,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     SERVER_PORT = random.randint(30000, 45000)
     command = ['python', self.SIMPLE_SERVER_PATH, str(SERVER_PORT)]
     server_process = subprocess.Popen(command)
-
-    # NOTE: Following error is raised if a delay is not long enough to allow
-    # the server process to set up and start listening:
-    #     <urlopen error [Errno 111] Connection refused>
-    # or, on Windows:
-    #     Failed to establish a new connection: [Errno 111] Connection refused'
-    # While 0.3s has consistently worked on Travis and local builds, it led to
-    # occasional failures in AppVeyor builds, so increasing this to 2s, sadly.
-    time.sleep(2)
+    utils.wait_for_server('localhost', SERVER_PORT)
 
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
@@ -1501,15 +1482,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     SERVER_PORT = random.randint(30000, 45000)
     command = ['python', self.SIMPLE_SERVER_PATH, str(SERVER_PORT)]
     server_process = subprocess.Popen(command)
-
-    # NOTE: Following error is raised if a delay is not long enough to allow
-    # the server process to set up and start listening:
-    #     <urlopen error [Errno 111] Connection refused>
-    # or, on Windows:
-    #     Failed to establish a new connection: [Errno 111] Connection refused'
-    # While 0.3s has consistently worked on Travis and local builds, it led to
-    # occasional failures in AppVeyor builds, so increasing this to 2s, sadly.
-    time.sleep(2)
+    utils.wait_for_server('localhost', SERVER_PORT)
 
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
@@ -1908,14 +1881,8 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     self.url = 'http://localhost:' + str(self.SERVER_PORT) + os.path.sep
     self.url2 = 'http://localhost:' + str(self.SERVER_PORT2) + os.path.sep
 
-    # NOTE: Following error is raised if a delay is not long enough to allow
-    # the server process to set up and start listening:
-    #     <urlopen error [Errno 111] Connection refused>
-    # or, on Windows:
-    #     Failed to establish a new connection: [Errno 111] Connection refused'
-    # While 0.3s has consistently worked on Travis and local builds, it led to
-    # occasional failures in AppVeyor builds, so increasing this to 2s, sadly.
-    time.sleep(2)
+    utils.wait_for_server('localhost', self.SERVER_PORT)
+    utils.wait_for_server('localhost', self.SERVER_PORT2)
 
     url_prefix = 'http://localhost:' + str(self.SERVER_PORT)
     url_prefix2 = 'http://localhost:' + str(self.SERVER_PORT2)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -130,11 +130,10 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     if cls.server_process.returncode is None:
       logger.info('\tServer process ' + str(cls.server_process.pid) + ' terminated.')
       cls.server_process.kill()
+      cls.server_process.wait()
 
     # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated for the test cases.  sleep
-    # for a bit to allow the kill'd server process to terminate.
-    time.sleep(.3)
+    # metadata, targets, and key files generated for the test cases
     shutil.rmtree(cls.temporary_directory)
 
 
@@ -1231,6 +1230,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         '/foo/foo1.1.tar.gz')
 
     server_process.kill()
+    server_process.wait()
 
 
 
@@ -1488,6 +1488,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     self.assertEqual(len(updated_targets), 1)
 
     server_process.kill()
+    server_process.wait()
 
 
 
@@ -1597,6 +1598,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     self.repository_updater.remove_obsolete_targets(destination_directory)
 
     server_process.kill()
+    server_process.wait()
 
 
 
@@ -1953,19 +1955,19 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     if self.server_process.returncode is None:
       logger.info('Server process ' + str(self.server_process.pid) + ' terminated.')
       self.server_process.kill()
+      self.server_process.wait()
 
     if self.server_process2.returncode is None:
       logger.info('Server 2 process ' + str(self.server_process2.pid) + ' terminated.')
       self.server_process2.kill()
+      self.server_process2.wait()
 
     # updater.Updater() populates the roledb with the name "test_repository1"
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
     # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated of all the test cases.  sleep
-    # for a bit to allow the kill'd server processes to terminate.
-    time.sleep(.3)
+    # metadata, targets, and key files generated of all the test cases
     shutil.rmtree(self.temporary_directory)
 
 

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -42,14 +42,11 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import os
-import time
 import shutil
-import copy
 import tempfile
 import logging
 import random
 import subprocess
-import sys
 import unittest
 import filecmp
 

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -63,6 +63,8 @@ import tuf.unittest_toolbox as unittest_toolbox
 import tuf.client.updater as updater
 import tuf.settings
 
+import utils
+
 import securesystemslib
 import six
 
@@ -96,9 +98,8 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     logger.info('\tServing on port: '+str(cls.SERVER_PORT))
     cls.url = 'http://localhost:'+str(cls.SERVER_PORT) + os.path.sep
 
-    # NOTE: Following error is raised if a delay is not applied:
-    # <urlopen error [Errno 111] Connection refused>
-    time.sleep(1)
+    utils.wait_for_server('localhost', cls.SERVER_PORT)
+
 
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,7 +46,7 @@ except NameError:
 # but the current blocking connect() seems to work fast on Linux and seems
 # to at least work on Windows (ECONNREFUSED unfortunately has a 2 second
 # timeout on Windows)
-def wait_for_server(host, port, timeout=5):
+def wait_for_server(host, port, timeout=10):
   start = time.time()
   remaining_timeout = timeout
   succeeded = False

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+# Copyright 2020, TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+<Program Name>
+  utils.py
+
+<Started>
+  August 3, 2020.
+
+<Author>
+  Jussi Kukkonen
+
+<Copyright>
+  See LICENSE-MIT OR LICENSE for licensing information.
+
+<Purpose>
+  Provide common utilities for TUF tests
+"""
+
+import errno
+import logging
+import socket
+import time
+
+logger = logging.getLogger(__name__)
+
+try:
+  # is defined in Python 3
+  TimeoutError
+except NameError:
+  # Define for Python 2
+  class TimeoutError(Exception):
+
+    def __init__(self, value="Timeout"):
+      self.value = value
+
+    def __str__(self):
+      return repr(self.value)
+
+# Wait until host:port accepts connections.
+# Raises TimeoutError if this does not happen within timeout seconds
+# There are major differences between operating systems on how this works
+# but the current blocking connect() seems to work fast on Linux and seems
+# to at least work on Windows (ECONNREFUSED unfortunately has a 2 second
+# timeout on Windows)
+def wait_for_server(host, port, timeout=5):
+  start = time.time()
+  remaining_timeout = timeout
+  succeeded = False
+  while not succeeded and remaining_timeout > 0:
+    try:
+      sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+      sock.settimeout(remaining_timeout)
+      sock.connect((host, port))
+      succeeded = True
+    except socket.timeout as e:
+      pass
+    except IOError as e:
+      # ECONNREFUSED is expected while the server is not started
+      if e.errno not in [errno.ECONNREFUSED]:
+        logger.warning("Unexpected error while waiting for server: " + str(e))
+      # Avoid pegging a core just for this
+      time.sleep(0.01)
+    finally:
+      if sock:
+        sock.close()
+        sock = None
+      remaining_timeout = timeout - (time.time() - start)
+
+  if not succeeded:
+    raise TimeoutError
+
+

--- a/tuf/download.py
+++ b/tuf/download.py
@@ -42,7 +42,9 @@ import requests
 import securesystemslib
 import securesystemslib.util
 import six
+
 import tuf.exceptions
+import tuf.formats
 
 import urllib3.exceptions
 

--- a/tuf/log.py
+++ b/tuf/log.py
@@ -450,6 +450,7 @@ def disable_file_logging():
 
   if file_handler:
     logger.removeHandler(file_handler)
+    file_handler.close()
     file_handler = None
     logger.debug('Removed the file handler.')
 


### PR DESCRIPTION
Improve reliability and speed of the tests: altogether a full test run is > 40% faster on my laptop and _should_ be more reliable as well (there's still a possibility that e.g. the `new wait_for_server()` is not handling some exceptions it should but the potential issues should be resolvable over time -- unlike sleep() that is inherently unreliable). 

Also add a missing import in download.py and close some unclosed handles that make it difficult to read test output

Fixes issue #1085

---

There's quite a bit of repetition in e.g. the simple-server using tests... I didn't try to refactor that at the same time but it might make sense to have a SimpleServerTestMixin that does the required initialization and cleanup.


