### PR TITLE
Log subproceses stdout and stderr in temp files

### DIFF
--- a/tests/simple_https_server.py
+++ b/tests/simple_https_server.py
@@ -48,20 +48,11 @@ PORT = 0
 keyfile = os.path.join('ssl_certs', 'ssl_cert.key')
 certfile = os.path.join('ssl_certs', 'ssl_cert.crt')
 
-def _generate_random_port():
-  return random.randint(30000, 45000)
-
 if len(sys.argv) > 1:
-  try:
-    PORT = int(sys.argv[1])
-    if PORT < 30000 or PORT > 45000:
-      raise ValueError
-
-  except ValueError:
-    PORT = _generate_random_port()
+  PORT = int(sys.argv[1])
 
 else:
-  PORT = _generate_random_port()
+  PORT = random.randint(30000, 45000)
 
 if len(sys.argv) > 2:
 

--- a/tests/simple_server.py
+++ b/tests/simple_server.py
@@ -41,20 +41,11 @@ from six.moves.SimpleHTTPServer import SimpleHTTPRequestHandler
 
 PORT = 0
 
-def _port_gen():
-  return random.randint(30000, 45000)
-
 if len(sys.argv) > 1:
-  try:
-    PORT = int(sys.argv[1])
-    if PORT < 30000 or PORT > 45000:
-      raise ValueError
-
-  except ValueError:
-    PORT = _port_gen()
+  PORT = int(sys.argv[1])
 
 else:
-  PORT = _port_gen()
+  PORT = random.randint(30000, 45000)
 
 
 class QuietHTTPRequestHandler(SimpleHTTPRequestHandler):

--- a/tests/slow_retrieval_server.py
+++ b/tests/slow_retrieval_server.py
@@ -85,12 +85,6 @@ class Handler(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):
 
 
 
-def get_random_port():
-  port = random.randint(30000, 45000)
-  return port
-
-
-
 def run(port, test_mode):
   server_address = ('localhost', port)
   httpd = HTTPServer_Test(server_address, Handler, test_mode)

--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -86,7 +86,6 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
     logger.info('Server process started.')
     logger.info('Server process id: ' + str(cls.server_process.pid))
     logger.info('Serving on port: ' + str(cls.SERVER_PORT))
-    cls.url = 'http://localhost:' + str(cls.SERVER_PORT) + os.path.sep
 
     utils.wait_for_server('localhost', cls.SERVER_PORT)
 

--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -82,12 +82,13 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
+    # Kills the server subprocess and closes the temp file used for logging.
+    cls.server_process_handler.clean()
+
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)
 
-    # Kills the server subprocess and closes the temp file used for logging.
-    cls.server_process_handler.clean()
 
 
 

--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -64,8 +64,6 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # setUpClass() is called before any of the test cases are executed.
-
     # Create a temporary directory to store the repository, metadata, and target
     # files.  'temporary_directory' must be deleted in TearDownModule() so that
     # temporary files are always removed, even when exceptions occur.
@@ -84,9 +82,6 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
-    # tearDownModule() is called after all the test cases have run.
-    # http://docs.python.org/2/library/unittest.html#class-and-module-fixtures
-
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)

--- a/tests/test_developer_tool.py
+++ b/tests/test_developer_tool.py
@@ -55,13 +55,11 @@ class TestProject(unittest.TestCase):
   def setUpClass(cls):
     cls.tmp_dir = tempfile.mkdtemp(dir = os.getcwd())
 
+
   @classmethod
   def tearDownClass(cls):
     shutil.rmtree(cls.tmp_dir)
 
-  def setUp(self):
-    # called before every test case
-    pass
 
   def tearDown(self):
     # called after every test case

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -66,8 +66,6 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # setUpClass() is called before any of the test cases are executed.
-
     # Create a temporary directory to store the repository, metadata, and target
     # files.  'temporary_directory' must be deleted in TearDownModule() so that
     # temporary files are always removed, even when exceptions occur.
@@ -86,9 +84,6 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
-    # tearDownModule() is called after all the test cases have run.
-    # http://docs.python.org/2/library/unittest.html#class-and-module-fixtures
-
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -84,12 +84,13 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
+    # Kills the server subprocess and closes the temp file used for logging.
+    cls.server_process_handler.clean()
+
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)
 
-    # Kills the server subprocess and closes the temp file used for logging.
-    cls.server_process_handler.clean()
 
 
 

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -41,10 +41,8 @@ from __future__ import unicode_literals
 
 import os
 import tempfile
-import random
 import shutil
 import json
-import subprocess
 import logging
 import unittest
 import sys
@@ -82,14 +80,7 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
     # the pre-generated metadata files have a specific structure, such
     # as a delegated role 'targets/role1', three target files, five key files,
     # etc.
-    cls.SERVER_PORT = random.randint(30000, 45000)
-    command = ['python', 'simple_server.py', str(cls.SERVER_PORT)]
-    cls.server_process = subprocess.Popen(command)
-    logger.info('Server process started.')
-    logger.info('Server process id: '+str(cls.server_process.pid))
-    logger.info('Serving on port: '+str(cls.SERVER_PORT))
-
-    utils.wait_for_server('localhost', cls.SERVER_PORT)
+    cls.server_process_handler = utils.TestServerProcess(log=logger)
 
 
 
@@ -102,11 +93,8 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)
 
-    # Kill the SimpleHTTPServer process.
-    if cls.server_process.returncode is None:
-      logger.info('Server process '+str(cls.server_process.pid)+' terminated.')
-      cls.server_process.kill()
-      cls.server_process.wait()
+    # Kills the server subprocess and closes the temp file used for logging.
+    cls.server_process_handler.clean()
 
 
 
@@ -142,8 +130,8 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = \
-      'http://localhost:' + str(self.SERVER_PORT) + repository_basepath
+    url_prefix = 'http://localhost:' \
+        + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client
     # directory copied from the original repository files.
@@ -165,6 +153,10 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
     unittest_toolbox.Modified_TestCase.tearDown(self)
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
+
+    # Logs stdout and stderr from the sever subprocess.
+    self.server_process_handler.flush_log()
+
 
 
   def test_without_tuf(self):

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -88,7 +88,6 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
     logger.info('Server process started.')
     logger.info('Server process id: '+str(cls.server_process.pid))
     logger.info('Serving on port: '+str(cls.SERVER_PORT))
-    cls.url = 'http://localhost:'+str(cls.SERVER_PORT) + os.path.sep
 
     utils.wait_for_server('localhost', cls.SERVER_PORT)
 

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -44,10 +44,8 @@ from __future__ import unicode_literals
 
 import os
 import tempfile
-import random
 import shutil
 import json
-import subprocess
 import logging
 import unittest
 import sys
@@ -86,14 +84,7 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
     # the pre-generated metadata files have a specific structure, such
     # as a delegated role 'targets/role1', three target files, five key files,
     # etc.
-    cls.SERVER_PORT = random.randint(30000, 45000)
-    command = ['python', 'simple_server.py', str(cls.SERVER_PORT)]
-    cls.server_process = subprocess.Popen(command)
-    logger.info('Server process started.')
-    logger.info('Server process id: '+str(cls.server_process.pid))
-    logger.info('Serving on port: '+str(cls.SERVER_PORT))
-
-    utils.wait_for_server('localhost', cls.SERVER_PORT)
+    cls.server_process_handler = utils.TestServerProcess(log=logger)
 
 
 
@@ -106,11 +97,8 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)
 
-    # Kill the SimpleHTTPServer process.
-    if cls.server_process.returncode is None:
-      logger.info('Server process '+str(cls.server_process.pid)+' terminated.')
-      cls.server_process.kill()
-      cls.server_process.wait()
+    # Kills the server subprocess and closes the temp file used for logging.
+    cls.server_process_handler.clean()
 
 
 
@@ -149,8 +137,8 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = \
-      'http://localhost:' + str(self.SERVER_PORT) + repository_basepath
+    url_prefix = 'http://localhost:' \
+        + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client
     # directory copied from the original repository files.
@@ -173,7 +161,8 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
-
+    # Logs stdout and stderr from the sever subprocess.
+    self.server_process_handler.flush_log()
 
 
   def test_with_tuf(self):

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -70,8 +70,6 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # setUpClass() is called before any of the test cases are executed.
-
     # Create a temporary directory to store the repository, metadata, and target
     # files.  'temporary_directory' must be deleted in TearDownModule() so that
     # temporary files are always removed, even when exceptions occur.
@@ -90,9 +88,6 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
-    # tearDownModule() is called after all the test cases have run.
-    # http://docs.python.org/2/library/unittest.html#class-and-module-fixtures
-
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -88,12 +88,13 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
+    # Kills the server subprocess and closes the temp file used for logging.
+    cls.server_process_handler.clean()
+
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)
 
-    # Kills the server subprocess and closes the temp file used for logging.
-    cls.server_process_handler.clean()
 
 
 

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -92,7 +92,6 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
     logger.info('Server process started.')
     logger.info('Server process id: '+str(cls.server_process.pid))
     logger.info('Serving on port: '+str(cls.SERVER_PORT))
-    cls.url = 'http://localhost:'+str(cls.SERVER_PORT) + os.path.sep
 
     utils.wait_for_server('localhost', cls.SERVER_PORT)
 

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -45,12 +45,10 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import os
-import random
 import time
 import tempfile
 import shutil
 import json
-import subprocess
 import logging
 import unittest
 import sys
@@ -94,14 +92,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # the pre-generated metadata files have a specific structure, such
     # as a delegated role 'targets/role1', three target files, five key files,
     # etc.
-    cls.SERVER_PORT = random.randint(30000, 45000)
-    command = ['python', 'simple_server.py', str(cls.SERVER_PORT)]
-    cls.server_process = subprocess.Popen(command)
-    logger.info('Server process started.')
-    logger.info('Server process id: '+str(cls.server_process.pid))
-    logger.info('Serving on port: '+str(cls.SERVER_PORT))
-
-    utils.wait_for_server('localhost', cls.SERVER_PORT)
+    cls.server_process_handler = utils.TestServerProcess(log=logger)
 
 
 
@@ -114,11 +105,8 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)
 
-    # Kill the SimpleHTTPServer process.
-    if cls.server_process.returncode is None:
-      logger.info('Server process '+str(cls.server_process.pid)+' terminated.')
-      cls.server_process.kill()
-      cls.server_process.wait()
+    # Kills the server subprocess and closes the temp file used for logging.
+    cls.server_process_handler.clean()
 
 
 
@@ -156,8 +144,8 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = \
-      'http://localhost:' + str(self.SERVER_PORT) + repository_basepath
+    url_prefix = 'http://localhost:' \
+        + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client
     # directory copied from the original repository files.
@@ -179,6 +167,9 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     unittest_toolbox.Modified_TestCase.tearDown(self)
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
+
+    # Logs stdout and stderr from the sever subprocess.
+    self.server_process_handler.flush_log()
 
 
   def test_without_tuf(self):

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -78,8 +78,6 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # setUpClass() is called before any of the test cases are executed.
-
     # Create a temporary directory to store the repository, metadata, and target
     # files.  'temporary_directory' must be deleted in TearDownModule() so that
     # temporary files are always removed, even when exceptions occur.
@@ -98,9 +96,6 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
-    # tearDownModule() is called after all the test cases have run.
-    # http://docs.python.org/2/library/unittest.html#class-and-module-fixtures
-
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -100,7 +100,6 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     logger.info('Server process started.')
     logger.info('Server process id: '+str(cls.server_process.pid))
     logger.info('Serving on port: '+str(cls.SERVER_PORT))
-    cls.url = 'http://localhost:'+str(cls.SERVER_PORT) + os.path.sep
 
     utils.wait_for_server('localhost', cls.SERVER_PORT)
 

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -96,12 +96,13 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
+    # Kills the server subprocess and closes the temp file used for logging.
+    cls.server_process_handler.clean()
+
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)
 
-    # Kills the server subprocess and closes the temp file used for logging.
-    cls.server_process_handler.clean()
 
 
 

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -83,12 +83,13 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
+    # Kills the server subprocess and closes the temp file used for logging.
+    cls.server_process_handler.clean()
+
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated for the test cases.
     shutil.rmtree(cls.temporary_directory)
 
-    # Kills the server subprocess and closes the temp file used for logging.
-    cls.server_process_handler.clean()
 
 
 

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -65,8 +65,6 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # setUpClass() is called before tests in an individual class are executed.
-
     # Create a temporary directory to store the repository, metadata, and target
     # files.  'temporary_directory' must be deleted in TearDownModule() so that
     # temporary files are always removed, even when exceptions occur.
@@ -85,9 +83,6 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
-    # tearDownModule() is called after all the tests have run.
-    # http://docs.python.org/2/library/unittest.html#class-and-module-fixtures
-
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated for the test cases.
     shutil.rmtree(cls.temporary_directory)

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -87,7 +87,6 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
     logger.info('\n\tServer process started.')
     logger.info('\tServer process id: '+str(cls.server_process.pid))
     logger.info('\tServing on port: '+str(cls.SERVER_PORT))
-    cls.url = 'http://localhost:'+str(cls.SERVER_PORT) + os.path.sep
 
     utils.wait_for_server('localhost', cls.SERVER_PORT)
 

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -40,9 +40,7 @@ from __future__ import unicode_literals
 
 import os
 import tempfile
-import random
 import shutil
-import subprocess
 import logging
 import unittest
 import sys
@@ -85,14 +83,7 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
     # the pre-generated metadata files have a specific structure, such
     # as a delegated role 'targets/role1', three target files, five key files,
     # etc.
-    cls.SERVER_PORT = random.randint(30000, 45000)
-    command = ['python', 'simple_server.py', str(cls.SERVER_PORT)]
-    cls.server_process = subprocess.Popen(command)
-    logger.info('Server process started.')
-    logger.info('Server process id: '+str(cls.server_process.pid))
-    logger.info('Serving on port: '+str(cls.SERVER_PORT))
-
-    utils.wait_for_server('localhost', cls.SERVER_PORT)
+    cls.server_process_handler = utils.TestServerProcess(log=logger)
 
 
 
@@ -105,12 +96,8 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)
 
-    # Kill the SimpleHTTPServer process.
-    if cls.server_process.returncode is None:
-      logger.info('Server process '+str(cls.server_process.pid)+' terminated.')
-      cls.server_process.kill()
-      cls.server_process.wait()
-
+    # Kills the server subprocess and closes the temp file used for logging.
+    cls.server_process_handler.clean()
 
 
 
@@ -149,8 +136,8 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = \
-      'http://localhost:' + str(self.SERVER_PORT) + repository_basepath
+    url_prefix = 'http://localhost:' \
+      + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client
     # directory copied from the original repository files.
@@ -172,6 +159,9 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
     unittest_toolbox.Modified_TestCase.tearDown(self)
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
+
+    # Logs stdout and stderr from the sever subprocess.
+    self.server_process_handler.flush_log()
 
 
   def test_with_tuf(self):

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -69,8 +69,6 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # setUpClass() is called before any of the test cases are executed.
-
     # Create a temporary directory to store the repository, metadata, and
     # target files.  'temporary_directory' must be deleted in TearDownModule()
     # so that temporary files are always removed, even when exceptions occur.
@@ -89,9 +87,6 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
-    # tearDownModule() is called after all the test cases have run.
-    # http://docs.python.org/2/library/unittest.html#class-and-module-fixtures
-
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -91,7 +91,6 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
     logger.info('Server process started.')
     logger.info('Server process id: '+str(cls.server_process.pid))
     logger.info('Serving on port: '+str(cls.SERVER_PORT))
-    cls.url = 'http://localhost:'+str(cls.SERVER_PORT) + os.path.sep
 
     utils.wait_for_server('localhost', cls.SERVER_PORT)
 

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -87,12 +87,13 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
+    # Kills the server subprocess and closes the temp file used for logging.
+    cls.server_process_handler.clean()
+
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)
 
-    # Kills the server subprocess and closes the temp file used for logging.
-    cls.server_process_handler.clean()
 
 
 

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -150,8 +150,6 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
     logger.debug('Server process 2 started.')
     logger.debug('Server 2 process id: ' + str(self.server_process2.pid))
     logger.debug('Serving 2 on port: ' + str(self.SERVER_PORT2))
-    self.url = 'http://localhost:' + str(self.SERVER_PORT) + os.path.sep
-    self.url2 = 'http://localhost:' + str(self.SERVER_PORT2) + os.path.sep
 
     utils.wait_for_server('localhost', self.SERVER_PORT)
     utils.wait_for_server('localhost', self.SERVER_PORT2)

--- a/tests/test_proxy_use.py
+++ b/tests/test_proxy_use.py
@@ -37,10 +37,8 @@ from __future__ import unicode_literals
 
 import logging
 import os
-import random
-import subprocess
-import sys
 import unittest
+import sys
 
 import tuf
 import tuf.download as download
@@ -78,25 +76,23 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
                                 " (proxy_server.py is Python2 only)")
 
     # Launch a simple HTTP server (serves files in the current dir).
-    cls.http_port = random.randint(30000, 45000)
-    cls.http_server_proc = popen_python(
-        ['simple_server.py', str(cls.http_port)])
+    cls.http_server_handler = utils.TestServerProcess(log=logger)
 
     # Launch an HTTPS server (serves files in the current dir).
-    cls.https_port = cls.http_port + 1
-    cls.https_server_proc = popen_python(
-        ['simple_https_server.py', str(cls.https_port)])
-
+    cls.https_server_handler = utils.TestServerProcess(log=logger,
+        server='simple_https_server.py',
+        port=cls.http_server_handler.port + 1)
 
     # Launch an HTTP proxy server derived from inaz2/proxy2.
     # This one is able to handle HTTP CONNECT requests, and so can pass HTTPS
     # requests on to the target server.
-    cls.http_proxy_port = cls.http_port + 2
-    cls.http_proxy_proc = popen_python(
-        ['proxy_server.py', str(cls.http_proxy_port)])
+    cls.http_proxy_handler = utils.TestServerProcess(log=logger,
+        server='proxy_server.py',
+        port=cls.http_server_handler.port + 2)
+
     # Note that the HTTP proxy server's address uses http://, regardless of the
     # type of connection used with the target server.
-    cls.http_proxy_addr = 'http://127.0.0.1:' + str(cls.http_proxy_port)
+    cls.http_proxy_addr = 'http://127.0.0.1:' + str(cls.http_proxy_handler.port)
 
 
     # Launch an HTTPS proxy server, also derived from inaz2/proxy2.
@@ -111,18 +107,15 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
     # 3rd arg: (optional) certificate file for telling the proxy what target
     #   server certs to accept in its HTTPS connection to the target server.
     #   This is only relevant if the proxy is in intercept mode.
-    cls.https_proxy_port = cls.http_port + 3
-    cls.https_proxy_proc = popen_python(
-        ['proxy_server.py', str(cls.https_proxy_port), 'intercept',
-        os.path.join('ssl_certs', 'ssl_cert.crt')])
+    good_cert_fpath = os.path.join('ssl_certs', 'ssl_cert.crt')
+    cls.https_proxy_handler = utils.TestServerProcess(log=logger,
+        server='proxy_server.py',
+        port=cls.http_server_handler.port + 3,
+        extra_cmd_args=['intercept', good_cert_fpath])
+
     # Note that the HTTPS proxy server's address uses https://, regardless of
     # the type of connection used with the target server.
-    cls.https_proxy_addr = 'https://localhost:' + str(cls.https_proxy_port)
-
-    utils.wait_for_server('localhost', cls.http_port)
-    utils.wait_for_server('localhost', cls.https_port)
-    utils.wait_for_server('localhost', cls.http_proxy_port)
-    utils.wait_for_server('localhost', cls.https_proxy_port)
+    cls.https_proxy_addr = 'https://localhost:' + str(cls.https_proxy_handler.port)
 
 
 
@@ -135,17 +128,15 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
     """
     unittest_toolbox.Modified_TestCase.tearDownClass()
 
-    for proc in [
-        cls.http_server_proc,
-        cls.https_server_proc,
-        cls.http_proxy_proc,
-        cls.https_proxy_proc,
+    for proc_handler in [
+        cls.http_server_handler,
+        cls.https_server_handler,
+        cls.http_proxy_handler,
+        cls.https_proxy_handler,
       ]:
-      if proc.returncode is None:
-        logger.info('\tTerminating process ' + str(proc.pid) + ' in cleanup.')
-        proc.kill()
-        # Drop return values of communicate()
-        proc.communicate()
+
+        # Kill the SimpleHTTPServer process.
+        proc_handler.clean()
 
 
 
@@ -163,16 +154,16 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
     # and its url on the server.
     current_dir = os.getcwd()
     target_filepath = self.make_temp_data_file(directory=current_dir)
-    rel_target_filepath = os.path.basename(target_filepath)
 
     with open(target_filepath, 'r') as target_file_object:
       self.target_data_length = len(target_file_object.read())
 
+    suffix = '/' + os.path.basename(target_filepath)
     self.url = \
-        'http://localhost:' + str(self.http_port) + '/' + rel_target_filepath
+        'http://localhost:' + str(self.http_server_handler.port) + suffix
 
     self.url_https = \
-        'https://localhost:' + str(self.https_port) + '/' + rel_target_filepath
+        'https://localhost:' + str(self.https_server_handler.port) + suffix
 
 
 
@@ -187,6 +178,15 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
 
     self.restore_all_modified_env_values()
 
+    for proc_handler in [
+        self.http_server_handler,
+        self.https_server_handler,
+        self.http_proxy_handler,
+        self.https_proxy_handler,
+      ]:
+
+        # Logs stdout and stderr from the sever subprocess.
+        proc_handler.flush_log()
 
 
 
@@ -352,29 +352,9 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
 
 
 
-
-
   def restore_all_modified_env_values(self):
     for key in self.old_env_values:
       self.restore_env_value(key)
-
-
-
-
-
-# TODO: Move this to a common test module (tests/common.py?)
-#       and strip it test_proxy_use.py and test_download.py.
-def popen_python(command_arg_list):
-  """
-  Run subprocess.Popen() to produce a process running a Python interpreter.
-  Uses the same Python interpreter that the current process is using, via
-  sys.executable.
-  """
-  assert sys.executable, 'Test cannot function: unable to determine ' \
-      'current Python interpreter via sys.executable.'
-
-  return subprocess.Popen(
-      [sys.executable] + command_arg_list, stderr=subprocess.PIPE)
 
 
 

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -40,10 +40,8 @@ from __future__ import unicode_literals
 
 import os
 import tempfile
-import random
 import datetime
 import shutil
-import subprocess
 import logging
 import unittest
 import sys
@@ -85,14 +83,7 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
     # the pre-generated metadata files have a specific structure, such
     # as a delegated role 'targets/role1', three target files, five key files,
     # etc.
-    cls.SERVER_PORT = random.randint(30000, 45000)
-    command = ['python', 'simple_server.py', str(cls.SERVER_PORT)]
-    cls.server_process = subprocess.Popen(command)
-    logger.info('Server process started.')
-    logger.info('Server process id: '+str(cls.server_process.pid))
-    logger.info('Serving on port: '+str(cls.SERVER_PORT))
-
-    utils.wait_for_server('localhost', cls.SERVER_PORT)
+    cls.server_process_handler = utils.TestServerProcess(log=logger)
 
 
 
@@ -105,11 +96,8 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)
 
-    # Kill the SimpleHTTPServer process.
-    if cls.server_process.returncode is None:
-      logger.info('Server process '+str(cls.server_process.pid)+' terminated.')
-      cls.server_process.kill()
-      cls.server_process.wait()
+    # Kills the server subprocess and closes the temp file used for logging.
+    cls.server_process_handler.clean()
 
 
 
@@ -148,8 +136,8 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = \
-      'http://localhost:' + str(self.SERVER_PORT) + repository_basepath
+    url_prefix = 'http://localhost:' \
+      + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client
     # directory copied from the original repository files.
@@ -171,6 +159,10 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
     unittest_toolbox.Modified_TestCase.tearDown(self)
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
+
+    # Logs stdout and stderr from the sever subprocess.
+    self.server_process_handler.flush_log()
+
 
 
   def test_without_tuf(self):

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -69,8 +69,6 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # setUpClass() is called before any of the test cases are executed.
-
     # Create a temporary directory to store the repository, metadata, and target
     # files.  'temporary_directory' must be deleted in TearDownModule() so that
     # temporary files are always removed, even when exceptions occur.
@@ -89,9 +87,6 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
-    # tearDownModule() is called after all the test cases have run.
-    # http://docs.python.org/2/library/unittest.html#class-and-module-fixtures
-
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -87,12 +87,13 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
+    # Kills the server subprocess and closes the temp file used for logging.
+    cls.server_process_handler.clean()
+
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)
 
-    # Kills the server subprocess and closes the temp file used for logging.
-    cls.server_process_handler.clean()
 
 
 

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -91,7 +91,6 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
     logger.info('Server process started.')
     logger.info('Server process id: '+str(cls.server_process.pid))
     logger.info('Serving on port: '+str(cls.SERVER_PORT))
-    cls.url = 'http://localhost:'+str(cls.SERVER_PORT) + os.path.sep
 
     utils.wait_for_server('localhost', cls.SERVER_PORT)
 

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -70,9 +70,6 @@ TOP_LEVEL_METADATA_FILES = ['root.json', 'targets.json', 'timestamp.json',
 class TestRepositoryToolFunctions(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
-
-    # setUpClass() is called before tests in an individual class are executed.
-
     # Create a temporary directory to store the repository, metadata, and target
     # files.  'temporary_directory' must be deleted in TearDownClass() so that
     # temporary files are always removed, even when exceptions occur.
@@ -84,10 +81,6 @@ class TestRepositoryToolFunctions(unittest.TestCase):
 
   @classmethod
   def tearDownClass(cls):
-
-    # tearDownModule() is called after all the tests have run.
-    # http://docs.python.org/2/library/unittest.html#class-and-module-fixtures
-
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated for the test cases.
     tuf.roledb.clear_roledb(clear_all=True)

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -58,9 +58,6 @@ repo_tool.disable_console_log_messages()
 class TestRepository(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
-
-    # setUpClass() is called before tests in an individual class are executed.
-
     # Create a temporary directory to store the repository, metadata, and target
     # files.  'temporary_directory' must be deleted in TearDownClass() so that
     # temporary files are always removed, even when exceptions occur.
@@ -69,10 +66,6 @@ class TestRepository(unittest.TestCase):
 
   @classmethod
   def tearDownClass(cls):
-
-    # tearDownModule() is called after all the tests have run.
-    # http://docs.python.org/2/library/unittest.html#class-and-module-fixtures
-
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated for the test cases.
     shutil.rmtree(cls.temporary_directory)
@@ -1160,9 +1153,6 @@ class TestSnapshot(unittest.TestCase):
 class TestTargets(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
-
-    # setUpClass() is called before tests in an individual class are executed.
-
     # Create a temporary directory to store the repository, metadata, and target
     # files.  'temporary_directory' must be deleted in TearDownClass() so that
     # temporary files are always removed, even when exceptions occur.
@@ -1172,10 +1162,6 @@ class TestTargets(unittest.TestCase):
 
   @classmethod
   def tearDownClass(cls):
-
-    # tearDownModule() is called after all the tests have run.
-    # http://docs.python.org/2/library/unittest.html#class-and-module-fixtures
-
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated for the test cases.
     shutil.rmtree(cls.temporary_directory)
@@ -1922,9 +1908,6 @@ class TestTargets(unittest.TestCase):
 class TestRepositoryToolFunctions(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
-
-    # setUpClass() is called before tests in an individual class are executed.
-
     # Create a temporary directory to store the repository, metadata, and target
     # files.  'temporary_directory' must be deleted in TearDownClass() so that
     # temporary files are always removed, even when exceptions occur.
@@ -1934,10 +1917,6 @@ class TestRepositoryToolFunctions(unittest.TestCase):
 
   @classmethod
   def tearDownClass(cls):
-
-    # tearDownModule() is called after all the tests have run.
-    # http://docs.python.org/2/library/unittest.html#class-and-module-fixtures
-
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated for the test cases.
     shutil.rmtree(cls.temporary_directory)

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -107,7 +107,6 @@ class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
     logger.info('Slow Retrieval Server process started.')
     logger.info('Server process id: '+str(server_process.pid))
     logger.info('Serving on port: '+str(self.SERVER_PORT))
-    url = 'http://localhost:'+str(self.SERVER_PORT) + os.path.sep
 
     # NOTE: Following error is raised if a delay is not long enough:
     # <urlopen error [Errno 111] Connection refused>

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -72,8 +72,6 @@ class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # setUpClass() is called before any of the test cases are executed.
-
     # Create a temporary directory to store the repository, metadata, and target
     # files.  'temporary_directory' must be deleted in TearDownModule() so that
     # temporary files are always removed, even when exceptions occur.
@@ -84,9 +82,6 @@ class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
-    # tearDownModule() is called after all the test cases have run.
-    # http://docs.python.org/2/library/unittest.html#class-and-module-fixtures
-
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated of all the test cases.
     shutil.rmtree(cls.temporary_directory)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -107,12 +107,13 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
+    # Kills the server subprocess and closes the temp file used for logging.
+    cls.server_process_handler.clean()
+
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated for the test cases
     shutil.rmtree(cls.temporary_directory)
 
-    # Kills the server subprocess and closes the temp file used for logging.
-    cls.server_process_handler.clean()
 
 
   def setUp(self):

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -110,7 +110,6 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     logger.info('\n\tServer process started.')
     logger.info('\tServer process id: '+str(cls.server_process.pid))
     logger.info('\tServing on port: '+str(cls.SERVER_PORT))
-    cls.url = 'http://localhost:'+str(cls.SERVER_PORT) + os.path.sep
 
     utils.wait_for_server('localhost', cls.SERVER_PORT)
 
@@ -1891,8 +1890,6 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     logger.debug('Server process 2 started.')
     logger.debug('Server 2 process id: ' + str(self.server_process2.pid))
     logger.debug('Serving 2 on port: ' + str(self.SERVER_PORT2))
-    self.url = 'http://localhost:' + str(self.SERVER_PORT) + os.path.sep
-    self.url2 = 'http://localhost:' + str(self.SERVER_PORT2) + os.path.sep
 
     utils.wait_for_server('localhost', self.SERVER_PORT)
     utils.wait_for_server('localhost', self.SERVER_PORT2)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -83,8 +83,6 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # setUpClass() is called before tests in an individual class are executed.
-
     # Create a temporary directory to store the repository, metadata, and target
     # files.  'temporary_directory' must be deleted in TearDownModule() so that
     # temporary files are always removed, even when exceptions occur.
@@ -109,9 +107,6 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
-    # tearDownModule() is called after all the tests have run.
-    # http://docs.python.org/2/library/unittest.html#class-and-module-fixtures
-
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated for the test cases
     shutil.rmtree(cls.temporary_directory)

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -72,8 +72,6 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # setUpClass() is called before tests in an individual class are executed.
-
     # Create a temporary directory to store the repository, metadata, and target
     # files.  'temporary_directory' must be deleted in TearDownModule() so that
     # temporary files are always removed, even when exceptions occur.
@@ -93,9 +91,6 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
-    # tearDownModule() is called after all the tests have run.
-    # http://docs.python.org/2/library/unittest.html#class-and-module-fixtures
-
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated for the test cases.
     shutil.rmtree(cls.temporary_directory)

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -91,12 +91,13 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def tearDownClass(cls):
+    # Kills the server subprocess and closes the temp file used for logging.
+    cls.server_process_handler.clean()
+
     # Remove the temporary repository directory, which should contain all the
     # metadata, targets, and key files generated for the test cases.
     shutil.rmtree(cls.temporary_directory)
 
-    # Kills the server subprocess and closes the temp file used for logging.
-    cls.server_process_handler.clean()
 
 
 

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -94,7 +94,6 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     logger.info('\n\tServer process started.')
     logger.info('\tServer process id: '+str(cls.server_process.pid))
     logger.info('\tServing on port: '+str(cls.SERVER_PORT))
-    cls.url = 'http://localhost:'+str(cls.SERVER_PORT) + os.path.sep
 
     utils.wait_for_server('localhost', cls.SERVER_PORT)
 

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -45,8 +45,6 @@ import os
 import shutil
 import tempfile
 import logging
-import random
-import subprocess
 import unittest
 import filecmp
 import sys
@@ -88,14 +86,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # assume the pre-generated metadata files have a specific structure, such
     # as a delegated role 'targets/role1', three target files, five key files,
     # etc.
-    cls.SERVER_PORT = random.randint(30000, 45000)
-    command = ['python', 'simple_server.py', str(cls.SERVER_PORT)]
-    cls.server_process = subprocess.Popen(command)
-    logger.info('\n\tServer process started.')
-    logger.info('\tServer process id: '+str(cls.server_process.pid))
-    logger.info('\tServing on port: '+str(cls.SERVER_PORT))
-
-    utils.wait_for_server('localhost', cls.SERVER_PORT)
+    cls.server_process_handler = utils.TestServerProcess(log=logger)
 
 
 
@@ -109,10 +100,8 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # metadata, targets, and key files generated for the test cases.
     shutil.rmtree(cls.temporary_directory)
 
-    # Kill the SimpleHTTPServer process.
-    if cls.server_process.returncode is None:
-      logger.info('\tServer process ' + str(cls.server_process.pid) + ' terminated.')
-      cls.server_process.kill()
+    # Kills the server subprocess and closes the temp file used for logging.
+    cls.server_process_handler.clean()
 
 
 
@@ -155,8 +144,8 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = \
-      'http://localhost:' + str(self.SERVER_PORT) + repository_basepath
+    url_prefix = 'http://localhost:' \
+        + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client
     # directory copied from the original repository files.
@@ -185,7 +174,8 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
-
+    # Logs stdout and stderr from the sever subprocess.
+    self.server_process_handler.flush_log()
 
 
   # UNIT TESTS.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -52,7 +52,7 @@ except NameError:
 # but the current blocking connect() seems to work fast on Linux and seems
 # to at least work on Windows (ECONNREFUSED unfortunately has a 2 second
 # timeout on Windows)
-def wait_for_server(host, port, timeout=10):
+def wait_for_server(host, server, port, timeout=10):
   start = time.time()
   remaining_timeout = timeout
   succeeded = False
@@ -77,7 +77,8 @@ def wait_for_server(host, port, timeout=10):
       remaining_timeout = timeout - (time.time() - start)
 
   if not succeeded:
-    raise TimeoutError
+    raise TimeoutError("Could not connect to the " + server \
+        + " on port " + str(port) + " !")
 
 
 def configure_test_logging(argv):
@@ -167,10 +168,8 @@ class TestServerProcess():
 
     if timeout > 0:
       try:
-        wait_for_server('localhost', self.port, timeout)
+        wait_for_server('localhost', self.server, self.port, timeout)
       except Exception as e:
-        self.__logger.error(
-            "Error while waiting for the server to start: " + repr(e))
         # Make sure that errors from the server side will be logged.
         self.flush_log()
         raise e

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -25,6 +25,9 @@ import errno
 import logging
 import socket
 import time
+import subprocess
+import tempfile
+import random
 
 import tuf.log
 
@@ -97,3 +100,112 @@ def configure_test_logging(argv):
 
   logging.basicConfig(level=loglevel)
   tuf.log.set_log_level(loglevel)
+
+
+class TestServerProcess():
+  """
+  <Purpose>
+    Creates a child process with the subprocess.Popen object and
+    TempFile object used for logging.
+
+   <Arguments>
+      log:
+        Logger which will be used for logging.
+
+      server:
+        Path to the server to run in the subprocess.
+        Default is "simpler_server.py".
+
+      port:
+        The port used to access the server. If none is provided,
+        then one will be generated.
+        Default is None.
+
+      timeout:
+        Time in seconds in which the server should start or otherwise
+        TimeoutError error will be raised.
+        If 0 is given, no check if the server has started will be done.
+        Default is 10.
+
+      popen_cwd:
+        Current working directory used when instancing a
+        subprocess.Popen object.
+        Default is "."
+
+      extra_cmd_args:
+        List of additional arguments for the command
+        which will start the subprocess.
+        More precisely "python -u <path_to_server> <port> <extra_cmd_args>".
+        Default is empty list.
+  """
+
+
+  def __init__(self, log, server='simple_server.py',
+      port=None, timeout=10, popen_cwd=".",
+      extra_cmd_args=[]):
+
+    # Create temporary log file used for logging stdout and stderr
+    # of the subprocess. In the mode "r+"" stands for reading and writing
+    # and "t" stands for text mode.
+    self.__temp_log_file = tempfile.TemporaryFile(mode='r+t')
+
+    self.server = server
+    self.port = port or random.randint(30000, 45000)
+    self.__logger = log
+
+    # The "-u" option forces stdin, stdout and stderr to be unbuffered.
+    command = ['python', '-u', server, str(self.port)] + extra_cmd_args
+
+    # We are reusing one server subprocess in multiple unit tests, but we are
+    # collecting the logs per test.
+    self.__server_process = subprocess.Popen(command,
+        stdout=self.__temp_log_file, stderr=subprocess.STDOUT, cwd=popen_cwd)
+
+    self.__logger.info('Server process with process id ' \
+        + str(self.__server_process.pid) + " serving on port " \
+        + str(self.port) + ' started.')
+
+    if timeout > 0:
+      try:
+        wait_for_server('localhost', self.port, timeout)
+      except Exception as e:
+        self.__logger.error(
+            "Error while waiting for the server to start: " + repr(e))
+        # Make sure that errors from the server side will be logged.
+        self.flush_log()
+        raise e
+
+
+
+  def flush_log(self):
+    """Logs contents from TempFile, truncates buffer"""
+
+    # Seek is needed to move the pointer to the beginning of the file, because
+    # the subprocess could have read and/or write and thus moved the pointer.
+    self.__temp_log_file.seek(0)
+    log_message = self.__temp_log_file.read()
+
+    if len(log_message) > 0:
+      title = "Test server (" + self.server + ") output:"
+      message = [title] + log_message.splitlines()
+      self.__logger.info('\n| '.join(message))
+
+      # Make sure the file is empty before the next test logs new information.
+      self.__temp_log_file.truncate(0)
+
+
+
+  def clean(self):
+    """Kills the subprocess and closes the TempFile.
+    Calls flush_log to check for logged information, but not yet flushed."""
+
+    # If there is anything logged, flush it before closing the resourses.
+    self.flush_log()
+
+    self.__temp_log_file.close()
+
+    if self.__server_process.returncode is None:
+      self.__logger.info('Server process ' + str(self.__server_process.pid) +
+          ' terminated.')
+      self.__server_process.kill()
+      self.__server_process.wait()


### PR DESCRIPTION
**Fixes issues #**: https://github.com/theupdateframework/tuf/issues/1039, https://github.com/theupdateframework/tuf/issues/1119

**Description of the changes being introduced by the pull request**:

**This pr replaces pr https://github.com/theupdateframework/tuf/pull/1041.**

Logging the stdout and stderr from the test subprocesses into
temporary files clean the console from unnecessary messages from
the server-side such as "code 404, message File not found" or
"GET" queries.

The unit tests are executed in sequential order and that's why
we can reuse one temporary file object for multiple tests.

I have used this pr to remove some redundant functions, comments, and variables.

For this pr I received great help from @jku!
Thanks!

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


