### PR TITLE
Add simple TUF role metadata model

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -89,7 +89,7 @@ class TestMetadata(unittest.TestCase):
                 ('targets', Targets)]:
 
             path = os.path.join(self.repo_dir, 'metadata', metadata + '.json')
-            metadata_obj = Metadata.read_from_json(path)
+            metadata_obj = Metadata.from_json_file(path)
 
             # Assert that generic method instantiates the right inner class for
             # each metadata type
@@ -103,31 +103,31 @@ class TestMetadata(unittest.TestCase):
             f.write(json.dumps(bad_metadata).encode('utf-8'))
 
         with self.assertRaises(ValueError):
-            Metadata.read_from_json(bad_metadata_path)
+            Metadata.from_json_file(bad_metadata_path)
 
         os.remove(bad_metadata_path)
 
 
     def test_compact_json(self):
         path = os.path.join(self.repo_dir, 'metadata', 'targets.json')
-        metadata_obj = Metadata.read_from_json(path)
+        metadata_obj = Metadata.from_json_file(path)
         self.assertTrue(
-                len(metadata_obj.as_json(compact=True)) <
-                len(metadata_obj.as_json()))
+                len(metadata_obj.to_json(compact=True)) <
+                len(metadata_obj.to_json()))
 
 
     def test_read_write_read_compare(self):
         for metadata in ['snapshot', 'timestamp', 'targets']:
             path = os.path.join(self.repo_dir, 'metadata', metadata + '.json')
-            metadata_obj = Metadata.read_from_json(path)
+            metadata_obj = Metadata.from_json_file(path)
 
             path_2 = path + '.tmp'
-            metadata_obj.write_to_json(path_2)
-            metadata_obj_2 = Metadata.read_from_json(path_2)
+            metadata_obj.to_json_file(path_2)
+            metadata_obj_2 = Metadata.from_json_file(path_2)
 
             self.assertDictEqual(
-                    metadata_obj.as_dict(),
-                    metadata_obj_2.as_dict())
+                    metadata_obj.to_dict(),
+                    metadata_obj_2.to_dict())
 
             os.remove(path_2)
 
@@ -135,7 +135,7 @@ class TestMetadata(unittest.TestCase):
     def test_sign_verify(self):
         # Load sample metadata (targets) and assert ...
         path = os.path.join(self.repo_dir, 'metadata', 'targets.json')
-        metadata_obj = Metadata.read_from_json(path)
+        metadata_obj = Metadata.from_json_file(path)
 
         # ... it has a single existing signature,
         self.assertTrue(len(metadata_obj.signatures) == 1)
@@ -180,7 +180,7 @@ class TestMetadata(unittest.TestCase):
         # with real data
         snapshot_path = os.path.join(
                 self.repo_dir, 'metadata', 'snapshot.json')
-        md = Metadata.read_from_json(snapshot_path)
+        md = Metadata.from_json_file(snapshot_path)
 
         self.assertEqual(md.signed.version, 1)
         md.signed.bump_version()
@@ -195,7 +195,7 @@ class TestMetadata(unittest.TestCase):
     def test_metadata_snapshot(self):
         snapshot_path = os.path.join(
                 self.repo_dir, 'metadata', 'snapshot.json')
-        snapshot = Metadata.read_from_json(snapshot_path)
+        snapshot = Metadata.from_json_file(snapshot_path)
 
         # Create a dict representing what we expect the updated data to be
         fileinfo = snapshot.signed.meta
@@ -211,7 +211,7 @@ class TestMetadata(unittest.TestCase):
     def test_metadata_timestamp(self):
         timestamp_path = os.path.join(
                 self.repo_dir, 'metadata', 'timestamp.json')
-        timestamp = Metadata.read_from_json(timestamp_path)
+        timestamp = Metadata.from_json_file(timestamp_path)
 
         self.assertEqual(timestamp.signed.version, 1)
         timestamp.signed.bump_version()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,10 @@
 # Copyright 2020, New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 """ Unit tests for api/metdata.py
+
 """
+
+import sys
 import logging
 import os
 import shutil
@@ -13,10 +16,21 @@ import unittest
 from datetime import timedelta
 from dateutil.relativedelta import relativedelta
 
-from tuf.api.metadata import (
-    Snapshot,
-    Timestamp,
-)
+# TODO: Remove case handling when fully dropping support for versions >= 3.6
+IS_PY_VERSION_SUPPORTED = sys.version_info >= (3, 6)
+
+# Use setUpModule to tell unittest runner to skip this test module gracefully.
+def setUpModule():
+    if not IS_PY_VERSION_SUPPORTED:
+        raise unittest.SkipTest("requires Python 3.6 or higher")
+
+# Since setUpModule is called after imports we need to import conditionally.
+if IS_PY_VERSION_SUPPORTED:
+    from tuf.api.metadata import (
+        Snapshot,
+        Timestamp,
+    )
+
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,7 +23,7 @@ IS_PY_VERSION_SUPPORTED = sys.version_info >= (3, 6)
 # Use setUpModule to tell unittest runner to skip this test module gracefully.
 def setUpModule():
     if not IS_PY_VERSION_SUPPORTED:
-        raise unittest.SkipTest("requires Python 3.6 or higher")
+        raise unittest.SkipTest('requires Python 3.6 or higher')
 
 # Since setUpModule is called after imports we need to import conditionally.
 if IS_PY_VERSION_SUPPORTED:
@@ -34,19 +34,22 @@ if IS_PY_VERSION_SUPPORTED:
         Targets
     )
 
+    from securesystemslib.interface import (
+        import_ed25519_publickey_from_file,
+        import_ed25519_privatekey_from_file
+    )
 
 logger = logging.getLogger(__name__)
 
 
 class TestMetadata(unittest.TestCase):
-    # TODO: Start Vault in a dev mode, and export VAULT_ADDR as well as VAULT_TOKEN.
-    # TODO: Enable the Vault Transit secrets engine.
+
     @classmethod
     def setUpClass(cls):
-
-        # Create a temporary directory to store the repository, metadata, and target
-        # files.  'temporary_directory' must be deleted in TearDownClass() so that
-        # temporary files are always removed, even when exceptions occur.
+        # Create a temporary directory to store the repository, metadata, and
+        # target files.  'temporary_directory' must be deleted in
+        # TearDownClass() so that temporary files are always removed, even when
+        # exceptions occur.
         cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
 
         test_repo_data = os.path.join(
@@ -72,43 +75,18 @@ class TestMetadata(unittest.TestCase):
             }
 
 
-    # TODO: Shut down Vault.
     @classmethod
     def tearDownClass(cls):
-
-        # Remove the temporary repository directory, which should contain all the
-        # metadata, targets, and key files generated for the test cases.
+        # Remove the temporary repository directory, which should contain all
+        # the metadata, targets, and key files generated for the test cases.
         shutil.rmtree(cls.temporary_directory)
 
 
-
-    # def _load_key_ring(self):
-    #     key_list = []
-    #     root_key = RAMKey.read_from_file(os.path.join(self.keystore_dir, 'root_key'),
-    #                                    'rsassa-pss-sha256', 'password')
-    #     key_list.append(root_key)
-
-    #     for key_file in os.listdir(self.keystore_dir):
-    #         if key_file.endswith('.pub'):
-    #             # ignore public keys
-    #             continue
-
-    #         if key_file.startswith('root_key'):
-    #             # root key is loaded
-    #         continue
-
-    #         key = RAMKey.read_from_file(os.path.join(self.keystore_dir, key_file),
-    #                                 'ed25519', 'password')
-    #         key_list.append(key)
-
-    #     threshold = Threshold(1, 5)
-    #     return KeyRing(threshold=threshold, keys=key_list)
-
     def test_generic_read(self):
         for metadata, inner_metadata_cls in [
-                ("snapshot", Snapshot),
-                ("timestamp", Timestamp),
-                ("targets", Targets)]:
+                ('snapshot', Snapshot),
+                ('timestamp', Timestamp),
+                ('targets', Targets)]:
 
             path = os.path.join(self.repo_dir, 'metadata', metadata + '.json')
             metadata_obj = Metadata.read_from_json(path)
@@ -134,6 +112,7 @@ class TestMetadata(unittest.TestCase):
 
         os.remove(bad_metadata_path)
 
+
     def test_compact_json(self):
         path = os.path.join(self.repo_dir, 'metadata', 'targets.json')
         metadata_obj = Metadata.read_from_json(path)
@@ -143,7 +122,7 @@ class TestMetadata(unittest.TestCase):
 
 
     def test_read_write_read_compare(self):
-        for metadata in ["snapshot", "timestamp", "targets"]:
+        for metadata in ['snapshot', 'timestamp', 'targets']:
             path = os.path.join(self.repo_dir, 'metadata', metadata + '.json')
             metadata_obj = Metadata.read_from_json(path)
 
@@ -223,9 +202,6 @@ class TestMetadata(unittest.TestCase):
                 self.repo_dir, 'metadata', 'snapshot.json')
         snapshot = Snapshot.read_from_json(snapshot_path)
 
-        # key_ring = self._load_key_ring()
-        # snapshot.verify(key_ring)
-
         # Create a dict representing what we expect the updated data to be
         fileinfo = snapshot.signed.meta
         hashes = {'sha256': 'c2986576f5fdfd43944e2b19e775453b96748ec4fe2638a6d2f32f1310967095'}
@@ -236,22 +212,11 @@ class TestMetadata(unittest.TestCase):
         snapshot.signed.update('role1', 2, 123, hashes)
         self.assertEqual(snapshot.signed.meta, fileinfo)
 
-        # snapshot.signable()
-
-        # snapshot.sign()
-
-        # snapshot.verify()
-
-        # snapshot.write_to_json(os.path.join(cls.temporary_directory, 'api_snapshot.json'))
-
 
     def test_metadata_timestamp(self):
         timestamp_path = os.path.join(
                 self.repo_dir, 'metadata', 'timestamp.json')
         timestamp = Timestamp.read_from_json(timestamp_path)
-
-        # key_ring = self._load_key_ring()
-        # timestamp.verify(key_ring)
 
         self.assertEqual(timestamp.signed.version, 1)
         timestamp.signed.bump_version()
@@ -279,10 +244,6 @@ class TestMetadata(unittest.TestCase):
         fileinfo['length'] = 520
         timestamp.signed.update(2, 520, hashes)
         self.assertEqual(timestamp.signed.meta['snapshot.json'], fileinfo)
-
-        # timestamp.sign()
-
-        # timestamp.write_to_json()
 
 
 # Run unit test.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -123,6 +123,29 @@ class TestMetadata(unittest.TestCase):
 
         os.remove(bad_metadata_path)
 
+    def test_compact_json(self):
+        path = os.path.join(self.repo_dir, 'metadata', 'targets.json')
+        metadata_obj = Metadata.read_from_json(path)
+        self.assertTrue(
+                len(metadata_obj.as_json(compact=True)) <
+                len(metadata_obj.as_json()))
+
+
+    def test_read_write_read_compare(self):
+        for metadata in ["snapshot", "timestamp", "targets"]:
+            path = os.path.join(self.repo_dir, 'metadata', metadata + '.json')
+            metadata_obj = Metadata.read_from_json(path)
+
+            path_2 = path + '.tmp'
+            metadata_obj.write_to_json(path_2)
+            metadata_obj_2 = Metadata.read_from_json(path_2)
+
+            self.assertDictEqual(
+                    metadata_obj.as_dict(),
+                    metadata_obj_2.as_dict())
+
+            os.remove(path_2)
+
 
     def test_metadata_base(self):
         # Use of Snapshot is arbitrary, we're just testing the base class features

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,7 @@
 
 # Copyright 2020, New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
-""" Unit tests for api/metdata.py
+""" Unit tests for api/metadata.py
 
 """
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -88,13 +88,25 @@ class TestMetadata(unittest.TestCase):
                 ('timestamp', Timestamp),
                 ('targets', Targets)]:
 
+            # Load JSON-formatted metdata of each supported type from file
+            # and from out-of-band read JSON string
             path = os.path.join(self.repo_dir, 'metadata', metadata + '.json')
             metadata_obj = Metadata.from_json_file(path)
+            with open(path, 'rb') as f:
+                metadata_str = f.read()
+            metadata_obj2 = Metadata.from_json(metadata_str)
 
-            # Assert that generic method instantiates the right inner class for
-            # each metadata type
+            # Assert that both methods instantiate the right inner class for
+            # each metadata type and ...
             self.assertTrue(
                     isinstance(metadata_obj.signed, inner_metadata_cls))
+            self.assertTrue(
+                    isinstance(metadata_obj2.signed, inner_metadata_cls))
+
+            # ... and return the same object (compared by dict representation)
+            self.assertDictEqual(
+                    metadata_obj.to_dict(), metadata_obj2.to_dict())
+
 
         # Assert that it chokes correctly on an unknown metadata type
         bad_metadata_path = 'bad-metadata.json'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -91,15 +91,10 @@ class TestMetadata(unittest.TestCase):
             path = os.path.join(self.repo_dir, 'metadata', metadata + '.json')
             metadata_obj = Metadata.read_from_json(path)
 
-            # Assert that generic method ...
-            # ... instantiates the right inner class for each metadata type
+            # Assert that generic method instantiates the right inner class for
+            # each metadata type
             self.assertTrue(
                     isinstance(metadata_obj.signed, inner_metadata_cls))
-            # ... and reads the same metadata file as the corresponding method
-            # on the inner class would do (compare their dict representation)
-            self.assertDictEqual(
-                    metadata_obj.as_dict(),
-                    inner_metadata_cls.read_from_json(path).as_dict())
 
         # Assert that it chokes correctly on an unknown metadata type
         bad_metadata_path = 'bad-metadata.json'
@@ -185,7 +180,7 @@ class TestMetadata(unittest.TestCase):
         # with real data
         snapshot_path = os.path.join(
                 self.repo_dir, 'metadata', 'snapshot.json')
-        md = Snapshot.read_from_json(snapshot_path)
+        md = Metadata.read_from_json(snapshot_path)
 
         self.assertEqual(md.signed.version, 1)
         md.signed.bump_version()
@@ -200,7 +195,7 @@ class TestMetadata(unittest.TestCase):
     def test_metadata_snapshot(self):
         snapshot_path = os.path.join(
                 self.repo_dir, 'metadata', 'snapshot.json')
-        snapshot = Snapshot.read_from_json(snapshot_path)
+        snapshot = Metadata.read_from_json(snapshot_path)
 
         # Create a dict representing what we expect the updated data to be
         fileinfo = snapshot.signed.meta
@@ -216,7 +211,7 @@ class TestMetadata(unittest.TestCase):
     def test_metadata_timestamp(self):
         timestamp_path = os.path.join(
                 self.repo_dir, 'metadata', 'timestamp.json')
-        timestamp = Timestamp.read_from_json(timestamp_path)
+        timestamp = Metadata.read_from_json(timestamp_path)
 
         self.assertEqual(timestamp.signed.version, 1)
         timestamp.signed.bump_version()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,7 @@ import shutil
 import tempfile
 import unittest
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 
 # TODO: Remove case handling when fully dropping support for versions >= 3.6
@@ -185,11 +185,11 @@ class TestMetadata(unittest.TestCase):
         self.assertEqual(md.signed.version, 1)
         md.signed.bump_version()
         self.assertEqual(md.signed.version, 2)
-        self.assertEqual(md.signed.expires, '2030-01-01T00:00:00Z')
+        self.assertEqual(md.signed.expires, datetime(2030, 1, 1, 0, 0))
         md.signed.bump_expiration()
-        self.assertEqual(md.signed.expires, '2030-01-02T00:00:00Z')
+        self.assertEqual(md.signed.expires, datetime(2030, 1, 2, 0, 0))
         md.signed.bump_expiration(timedelta(days=365))
-        self.assertEqual(md.signed.expires, '2031-01-02T00:00:00Z')
+        self.assertEqual(md.signed.expires, datetime(2031, 1, 2, 0, 0))
 
 
     def test_metadata_snapshot(self):
@@ -217,20 +217,20 @@ class TestMetadata(unittest.TestCase):
         timestamp.signed.bump_version()
         self.assertEqual(timestamp.signed.version, 2)
 
-        self.assertEqual(timestamp.signed.expires, '2030-01-01T00:00:00Z')
+        self.assertEqual(timestamp.signed.expires, datetime(2030, 1, 1, 0, 0))
         timestamp.signed.bump_expiration()
-        self.assertEqual(timestamp.signed.expires, '2030-01-02T00:00:00Z')
+        self.assertEqual(timestamp.signed.expires, datetime(2030, 1, 2, 0, 0))
         timestamp.signed.bump_expiration(timedelta(days=365))
-        self.assertEqual(timestamp.signed.expires, '2031-01-02T00:00:00Z')
+        self.assertEqual(timestamp.signed.expires, datetime(2031, 1, 2, 0, 0))
 
         # Test whether dateutil.relativedelta works, this provides a much
         # easier to use interface for callers
         delta = relativedelta(days=1)
         timestamp.signed.bump_expiration(delta)
-        self.assertEqual(timestamp.signed.expires, '2031-01-03T00:00:00Z')
+        self.assertEqual(timestamp.signed.expires, datetime(2031, 1, 3, 0, 0))
         delta = relativedelta(years=5)
         timestamp.signed.bump_expiration(delta)
-        self.assertEqual(timestamp.signed.expires, '2036-01-03T00:00:00Z')
+        self.assertEqual(timestamp.signed.expires, datetime(2036, 1, 3, 0, 0))
 
         hashes = {'sha256': '0ae9664468150a9aa1e7f11feecb32341658eb84292851367fea2da88e8a58dc'}
         fileinfo = timestamp.signed.meta['snapshot.json']

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -279,11 +279,11 @@ class Timestamp(Signed):
 
     # Update metadata about the snapshot metadata.
     def update(self, version: int, length: int, hashes: JsonDict) -> None:
-        fileinfo = self.meta.get('snapshot.json', {})
-        fileinfo['version'] = version
-        fileinfo['length'] = length
-        fileinfo['hashes'] = hashes
-        self.meta['snapshot.json'] = fileinfo
+        self.meta['snapshot.json'] = {
+            'version': version,
+            'length': length,
+            'hashes': hashes
+        }
 
 
 class Snapshot(Signed):

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -32,9 +32,6 @@ from securesystemslib.formats import encode_canonical
 from securesystemslib.util import load_json_file, persist_temp_file
 from securesystemslib.storage import StorageBackendInterface
 from securesystemslib.keys import create_signature, verify_signature
-from tuf.repository_lib import (
-    _strip_version_number
-)
 
 import iso8601
 import tuf.formats
@@ -287,46 +284,6 @@ class Signed:
             'spec_version': self.spec_version,
             'expires': self.expires
         }
-
-    @classmethod
-    def read_from_json(
-            cls, filename: str,
-            storage_backend: Optional[StorageBackendInterface] = None
-            ) -> Metadata:
-        signable = load_json_file(filename, storage_backend)
-        """Loads corresponding JSON-formatted metadata from file storage.
-
-        Arguments:
-            filename: The path to read the file from.
-            storage_backend: An object that implements
-                securesystemslib.storage.StorageBackendInterface. Per default
-                a (local) FilesystemBackend is used.
-
-        Raises:
-            securesystemslib.exceptions.StorageError: The file cannot be read.
-            securesystemslib.exceptions.Error, ValueError: The metadata cannot
-                be parsed.
-
-        Returns:
-            A TUF Metadata object whose signed attribute contains an object
-            of this class.
-
-        """
-        # FIXME: It feels dirty to access signable["signed"]["version"] here in
-        # order to do this check, and also a bit random (there are likely other
-        # things to check), but later we don't have the filename anymore. If we
-        # want to stick to the check, which seems reasonable, we should maybe
-        # think of a better place.
-        _, fn_prefix = _strip_version_number(filename, True)
-        if fn_prefix and fn_prefix != signable['signed']['version']:
-            raise ValueError(
-                f'version filename prefix ({fn_prefix}) must align with '
-                f'version in metadata ({signable["signed"]["version"]}).')
-
-        return Metadata(
-            signed=cls(**signable['signed']),
-            signatures=signable['signatures'])
-
 
 class Timestamp(Signed):
     """A container for the signed part of timestamp metadata.

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -4,24 +4,6 @@ This module provides container classes for TUF role metadata, including methods
 to read/serialize/write from and to JSON, perform TUF-compliant metadata
 updates, and create and verify signatures.
 
-TODO:
- * Validation (some thoughts ...)
-   - Avoid schema, see secure-systems-lab/securesystemslib#183
-   - Provide methods to validate JSON representation (at user boundary)
-   - Fail on bad json metadata in read_from_json method
-   - Be lenient on bad/invalid metadata objects in memory, they might be
-     work in progress. E.g. it might be convenient to create empty metadata
-     and assign attributes later on.
-   - Fail on bad json metadata in write_to_json method, but with option to
-     disable check as there might be a justified reason to write WIP
-     metadata to json.
-
- * Add Root metadata class
-
- * Add classes for other complex metadata attributes, see 'signatures' (in
-   Metadata) 'meta'/'targets' (in Timestamp, Snapshot, Targets), 'delegations'
-   (in Targets), 'keys'/'roles' (in not yet existent 'Delegation'), ...
-
 """
 # Imports
 from datetime import datetime, timedelta

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -29,7 +29,11 @@ import logging
 import tempfile
 
 from securesystemslib.formats import encode_canonical
-from securesystemslib.util import load_json_file, persist_temp_file
+from securesystemslib.util import (
+    load_json_file,
+    load_json_string,
+    persist_temp_file
+)
 from securesystemslib.storage import StorageBackendInterface
 from securesystemslib.keys import create_signature, verify_signature
 
@@ -76,6 +80,24 @@ class Metadata():
             'signatures': self.signatures,
             'signed': self.signed.to_dict()
         }
+
+    @classmethod
+    def from_json(cls, metadata_json: str) -> 'Metadata':
+        """Loads JSON-formatted TUF metadata from a string.
+
+        Arguments:
+            metadata_json: TUF metadata in JSON-string representation.
+
+        Raises:
+            securesystemslib.exceptions.Error, ValueError, KeyError: The
+                metadata cannot be parsed.
+
+        Returns:
+            A TUF Metadata object.
+
+        """
+        return cls.from_dict(load_json_string(metadata_json))
+
 
     def to_json(self, compact: bool = False) -> None:
         """Returns the optionally compacted JSON representation of self. """

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -18,9 +18,12 @@ TODO:
 
  * Add Root metadata class
 
+ * Add classes for other complex metadata attributes, see 'signatures' (in
+   Metadata) 'meta'/'targets' (in Timestamp, Snapshot, Targets), 'delegations'
+   (in Targets), 'keys'/'roles' (in not yet existent 'Delegation'), ...
+
 """
 # Imports
-
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
@@ -42,12 +45,10 @@ import tuf.formats
 
 
 # Types
-
 JsonDict = Dict[str, Any]
 
 
 # Classes.
-
 class Metadata():
     """A container for signed TUF metadata.
 
@@ -74,126 +75,8 @@ class Metadata():
         self.signed = signed
         self.signatures = signatures
 
-    def to_dict(self) -> JsonDict:
-        """Returns the JSON-serializable dictionary representation of self. """
-        return {
-            'signatures': self.signatures,
-            'signed': self.signed.to_dict()
-        }
 
-    @classmethod
-    def from_json(cls, metadata_json: str) -> 'Metadata':
-        """Loads JSON-formatted TUF metadata from a string.
-
-        Arguments:
-            metadata_json: TUF metadata in JSON-string representation.
-
-        Raises:
-            securesystemslib.exceptions.Error, ValueError, KeyError: The
-                metadata cannot be parsed.
-
-        Returns:
-            A TUF Metadata object.
-
-        """
-        return cls.from_dict(load_json_string(metadata_json))
-
-
-    def to_json(self, compact: bool = False) -> None:
-        """Returns the optionally compacted JSON representation of self. """
-        return json.dumps(
-                self.to_dict(),
-                indent=(None if compact else 1),
-                separators=((',', ':') if compact else (',', ': ')),
-                sort_keys=True)
-
-    def sign(self, key: JsonDict, append: bool = False) -> JsonDict:
-        """Creates signature over 'signed' and assigns it to 'signatures'.
-
-        Arguments:
-            key: A securesystemslib-style private key object used for signing.
-            append: A boolean indicating if the signature should be appended to
-                the list of signatures or replace any existing signatures. The
-                default behavior is to replace signatures.
-
-        Raises:
-            securesystemslib.exceptions.FormatError: Key argument is malformed.
-            securesystemslib.exceptions.CryptoError, \
-                    securesystemslib.exceptions.UnsupportedAlgorithmError:
-                Signing errors.
-
-        Returns:
-            A securesystemslib-style signature object.
-
-        """
-        signature = create_signature(key, self.signed.to_canonical_bytes())
-
-        if append:
-            self.signatures.append(signature)
-        else:
-            self.signatures = [signature]
-
-        return signature
-
-    def verify(self, key: JsonDict) -> bool:
-        """Verifies 'signatures' over 'signed' that match the passed key by id.
-
-        Arguments:
-            key: A securesystemslib-style public key object.
-
-        Raises:
-            securesystemslib.exceptions.FormatError: Key argument is malformed.
-            securesystemslib.exceptions.CryptoError, \
-                    securesystemslib.exceptions.UnsupportedAlgorithmError:
-                Signing errors.
-
-        Returns:
-            A boolean indicating if all identified signatures are valid. False
-            if no signature was found for the keyid or any of the found
-            signatures is invalid.
-
-            FIXME: Is this behavior expected? An alternative approach would be
-            to raise an exception if no signature is found for the keyid,
-            and/or if more than one sigantures are found for the keyid.
-
-        """
-        signatures_for_keyid = list(filter(
-                lambda sig: sig['keyid'] == key['keyid'], self.signatures))
-
-        if not signatures_for_keyid:
-            return False
-
-        for signature in signatures_for_keyid:
-            if not verify_signature(
-                    key, signature, self.signed.to_canonical_bytes()):
-                return False
-
-        return True
-
-    @classmethod
-    def from_json_file(
-            cls, filename: str,
-            storage_backend: Optional[StorageBackendInterface] = None
-            ) -> 'Metadata':
-        """Loads JSON-formatted TUF metadata from file storage.
-
-        Arguments:
-            filename: The path to read the file from.
-            storage_backend: An object that implements
-                securesystemslib.storage.StorageBackendInterface. Per default
-                a (local) FilesystemBackend is used.
-
-        Raises:
-            securesystemslib.exceptions.StorageError: The file cannot be read.
-            securesystemslib.exceptions.Error, ValueError, KeyError: The
-                metadata cannot be parsed.
-
-        Returns:
-            A TUF Metadata object.
-
-        """
-        return cls.from_dict(load_json_file(filename, storage_backend))
-
+    # Deserialization (factories).
     @classmethod
     def from_dict(cls, metadata: JsonDict) -> 'Metadata':
         """Creates Metadata object from its JSON/dict representation.
@@ -237,6 +120,67 @@ class Metadata():
                 signatures=metadata['signatures'])
 
 
+    @classmethod
+    def from_json(cls, metadata_json: str) -> 'Metadata':
+        """Loads JSON-formatted TUF metadata from a string.
+
+        Arguments:
+            metadata_json: TUF metadata in JSON-string representation.
+
+        Raises:
+            securesystemslib.exceptions.Error, ValueError, KeyError: The
+                metadata cannot be parsed.
+
+        Returns:
+            A TUF Metadata object.
+
+        """
+        return cls.from_dict(load_json_string(metadata_json))
+
+
+    @classmethod
+    def from_json_file(
+            cls, filename: str,
+            storage_backend: Optional[StorageBackendInterface] = None
+            ) -> 'Metadata':
+        """Loads JSON-formatted TUF metadata from file storage.
+
+        Arguments:
+            filename: The path to read the file from.
+            storage_backend: An object that implements
+                securesystemslib.storage.StorageBackendInterface. Per default
+                a (local) FilesystemBackend is used.
+
+        Raises:
+            securesystemslib.exceptions.StorageError: The file cannot be read.
+            securesystemslib.exceptions.Error, ValueError, KeyError: The
+                metadata cannot be parsed.
+
+        Returns:
+            A TUF Metadata object.
+
+        """
+        return cls.from_dict(load_json_file(filename, storage_backend))
+
+
+    # Serialization.
+    def to_dict(self) -> JsonDict:
+        """Returns the JSON-serializable dictionary representation of self. """
+        return {
+            'signatures': self.signatures,
+            'signed': self.signed.to_dict()
+        }
+
+
+    def to_json(self, compact: bool = False) -> None:
+        """Returns the optionally compacted JSON representation of self. """
+        return json.dumps(
+                self.to_dict(),
+                indent=(None if compact else 1),
+                separators=((',', ':') if compact else (',', ': ')),
+                sort_keys=True)
+
+
     def to_json_file(
             self, filename: str, compact: bool = False,
             storage_backend: StorageBackendInterface = None) -> None:
@@ -257,6 +201,73 @@ class Metadata():
         with tempfile.TemporaryFile() as f:
             f.write(self.to_json(compact).encode('utf-8'))
             persist_temp_file(f, filename, storage_backend)
+
+
+    # Signatures.
+    def sign(self, key: JsonDict, append: bool = False) -> JsonDict:
+        """Creates signature over 'signed' and assigns it to 'signatures'.
+
+        Arguments:
+            key: A securesystemslib-style private key object used for signing.
+            append: A boolean indicating if the signature should be appended to
+                the list of signatures or replace any existing signatures. The
+                default behavior is to replace signatures.
+
+        Raises:
+            securesystemslib.exceptions.FormatError: Key argument is malformed.
+            securesystemslib.exceptions.CryptoError, \
+                    securesystemslib.exceptions.UnsupportedAlgorithmError:
+                Signing errors.
+
+        Returns:
+            A securesystemslib-style signature object.
+
+        """
+        signature = create_signature(key, self.signed.to_canonical_bytes())
+
+        if append:
+            self.signatures.append(signature)
+        else:
+            self.signatures = [signature]
+
+        return signature
+
+
+    def verify(self, key: JsonDict) -> bool:
+        """Verifies 'signatures' over 'signed' that match the passed key by id.
+
+        Arguments:
+            key: A securesystemslib-style public key object.
+
+        Raises:
+            securesystemslib.exceptions.FormatError: Key argument is malformed.
+            securesystemslib.exceptions.CryptoError, \
+                    securesystemslib.exceptions.UnsupportedAlgorithmError:
+                Signing errors.
+
+        Returns:
+            A boolean indicating if all identified signatures are valid. False
+            if no signature was found for the keyid or any of the found
+            signatures is invalid.
+
+            FIXME: Is this behavior expected? An alternative approach would be
+            to raise an exception if no signature is found for the keyid,
+            and/or if more than one sigantures are found for the keyid.
+
+        """
+        signatures_for_keyid = list(filter(
+                lambda sig: sig['keyid'] == key['keyid'], self.signatures))
+
+        if not signatures_for_keyid:
+            return False
+
+        for signature in signatures_for_keyid:
+            if not verify_signature(
+                    key, signature, self.signed.to_canonical_bytes()):
+                return False
+
+        return True
+
 
 class Signed:
     """A base class for the signed part of TUF metadata.
@@ -292,6 +303,8 @@ class Signed:
             raise ValueError(f'version must be < 0, got {version}')
         self.version = version
 
+
+    # Deserialization (factories).
     @classmethod
     def from_dict(cls, signed_dict: JsonDict) -> 'Signed':
         """Creates Signed object from its JSON/dict representation. """
@@ -313,17 +326,12 @@ class Signed:
         # that subclass (see e.g. Metadata.from_dict).
         return cls(**signed_dict)
 
+
+    # Serialization.
     def to_canonical_bytes(self) -> bytes:
         """Returns the UTF-8 encoded canonical JSON representation of self. """
         return encode_canonical(self.to_dict()).encode('UTF-8')
 
-    def bump_expiration(self, delta: timedelta = timedelta(days=1)) -> None:
-        """Increments the expires attribute by the passed timedelta. """
-        self.expires += delta
-
-    def bump_version(self) -> None:
-        """Increments the metadata version number by 1."""
-        self.version += 1
 
     def to_dict(self) -> JsonDict:
         """Returns the JSON-serializable dictionary representation of self. """
@@ -333,6 +341,18 @@ class Signed:
             'spec_version': self.spec_version,
             'expires': self.expires.isoformat() + 'Z'
         }
+
+
+    # Modification.
+    def bump_expiration(self, delta: timedelta = timedelta(days=1)) -> None:
+        """Increments the expires attribute by the passed timedelta. """
+        self.expires += delta
+
+
+    def bump_version(self) -> None:
+        """Increments the metadata version number by 1."""
+        self.version += 1
+
 
 class Timestamp(Signed):
     """A container for the signed part of timestamp metadata.
@@ -360,6 +380,8 @@ class Timestamp(Signed):
         # TODO: Add class for meta
         self.meta = meta
 
+
+    # Serialization.
     def to_dict(self) -> JsonDict:
         """Returns the JSON-serializable dictionary representation of self. """
         json_dict = super().to_dict()
@@ -368,6 +390,8 @@ class Timestamp(Signed):
         })
         return json_dict
 
+
+    # Modification.
     def update(self, version: int, length: int, hashes: JsonDict) -> None:
         """Assigns passed info about snapshot metadata to meta dict. """
         self.meta['snapshot.json'] = {
@@ -410,6 +434,7 @@ class Snapshot(Signed):
         # TODO: Add class for meta
         self.meta = meta
 
+    # Serialization.
     def to_dict(self) -> JsonDict:
         """Returns the JSON-serializable dictionary representation of self. """
         json_dict = super().to_dict()
@@ -418,7 +443,8 @@ class Snapshot(Signed):
         })
         return json_dict
 
-    # Add or update metadata about the targets metadata.
+
+    # Modification.
     def update(
             self, rolename: str, version: int, length: Optional[int] = None,
             hashes: Optional[JsonDict] = None) -> None:
@@ -496,6 +522,7 @@ class Targets(Signed):
         self.delegations = delegations
 
 
+    # Serialization.
     def to_dict(self) -> JsonDict:
         """Returns the JSON-serializable dictionary representation of self. """
         json_dict = super().to_dict()
@@ -505,7 +532,7 @@ class Targets(Signed):
         })
         return json_dict
 
-    # Add or update metadata about the target.
+    # Modification.
     def update(self, filename: str, fileinfo: JsonDict) -> None:
         """Assigns passed target file info to meta dict. """
         self.targets[filename] = fileinfo

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -22,7 +22,6 @@ from securesystemslib.util import (
 from securesystemslib.storage import StorageBackendInterface
 from securesystemslib.keys import create_signature, verify_signature
 
-import iso8601
 import tuf.formats
 import tuf.exceptions
 
@@ -295,8 +294,9 @@ class Signed:
         # Convert 'expires' TUF metadata string to a datetime object, which is
         # what the constructor expects and what we store. The inverse operation
         # is implemented in 'to_dict'.
-        signed_dict['expires'] = iso8601.parse_date(
-                signed_dict['expires']).replace(tzinfo=None)
+        signed_dict['expires'] = datetime.strptime(
+                signed_dict['expires'],
+                "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=None)
         # NOTE: We write the converted 'expires' back into 'signed_dict' above
         # so that we can pass it to the constructor as  '**signed_dict' below,
         # along with other fields that belong to Signed subclasses.

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1,0 +1,277 @@
+"""TUF role metadata model.
+
+This module provides container classes for TUF role metadata, including methods
+to read/serialize/write from and to JSON, perform TUF-compliant metadata
+updates, and create and verify signatures.
+
+TODO:
+
+ * Add docstrings
+
+ * Finalize/Document Verify/Sign functions (I am not fully sure about expected
+   behavior). See
+   https://github.com/theupdateframework/tuf/pull/1060#issuecomment-660056376
+
+ * Validation (some thoughts ...)
+   - Avoid schema, see secure-systems-lab/securesystemslib#183
+   - Provide methods to validate JSON representation (at user boundary)
+   - Fail on bad json metadata in read_from_json method
+   - Be lenient on bad/invalid metadata objects in memory, they might be
+     work in progress. E.g. it might be convenient to create empty metadata
+     and assign attributes later on.
+   - Fail on bad json metadata in write_to_json method, but with option to
+     disable check as there might be a justified reason to write WIP
+     metadata to json.
+
+ * It might be nice to have a generic Metadata.read_from_json that
+   can load any TUF role metadata and instantiate the appropriate object based
+   on the json '_type' field.
+
+ * Add Root metadata class
+
+"""
+# Imports
+
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+import json
+import logging
+import tempfile
+
+from securesystemslib.formats import encode_canonical
+from securesystemslib.util import load_json_file, persist_temp_file
+from securesystemslib.storage import StorageBackendInterface
+from tuf.repository_lib import (
+    _get_written_metadata,
+    _strip_version_number
+)
+
+import iso8601
+import tuf.formats
+
+
+# Types
+
+JsonDict = Dict[str, Any]
+
+
+# Classes.
+
+class Metadata():
+    def __init__(
+            self, signed: 'Signed' = None, signatures: list = None) -> None:
+        # TODO: How much init magic do we want?
+        self.signed = signed
+        self.signatures = signatures
+
+    def as_dict(self) -> JsonDict:
+        return {
+            'signatures': self.signatures,
+            'signed': self.signed.as_dict()
+        }
+
+    # def __update_signature(self, signatures, keyid, signature):
+    #     updated = False
+    #     keyid_signature = {'keyid':keyid, 'sig':signature}
+    #     for idx, keyid_sig in enumerate(signatures):
+    #         if keyid_sig['keyid'] == keyid:
+    #             signatures[idx] = keyid_signature
+    #             updated = True
+    #     if not updated:
+    #         signatures.append(keyid_signature)
+
+    # def sign(self, key_ring: ???) -> JsonDict:
+    #     # FIXME: Needs documentation of expected behavior
+    #     signed_bytes = self.signed_bytes
+    #     signatures = self.__signatures
+
+    #     for key in key_ring.keys:
+    #         signature = key.sign(self.signed_bytes)
+    #         self.__update_signature(signatures, key.keyid, signature)
+
+    #     self.__signatures = signatures
+    #     return self.signable
+
+    # def verify(self, key_ring: ???) -> bool:
+    #     # FIXME: Needs documentation of expected behavior
+    #     signed_bytes = self.signed.signed_bytes
+    #     signatures = self.signatures
+    #     verified_keyids = set()
+
+    #     for signature in signatures:
+    #         # TODO: handle an empty keyring
+    #         for key in key_ring.keys:
+    #             keyid = key.keyid
+    #             if keyid == signature['keyid']:
+    #                 try:
+    #                     verified = key.verify(signed_bytes, signature)
+    #                 except:
+    #                     logging.exception(f'Could not verify signature for key {keyid}')
+    #                     continue
+    #                 else:
+    #                     # Avoid https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-6174
+    #                     verified_keyids.add(keyid)
+
+    #                     break
+
+    #     return len(verified_keyids) >= key_ring.threshold.least
+
+    def write_to_json(
+            self, filename: str,
+            storage_backend: StorageBackendInterface = None) -> None:
+         with tempfile.TemporaryFile() as f:
+            f.write(_get_written_metadata(self.sign()).encode_canonical())
+            persist_temp_file(f, filename, storage_backend)
+
+
+class Signed:
+    # NOTE: Signed is a stupid name, because this might not be signed yet, but
+    # we keep it to match spec terminology (I often refer to this as "payload",
+    # or "inner metadata")
+
+    # TODO: Re-think default values. It might be better to pass some things
+    # as args and not es kwargs. Then we'd need to pop those from
+    # signable["signed"] in read_from_json and pass them explicitly, which
+    # some say is better than implicit. :)
+    def __init__(
+            self, _type: str = None, version: int = 0,
+            spec_version: str = None, expires: datetime = None
+        ) -> None:
+        # TODO: How much init magic do we want?
+
+        self._type = _type
+        self.spec_version = spec_version
+
+        # We always intend times to be UTC
+        # NOTE: we could do this with datetime.fromisoformat() but that is not
+        # available in Python 2.7's datetime
+        # NOTE: Store as datetime object for convenient handling, use 'expires'
+        # property to get the TUF metadata format representation
+        self.__expiration = iso8601.parse_date(expires).replace(tzinfo=None)
+
+        if version < 0:
+            raise ValueError(f'version must be < 0, got {version}')
+        self.version = version
+
+    @property
+    def signed_bytes(self) -> bytes:
+        return encode_canonical(self.as_dict()).encode('UTF-8')
+
+    @property
+    def expires(self) -> str:
+        """The expiration property in TUF metadata format."""
+        return self.__expiration.isoformat() + 'Z'
+
+    def bump_expiration(self, delta: timedelta = timedelta(days=1)) -> None:
+        self.__expiration = self.__expiration + delta
+
+    def bump_version(self) -> None:
+        self.version += 1
+
+    def as_dict(self) -> JsonDict:
+        # NOTE: The classes should be the single source of truth about metadata
+        # let's define the dict representation here and not in some dubious
+        # build_dict_conforming_to_schema
+        return {
+            '_type': self._type,
+            'version': self.version,
+            'spec_version': self.spec_version,
+            'expires': self.expires
+        }
+
+    @classmethod
+    def read_from_json(
+            cls, filename: str,
+            storage_backend: Optional[StorageBackendInterface] = None
+            ) -> Metadata:
+        signable = load_json_file(filename, storage_backend)
+
+        # FIXME: It feels dirty to access signable["signed"]["version"] here in
+        # order to do this check, and also a bit random (there are likely other
+        # things to check), but later we don't have the filename anymore. If we
+        # want to stick to the check, which seems reasonable, we should maybe
+        # think of a better place.
+        _, fn_prefix = _strip_version_number(filename, True)
+        if fn_prefix and fn_prefix != signable['signed']['version']:
+            raise ValueError(
+                f'version filename prefix ({fn_prefix}) must align with '
+                f'version in metadata ({signable["signed"]["version"]}).')
+
+        return Metadata(
+            signed=cls(**signable['signed']),
+            signatures=signable['signatures'])
+
+
+class Timestamp(Signed):
+    def __init__(self, meta: JsonDict = None, **kwargs) -> None:
+        super().__init__(**kwargs)
+        # TODO: How much init magic do we want?
+        # TODO: Is there merit in creating classes for dict fields?
+        self.meta = meta
+
+    def as_dict(self) -> JsonDict:
+        json_dict = super().as_dict()
+        json_dict.update({
+            'meta': self.meta
+        })
+        return json_dict
+
+    # Update metadata about the snapshot metadata.
+    def update(self, version: int, length: int, hashes: JsonDict) -> None:
+        fileinfo = self.meta.get('snapshot.json', {})
+        fileinfo['version'] = version
+        fileinfo['length'] = length
+        fileinfo['hashes'] = hashes
+        self.meta['snapshot.json'] = fileinfo
+
+
+class Snapshot(Signed):
+    def __init__(self, meta: JsonDict = None, **kwargs) -> None:
+        # TODO: How much init magic do we want?
+        # TODO: Is there merit in creating classes for dict fields?
+        super().__init__(**kwargs)
+        self.meta = meta
+
+    def as_dict(self) -> JsonDict:
+        json_dict = super().as_dict()
+        json_dict.update({
+            'meta': self.meta
+        })
+        return json_dict
+
+    # Add or update metadata about the targets metadata.
+    def update(
+            self, rolename: str, version: int, length: Optional[int] = None,
+            hashes: Optional[JsonDict] = None) -> None:
+        metadata_fn = f'{rolename}.json'
+
+        self.meta[metadata_fn] = {'version': version}
+        if length is not None:
+            self.meta[metadata_fn]['length'] = length
+
+        if hashes is not None:
+            self.meta[metadata_fn]['hashes'] = hashes
+
+
+class Targets(Signed):
+    def __init__(
+            self, targets: JsonDict = None, delegations: JsonDict = None,
+            **kwargs) -> None:
+        # TODO: How much init magic do we want?
+        # TODO: Is there merit in creating classes for dict fields?
+        super().__init__(**kwargs)
+        self.targets = targets
+        self.delegations = delegations
+
+    def as_dict(self) -> JsonDict:
+        json_dict = super().as_dict()
+        json_dict.update({
+            'targets': self.targets,
+            'delegations': self.delegations,
+        })
+        return json_dict
+
+    # Add or update metadata about the target.
+    def update(self, filename: str, fileinfo: JsonDict) -> None:
+        self.targets[filename] = fileinfo


### PR DESCRIPTION
This PR copies over the new `api/metadata.py` module (+ tests) added in #1060, which has shifted focus to implementing a Hashicorp Vault interface.

Co-authorship by @trishankatdatadog, @joshuagl, @sechkova and me plus note-worthy commit message details are preserved in a single squashed commit.

Missing TODOs items for this PR include at least.

- [x] add code documentation (docstrings)
- [x] finalize signature creation and verification interface
- [ ] add input validatation

See doc header of `api/metadata.py` for more details


