### PR TITLE
Raise an error on loading/writing unsigned metadata

### DIFF
--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -31,6 +31,7 @@ from __future__ import unicode_literals
 import unittest
 import datetime
 import sys
+import os
 
 import tuf
 import tuf.formats
@@ -38,6 +39,7 @@ import tuf.formats
 import utils
 
 import securesystemslib
+import securesystemslib.util
 import six
 
 
@@ -778,20 +780,10 @@ class TestFormats(unittest.TestCase):
 
   def test_make_signable(self):
     # Test conditions for expected make_signable() behavior.
-    root = {'_type': 'root',
-            'spec_version': '1.0.0',
-            'version': 8,
-            'consistent_snapshot': False,
-            'expires': '1985-10-21T13:20:00Z',
-            'keys': {'123abc': {'keytype': 'rsa',
-                                'scheme': 'rsassa-pss-sha256',
-                                'keyval': {'public': 'pubkey',
-                                           'private': 'privkey'}}},
-            'roles': {'root': {'keyids': ['123abc'],
-                               'threshold': 1,
-                               'paths': ['path1/', 'path2']}}}
-
     SIGNABLE_SCHEMA = tuf.formats.SIGNABLE_SCHEMA
+    root_file = os.path.join('repository_data', 'repository', 'metadata',
+        'root.json')
+    root = securesystemslib.util.load_json_file(root_file)
     self.assertTrue(SIGNABLE_SCHEMA.matches(tuf.formats.make_signable(root)))
     signable = tuf.formats.make_signable(root)
     self.assertEqual('root', tuf.formats.check_signable_object_format(signable))
@@ -902,19 +894,9 @@ class TestFormats(unittest.TestCase):
 
   def test_check_signable_object_format(self):
     # Test condition for a valid argument.
-    root = {'_type': 'root',
-            'spec_version': '1.0.0',
-            'version': 8,
-            'consistent_snapshot': False,
-            'expires': '1985-10-21T13:20:00Z',
-            'keys': {'123abc': {'keytype': 'rsa',
-                                'scheme': 'rsassa-pss-sha256',
-                                'keyval': {'public': 'pubkey',
-                                           'private': 'privkey'}}},
-            'roles': {'root': {'keyids': ['123abc'],
-                               'threshold': 1,
-                               'paths': ['path1/', 'path2']}}}
-
+    root_file = os.path.join('repository_data', 'repository', 'metadata',
+        'root.json')
+    root = securesystemslib.util.load_json_file(root_file)
     root = tuf.formats.make_signable(root)
     self.assertEqual('root', tuf.formats.check_signable_object_format(root))
 

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -357,10 +357,13 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
   def test_root_rotation_missing_keys(self):
     repository = repo_tool.load_repository(self.repository_directory)
 
-    # A partially written root.json (threshold = 1, and not signed in this
-    # case) causes an invalid root chain later.
+    # A partially written root.json (threshold = 2, and signed with only 1 key)
+    # causes an invalid root chain later.
+    repository.root.threshold = 2
+    repository.root.load_signing_key(self.role_keys['root']['private'])
     repository.snapshot.load_signing_key(self.role_keys['snapshot']['private'])
     repository.timestamp.load_signing_key(self.role_keys['timestamp']['private'])
+
     repository.write('root')
     repository.write('snapshot')
     repository.write('timestamp')
@@ -371,9 +374,9 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
                     os.path.join(self.repository_directory, 'metadata'))
 
     # Create a new, valid root.json.
-    repository.root.threshold = 2
+    # Still not valid, because it is not written with a threshold of 2
+    # previous keys
     repository.root.add_verification_key(self.role_keys['role1']['public'])
-    repository.root.load_signing_key(self.role_keys['root']['private'])
     repository.root.load_signing_key(self.role_keys['role1']['private'])
 
     repository.writeall()

--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -855,7 +855,12 @@ def load_project(project_directory, prefix='', new_targets_location=None,
   targets_metadata_path = os.path.join(project_directory, metadata_directory,
       project_filename)
   signable = securesystemslib.util.load_json_file(targets_metadata_path)
-  tuf.formats.check_signable_object_format(signable)
+  try:
+    tuf.formats.check_signable_object_format(signable)
+  except tuf.exceptions.UnsignedMetadataError:
+    # Downgrade the error to a warning because a use case exists where
+    # metadata may be generated unsigned on one machine and signed on another.
+    logger.warning('Unsigned metadata object: ' + repr(signable))
   targets_metadata = signable['signed']
 
   # Remove the prefix from the metadata.

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -938,6 +938,9 @@ def check_signable_object_format(signable):
     securesystemslib.exceptions.FormatError, if 'signable' does not have the
     correct format.
 
+    tuf.exceptions.UnsignedMetadataError, if 'signable' does not have any
+    signatures
+
   <Side Effects>
     None.
 
@@ -964,6 +967,10 @@ def check_signable_object_format(signable):
   except KeyError as error:
     six.raise_from(securesystemslib.exceptions.FormatError(
         'Unrecognized type ' + repr(role_type)), error)
+
+  if not signable['signatures']:
+    raise tuf.exceptions.UnsignedMetadataError('Signable object of type ' +
+        repr(role_type) + ' has no signatures ', signable)
 
   # 'securesystemslib.exceptions.FormatError' raised if 'signable' does not
   # have a properly formatted role schema.

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -505,7 +505,13 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
   try:
     # Initialize the key and role metadata of the top-level roles.
     signable = securesystemslib.util.load_json_file(root_filename)
-    tuf.formats.check_signable_object_format(signable)
+    try:
+      tuf.formats.check_signable_object_format(signable)
+    except tuf.exceptions.UnsignedMetadataError:
+      # Downgrade the error to a warning because a use case exists where
+      # metadata may be generated unsigned on one machine and signed on another.
+      logger.warning('Unsigned metadata object: ' + repr(signable))
+
     root_metadata = signable['signed']
     tuf.keydb.create_keydb_from_root_metadata(root_metadata, repository_name)
     tuf.roledb.create_roledb_from_root_metadata(root_metadata, repository_name)
@@ -586,7 +592,13 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
 
   try:
     signable = securesystemslib.util.load_json_file(snapshot_filename)
-    tuf.formats.check_signable_object_format(signable)
+    try:
+      tuf.formats.check_signable_object_format(signable)
+    except tuf.exceptions.UnsignedMetadataError:
+      # Downgrade the error to a warning because a use case exists where
+      # metadata may be generated unsigned on one machine and signed on another.
+      logger.warning('Unsigned metadata object: ' + repr(signable))
+
     snapshot_metadata = signable['signed']
 
     for signature in signable['signatures']:
@@ -622,7 +634,13 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
 
   try:
     signable = securesystemslib.util.load_json_file(targets_filename)
-    tuf.formats.check_signable_object_format(signable)
+    try:
+      tuf.formats.check_signable_object_format(signable)
+    except tuf.exceptions.UnsignedMetadataError:
+      # Downgrade the error to a warning because a use case exists where
+      # metadata may be generated unsigned on one machine and signed on another.
+      logger.warning('Unsigned metadata object: ' + repr(signable))
+
     targets_metadata = signable['signed']
 
     for signature in signable['signatures']:
@@ -1862,7 +1880,13 @@ def sign_metadata(metadata_object, keyids, filename, repository_name):
 
   # Raise 'securesystemslib.exceptions.FormatError' if the resulting 'signable'
   # is not formatted correctly.
-  tuf.formats.check_signable_object_format(signable)
+  try:
+    tuf.formats.check_signable_object_format(signable)
+  except tuf.exceptions.UnsignedMetadataError:
+    # Downgrade the error to a warning because a use case exists where
+    # metadata may be generated unsigned on one machine and signed on another.
+    logger.warning('Unsigned metadata object: ' + repr(signable))
+
 
   return signable
 


### PR DESCRIPTION
**Fixes issue #**: #1050

**Description of the changes being introduced by the pull request**:
- Modify  `check_signable_object_format() `to raise an error if signable has an empty 'signatures' list.
- Remove usage of empty signing keys lists in developer_tool 
- Update test cases which use unsigned metadata.

~~**Note** Marked as WIP since `test_root_rotation_missing_keys` correctly fails due to a known verification issue on the Updater (#1101)~~

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


