### PR TITLE
Add a way to disable hash prefix when using consistent_snapshot

### DIFF
--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1291,6 +1291,39 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     self.repository_updater.download_target(targetinfo2,
                                             destination_directory)
 
+    # Checks if the file has been successfully downloaded
+    download_filepath = os.path.join(destination_directory, target_filepath2)
+    self.assertTrue(os.path.exists(download_filepath))
+
+    # Removes the file so that it can be downloaded again in the next test
+    os.remove(download_filepath)
+
+    # Test downloading with consistent snapshot enabled, but without adding
+    # the hash of the file as a prefix to its name.
+
+    file1_path = targetinfo2['filepath']
+    file1_hashes = securesystemslib.util.get_file_hashes(
+        os.path.join(self.repository_directory, 'targets', file1_path),
+        hash_algorithms=['sha256', 'sha512'])
+
+    # Currently in the repository directory, those three files exists:
+    # "file1.txt", "<sha256_hash>.file1.txt" and "<sha512_hash>.file1.txt"
+    # where both sha256 and sha512 hashes are for file file1.txt.
+    # Remove the files with the hash digest prefix to ensure that
+    # the served target file is not prefixed.
+    os.remove(os.path.join(self.repository_directory, 'targets',
+        file1_hashes['sha256'] + '.' + file1_path))
+    os.remove(os.path.join(self.repository_directory, 'targets',
+        file1_hashes['sha512'] + '.' + file1_path))
+
+
+    self.repository_updater.download_target(targetinfo2,
+                                            destination_directory,
+                                            prefix_filename_with_hash=False)
+
+    # Checks if the file has been successfully downloaded
+    self.assertTrue(os.path.exists(download_filepath))
+
     # Test for a destination that cannot be written to (apart from a target
     # file that already exists at the destination) and which raises an
     # exception.

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1323,7 +1323,8 @@ class Updater(object):
 
 
 
-  def _get_target_file(self, target_filepath, file_length, file_hashes):
+  def _get_target_file(self, target_filepath, file_length, file_hashes,
+      prefix_filename_with_hash):
     """
     <Purpose>
       Non-public method that safely (i.e., the file length and hash are
@@ -1341,6 +1342,13 @@ class Updater(object):
 
       file_hashes:
         The expected hashes of the target file.
+
+      prefix_filename_with_hash:
+        Whether to prefix the targets file names with their hash when using
+        consistent snapshot.
+        This should be set to False when the served target filenames are not
+        prefixed with hashes (in this case the server uses other means
+        to ensure snapshot consistency).
 
     <Exceptions>
       tuf.exceptions.NoWorkingMirrorError:
@@ -1365,7 +1373,7 @@ class Updater(object):
       self._hard_check_file_length(target_file_object, file_length)
       self._check_hashes(target_file_object, file_hashes)
 
-    if self.consistent_snapshot:
+    if self.consistent_snapshot and prefix_filename_with_hash:
       # Note: values() does not return a list in Python 3.  Use list()
       # on values() for Python 2+3 compatibility.
       target_digest = list(file_hashes.values()).pop()
@@ -3192,7 +3200,8 @@ class Updater(object):
 
 
 
-  def download_target(self, target, destination_directory):
+  def download_target(self, target, destination_directory,
+      prefix_filename_with_hash=True):
     """
     <Purpose>
       Download 'target' and verify it is trusted.
@@ -3208,6 +3217,14 @@ class Updater(object):
 
       destination_directory:
         The directory to save the downloaded target file.
+
+      prefix_filename_with_hash:
+        Whether to prefix the targets file names with their hash when using
+        consistent snapshot.
+        This should be set to False when the served target filenames are not
+        prefixed with hashes (in this case the server uses other means
+        to ensure snapshot consistency).
+        Default is True.
 
     <Exceptions>
       securesystemslib.exceptions.FormatError:
@@ -3243,7 +3260,7 @@ class Updater(object):
     # '_get_target_file()' checks every mirror and returns the first target
     # that passes verification.
     target_file_object = self._get_target_file(target_filepath, trusted_length,
-        trusted_hashes)
+        trusted_hashes, prefix_filename_with_hash)
 
     # We acquired a target file object from a mirror.  Move the file into place
     # (i.e., locally to 'destination_directory').  Note: join() discards


### PR DESCRIPTION
**Fixes issue #**: https://github.com/theupdateframework/tuf/issues/1080

**Description of the changes being introduced by the pull request**:
Currently, if the repository is consistent_snapshot,
Updater will prefix the target filename with the hash
when constructing the download URL.
For some adopters of TUF (like Warehouse) this is not wanted
(warehouse target file paths are "consistent",
even if the filenames are not).

For example, Warehouse doesn't follow what tuf
(the reference implementation and specification) advice for naming
consistent filenames, which is to prefix the filename with the hash
of the files contents.
However, the target filenames it does use are consistent,
only the hash is part of the target's file path
not the target's file name.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


