### PR TITLE
PoC(tap13): User Selection of the Top-Level Target Files Through Mapping Metadata

### DIFF
--- a/tests/repository_data/client/targets_map.json
+++ b/tests/repository_data/client/targets_map.json
@@ -1,0 +1,16 @@
+{
+ "targets_filename": "role1",
+ "keys":{
+  "c8022fa1e9b9cb239a6b362bbdffa9649e61ad2cb699d2e4bc4fdf7930a0e64a": {
+   "keyid_hash_algorithms": [
+    "sha256",
+    "sha512"
+   ],
+   "keytype": "ed25519",
+   "keyval": {
+    "public": "fcf224e55fa226056adf113ef1eb3d55e308b75b321c8c8316999d8c4fd9e0d9"
+   },
+   "scheme": "ed25519"
+  }
+ }
+}

--- a/tests/repository_data/client/targets_map.json
+++ b/tests/repository_data/client/targets_map.json
@@ -1,5 +1,5 @@
 {
- "targets_filename": "role1",
+ "targets_rolename": "role1",
  "keys":{
   "c8022fa1e9b9cb239a6b362bbdffa9649e61ad2cb699d2e4bc4fdf7930a0e64a": {
    "keyid_hash_algorithms": [

--- a/tests/repository_data/targets_map.json
+++ b/tests/repository_data/targets_map.json
@@ -1,0 +1,16 @@
+{
+ "targets_filename": "role1",
+ "keys":{
+  "c8022fa1e9b9cb239a6b362bbdffa9649e61ad2cb699d2e4bc4fdf7930a0e64a": {
+   "keyid_hash_algorithms": [
+    "sha256",
+    "sha512"
+   ],
+   "keytype": "ed25519",
+   "keyval": {
+    "public": "fcf224e55fa226056adf113ef1eb3d55e308b75b321c8c8316999d8c4fd9e0d9"
+   },
+   "scheme": "ed25519"
+  }
+ }
+}

--- a/tests/repository_data/targets_map.json
+++ b/tests/repository_data/targets_map.json
@@ -1,5 +1,5 @@
 {
- "targets_filename": "role1",
+ "targets_rolename": "role1",
  "keys":{
   "c8022fa1e9b9cb239a6b362bbdffa9649e61ad2cb699d2e4bc4fdf7930a0e64a": {
    "keyid_hash_algorithms": [

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1813,7 +1813,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # set the correct map file
     targets_map_file = os.path.join(self.client_directory, 'targets_map.json')
 
-    # Creating a repository instance using the targets map file. 
+    # Creating a repository instance using the targets map file.
     self.repository_updater = updater.Updater(self.repository_name,
         self.repository_mirrors, targets_map_file)
 
@@ -1860,6 +1860,7 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     original_client = os.path.join(original_repository_files, 'client', 'test_repository1')
     original_keystore = os.path.join(original_repository_files, 'keystore')
     original_map_file = os.path.join(original_repository_files, 'map.json')
+    original_targets_map_file = os.path.join(original_repository_files, 'targets_map.json')
 
     # Save references to the often-needed client repository directories.
     # Test cases need these references to access metadata and target files.
@@ -1884,6 +1885,7 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
         'keystore')
     self.map_file = os.path.join(self.client_directory, 'map.json')
     self.map_file2 = os.path.join(self.client_directory2, 'map.json')
+    self.targets_map_file = os.path.join(self.temporary_repository_root, 'targets_map_file')
 
     # Copy the original 'repository', 'client', and 'keystore' directories
     # to the temporary repository the test cases can use.
@@ -1894,6 +1896,7 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     shutil.copyfile(original_map_file, self.map_file)
     shutil.copyfile(original_map_file, self.map_file2)
     shutil.copytree(original_keystore, self.keystore_directory)
+    shutil.copyfile(original_targets_map_file, self.targets_map_file)
 
     # Launch a SimpleHTTPServer (serves files in the current directory).
     # Test cases will request metadata and target files that have been
@@ -2149,6 +2152,25 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     # Test for a repository that doesn't exist.
     multi_repo_updater.map_file['repositories']['bad_repo_name'] = ['https://bogus:30002']
     self.assertEqual(None, multi_repo_updater.get_updater('bad_repo_name'))
+
+
+
+
+
+  def test_targets_map_file(self):
+    map_file = os.path.join(self.client_directory, 'map.json')
+    multi_repo_updater = updater.MultiRepoUpdater(map_file, self.targets_map_file)
+
+    #self.assertTrue('targets_map.json' in multi_repo_updater.targets_map_filename)
+
+    print(multi_repo_updater.map_file)
+    print(multi_repo_updater.repository_names_to_mirrors)
+    print(multi_repo_updater.repository_names_to_updaters)
+
+    # Does the repository use the targets map file?
+    repository_updater = multi_repo_updater.get_updater('test_repository2')
+
+    self.assertEqual(repository_updater.targets_map_file['targets_filename'], 'role1')
 
 
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1801,6 +1801,23 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         targets=targets, skip_refresh=False)
 
 
+  def test_15__targets_map_file(self):
+    targets_map_file = os.path.join(self.client_directory, 'targets_map.json')
+    # Creating a repository instance using the targets map file. The test cases
+    # will use this client updater to refresh metadata, fetch target files, etc.
+    self.repository_updater = updater.Updater(self.repository_name,
+        self.repository_mirrors, targets_map_file)
+
+    all_targets = self.repository_updater.all_targets()
+    self.assertEqual(len(all_targets), 1)
+
+
+
+
+
+
+
+
 
 
 class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -2161,12 +2161,6 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     map_file = os.path.join(self.client_directory, 'map.json')
     multi_repo_updater = updater.MultiRepoUpdater(map_file, self.targets_map_file)
 
-    #self.assertTrue('targets_map.json' in multi_repo_updater.targets_map_filename)
-
-    print(multi_repo_updater.map_file)
-    print(multi_repo_updater.repository_names_to_mirrors)
-    print(multi_repo_updater.repository_names_to_updaters)
-
     # Does the repository use the targets map file?
     repository_updater = multi_repo_updater.get_updater('test_repository2')
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1818,7 +1818,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         self.repository_mirrors, targets_map_file)
 
     #ensure the map file was set
-    self.assertEqual('role1', self.repository_updater.targets_map_file['targets_filename'])
+    self.assertEqual('role1', self.repository_updater.targets_map_file['targets_rolename'])
 
     # ensure that only targets in the targets map file are loaded
     all_targets = self.repository_updater.all_targets()
@@ -2164,7 +2164,7 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     # Does the repository use the targets map file?
     repository_updater = multi_repo_updater.get_updater('test_repository2')
 
-    self.assertEqual(repository_updater.targets_map_file['targets_filename'], 'role1')
+    self.assertEqual(repository_updater.targets_map_file['targets_rolename'], 'role1')
 
 
 

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -186,6 +186,10 @@ class MultiRepoUpdater(object):
       The path of the map file.  The map file is needed to determine which
       repositories to query given a target file.
 
+    targets_map_filename:
+      The path of the targets map file. This targets map file
+      will be used by all repositories.
+
   <Exceptions>
     securesystemslib.exceptions.FormatError, if the map file is improperly
     formatted.
@@ -595,6 +599,9 @@ class Updater(object):
     self.repository_name:
       The name of the updater instance.
 
+    self.targets_map_file:
+      The contents of the targets map file.
+
   <Updater Methods>
     refresh():
       This method downloads, verifies, and loads metadata for the top-level
@@ -673,6 +680,10 @@ class Updater(object):
                                           'metadata_path': 'metadata',
                                           'targets_path': 'targets',
                                           'confined_target_dirs': ['']}}
+      targets_map_file:
+        The name of the targets map file. If one is not provided,
+        self.targets_map_file will be set to None and the top-level
+        targets metadata from the repository will be used.
 
     <Exceptions>
       securesystemslib.exceptions.FormatError:

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -199,7 +199,7 @@ class MultiRepoUpdater(object):
     None.
   """
 
-  def __init__(self, map_file):
+  def __init__(self, map_file, targets_map_filename=None):
     # Is 'map_file' a path?  If not, raise
     # 'securesystemslib.exceptions.FormatError'.  The actual content of the map
     # file is validated later on in this method.
@@ -228,6 +228,14 @@ class MultiRepoUpdater(object):
     #  }
     self.repository_names_to_mirrors = self.map_file['repositories']
 
+    self.targets_map_filename = None
+
+    if targets_map_filename is not None:
+      # Is 'targets_map_file' a path?  If not, raise
+      # 'securesystemslib.exceptions.FormatError'.  The actual content of the map
+      # file is validated later on in this method.
+      securesystemslib.formats.PATH_SCHEMA.check_match(targets_map_filename)
+      self.targets_map_filename = targets_map_filename
 
 
   def get_valid_targetinfo(self, target_filename, match_custom_field=True):
@@ -517,7 +525,7 @@ class MultiRepoUpdater(object):
           # NOTE: State (e.g., keys) should NOT be shared across different
           # updater instances.
           logger.debug('Adding updater for ' + repr(repository_name))
-          updater = tuf.client.updater.Updater(repository_name, mirrors)
+          updater = tuf.client.updater.Updater(repository_name, mirrors, self.targets_map_filename)
 
         except Exception:
           return None

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -867,7 +867,7 @@ class Updater(object):
     # the 'targets.json' file on the repository and instead load
     # the targets metadata indicated by the targets map file.
     if metadata_role == 'targets' and self.targets_map_file is not None:
-      metadata_filename = self.targets_map_file['targets_filename'] + '.json'
+      metadata_filename = self.targets_map_file['targets_rolename'] + '.json'
     else:
       metadata_filename = metadata_role + '.json'
     metadata_filepath = os.path.join(metadata_directory, metadata_filename)
@@ -1835,7 +1835,7 @@ class Updater(object):
     # Construct the metadata filename as expected by the download/mirror
     # modules.
     if self.targets_map_file is not None and metadata_role == 'targets':
-      metadata_filename = self.targets_map_file['targets_filename'] + '.json'
+      metadata_filename = self.targets_map_file['targets_rolename'] + '.json'
     else:
       metadata_filename = metadata_role + '.json'
 
@@ -1973,7 +1973,7 @@ class Updater(object):
     """
 
     if self.targets_map_file is not None and metadata_role == 'targets':
-      metadata_filename = self.targets_map_file['targets_filename'] + '.json'
+      metadata_filename = self.targets_map_file['targets_rolename'] + '.json'
     else:
       metadata_filename = metadata_role + '.json'
     expected_versioninfo = None

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -693,6 +693,11 @@ class Updater(object):
         If there is an error with the updater's repository files, such
         as a missing 'root.json' file.
 
+    tuf.exceptions.Error:
+      If the targets map file cannot be loaded. This may be due to a
+      securesystemslib.exceptions.Error if the targets map filename
+      cannot be parsed, or and IOError in the case of runtime exceptions.
+
     <Side Effects>
       Th metadata files (e.g., 'root.json', 'targets.json') for the top- level
       roles are read from disk and stored in dictionaries.  In addition, the

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1967,7 +1967,10 @@ class Updater(object):
       None.
     """
 
-    metadata_filename = metadata_role + '.json'
+    if self.targets_map_file is not None and metadata_role == 'targets':
+      metadata_filename = self.targets_map_file['targets_filename'] + '.json'
+    else:
+      metadata_filename = metadata_role + '.json'
     expected_versioninfo = None
 
     # Ensure the referenced metadata has been loaded.  The 'root' role may be

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -276,6 +276,12 @@ REPO_NAMES_TO_MIRRORS_SCHEMA = SCHEMA.DictOf(
   key_schema = NAME_SCHEMA,
   value_schema = SCHEMA.ListOf(securesystemslib.formats.URL_SCHEMA))
 
+# An object containing the targets map file. The format of the targets
+# map file is covered in TAP 13
+TARGETS_MAPFILE_SCHEMA = SCHEMA.Object(
+  targets_filename = NAME_SCHEMA,
+  keys = KEYDICT_SCHEMA)
+
 # An object containing the map file's "mapping" attribute.
 MAPPING_SCHEMA = SCHEMA.ListOf(SCHEMA.Object(
   paths = RELPATHS_SCHEMA,

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -279,7 +279,7 @@ REPO_NAMES_TO_MIRRORS_SCHEMA = SCHEMA.DictOf(
 # An object containing the targets map file. The format of the targets
 # map file is covered in TAP 13
 TARGETS_MAPFILE_SCHEMA = SCHEMA.Object(
-  targets_filename = NAME_SCHEMA,
+  targets_rolename = NAME_SCHEMA,
   keys = KEYDICT_SCHEMA)
 
 # An object containing the map file's "mapping" attribute.

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -79,6 +79,11 @@ def create_keydb_from_root_metadata(root_metadata, repository_name='default', ta
       The name of the repository to store the key information.  If not supplied,
       the key database is populated for the 'default' repository.
 
+    targets_map_file:
+      The contents of the targets map file. The keys from the targets map file
+      will be added to the keydb. If not provided the keys from the default
+      targets files will be used.
+
   <Exceptions>
     securesystemslib.exceptions.FormatError, if 'root_metadata' does not have the correct format.
 

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -60,7 +60,7 @@ _keydb_dict = {}
 _keydb_dict['default'] = {}
 
 
-def create_keydb_from_root_metadata(root_metadata, repository_name='default'):
+def create_keydb_from_root_metadata(root_metadata, repository_name='default', targets_map_file = None):
   """
   <Purpose>
     Populate the key database with the unique keys found in 'root_metadata'.
@@ -110,6 +110,44 @@ def create_keydb_from_root_metadata(root_metadata, repository_name='default'):
 
   else:
     create_keydb(repository_name)
+
+
+  if targets_map_file is not None:
+    tuf.formats.TARGETS_MAPFILE_SCHEMA.check_match(targets_map_file)
+
+    for junk, key_metadata in six.iteritems(targets_map_file['keys']):
+      if key_metadata['keytype'] in _SUPPORTED_KEY_TYPES:
+        # 'key_metadata' is stored in 'KEY_SCHEMA' format.  Call
+        # create_from_metadata_format() to get the key in 'RSAKEY_SCHEMA' format,
+        # which is the format expected by 'add_key()'.  Note: The 'keyids'
+        # returned by format_metadata_to_key() include keyids in addition to the
+        # default keyid listed in 'key_dict'.  The additional keyids are
+        # generated according to securesystemslib.settings.HASH_ALGORITHMS.
+
+        # The repo may have used hashing algorithms for the generated keyids that
+        # doesn't match the client's set of hash algorithms.  Make sure to only
+        # used the repo's selected hashing algorithms.
+        hash_algorithms = securesystemslib.settings.HASH_ALGORITHMS
+        securesystemslib.settings.HASH_ALGORITHMS = key_metadata['keyid_hash_algorithms']
+        key_dict, keyids = securesystemslib.keys.format_metadata_to_key(key_metadata)
+        securesystemslib.settings.HASH_ALGORITHMS = hash_algorithms
+
+        try:
+          for keyid in keyids:
+            # Make sure to update key_dict['keyid'] to use one of the other valid
+            # keyids, otherwise add_key() will have no reference to it.
+            key_dict['keyid'] = keyid
+            add_key(key_dict, keyid=None, repository_name=repository_name)
+
+        # Although keyid duplicates should *not* occur (unique dict keys), log a
+        # warning and continue.  However, 'key_dict' may have already been
+        # adding to the keydb elsewhere.
+        except tuf.exceptions.KeyAlreadyExistsError as e: # pragma: no cover
+          logger.warning(e)
+          continue
+
+      else:
+        logger.warning('Root Metadata file contains a key with an invalid keytype.')
 
   # Iterate the keys found in 'root_metadata' by converting them to
   # 'RSAKEY_SCHEMA' if their type is 'rsa', and then adding them to the

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -92,6 +92,10 @@ def create_roledb_from_root_metadata(root_metadata, repository_name='default', t
       The name of the repository to store 'root_metadata'.  If not supplied,
       'rolename' is added to the 'default' repository.
 
+    targets_map_file:
+      The contents of the targets map file. This will be used to add the keys
+      to the targets role. If not provided, the default targets keys will be used.
+
   <Exceptions>
     securesystemslib.exceptions.FormatError, if 'root_metadata' does not have
     the correct object format.

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -76,7 +76,8 @@ _dirty_roles['default'] = set()
 TOP_LEVEL_ROLES = ['root', 'targets', 'snapshot', 'timestamp']
 
 
-def create_roledb_from_root_metadata(root_metadata, repository_name='default', targets_map_file = None):
+def create_roledb_from_root_metadata(root_metadata, repository_name='default',
+    targets_map_file=None):
   """
   <Purpose>
     Create a role database containing all of the unique roles found in
@@ -144,7 +145,7 @@ def create_roledb_from_root_metadata(root_metadata, repository_name='default', t
       roleinfo['previous_keyids'] = roleinfo['keyids']
       roleinfo['previous_threshold'] = roleinfo['threshold']
 
-    if rolename == 'targets' and targets_map_file is not None:
+    elif rolename == 'targets' and targets_map_file is not None:
       roleinfo['keyids'] = []
       for keyid in targets_map_file['keys']:
         roleinfo['keyids'].append(keyid)

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -76,7 +76,7 @@ _dirty_roles['default'] = set()
 TOP_LEVEL_ROLES = ['root', 'targets', 'snapshot', 'timestamp']
 
 
-def create_roledb_from_root_metadata(root_metadata, repository_name='default'):
+def create_roledb_from_root_metadata(root_metadata, repository_name='default', targets_map_file = None):
   """
   <Purpose>
     Create a role database containing all of the unique roles found in
@@ -139,6 +139,11 @@ def create_roledb_from_root_metadata(root_metadata, repository_name='default'):
       roleinfo['expires'] = root_metadata['expires']
       roleinfo['previous_keyids'] = roleinfo['keyids']
       roleinfo['previous_threshold'] = roleinfo['threshold']
+
+    if rolename == 'targets' and targets_map_file is not None:
+      roleinfo['keyids'] = []
+      for keyid, _ in targets_map_file['keys']:
+        roleinfo['keyids'].append(keyid)
 
     roleinfo['signatures'] = []
     roleinfo['signing_keyids'] = []

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -142,7 +142,7 @@ def create_roledb_from_root_metadata(root_metadata, repository_name='default', t
 
     if rolename == 'targets' and targets_map_file is not None:
       roleinfo['keyids'] = []
-      for keyid, _ in targets_map_file['keys']:
+      for keyid in targets_map_file['keys']:
         roleinfo['keyids'].append(keyid)
 
     roleinfo['signatures'] = []


### PR DESCRIPTION
This pr adds support for [TAP 13](https://github.com/theupdateframework/taps/pull/118/files). It adds support for targets mapping metadata that is defined by the client. This mapping metadata allows the client to specify which targets metadata file on the repository they would like to use as top-level targets. This mechanism allows repository managers to split a repository into multiple namespaces and for clients to specify which of these namespaces to trust.


