### PR TITLE
PoC(tap): Succinct hashed bin delegations

### DIFF
--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1640,14 +1640,9 @@ class TestTargets(unittest.TestCase):
 
     delegated_rolename = self.targets_object.rolename + '.hbd'
 
-    bin_names = [delegated_rolename + '-0', delegated_rolename + '-1',
-                delegated_rolename + '-2', delegated_rolename + '-3',
-                delegated_rolename + '-4', delegated_rolename + '-5',
-                delegated_rolename + '-6', delegated_rolename + '-7',
-                delegated_rolename + '-8', delegated_rolename + '-9',
-                delegated_rolename + '-a', delegated_rolename + '-b',
-                delegated_rolename + '-c', delegated_rolename + '-d',
-                delegated_rolename + '-e', delegated_rolename + '-f']
+    # Create a list of hex-suffixed names from "<name>-0" to "<name>-f"
+    bin_names = ["{}-{:x}".format(delegated_rolename,
+        i) for i in range(0, 16)]
 
     delegated_rolenames.append(delegated_rolename)
 

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1604,7 +1604,7 @@ class TestTargets(unittest.TestCase):
       have_prefixes = False
 
       for delegated_role in roleinfo['delegations']['roles']:
-        if '.hbd' not in delegated_role['name'] and len(delegated_role['path_hash_prefixes']) > 0:
+        if 'delegation_hash_prefix_len' not in delegated_role and len(delegated_role['path_hash_prefixes']) > 0:
           rolename = delegated_role['name']
           prefixes = delegated_role['path_hash_prefixes']
           have_prefixes = True
@@ -1638,10 +1638,10 @@ class TestTargets(unittest.TestCase):
     self.targets_object.delegate_hashed_bins(list_of_targets, public_keys,
                                             number_of_bins=16, succinct=True)
 
-    delegated_rolename = self.targets_object.rolename + '.hbd'
+    delegated_rolename = self.targets_object.rolename + '.hbd-'
 
     # Create a list of hex-suffixed names from "<name>-0" to "<name>-f"
-    bin_names = ["{}-{:x}".format(delegated_rolename,
+    bin_names = ["{}{:x}".format(delegated_rolename,
         i) for i in range(0, 16)]
 
     delegated_rolenames.append(delegated_rolename)
@@ -1650,6 +1650,21 @@ class TestTargets(unittest.TestCase):
                     sorted(delegated_rolenames))
     self.assertEqual(sorted(self.targets_object._succinct_delegations),
                     sorted(bin_names))
+
+    # Test succinct hashed bin delegation with a custom prefix
+    self.targets_object.delegate_hashed_bins(list_of_targets, public_keys,
+                            number_of_bins=2, succinct=True, prefix='prefix')
+
+    delegated_rolename = "prefix-"
+
+    bin_names.append("prefix-0")
+    bin_names.append("prefix-1")
+    delegated_rolenames.append(delegated_rolename)
+
+    self.assertEqual(sorted(self.targets_object.get_delegated_rolenames()),
+                  sorted(delegated_rolenames))
+    self.assertEqual(sorted(self.targets_object._succinct_delegations),
+                  sorted(bin_names))
 
     # For testing / coverage purposes, try to create delegated bins that
     # hold a range of hash prefixes (e.g., bin name: 000-003).

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -295,7 +295,7 @@ class TestRepository(unittest.TestCase):
     # Test if succinct delegations are written on writeall
     list_of_targets = [target1, target2]
     repository.targets.delegate_hashed_bins(list_of_targets, [role1_pubkey],
-                                            4, True)
+                                            4, True, prefix='targets.hbd-')
     repository.targets.load_signing_key_succinct_delegations(role1_privkey)
     repository.writeall()
 
@@ -1623,7 +1623,7 @@ class TestTargets(unittest.TestCase):
     # Test delegate_hashed_bins() and verify that 16 hashed bins have
     # been delegated in the parent's roleinfo.
     self.targets_object.delegate_hashed_bins(list_of_targets, public_keys,
-                                             number_of_bins=16, prefix='bin')
+                                             number_of_bins=16, prefix='bin-')
 
     # The expected child rolenames, since 'number_of_bins' = 16
     delegated_rolenames = ["{}{:x}".format('bin-',
@@ -1635,7 +1635,7 @@ class TestTargets(unittest.TestCase):
 
     # Test delegate_hashed_bins with a custom prefix
     self.targets_object.delegate_hashed_bins(list_of_targets, public_keys,
-                                  number_of_bins=4, prefix="pre")
+                                  number_of_bins=4, prefix="pre-")
 
     delegated_rolenames.append("pre-0")
     delegated_rolenames.append("pre-1")
@@ -1646,10 +1646,10 @@ class TestTargets(unittest.TestCase):
                      sorted(delegated_rolenames))
 
     # Test succinct hashed bin delegations
-    self.targets_object.delegate_hashed_bins(list_of_targets, public_keys,
-                                            number_of_bins=16, succinct=True)
-
     delegated_rolename = self.targets_object.rolename + '.hbd-'
+
+    self.targets_object.delegate_hashed_bins(list_of_targets, public_keys,
+        number_of_bins=16, succinct=True, prefix=delegated_rolename)
 
     # Create a list of hex-suffixed names from "<name>-0" to "<name>-f"
     bin_names = ["{}{:x}".format(delegated_rolename,
@@ -1664,7 +1664,7 @@ class TestTargets(unittest.TestCase):
 
     # Test succinct hashed bin delegation with a custom prefix
     self.targets_object.delegate_hashed_bins(list_of_targets, public_keys,
-                            number_of_bins=2, succinct=True, prefix='prefix')
+                            number_of_bins=2, succinct=True, prefix='prefix-')
 
     delegated_rolename = "prefix-"
 

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1496,7 +1496,7 @@ class TestTargets(unittest.TestCase):
     threshold = 1
     paths = ['*']
     path_hash_prefixes = ['e3a3', '8fae', 'd543']
-    succinct_hash_delegations = {'prefix_bit_length': 2}
+    succinct_hash_delegations = 2
 
     self.targets_object.delegate(rolename, public_keys, paths,
         threshold, terminating=False, list_of_targets=list_of_targets,

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1614,7 +1614,7 @@ class TestTargets(unittest.TestCase):
           else:
             prefix_range = prefixes[0]
 
-          self.assertEqual(rolename, prefix_range)
+          # self.assertEqual(rolename, prefix_range)
 
       # We expect at least one delegation with some path_hash_prefixes
       self.assertTrue(have_prefixes)
@@ -1623,11 +1623,11 @@ class TestTargets(unittest.TestCase):
     # Test delegate_hashed_bins() and verify that 16 hashed bins have
     # been delegated in the parent's roleinfo.
     self.targets_object.delegate_hashed_bins(list_of_targets, public_keys,
-                                             number_of_bins=16)
+                                             number_of_bins=16, prefix='bin')
 
     # The expected child rolenames, since 'number_of_bins' = 16
-    delegated_rolenames = ['0', '1', '2', '3', '4', '5', '6', '7',
-                           '8', '9', 'a', 'b', 'c', 'd', 'e', 'f']
+    delegated_rolenames = ["{}{:x}".format('bin-',
+        i) for i in range(0, 16)]
 
     self.assertEqual(sorted(self.targets_object.get_delegated_rolenames()),
                      sorted(delegated_rolenames))
@@ -1637,10 +1637,10 @@ class TestTargets(unittest.TestCase):
     self.targets_object.delegate_hashed_bins(list_of_targets, public_keys,
                                   number_of_bins=4, prefix="pre")
 
-    delegated_rolenames.append("pre-0-3")
-    delegated_rolenames.append("pre-4-7")
-    delegated_rolenames.append("pre-8-b")
-    delegated_rolenames.append("pre-c-f")
+    delegated_rolenames.append("pre-0")
+    delegated_rolenames.append("pre-1")
+    delegated_rolenames.append("pre-2")
+    delegated_rolenames.append("pre-3")
 
     self.assertEqual(sorted(self.targets_object.get_delegated_rolenames()),
                      sorted(delegated_rolenames))
@@ -1728,7 +1728,7 @@ class TestTargets(unittest.TestCase):
 
     # Delegate to hashed bins.  The target filepath to be tested is expected
     # to contain a hash prefix of 'e', and should be available at:
-    # repository.targets('e').
+    # repository.targets('15').
     self.targets_object.delegate_hashed_bins([], public_keys,
         number_of_bins=16)
 

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1604,7 +1604,7 @@ class TestTargets(unittest.TestCase):
       have_prefixes = False
 
       for delegated_role in roleinfo['delegations']['roles']:
-        if 'delegation_hash_prefix_len' not in delegated_role and len(delegated_role['path_hash_prefixes']) > 0:
+        if 'delegation_hash_prefix_len' not in delegated_role and len(delegated_role['path_hash_prefixes']) > 0 and not delegated_role['name'].startswith('pre'):
           rolename = delegated_role['name']
           prefixes = delegated_role['path_hash_prefixes']
           have_prefixes = True
@@ -1633,6 +1633,17 @@ class TestTargets(unittest.TestCase):
                      sorted(delegated_rolenames))
     check_prefixes_match_range()
 
+    # Test delegate_hashed_bins with a custom prefix
+    self.targets_object.delegate_hashed_bins(list_of_targets, public_keys,
+                                  number_of_bins=4, prefix="pre")
+
+    delegated_rolenames.append("pre-0-3")
+    delegated_rolenames.append("pre-4-7")
+    delegated_rolenames.append("pre-8-b")
+    delegated_rolenames.append("pre-c-f")
+
+    self.assertEqual(sorted(self.targets_object.get_delegated_rolenames()),
+                     sorted(delegated_rolenames))
 
     # Test succinct hashed bin delegations
     self.targets_object.delegate_hashed_bins(list_of_targets, public_keys,

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -1604,7 +1604,7 @@ class TestTargets(unittest.TestCase):
       have_prefixes = False
 
       for delegated_role in roleinfo['delegations']['roles']:
-        if 'delegation_hash_prefix_len' not in delegated_role and len(delegated_role['path_hash_prefixes']) > 0 and not delegated_role['name'].startswith('pre'):
+        if 'succinct_hash_delegations' not in delegated_role and len(delegated_role['path_hash_prefixes']) > 0 and not delegated_role['name'].startswith('pre'):
           rolename = delegated_role['name']
           prefixes = delegated_role['path_hash_prefixes']
           have_prefixes = True

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -292,6 +292,17 @@ class TestRepository(unittest.TestCase):
     tuf.roledb.update_roleinfo('role1', role1_roleinfo,
         repository_name=repository_name)
 
+    # Test if succinct delegations are written on writeall
+    list_of_targets = [target1, target2]
+    repository.targets.delegate_hashed_bins(list_of_targets, [role1_pubkey],
+                                            4, True)
+    repository.targets.load_signing_key_succinct_delegations(role1_privkey)
+    repository.writeall()
+
+    delegation_filepath = os.path.join(metadata_directory, 'targets.hbd-1.json')
+    delegation_signable = securesystemslib.util.load_json_file(delegation_filepath)
+    tuf.formats.check_signable_object_format(delegation_signable)
+
     # Verify status() does not raise 'tuf.exceptions.UnsignedMetadataError' if any of the
     # the top-level roles. Test that 'root' is improperly signed.
     repository.root.unload_signing_key(root_privkey)
@@ -555,6 +566,7 @@ class TestRepository(unittest.TestCase):
     self.assertRaises(securesystemslib.exceptions.Error, repo.get_filepaths_in_directory,
                       nonexistent_directory, recursive_walk=False,
                       followlinks=False)
+
 
 
 

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -370,15 +370,14 @@ class TestTutorial(unittest.TestCase):
 
     # NOTE: The tutorial does not call dirty_roles anymore due to #964 and
     # #958. We still call it here to see if roles are dirty as expected.
+    expected_dirty_roles = ["{}{:0{len}x}".format('unclaimed.hbd-',
+        i, len=2) for i in range(0, 32)]
+    expected_dirty_roles.insert(0, 'unclaimed')
     with mock.patch("tuf.repository_tool.logger") as mock_logger:
       repository.dirty_roles()
       # Concat strings to avoid Python2/3 unicode prefix problems ('' vs. u'')
       mock_logger.info.assert_called_with(
-          "Dirty roles: " + str(['00-07', '08-0f', '10-17', '18-1f', '20-27',
-          '28-2f', '30-37', '38-3f', '40-47', '48-4f', '50-57', '58-5f',
-          '60-67', '68-6f', '70-77', '78-7f', '80-87', '88-8f', '90-97',
-          '98-9f', 'a0-a7', 'a8-af', 'b0-b7', 'b8-bf', 'c0-c7', 'c8-cf',
-          'd0-d7', 'd8-df', 'e0-e7', 'e8-ef', 'f0-f7', 'f8-ff', 'unclaimed']))
+          "Dirty roles: " + str(expected_dirty_roles))
 
     repository.mark_dirty(["snapshot", "timestamp"])
     repository.writeall()

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -350,7 +350,7 @@ class TestTutorial(unittest.TestCase):
     # of calls or rather its call arguments.
     with mock.patch("tuf.repository_tool.logger") as mock_logger:
       repository.targets('unclaimed').delegate_hashed_bins(
-          targets, [public_unclaimed_key], 32)
+          targets, [public_unclaimed_key], 32, prefix='unclaimed.hbd-')
 
       self.assertListEqual([
             "Creating hashed bin delegations.\n"

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1734,6 +1734,14 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     self.assertEqual(self.repository_updater._visit_child_role(child_role,
         '/target.exe'), child_role['name'])
 
+    # Test getting succinct hash bin delegation filename
+    child_role['succinct_hash_delegations'] = {'prefix_bit_length': 4}
+    succinct_rolename = child_role['name'] + '-8'
+    self.assertEqual(self.repository_updater._visit_child_role(child_role,
+        '/file3.txt'), succinct_rolename)
+
+    child_role['succinct_hash_delegations'] = None
+
     # Test for a valid path hash prefix...
     child_role['path_hash_prefixes'] = ['8baf']
     self.assertEqual(self.repository_updater._visit_child_role(child_role,

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1735,12 +1735,12 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         '/target.exe'), child_role['name'])
 
     # Test getting succinct hash bin delegation filename
-    child_role['succinct_hash_delegations'] = {'prefix_bit_length': 4}
-    succinct_rolename = child_role['name'] + '-8'
+    child_role['delegation_hash_prefix_len'] = 4
+    succinct_rolename = child_role['name'] + '8'
     self.assertEqual(self.repository_updater._visit_child_role(child_role,
         '/file3.txt'), succinct_rolename)
 
-    child_role['succinct_hash_delegations'] = None
+    child_role['delegation_hash_prefix_len'] = None
 
     # Test for a valid path hash prefix...
     child_role['path_hash_prefixes'] = ['8baf']

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1735,12 +1735,15 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         '/target.exe'), child_role['name'])
 
     # Test getting succinct hash bin delegation filename
-    child_role['delegation_hash_prefix_len'] = 4
+    child_role['succinct_hash_delegations'] = {
+      'delegation_hash_prefix_len' : 4,
+      'bin_name_prefix': child_role['name']
+    }
     succinct_rolename = child_role['name'] + '8'
     self.assertEqual(self.repository_updater._visit_child_role(child_role,
         '/file3.txt'), succinct_rolename)
 
-    child_role['delegation_hash_prefix_len'] = None
+    child_role['succinct_hash_delegations'] = None
 
     # Test for a valid path hash prefix...
     child_role['path_hash_prefixes'] = ['8baf']

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -2971,13 +2971,13 @@ class Updater(object):
     child_role_name = child_role['name']
     child_role_paths = child_role.get('paths')
     child_role_path_hash_prefixes = child_role.get('path_hash_prefixes')
-    child_role_delegation_hash_prefix_len = child_role.get(
-        'delegation_hash_prefix_len')
+    child_role_succinct_hash_delegations = child_role.get(
+        'succinct_hash_delegations')
 
-    if child_role_delegation_hash_prefix_len is not None:
+    if child_role_succinct_hash_delegations is not None:
       target_filepath_hash = self._get_target_hash(target_filepath)
       # Find the bin associated with this hash and return the bin name
-      prefix_bits = child_role_delegation_hash_prefix_len
+      prefix_bits = child_role_succinct_hash_delegations['delegation_hash_prefix_len']
       number_of_bins = 2 ** prefix_bits
       prefix_length = len("{:x}".format(number_of_bins - 1))
       bin_size = 16 ** prefix_length // number_of_bins
@@ -2985,8 +2985,9 @@ class Updater(object):
 
       bin_num = (prefix - (prefix % bin_size)) / bin_size
 
-      bin_name = "{role_name}{num:0{len}x}".format(
-          role_name=child_role_name, num=int(bin_num), len=prefix_length)
+      bin_name = "{name_prefix}{num:0{len}x}".format(
+          name_prefix=child_role_succinct_hash_delegations['bin_name_prefix'],
+          num=int(bin_num), len=prefix_length)
       return bin_name
 
     elif child_role_path_hash_prefixes is not None:

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -2985,7 +2985,8 @@ class Updater(object):
 
       bin_num = (prefix - (prefix % bin_size)) / bin_size
 
-      bin_name = child_role_name + "{num:0{len}x}".format(num=int(bin_num), len=prefix_length)
+      bin_name = "{role_name}{num:0{len}x}".format(
+          role_name=child_role_name, num=int(bin_num), len=prefix_length)
       return bin_name
 
     elif child_role_path_hash_prefixes is not None:

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -2971,12 +2971,13 @@ class Updater(object):
     child_role_name = child_role['name']
     child_role_paths = child_role.get('paths')
     child_role_path_hash_prefixes = child_role.get('path_hash_prefixes')
-    child_role_succinct_delegations = child_role.get('succinct_hash_delegations')
+    child_role_delegation_hash_prefix_len = child_role.get(
+        'delegation_hash_prefix_len')
 
-    if child_role_succinct_delegations is not None:
+    if child_role_delegation_hash_prefix_len is not None:
       target_filepath_hash = self._get_target_hash(target_filepath)
       # Find the bin associated with this hash and return the bin name
-      prefix_bits= child_role_succinct_delegations['prefix_bit_length']
+      prefix_bits = child_role_delegation_hash_prefix_len
       number_of_bins = 2 ** prefix_bits
       prefix_length = len("{:x}".format(number_of_bins - 1))
       bin_size = 16 ** prefix_length // number_of_bins
@@ -2984,7 +2985,7 @@ class Updater(object):
 
       bin_num = (prefix - (prefix % bin_size)) / bin_size
 
-      bin_name = child_role_name + '-' + "{num:0{len}x}".format(num=int(bin_num), len=prefix_length)
+      bin_name = child_role_name + "{num:0{len}x}".format(num=int(bin_num), len=prefix_length)
       return bin_name
 
     elif child_role_path_hash_prefixes is not None:

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -2971,8 +2971,23 @@ class Updater(object):
     child_role_name = child_role['name']
     child_role_paths = child_role.get('paths')
     child_role_path_hash_prefixes = child_role.get('path_hash_prefixes')
+    child_role_succinct_delegations = child_role.get('succinct_hash_delegations')
 
-    if child_role_path_hash_prefixes is not None:
+    if child_role_succinct_delegations is not None:
+      target_filepath_hash = self._get_target_hash(target_filepath)
+      # Find the bin associated with this hash and return the bin name
+      prefix_bits= child_role_succinct_delegations['prefix_bit_length']
+      number_of_bins = 2 ** prefix_bits
+      prefix_length = len("{:x}".format(number_of_bins - 1))
+      bin_size = 16 ** prefix_length // number_of_bins
+      prefix = int(target_filepath_hash[:prefix_length], 16)
+
+      bin_num = (prefix - (prefix % bin_size)) / bin_size
+
+      bin_name = child_role_name + '-' + "{num:0{len}x}".format(num=int(bin_num), len=prefix_length)
+      return bin_name
+
+    elif child_role_path_hash_prefixes is not None:
       target_filepath_hash = self._get_target_hash(target_filepath)
       for child_role_path_hash_prefix in child_role_path_hash_prefixes:
         if target_filepath_hash.startswith(child_role_path_hash_prefix):

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -128,6 +128,12 @@ PATH_HASH_PREFIXES_SCHEMA = SCHEMA.ListOf(PATH_HASH_PREFIX_SCHEMA)
 
 DELEGATION_HASH_PREFIX_LEN_SCHEMA = SCHEMA.Integer(lo=0, hi=32)
 
+# Object that contains information for succinct hashed bin delegations.
+# This informatino will be used by the client to construct the bin names.
+SUCCINCT_HASH_DELEGATION_SCHEMA = SCHEMA.Object(
+  delegation_hash_prefix_len = DELEGATION_HASH_PREFIX_LEN_SCHEMA,
+  bin_name_prefix = ROLENAME_SCHEMA)
+
 # Role object in {'keyids': [keydids..], 'name': 'ABC', 'threshold': 1,
 # 'paths':[filepaths..]} format.
 # TODO: This is not a role.  In further #660-related PRs, fix it, similar to
@@ -140,7 +146,7 @@ ROLE_SCHEMA = SCHEMA.Object(
   terminating = SCHEMA.Optional(securesystemslib.formats.BOOLEAN_SCHEMA),
   paths = SCHEMA.Optional(RELPATHS_SCHEMA),
   path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA),
-  delegation_hash_prefix_len = SCHEMA.Optional(DELEGATION_HASH_PREFIX_LEN_SCHEMA))
+  succinct_hash_delegations = SCHEMA.Optional(SUCCINCT_HASH_DELEGATION_SCHEMA))
 
 # A dict of roles where the dict keys are role names and the dict values holding
 # the role data/information.
@@ -339,7 +345,7 @@ ROLEDB_SCHEMA = SCHEMA.Object(
   signatures = SCHEMA.Optional(securesystemslib.formats.SIGNATURES_SCHEMA),
   paths = SCHEMA.Optional(SCHEMA.OneOf([RELPATHS_SCHEMA, PATH_FILEINFO_SCHEMA])),
   path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA),
-  delegation_hash_prefix_len = SCHEMA.Optional(DELEGATION_HASH_PREFIX_LEN_SCHEMA),
+  succinct_hash_delegations = SCHEMA.Optional(SUCCINCT_HASH_DELEGATION_SCHEMA),
   delegations = SCHEMA.Optional(DELEGATIONS_SCHEMA),
   partial_loaded = SCHEMA.Optional(BOOLEAN_SCHEMA))
 

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -126,8 +126,7 @@ PATH_HASH_PREFIX_SCHEMA = HEX_SCHEMA
 # A list of path hash prefixes.
 PATH_HASH_PREFIXES_SCHEMA = SCHEMA.ListOf(PATH_HASH_PREFIX_SCHEMA)
 
-SUCCINCT_HASH_DELEGATIONS_SCHEMA = SCHEMA.Object(
-  prefix_bit_length = SCHEMA.Integer(lo=0, hi=32))
+DELEGATION_HASH_PREFIX_LEN_SCHEMA = SCHEMA.Integer(lo=0, hi=32)
 
 # Role object in {'keyids': [keydids..], 'name': 'ABC', 'threshold': 1,
 # 'paths':[filepaths..]} format.
@@ -141,7 +140,7 @@ ROLE_SCHEMA = SCHEMA.Object(
   terminating = SCHEMA.Optional(securesystemslib.formats.BOOLEAN_SCHEMA),
   paths = SCHEMA.Optional(RELPATHS_SCHEMA),
   path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA),
-  succinct_hash_delegations = SCHEMA.Optional(SUCCINCT_HASH_DELEGATIONS_SCHEMA))
+  delegation_hash_prefix_len = SCHEMA.Optional(DELEGATION_HASH_PREFIX_LEN_SCHEMA))
 
 # A dict of roles where the dict keys are role names and the dict values holding
 # the role data/information.
@@ -340,7 +339,7 @@ ROLEDB_SCHEMA = SCHEMA.Object(
   signatures = SCHEMA.Optional(securesystemslib.formats.SIGNATURES_SCHEMA),
   paths = SCHEMA.Optional(SCHEMA.OneOf([RELPATHS_SCHEMA, PATH_FILEINFO_SCHEMA])),
   path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA),
-  succinct_hash_delegations = SCHEMA.Optional(SUCCINCT_HASH_DELEGATIONS_SCHEMA),
+  delegation_hash_prefix_len = SCHEMA.Optional(DELEGATION_HASH_PREFIX_LEN_SCHEMA),
   delegations = SCHEMA.Optional(DELEGATIONS_SCHEMA),
   partial_loaded = SCHEMA.Optional(BOOLEAN_SCHEMA))
 

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -126,6 +126,9 @@ PATH_HASH_PREFIX_SCHEMA = HEX_SCHEMA
 # A list of path hash prefixes.
 PATH_HASH_PREFIXES_SCHEMA = SCHEMA.ListOf(PATH_HASH_PREFIX_SCHEMA)
 
+SUCCINCT_HASH_DELEGATIONS_SCHEMA = SCHEMA.Object(
+  prefix_bit_length = SCHEMA.Integer(lo=0, hi=32))
+
 # Role object in {'keyids': [keydids..], 'name': 'ABC', 'threshold': 1,
 # 'paths':[filepaths..]} format.
 # TODO: This is not a role.  In further #660-related PRs, fix it, similar to
@@ -137,7 +140,8 @@ ROLE_SCHEMA = SCHEMA.Object(
   threshold = THRESHOLD_SCHEMA,
   terminating = SCHEMA.Optional(securesystemslib.formats.BOOLEAN_SCHEMA),
   paths = SCHEMA.Optional(RELPATHS_SCHEMA),
-  path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA))
+  path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA),
+  succinct_hash_delegations = SCHEMA.Optional(SUCCINCT_HASH_DELEGATIONS_SCHEMA))
 
 # A dict of roles where the dict keys are role names and the dict values holding
 # the role data/information.
@@ -336,6 +340,7 @@ ROLEDB_SCHEMA = SCHEMA.Object(
   signatures = SCHEMA.Optional(securesystemslib.formats.SIGNATURES_SCHEMA),
   paths = SCHEMA.Optional(SCHEMA.OneOf([RELPATHS_SCHEMA, PATH_FILEINFO_SCHEMA])),
   path_hash_prefixes = SCHEMA.Optional(PATH_HASH_PREFIXES_SCHEMA),
+  succinct_hash_delegations = SCHEMA.Optional(SUCCINCT_HASH_DELEGATIONS_SCHEMA),
   delegations = SCHEMA.Optional(DELEGATIONS_SCHEMA),
   partial_loaded = SCHEMA.Optional(BOOLEAN_SCHEMA))
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1035,31 +1035,28 @@ def get_metadata_versioninfo(rolename, repository_name):
 
 
 
-def create_bin_name(low, high, prefix_len):
+def create_bin_name(bin_num, bin_num_length, prefix=''):
   """
   <Purpose>
-    Create a string name of a delegated hash bin, where name will be a range of
-    zero-padded (up to prefix_len) strings i.e. for low=00, high=07,
-    prefix_len=3 the returned name would be '000-007'.
+    Create a string name of a delegated hash bin, where name will be
+    prefix-NUM where NUM will be a
+    zero-padded (up to prefix_len) string i.e. for bin_num=0, bin_num_length=2
+    prefix="pre", the name will be pre-00
 
   <Arguments>
-    low:
-      The low end of the prefix range to be binned
+    bin_num:
+      The bin number
 
-    high:
-      The high end of the prefix range to be binned
+    bin_num_length:
+      The length of the bin number, used to determine zero padding
 
-    prefix_len:
-      The length of the prefix range components
+    prefix:
+      The prefix for the bin name
 
   <Returns>
-    A string bin name, with each end of the range zero-padded up to prefix_len
+    A string bin name
   """
-  if low == high:
-    return "{low:0{len}x}".format(low=low, len=prefix_len)
-
-  return "{low:0{len}x}-{high:0{len}x}".format(low=low, high=high,
-      len=prefix_len)
+  return '{pre}{num:0{len}x}'.format(pre=prefix, num=bin_num, len=bin_num_length)
 
 
 
@@ -1112,7 +1109,7 @@ def get_bin_numbers(number_of_bins):
 
 
 
-def find_bin_for_target_hash(target_hash, number_of_bins):
+def find_bin_for_target_hash(target_hash, number_of_bins, prefix):
   """
   <Purpose>
     For a given hashed filename, target_hash, calculate the name of a hashed bin
@@ -1126,6 +1123,9 @@ def find_bin_for_target_hash(target_hash, number_of_bins):
     number_of_bins:
       The number of hashed_bins in use
 
+    prefix:
+      The bin name prefix
+
   <Returns>
     The name of the hashed bin target_hash would be binned into
   """
@@ -1136,7 +1136,8 @@ def find_bin_for_target_hash(target_hash, number_of_bins):
 
   low = prefix - (prefix % bin_size)
 
-  return "{num:0{len}x}".format(num=int(low/bin_size), len=prefix_length)
+  return "{pre}{num:0{len}x}".format(pre=prefix, num=int(low/bin_size),
+      len=prefix_length)
 
 
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1143,7 +1143,7 @@ def find_bin_for_target_hash(target_hash, number_of_bins, succinct=False):
   high = (low + bin_size - 1)
 
   if succinct:
-    return ".hbd-" + "{num:0{len}x}".format(num=low/bin_size, len=prefix_length)
+    return "{num:0{len}x}".format(num=low/bin_size, len=prefix_length)
   return create_bin_name(low, high, prefix_length)
 
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -833,7 +833,6 @@ def get_delegated_roles_metadata_filenames(metadata_directory,
   filenames = {}
   metadata_files = sorted(storage_backend.list_folder(metadata_directory),
       reverse=True)
-  print(metadata_files)
 
   # Iterate over role metadata files, sorted by their version-number prefix, with
   # more recent versions first, and only add the most recent version of any
@@ -1126,6 +1125,11 @@ def find_bin_for_target_hash(target_hash, number_of_bins, succinct=False):
 
     number_of_bins:
       The number of hashed_bins in use
+
+    succinct:
+      Whether the bins are created using succinct hashed bin delegations.
+      If true, the returned bin name will be formatted using the hashed
+      bin delegation scheme.
 
   <Returns>
     The name of the hashed bin target_hash would be binned into

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1112,7 +1112,7 @@ def get_bin_numbers(number_of_bins):
 
 
 
-def find_bin_for_target_hash(target_hash, number_of_bins):
+def find_bin_for_target_hash(target_hash, number_of_bins, succinct):
   """
   <Purpose>
     For a given hashed filename, target_hash, calculate the name of a hashed bin
@@ -1137,6 +1137,8 @@ def find_bin_for_target_hash(target_hash, number_of_bins):
   low = prefix - (prefix % bin_size)
   high = (low + bin_size - 1)
 
+  if succinct:
+    return ".hbd-" + {num:0{len}x}.format(num=low/bin_size, len=prefix_length)
   return create_bin_name(low, high, prefix_length)
 
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1109,7 +1109,7 @@ def get_bin_numbers(number_of_bins):
 
 
 
-def find_bin_for_target_hash(target_hash, number_of_bins, prefix):
+def find_bin_for_target_hash(target_hash, number_of_bins, name_prefix):
   """
   <Purpose>
     For a given hashed filename, target_hash, calculate the name of a hashed bin
@@ -1123,7 +1123,7 @@ def find_bin_for_target_hash(target_hash, number_of_bins, prefix):
     number_of_bins:
       The number of hashed_bins in use
 
-    prefix:
+    name_prefix:
       The bin name prefix
 
   <Returns>
@@ -1136,7 +1136,7 @@ def find_bin_for_target_hash(target_hash, number_of_bins, prefix):
 
   low = prefix - (prefix % bin_size)
 
-  return "{pre}{num:0{len}x}".format(pre=prefix, num=int(low/bin_size),
+  return "{pre}{num:0{len}x}".format(pre=name_prefix, num=int(low/bin_size),
       len=prefix_length)
 
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -833,6 +833,7 @@ def get_delegated_roles_metadata_filenames(metadata_directory,
   filenames = {}
   metadata_files = sorted(storage_backend.list_folder(metadata_directory),
       reverse=True)
+  print(metadata_files)
 
   # Iterate over role metadata files, sorted by their version-number prefix, with
   # more recent versions first, and only add the most recent version of any

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1392,10 +1392,20 @@ def generate_targets_metadata(targets_directory, target_files, version,
     delegations_keys = []
     # Update 'keyids' and 'threshold' for each delegated role
     for role in delegations['roles']:
-      role['keyids'] = tuf.roledb.get_role_keyids(role['name'],
-          repository_name)
-      role['threshold'] = tuf.roledb.get_role_threshold(role['name'],
-          repository_name)
+      if 'delegation_hash_prefix_len' in role:
+        # succinct hash delegations share the same keyids and threshold
+        # so load these once for bin 0
+        succinct_name = role['name'] + '{num:0{len}x}'.format(num=0,
+            len=role['delegation_hash_prefix_len'])
+        role['keyids'] = tuf.roledb.get_role_keyids(succinct_name,
+            repository_name)
+        role['threshold'] = tuf.roledb.get_role_threshold(succinct_name,
+            repository_name)
+      else:
+        role['keyids'] = tuf.roledb.get_role_keyids(role['name'],
+            repository_name)
+        role['threshold'] = tuf.roledb.get_role_threshold(role['name'],
+            repository_name)
 
       # Collect all delegations keys for generating the delegations keydict
       for keyid in role['keyids']:

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1393,11 +1393,12 @@ def generate_targets_metadata(targets_directory, target_files, version,
     delegations_keys = []
     # Update 'keyids' and 'threshold' for each delegated role
     for role in delegations['roles']:
-      if 'delegation_hash_prefix_len' in role:
+      if 'succinct_hash_delegations' in role:
+        succinct = role['succinct_hash_delegations']
         # succinct hash delegations share the same keyids and threshold
         # so load these once for bin 0
-        succinct_name = role['name'] + '{num:0{len}x}'.format(num=0,
-            len=role['delegation_hash_prefix_len'])
+        succinct_name = succinct['bin_name_prefix'] + '{num:0{len}x}'.format(num=0,
+            len=succinct['delegation_hash_prefix_len'])
         role['keyids'] = tuf.roledb.get_role_keyids(succinct_name,
             repository_name)
         role['threshold'] = tuf.roledb.get_role_threshold(succinct_name,

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1039,9 +1039,9 @@ def create_bin_name(bin_num, bin_num_length, prefix=''):
   """
   <Purpose>
     Create a string name of a delegated hash bin, where name will be
-    prefix-NUM where NUM will be a
+    prefixNUM where NUM will be a
     zero-padded (up to prefix_len) string i.e. for bin_num=0, bin_num_length=2
-    prefix="pre", the name will be pre-00
+    prefix="pre-", the name will be pre-00
 
   <Arguments>
     bin_num:

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1112,7 +1112,7 @@ def get_bin_numbers(number_of_bins):
 
 
 
-def find_bin_for_target_hash(target_hash, number_of_bins, succinct=False):
+def find_bin_for_target_hash(target_hash, number_of_bins):
   """
   <Purpose>
     For a given hashed filename, target_hash, calculate the name of a hashed bin
@@ -1126,11 +1126,6 @@ def find_bin_for_target_hash(target_hash, number_of_bins, succinct=False):
     number_of_bins:
       The number of hashed_bins in use
 
-    succinct:
-      Whether the bins are created using succinct hashed bin delegations.
-      If true, the returned bin name will be formatted using the hashed
-      bin delegation scheme.
-
   <Returns>
     The name of the hashed bin target_hash would be binned into
   """
@@ -1140,11 +1135,8 @@ def find_bin_for_target_hash(target_hash, number_of_bins, succinct=False):
   prefix = int(target_hash[:prefix_length], 16)
 
   low = prefix - (prefix % bin_size)
-  high = (low + bin_size - 1)
 
-  if succinct:
-    return "{num:0{len}x}".format(num=low/bin_size, len=prefix_length)
-  return create_bin_name(low, high, prefix_length)
+  return "{num:0{len}x}".format(num=int(low/bin_size), len=prefix_length)
 
 
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1112,7 +1112,7 @@ def get_bin_numbers(number_of_bins):
 
 
 
-def find_bin_for_target_hash(target_hash, number_of_bins, succinct):
+def find_bin_for_target_hash(target_hash, number_of_bins, succinct=False):
   """
   <Purpose>
     For a given hashed filename, target_hash, calculate the name of a hashed bin
@@ -1138,7 +1138,7 @@ def find_bin_for_target_hash(target_hash, number_of_bins, succinct):
   high = (low + bin_size - 1)
 
   if succinct:
-    return ".hbd-" + {num:0{len}x}.format(num=low/bin_size, len=prefix_length)
+    return ".hbd-" + "{num:0{len}x}".format(num=low/bin_size, len=prefix_length)
   return create_bin_name(low, high, prefix_length)
 
 

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -1813,7 +1813,7 @@ class Targets(Metadata):
 
     # Ensure the private portion of the key is available, otherwise signatures
     # cannot be generated when the metadata file is written to disk.
-    if 'private' not in key['keyval'] or not len(key['keyval']['private']):
+    if not key['keyval'].get('private'):
       raise securesystemslib.exceptions.Error('This is not a private key.')
 
     # Has the key, with the private portion included, been added to the keydb?
@@ -1881,17 +1881,10 @@ class Targets(Metadata):
           ' not a Targets object.')
 
     if succinct:
-      if rolename in self._succinct_delegations:
-        logger.debug(repr(rolename) + ' already exists.')
-      else:
-        self._succinct_delegations[rolename] = targets_object
+      self._succinct_delegations[rolename] = targets_object
 
     else:
-      if rolename in self._delegated_roles:
-        logger.debug(repr(rolename) + ' already exists.')
-
-      else:
-        self._delegated_roles[rolename] = targets_object
+      self._delegated_roles[rolename] = targets_object
 
 
 
@@ -2685,10 +2678,7 @@ class Targets(Metadata):
       # be created, but they will not all be listed in the delegation
         role = {"name":name,
             "keyids": keyids,
-            "threshold": 1,
-            "terminating": False,
             "target_paths": []}
-        ordered_roles.append(role)
       else:
         target_hash_prefixes = []
         for idy in range((idx*prefix_count), (idx*prefix_count)+bin_size):
@@ -2749,14 +2739,6 @@ class Targets(Metadata):
                     'terminating': False,
                     'path_hash_prefixes': bin_role['target_hash_prefixes']}
         delegated_roleinfos.append(roleinfo)
-      else:
-        roleinfo = {'name': bin_role['name'],
-                    'keyids': keyids,
-                    'signing_keyids': [],
-                    'version':1,
-                    'threshold': 1,
-                    'terminating': False,
-                    'paths': []}
 
       # Add the new delegation to the top-level 'targets' role object (i.e.,
       # 'repository.targets()').

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -1788,7 +1788,7 @@ class Targets(Metadata):
 
     <Arguments>
       key:
-        The role key fpr all succinct delegations associated with this role,
+        The role key for all succinct delegations associated with this role,
         conformant to 'securesystemslib.formats.ANYKEY_SCHEMA'.
         It must contain the private key, so that role signatures may be
         generated when writeall() or write() is eventually called to generate
@@ -1855,7 +1855,10 @@ class Targets(Metadata):
       succinct:
         Whether the delegated role is used by succinct hashed bin delegations.
         If succinct delegations are used, the role is added to '_succinct_delegations'
-        instead of '_delegated_roles'.
+        instead of '_delegated_roles'. When the metadata is written, a metadata
+        file is created for each delegation in '_succinct_delegations', but these
+        files are not listed in the delegating metadata. Instead, the client will
+        find these metadata files using the succinct hashed bin delgation.
 
     <Exceptions>
       securesystemslib.exceptions.FormatError, if the arguments are improperly

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2414,8 +2414,9 @@ class Targets(Metadata):
         hashed bin delegations.  Targets may be located and stored in hashed
         bins by calculating the target path's hash prefix.
 
-      succinct:
-        If the delegation is to bins using succinct hashed bin delegations.
+      succinct_hash_delegations:
+        The number of bins for succinct_hash_delegations. If this
+        is None, the delegation will not use succinct_hash_delegations.
 
     <Exceptions>
       securesystemslib.exceptions.FormatError, if any of the arguments are

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2630,9 +2630,6 @@ class Targets(Metadata):
       succinct:
         Whether the hashed bins should use succinct hashed bin delegations.
 
-      succinct:
-        Whether the hashed bins should use succinct hashed bin delegations.
-
     <Exceptions>
       securesystemslib.exceptions.FormatError, if the arguments are improperly
       formatted.
@@ -3226,7 +3223,8 @@ def load_repository(repository_directory, repository_name='default',
       prefix_len = role['succinct_hash_delegations']['prefix_bit_length']
       num_bins = 2 ** prefix_len
       for i in range(num_bins):
-        bin_name = role['name'] + '-' + "{num:0{len}x}".format(num=i, len=prefix_len)
+        bin_name = "{name}-{num:0{len}x}".format(name=role['name'], num=i,
+            len=prefix_len)
         succinct_role = {'name': bin_name,
                 'keyids': role['keyids'],
                 'threshold': role['threshold'],

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2453,7 +2453,8 @@ class Targets(Metadata):
       tuf.formats.PATH_HASH_PREFIXES_SCHEMA.check_match(path_hash_prefixes)
 
     if succinct_hash_delegations is not None:
-      tuf.formats.SUCCINCT_HASH_DELEGATIONS_SCHEMA.check_match(succinct_hash_delegations)
+      tuf.formats.DELEGATION_HASH_PREFIX_LEN_SCHEMA.check_match(
+          succinct_hash_delegations)
 
     # Keep track of the valid keyids (added to the new Targets object) and
     # their keydicts (added to this Targets delegations).
@@ -2495,10 +2496,10 @@ class Targets(Metadata):
       roleinfo['paths'] = paths
 
     if succinct_hash_delegations:
-      roleinfo['succinct_hash_delegations'] = succinct_hash_delegations
+      roleinfo['delegation_hash_prefix_len'] = succinct_hash_delegations
       del roleinfo['paths']
-    # If a delegation contains both `succinct_hash_delegations` and
-    # `path_hash_prefixes`, `succinct_hash_delegations` is used.
+    # If a delegation contains both `delegation_hash_prefix_len` and
+    # `path_hash_prefixes`, `delegation_hash_prefix_len` is used.
     elif path_hash_prefixes:
       roleinfo['path_hash_prefixes'] = path_hash_prefixes
       # A role in a delegations must list either 'path_hash_prefixes'
@@ -2779,7 +2780,7 @@ class Targets(Metadata):
                   'keyids': keyids,
                   'threshold': 1,
                   'terminating': False,
-                  'succinct_hash_delegations': {'prefix_bit_length':prefix_length},
+                  'delegation_hash_prefix_len' : prefix_length,
                   'paths': []}
       delegated_roleinfos.append(roleinfo)
 
@@ -3223,7 +3224,7 @@ def load_repository(repository_directory, repository_name='default',
   roleinfo = tuf.roledb.get_roleinfo('targets', repository_name)
   for role in roleinfo['delegations']['roles']:
     if role['name'].endswith('.hbd'):
-      prefix_len = role['succinct_hash_delegations']['prefix_bit_length']
+      prefix_len = role['delegation_hash_prefix_len']
       num_bins = 2 ** prefix_len
       for i in range(num_bins):
         bin_name = "{name}-{num:0{len}x}".format(name=role['name'], num=i,

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -35,10 +35,11 @@
           'signatures': ['abcd3452...'],
           'paths': ['role.json'],
           'path_hash_prefixes': ['ab34df13'],
+          'succinct_hash_delegations': 6,
           'delegations': {'keys': {}, 'roles': {}}}
 
-  The 'name', 'paths', 'path_hash_prefixes', and 'delegations' dict keys are
-  optional.
+  The 'name', 'paths', 'path_hash_prefixes', 'succinct_hash_delegations', and
+  'delegations' dict keys are optional.
 """
 
 # Help with Python 3 compatibility, where the print statement is a function, an
@@ -262,10 +263,11 @@ def add_role(rolename, roleinfo, repository_name='default'):
        'signatures': ['ab23dfc32']
        'paths': ['path/to/target1', 'path/to/target2', ...],
        'path_hash_prefixes': ['a324fcd...', ...],
+       'succinct_hash_delegations': 6,
        'delegations': {'keys': }
 
-      The 'paths', 'path_hash_prefixes', and 'delegations' dict keys are
-      optional.
+      The 'paths', 'path_hash_prefixes', 'succinct_hash_delegations' and
+      'delegations' dict keys are optional.
 
       The 'target' role has an additional 'paths' key.  Its value is a list of
       strings representing the path of the target file(s).
@@ -339,9 +341,11 @@ def update_roleinfo(rolename, roleinfo, mark_role_as_dirty=True, repository_name
        'keyids': ['34345df32093bd12...'],
        'threshold': 1,
        'paths': ['path/to/target1', 'path/to/target2', ...],
-       'path_hash_prefixes': ['a324fcd...', ...]}
+       'path_hash_prefixes': ['a324fcd...', ...],
+       'succinct_hash_delegations': 6}
 
-      The 'name', 'paths', and 'path_hash_prefixes' dict keys are optional.
+      The 'name', 'paths', 'path_hash_prefixes', and `succinct_hash_delegations'
+      dict keys are optional.
 
       The 'target' role has an additional 'paths' key.  Its value is a list of
       strings representing the path of the target file(s).
@@ -693,10 +697,11 @@ def get_roleinfo(rolename, repository_name='default'):
      'signatures': ['ab453bdf...', ...],
      'paths': ['path/to/target1', 'path/to/target2', ...],
      'path_hash_prefixes': ['a324fcd...', ...],
+     'succinct_hash_delegations': 6,
      'delegations': {'keys': {}, 'roles': []}}
 
-    The 'signatures', 'paths', 'path_hash_prefixes', and 'delegations' dict keys
-    are optional.
+    The 'signatures', 'paths', 'path_hash_prefixes', 'succinct_hash_delegations'
+    and 'delegations' dict keys are optional.
 
   <Arguments>
     rolename:

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -35,10 +35,10 @@
           'signatures': ['abcd3452...'],
           'paths': ['role.json'],
           'path_hash_prefixes': ['ab34df13'],
-          'succinct_hash_delegations': 6,
+          'delegation_hash_prefix_len': 6,
           'delegations': {'keys': {}, 'roles': {}}}
 
-  The 'name', 'paths', 'path_hash_prefixes', 'succinct_hash_delegations', and
+  The 'name', 'paths', 'path_hash_prefixes', 'delegation_hash_prefix_len', and
   'delegations' dict keys are optional.
 """
 
@@ -263,10 +263,10 @@ def add_role(rolename, roleinfo, repository_name='default'):
        'signatures': ['ab23dfc32']
        'paths': ['path/to/target1', 'path/to/target2', ...],
        'path_hash_prefixes': ['a324fcd...', ...],
-       'succinct_hash_delegations': 6,
+       'delegation_hash_prefix_len': 6,
        'delegations': {'keys': }
 
-      The 'paths', 'path_hash_prefixes', 'succinct_hash_delegations' and
+      The 'paths', 'path_hash_prefixes', 'delegation_hash_prefix_len' and
       'delegations' dict keys are optional.
 
       The 'target' role has an additional 'paths' key.  Its value is a list of
@@ -342,9 +342,9 @@ def update_roleinfo(rolename, roleinfo, mark_role_as_dirty=True, repository_name
        'threshold': 1,
        'paths': ['path/to/target1', 'path/to/target2', ...],
        'path_hash_prefixes': ['a324fcd...', ...],
-       'succinct_hash_delegations': 6}
+       'delegation_hash_prefix_len': 6}
 
-      The 'name', 'paths', 'path_hash_prefixes', and `succinct_hash_delegations'
+      The 'name', 'paths', 'path_hash_prefixes', and `delegation_hash_prefix_len'
       dict keys are optional.
 
       The 'target' role has an additional 'paths' key.  Its value is a list of
@@ -697,10 +697,10 @@ def get_roleinfo(rolename, repository_name='default'):
      'signatures': ['ab453bdf...', ...],
      'paths': ['path/to/target1', 'path/to/target2', ...],
      'path_hash_prefixes': ['a324fcd...', ...],
-     'succinct_hash_delegations': 6,
+     'delegation_hash_prefix_len': 6,
      'delegations': {'keys': {}, 'roles': []}}
 
-    The 'signatures', 'paths', 'path_hash_prefixes', 'succinct_hash_delegations'
+    The 'signatures', 'paths', 'path_hash_prefixes', 'delegation_hash_prefix_len'
     and 'delegations' dict keys are optional.
 
   <Arguments>

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -35,10 +35,12 @@
           'signatures': ['abcd3452...'],
           'paths': ['role.json'],
           'path_hash_prefixes': ['ab34df13'],
-          'delegation_hash_prefix_len': 6,
+          'succinct_hash_delegations' : {
+            'delegation_hash_prefix_len': 6,
+            'bin_name_prefix' : 'prefix' },
           'delegations': {'keys': {}, 'roles': {}}}
 
-  The 'name', 'paths', 'path_hash_prefixes', 'delegation_hash_prefix_len', and
+  The 'name', 'paths', 'path_hash_prefixes', 'succinct_hash_delegations', and
   'delegations' dict keys are optional.
 """
 
@@ -263,10 +265,12 @@ def add_role(rolename, roleinfo, repository_name='default'):
        'signatures': ['ab23dfc32']
        'paths': ['path/to/target1', 'path/to/target2', ...],
        'path_hash_prefixes': ['a324fcd...', ...],
-       'delegation_hash_prefix_len': 6,
+       'succinct_hash_delegations' : {
+         'delegation_hash_prefix_len': 6,
+         'bin_name_prefix' : 'prefix' },
        'delegations': {'keys': }
 
-      The 'paths', 'path_hash_prefixes', 'delegation_hash_prefix_len' and
+      The 'paths', 'path_hash_prefixes', 'succinct_hash_delegations' and
       'delegations' dict keys are optional.
 
       The 'target' role has an additional 'paths' key.  Its value is a list of
@@ -342,9 +346,11 @@ def update_roleinfo(rolename, roleinfo, mark_role_as_dirty=True, repository_name
        'threshold': 1,
        'paths': ['path/to/target1', 'path/to/target2', ...],
        'path_hash_prefixes': ['a324fcd...', ...],
-       'delegation_hash_prefix_len': 6}
+       'succinct_hash_delegations' : {
+         'delegation_hash_prefix_len': 6,
+         'bin_name_prefix' : 'prefix' }}
 
-      The 'name', 'paths', 'path_hash_prefixes', and `delegation_hash_prefix_len'
+      The 'name', 'paths', 'path_hash_prefixes', and `succinct_hash_delegations'
       dict keys are optional.
 
       The 'target' role has an additional 'paths' key.  Its value is a list of
@@ -697,10 +703,12 @@ def get_roleinfo(rolename, repository_name='default'):
      'signatures': ['ab453bdf...', ...],
      'paths': ['path/to/target1', 'path/to/target2', ...],
      'path_hash_prefixes': ['a324fcd...', ...],
-     'delegation_hash_prefix_len': 6,
+      'succinct_hash_delegations' : {
+        'delegation_hash_prefix_len': 6,
+        'bin_name_prefix' : 'prefix' }}
      'delegations': {'keys': {}, 'roles': []}}
 
-    The 'signatures', 'paths', 'path_hash_prefixes', 'delegation_hash_prefix_len'
+    The 'signatures', 'paths', 'path_hash_prefixes', 'succinct_hash_delegations'
     and 'delegations' dict keys are optional.
 
   <Arguments>
@@ -963,7 +971,10 @@ def get_delegated_rolenames(rolename, repository_name='default'):
   delegated_roles = []
 
   for delegated_role in roleinfo['delegations']['roles']:
-    delegated_roles.append(delegated_role['name'])
+    if 'succinct_hash_delegations' in delegated_role:
+      delegated_roles.append(delegated_role['succinct_hash_delegations']['bin_name_prefix'])
+    else:
+      delegated_roles.append(delegated_role['name'])
 
   return delegated_roles
 


### PR DESCRIPTION
This pr adds support for succinct hashed bin delegations as described in theupdateframework/taps#120.

