### PR TITLE
Fix updater workflow

### DIFF
--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1728,14 +1728,14 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
 
 
-  def test_11__verify_uncompressed_metadata_file(self):
+  def test_11__verify_metadata_file(self):
     # Test for invalid metadata content.
     metadata_file_object = tempfile.TemporaryFile()
     metadata_file_object.write(b'X')
     metadata_file_object.seek(0)
 
     self.assertRaises(tuf.exceptions.InvalidMetadataJSONError,
-        self.repository_updater._verify_uncompressed_metadata_file,
+        self.repository_updater._verify_metadata_file,
         metadata_file_object, 'root')
 
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1740,26 +1740,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
 
 
-  def test_12__verify_root_chain_link(self):
-    # Test for an invalid signature in the chain link.
-    # current = (i.e., 1.root.json)
-    # next = signable for the next metadata in the chain (i.e., 2.root.json)
-    rolename = 'root'
-    current_root = self.repository_updater.metadata['current']['root']
-
-    targets_path = os.path.join(self.repository_directory, 'metadata', 'targets.json')
-
-    # 'next_invalid_root' is a Targets signable, as written to disk.
-    # We use the Targets metadata here to ensure the signatures are invalid.
-    next_invalid_root = securesystemslib.util.load_json_file(targets_path)
-
-    self.assertRaises(securesystemslib.exceptions.BadSignatureError,
-        self.repository_updater._verify_root_chain_link, rolename, current_root,
-        next_invalid_root)
-
-
-
-  def test_13__get_file(self):
+  def test_12__get_file(self):
     # Test for an "unsafe" download, where the file is downloaded up to
     # a required length (and no more).  The "safe" download approach
     # downloads an exact required length.
@@ -1779,7 +1760,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     self.repository_updater._get_file('targets.json', verify_target_file,
         file_type, file_size, download_safely=False)
 
-  def test_14__targets_of_role(self):
+  def test_13__targets_of_role(self):
     # Test case where a list of targets is given.  By default, the 'targets'
     # parameter is None.
     targets = [{'filepath': 'file1.txt', 'fileinfo': {'length': 1, 'hashes': {'sha256': 'abc'}}}]

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1370,12 +1370,12 @@ class Updater(object):
 
 
 
-  def _verify_uncompressed_metadata_file(self, metadata_file_object,
+  def _verify_metadata_file(self, metadata_file_object,
       metadata_role):
     """
     <Purpose>
-      Non-public method that verifies an uncompressed metadata file.  An
-      exception is raised if 'metadata_file_object is invalid.  There is no
+      Non-public method that verifies a metadata file.  An exception is
+      raised if 'metadata_file_object is invalid.  There is no
       return value.
 
     <Arguments>
@@ -1569,7 +1569,7 @@ class Updater(object):
           except KeyError:
             logger.info(metadata_role + ' not available locally.')
 
-        self._verify_uncompressed_metadata_file(file_object, metadata_role)
+        self._verify_metadata_file(file_object, metadata_role)
 
       except Exception as exception:
         # Remember the error from this mirror, and "reset" the target file.

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1590,24 +1590,6 @@ class Updater(object):
 
 
 
-  def _verify_root_chain_link(self, rolename, current_root_metadata,
-    next_root_metadata):
-
-    if rolename != 'root':
-      return True
-
-    current_root_role = current_root_metadata['roles'][rolename]
-
-    # Verify next metadata with current keys/threshold
-    valid = tuf.sig.verify(next_root_metadata, rolename, self.repository_name,
-        current_root_role['threshold'], current_root_role['keyids'])
-
-    if not valid:
-      raise securesystemslib.exceptions.BadSignatureError('Root is not signed'
-          ' by previous threshold of keys.')
-
-
-
 
 
   def _get_file(self, filepath, verify_file_function, file_type, file_length,
@@ -1801,9 +1783,6 @@ class Updater(object):
     # stored for 'metadata_role'.
     updated_metadata_object = metadata_signable['signed']
     current_metadata_object = self.metadata['current'].get(metadata_role)
-
-    self._verify_root_chain_link(metadata_role, current_metadata_object,
-        metadata_signable)
 
     # Finally, update the metadata and fileinfo stores, and rebuild the
     # key and role info for the top-level roles if 'metadata_role' is root.


### PR DESCRIPTION
**Fixes issue #**: N/A

**Description of the changes being introduced by the pull request**:
The updater was not adhering to the detailed client workflow. Specifically newly downloaded root metadata was not being verified with a threshold of signatures from itself.

Per the detailed client workflow in the specification step 1.2
> Version N+1 of the root metadata file MUST have been signed by:
(1) a threshold of keys specified in the trusted root metadata file (version N), and
(2) a threshold of keys specified in the new root metadata file being validated (version N+1)."

This PR ensures that point two is verified by the updater.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


