### PR TITLE
PoC(tap): Snapshot merkle tree

### DIFF
--- a/tests/repository_data/repository/metadata/role1-snapshot.json
+++ b/tests/repository_data/repository/metadata/role1-snapshot.json
@@ -1,11 +1,14 @@
 {
  "leaf_contents": {
+  "name": "role1",
   "version": 1
  },
  "merkle_path": {
-  "0": "d0657b1fe8cd74976421241692e36b86ebd8f923a3f71ec99dbcacac319a11eb"
+  "0": "3bd2912d01accd816767dcde96a2b470dc5bb51cefe3b3aeb3aca7fdc1704d6b",
+  "1": "70304860310d2c6f0a05f2ccbfb49a4a6d6d3c7a9ff9c93e0b91b2e0ab7fff97"
  },
  "path_directions": {
-  "0": 1
+  "0": -1,
+  "1": -1
  }
 }

--- a/tests/repository_data/repository/metadata/role1-snapshot.json
+++ b/tests/repository_data/repository/metadata/role1-snapshot.json
@@ -1,0 +1,11 @@
+{
+ "leaf_contents": {
+  "version": 1
+ },
+ "merkle_path": {
+  "0": "d0657b1fe8cd74976421241692e36b86ebd8f923a3f71ec99dbcacac319a11eb"
+ },
+ "path_directions": {
+  "0": 1
+ }
+}

--- a/tests/repository_data/repository/metadata/role2-snapshot.json
+++ b/tests/repository_data/repository/metadata/role2-snapshot.json
@@ -1,10 +1,11 @@
 {
  "leaf_contents": {
+  "name": "role2",
   "version": 1
  },
  "merkle_path": {
-  "0": "abcfdd2bed858c5d7e8866a21bbdee0ca94cc03fd61f9a8c7ccbe4e50a78044a",
-  "1": "d5d4546f9bfcce78a079fff48828b922091b5be9e874d5d2ce075e314dd19e13"
+  "0": "9a8cf4b3e3cf611d339867f295792c3105d3d8ebfcd559607f9528ba7511e52a",
+  "1": "70304860310d2c6f0a05f2ccbfb49a4a6d6d3c7a9ff9c93e0b91b2e0ab7fff97"
  },
  "path_directions": {
   "0": 1,

--- a/tests/repository_data/repository/metadata/role2-snapshot.json
+++ b/tests/repository_data/repository/metadata/role2-snapshot.json
@@ -1,0 +1,13 @@
+{
+ "leaf_contents": {
+  "version": 1
+ },
+ "merkle_path": {
+  "0": "abcfdd2bed858c5d7e8866a21bbdee0ca94cc03fd61f9a8c7ccbe4e50a78044a",
+  "1": "d5d4546f9bfcce78a079fff48828b922091b5be9e874d5d2ce075e314dd19e13"
+ },
+ "path_directions": {
+  "0": 1,
+  "1": -1
+ }
+}

--- a/tests/repository_data/repository/metadata/targets-snapshot.json
+++ b/tests/repository_data/repository/metadata/targets-snapshot.json
@@ -1,13 +1,12 @@
 {
  "leaf_contents": {
+  "name": "targets",
   "version": 1
  },
  "merkle_path": {
-  "0": "4d9f52a07628625e664bfd96868b69d5b4e81debf3f00ed3940e00cd8dc3da70",
-  "1": "d5d4546f9bfcce78a079fff48828b922091b5be9e874d5d2ce075e314dd19e13"
+  "0": "30e11c75a8fa88fd36cc2a4796c5c9f405c9ae52b7adf4180d1c351141e5037a"
  },
  "path_directions": {
-  "0": -1,
-  "1": -1
+  "0": 1
  }
 }

--- a/tests/repository_data/repository/metadata/targets-snapshot.json
+++ b/tests/repository_data/repository/metadata/targets-snapshot.json
@@ -1,0 +1,13 @@
+{
+ "leaf_contents": {
+  "version": 1
+ },
+ "merkle_path": {
+  "0": "4d9f52a07628625e664bfd96868b69d5b4e81debf3f00ed3940e00cd8dc3da70",
+  "1": "d5d4546f9bfcce78a079fff48828b922091b5be9e874d5d2ce075e314dd19e13"
+ },
+ "path_directions": {
+  "0": -1,
+  "1": -1
+ }
+}

--- a/tests/repository_data/repository/metadata/timestamp-merkle.json
+++ b/tests/repository_data/repository/metadata/timestamp-merkle.json
@@ -1,0 +1,25 @@
+{
+ "signatures": [
+  {
+   "keyid": "8a1c4a3ac2d515dec982ba9910c5fd79b91ae57f625b9cff25d06bf0a61c1758",
+   "sig": "c900d68461b8defb7d5d081376576c54f6e619ef8fde33d07b88e2763f123fbb10844168b7dfc638e0b137a8289bf56253a528e4b771ea5277182950f1517c0c"
+  }
+ ],
+ "signed": {
+  "_type": "timestamp",
+  "expires": "2030-01-01T00:00:00Z",
+  "merkle_root": "2b232a308f285d2ef594fa4410d3982f3982e33c28cd73fe1f23a0014be7da77",
+  "meta": {
+   "snapshot.json": {
+    "hashes": {
+     "sha256": "8f88e2ba48b412c3843e9bb26e1b6f8fc9e98aceb0fbaa97ba37b4c98717d7ab",
+     "sha512": "fe9ed4b709776cc24e877babc76928cd119c18a806f432650ef6a5c687b0b5411df3c7fb3b69eda1163db83e1ae24ee3e22c9152e548b04f0a0884ee65310a95"
+    },
+    "length": 515,
+    "version": 1
+   }
+  },
+  "spec_version": "1.0.0",
+  "version": 1
+ }
+}

--- a/tests/repository_data/repository/metadata/timestamp-merkle.json
+++ b/tests/repository_data/repository/metadata/timestamp-merkle.json
@@ -2,13 +2,13 @@
  "signatures": [
   {
    "keyid": "8a1c4a3ac2d515dec982ba9910c5fd79b91ae57f625b9cff25d06bf0a61c1758",
-   "sig": "c900d68461b8defb7d5d081376576c54f6e619ef8fde33d07b88e2763f123fbb10844168b7dfc638e0b137a8289bf56253a528e4b771ea5277182950f1517c0c"
+   "sig": "1790a53390ab9928ba5c46e7a30a4e0348976e26f34d8cdd29ee11d644276dfc72e3fff6d1a7a913a42a1443cda12a738a3e4803818e970446a91e0e99f24601"
   }
  ],
  "signed": {
   "_type": "timestamp",
   "expires": "2030-01-01T00:00:00Z",
-  "merkle_root": "2b232a308f285d2ef594fa4410d3982f3982e33c28cd73fe1f23a0014be7da77",
+  "merkle_root": "76eb3066cb278633fda18fa6e3ae33d783ff154e813e2752eb7bc8b65568a41b",
   "meta": {
    "snapshot.json": {
     "hashes": {

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python
+
+"""
+<Program Name>
+  test_auditor.py
+
+<Author>
+  Marina Moore
+
+<Started>
+  January 29, 2021
+
+<Copyright>
+  See LICENSE-MIT OR LICENSE for licensing information.
+
+<Purpose>
+  'test-auditor.py' provides a collection of methods that test the public /
+  non-public methods and functions of 'tuf.client.auditor.py'.
+
+"""
+
+import unittest
+import tempfile
+import os
+import logging
+import shutil
+
+import tuf
+import tuf.exceptions
+import tuf.log
+import tuf.keydb
+import tuf.roledb
+import tuf.repository_tool as repo_tool
+import tuf.repository_lib as repo_lib
+import tuf.unittest_toolbox as unittest_toolbox
+import tuf.client.auditor as auditor
+
+from tests import utils
+
+import securesystemslib
+
+logger = logging.getLogger(__name__)
+repo_tool.disable_console_log_messages()
+
+
+class TestAuditor(unittest_toolbox.Modified_TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    # setUpClass is called before tests in an individual class are executed.
+
+    # Create a temporary directory to store the repository, metadata, and target
+    # files.  'temporary_directory' must be deleted in TearDownModule() so that
+    # temporary files are always removed, even when exceptions occur.
+    cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
+
+    # Needed because in some tests simple_server.py cannot be found.
+    # The reason is that the current working directory
+    # has been changed when executing a subprocess.
+    cls.SIMPLE_SERVER_PATH = os.path.join(os.getcwd(), 'simple_server.py')
+
+    # Launch a SimpleHTTPServer (serves files in the current directory).
+    # Test cases will request metadata and target files that have been
+    # pre-generated in 'tuf/tests/repository_data', which will be served
+    # by the SimpleHTTPServer launched here.  The test cases of 'test_updater.py'
+    # assume the pre-generated metadata files have a specific structure, such
+    # as a delegated role 'targets/role1', three target files, five key files,
+    # etc.
+    cls.server_process_handler = utils.TestServerProcess(log=logger,
+        server=cls.SIMPLE_SERVER_PATH)
+
+
+  @classmethod
+  def tearDownClass(cls):
+    # Cleans the resources and flush the logged lines (if any).
+    cls.server_process_handler.clean()
+
+    # Remove the temporary repository directory, which should contain all the
+    # metadata, targets, and key files generated for the test cases
+    shutil.rmtree(cls.temporary_directory)
+
+
+  def setUp(self):
+    # We are inheriting from custom class.
+    unittest_toolbox.Modified_TestCase.setUp(self)
+
+    tuf.roledb.clear_roledb(clear_all=True)
+    tuf.keydb.clear_keydb(clear_all=True)
+
+    self.repository_name = 'test_repository1'
+
+    # Copy the original repository files provided in the test folder so that
+    # any modifications made to repository files are restricted to the copies.
+    # The 'repository_data' directory is expected to exist in 'tuf.tests/'.
+    original_repository_files = os.path.join(os.getcwd(), 'repository_data')
+    temporary_repository_root = \
+      self.make_temp_directory(directory=self.temporary_directory)
+
+    # The original repository, keystore, and client directories will be copied
+    # for each test case.
+    original_repository = os.path.join(original_repository_files, 'repository')
+    original_keystore = os.path.join(original_repository_files, 'keystore')
+    original_client = os.path.join(original_repository_files, 'client')
+
+    # Save references to the often-needed client repository directories.
+    # Test cases need these references to access metadata and target files.
+    self.repository_directory = \
+      os.path.join(temporary_repository_root, 'repository')
+    self.keystore_directory = \
+      os.path.join(temporary_repository_root, 'keystore')
+
+    self.client_directory = os.path.join(temporary_repository_root,
+        'client')
+    self.client_metadata = os.path.join(self.client_directory,
+        self.repository_name, 'metadata')
+    self.client_metadata_current = os.path.join(self.client_metadata,
+        'current')
+    self.client_metadata_previous = os.path.join(self.client_metadata,
+        'previous')
+
+    # Copy the original 'repository', 'client', and 'keystore' directories
+    # to the temporary repository the test cases can use.
+    shutil.copytree(original_repository, self.repository_directory)
+    shutil.copytree(original_client, self.client_directory)
+    shutil.copytree(original_keystore, self.keystore_directory)
+
+    # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
+    repository_basepath = self.repository_directory[len(os.getcwd()):]
+    url_prefix = 'http://localhost:' \
+        + str(self.server_process_handler.port) + repository_basepath
+
+    # Setting 'tuf.settings.repository_directory' with the temporary client
+    # directory copied from the original repository files.
+    tuf.settings.repositories_directory = self.client_directory
+
+    # replace timestamp with a merkle timestamp
+    merkle_timestamp = os.path.join(self.repository_directory, 'metadata', 'timestamp-merkle.json')
+    timestamp = os.path.join(self.repository_directory, 'metadata', 'timestamp.json')
+    shutil.move(merkle_timestamp, timestamp)
+
+    # Metadata role keys are needed by the test cases to make changes to the
+    # repository (e.g., adding a new target file to 'targets.json' and then
+    # requesting a refresh()).
+    self.role_keys = _load_role_keys(self.keystore_directory)
+
+   # The repository must be rewritten with 'consistent_snapshot' set.
+    repository = repo_tool.load_repository(self.repository_directory)
+
+    # Write metadata for all the top-level roles , since consistent snapshot
+    # is now being set to true (i.e., the pre-generated repository isn't set
+    # to support consistent snapshots.  A new version of targets.json is needed
+    # to ensure <digest>.filename target files are written to disk.
+    repository.targets.load_signing_key(self.role_keys['targets']['private'])
+    repository.root.load_signing_key(self.role_keys['root']['private'])
+    repository.snapshot.load_signing_key(self.role_keys['snapshot']['private'])
+    repository.timestamp.load_signing_key(self.role_keys['timestamp']['private'])
+
+    repository.mark_dirty(['targets', 'root', 'snapshot', 'timestamp'])
+    repository.writeall(snapshot_merkle=True, consistent_snapshot=True)
+
+    # Move the staged metadata to the "live" metadata.
+    shutil.rmtree(os.path.join(self.repository_directory, 'metadata'))
+    shutil.copytree(os.path.join(self.repository_directory, 'metadata.staged'),
+                    os.path.join(self.repository_directory, 'metadata'))
+
+    self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
+                                           'metadata_path': 'metadata',
+                                           'targets_path': 'targets'}}
+
+
+
+
+  def tearDown(self):
+    # We are inheriting from custom class.
+    unittest_toolbox.Modified_TestCase.tearDown(self)
+    tuf.roledb.clear_roledb(clear_all=True)
+    tuf.keydb.clear_keydb(clear_all=True)
+
+    # Logs stdout and stderr from the sever subprocess.
+    self.server_process_handler.flush_log()
+
+
+  # UNIT TESTS.
+
+  def test_1__init_exceptions(self):
+    # Invalid arguments
+    self.assertRaises(securesystemslib.exceptions.FormatError, auditor.Auditor,
+        5, self.repository_mirrors)
+    self.assertRaises(securesystemslib.exceptions.FormatError, auditor.Auditor,
+        self.repository_name, 5)
+
+
+
+  def test_2__verify_merkle_tree(self):
+    repository_auditor = auditor.Auditor(self.repository_name, self.repository_mirrors)
+    # skip version 1 as it was written without consistent snapshots
+    repository_auditor.last_version_verified = 1
+
+    # The repository must be rewritten with 'consistent_snapshot' set.
+    repository = repo_tool.load_repository(self.repository_directory)
+
+    # Write metadata for all the top-level roles , since consistent snapshot
+    # is now being set to true (i.e., the pre-generated repository isn't set
+    # to support consistent snapshots.  A new version of targets.json is needed
+    # to ensure <digest>.filename target files are written to disk.
+    repository.targets.load_signing_key(self.role_keys['targets']['private'])
+    repository.root.load_signing_key(self.role_keys['root']['private'])
+    repository.snapshot.load_signing_key(self.role_keys['snapshot']['private'])
+    repository.timestamp.load_signing_key(self.role_keys['timestamp']['private'])
+
+    repository.targets.add_target('file1.txt')
+
+    repository.mark_dirty(['targets', 'root', 'snapshot', 'timestamp'])
+    repository.writeall(snapshot_merkle=True, consistent_snapshot=True)
+
+    # Move the staged metadata to the "live" metadata.
+    shutil.rmtree(os.path.join(self.repository_directory, 'metadata'))
+    shutil.copytree(os.path.join(self.repository_directory, 'metadata.staged'),
+                    os.path.join(self.repository_directory, 'metadata'))
+
+
+    # Normal case, should not error
+    repository_auditor.verify()
+
+    self.assertEqual(repository_auditor.version_info['role1.json'], 1)
+    self.assertEqual(repository_auditor.version_info['targets.json'], 3)
+    self.assertEqual(repository_auditor.last_version_verified, 3)
+
+    # modify targets
+    repository.targets.add_target('file2.txt')
+
+    repository.targets.load_signing_key(self.role_keys['targets']['private'])
+    repository.root.load_signing_key(self.role_keys['root']['private'])
+    repository.snapshot.load_signing_key(self.role_keys['snapshot']['private'])
+    repository.timestamp.load_signing_key(self.role_keys['timestamp']['private'])
+
+
+    repository.mark_dirty(['targets', 'root', 'snapshot', 'timestamp'])
+    repository.writeall(snapshot_merkle=True, consistent_snapshot=True)
+
+    # Move the staged metadata to the "live" metadata.
+    shutil.rmtree(os.path.join(self.repository_directory, 'metadata'))
+    shutil.copytree(os.path.join(self.repository_directory, 'metadata.staged'),
+                    os.path.join(self.repository_directory, 'metadata'))
+
+    repository_auditor.verify()
+
+    # Ensure the auditor checked the latest targets
+    self.assertEqual(repository_auditor.version_info['targets.json'], 4)
+
+    # Test rollback attack detection
+    repository_auditor.version_info['targets.json'] = 5
+    repository_auditor.last_version_verified = 3
+
+    self.assertRaises(tuf.exceptions.RepositoryError, repository_auditor.verify)
+
+
+
+
+def _load_role_keys(keystore_directory):
+
+  # Populating 'self.role_keys' by importing the required public and private
+  # keys of 'tuf/tests/repository_data/'.  The role keys are needed when
+  # modifying the remote repository used by the test cases in this unit test.
+
+  # The pre-generated key files in 'repository_data/keystore' are all encrypted with
+  # a 'password' passphrase.
+  EXPECTED_KEYFILE_PASSWORD = 'password'
+
+  # Store and return the cryptography keys of the top-level roles, including 1
+  # delegated role.
+  role_keys = {}
+
+  root_key_file = os.path.join(keystore_directory, 'root_key')
+  targets_key_file = os.path.join(keystore_directory, 'targets_key')
+  snapshot_key_file = os.path.join(keystore_directory, 'snapshot_key')
+  timestamp_key_file = os.path.join(keystore_directory, 'timestamp_key')
+  delegation_key_file = os.path.join(keystore_directory, 'delegation_key')
+
+  role_keys = {'root': {}, 'targets': {}, 'snapshot': {}, 'timestamp': {},
+               'role1': {}}
+
+  # Import the top-level and delegated role public keys.
+  role_keys['root']['public'] = \
+    repo_tool.import_rsa_publickey_from_file(root_key_file+'.pub')
+  role_keys['targets']['public'] = \
+    repo_tool.import_ed25519_publickey_from_file(targets_key_file+'.pub')
+  role_keys['snapshot']['public'] = \
+    repo_tool.import_ed25519_publickey_from_file(snapshot_key_file+'.pub')
+  role_keys['timestamp']['public'] = \
+      repo_tool.import_ed25519_publickey_from_file(timestamp_key_file+'.pub')
+  role_keys['role1']['public'] = \
+      repo_tool.import_ed25519_publickey_from_file(delegation_key_file+'.pub')
+
+  # Import the private keys of the top-level and delegated roles.
+  role_keys['root']['private'] = \
+    repo_tool.import_rsa_privatekey_from_file(root_key_file,
+                                              EXPECTED_KEYFILE_PASSWORD)
+  role_keys['targets']['private'] = \
+    repo_tool.import_ed25519_privatekey_from_file(targets_key_file,
+                                              EXPECTED_KEYFILE_PASSWORD)
+  role_keys['snapshot']['private'] = \
+    repo_tool.import_ed25519_privatekey_from_file(snapshot_key_file,
+                                              EXPECTED_KEYFILE_PASSWORD)
+  role_keys['timestamp']['private'] = \
+    repo_tool.import_ed25519_privatekey_from_file(timestamp_key_file,
+                                              EXPECTED_KEYFILE_PASSWORD)
+  role_keys['role1']['private'] = \
+    repo_tool.import_ed25519_privatekey_from_file(delegation_key_file,
+                                              EXPECTED_KEYFILE_PASSWORD)
+
+  return role_keys
+
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -476,33 +476,33 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     test_nodes = {}
     test_nodes['file1'] = tuf.formats.make_metadata_fileinfo(5, None, None)
 
-    root_1, leaves = repo_lib.build_merkle_tree(test_nodes)
-    repo_lib.write_merkle_paths(root_1, leaves, storage_backend,
+    root_1, leaves = repo_lib._build_merkle_tree(test_nodes)
+    repo_lib._write_merkle_paths(root_1, leaves, storage_backend,
         temporary_directory)
 
     file_path = os.path.join(temporary_directory, 'file1-snapshot.json')
     self.assertTrue(os.path.exists(file_path))
 
     test_nodes['file2'] = tuf.formats.make_metadata_fileinfo(5, None, None)
-    root_2, leaves = repo_lib.build_merkle_tree(test_nodes)
+    root_2, leaves = repo_lib._build_merkle_tree(test_nodes)
 
-    self.assertEqual(root_2.left().hash(), root_1.hash())
+    self.assertEqual(root_2.left.digest, root_1.digest)
 
     test_nodes['file3'] = tuf.formats.make_metadata_fileinfo(5, None, None)
     test_nodes['file4'] = tuf.formats.make_metadata_fileinfo(5, None, None)
 
-    root_3, leaves = repo_lib.build_merkle_tree(test_nodes)
+    root_3, leaves = repo_lib._build_merkle_tree(test_nodes)
 
-    self.assertEqual(root_3.left().hash(), root_2.hash())
+    self.assertEqual(root_3.left.digest, root_2.digest)
 
     test_nodes['file5'] = tuf.formats.make_metadata_fileinfo(5, None, None)
 
-    root_4, leaves = repo_lib.build_merkle_tree(test_nodes)
+    root_4, leaves = repo_lib._build_merkle_tree(test_nodes)
 
-    repo_lib.write_merkle_paths(root_4, leaves, storage_backend,
+    repo_lib._write_merkle_paths(root_4, leaves, storage_backend,
         temporary_directory)
 
-    self.assertEqual(root_4.left().hash(), root_3.hash())
+    self.assertEqual(root_4.left.digest, root_3.digest)
 
     # Ensure that the paths are written to the directory
     file_path = os.path.join(temporary_directory, 'file1-snapshot.json')
@@ -516,7 +516,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     test_nodes['role1'] = tuf.formats.make_metadata_fileinfo(1, None, None)
     test_nodes['role2'] = tuf.formats.make_metadata_fileinfo(1, None, None)
 
-    root, leaves = repo_lib.build_merkle_tree(test_nodes)
+    root, leaves = repo_lib._build_merkle_tree(test_nodes)
 
 
 
@@ -566,7 +566,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
       repo_lib.generate_snapshot_metadata(metadata_directory, version,
                                           expiration_date,
                                           storage_backend,
-                                          consistent_snapshot=False)
+                                          consistent_snapshot=False)[0]
     self.assertTrue(tuf.formats.SNAPSHOT_SCHEMA.matches(snapshot_metadata))
 
 
@@ -595,7 +595,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
                                           expiration_date,
                                           storage_backend,
                                           consistent_snapshot=False,
-                                          use_length=True)
+                                          use_length=True)[0]
     self.assertTrue(tuf.formats.SNAPSHOT_SCHEMA.matches(snapshot_metadata))
 
     metadata_files_info_dict = snapshot_metadata['meta']
@@ -610,7 +610,8 @@ class TestRepositoryToolFunctions(unittest.TestCase):
       # In the repository, the file "role_file.xml" have been added to make
       # sure that non-json files aren't loaded. This file should be filtered.
       if stripped_filename.endswith('.json'):
-        if stripped_filename not in TOP_LEVEL_METADATA_FILES:
+        if stripped_filename not in TOP_LEVEL_METADATA_FILES and \
+            not stripped_filename.endswith('-snapshot.json'):
           # Check that length is not calculated but hashes is
           self.assertIn('length', metadata_files_info_dict[stripped_filename])
           self.assertNotIn('hashes', metadata_files_info_dict[stripped_filename])
@@ -626,7 +627,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
                                           expiration_date,
                                           storage_backend,
                                           consistent_snapshot=False,
-                                          use_hashes=True)
+                                          use_hashes=True)[0]
     self.assertTrue(tuf.formats.SNAPSHOT_SCHEMA.matches(snapshot_metadata))
 
     metadata_files_info_dict = snapshot_metadata['meta']
@@ -641,7 +642,8 @@ class TestRepositoryToolFunctions(unittest.TestCase):
       # In the repository, the file "role_file.xml" have been added to make
       # sure that non-json files aren't loaded. This file should be filtered.
       if stripped_filename.endswith('.json'):
-        if stripped_filename not in TOP_LEVEL_METADATA_FILES:
+        if stripped_filename not in TOP_LEVEL_METADATA_FILES and \
+            not stripped_filename.endswith('-snapshot.json'):
           # Check that hashes is not calculated but length is
           self.assertNotIn('length', metadata_files_info_dict[stripped_filename])
           self.assertIn('hashes', metadata_files_info_dict[stripped_filename])
@@ -658,7 +660,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
                                           storage_backend,
                                           consistent_snapshot=False,
                                           use_length=True,
-                                          use_hashes=True)
+                                          use_hashes=True)[0]
     self.assertTrue(tuf.formats.SNAPSHOT_SCHEMA.matches(snapshot_metadata))
 
     metadata_files_info_dict = snapshot_metadata['meta']
@@ -673,7 +675,8 @@ class TestRepositoryToolFunctions(unittest.TestCase):
       # In the repository, the file "role_file.xml" have been added to make
       # sure that non-json files aren't loaded. This file should be filtered.
       if stripped_filename.endswith('.json'):
-        if stripped_filename not in TOP_LEVEL_METADATA_FILES:
+        if stripped_filename not in TOP_LEVEL_METADATA_FILES and \
+            not stripped_filename.endswith('-snapshot.json'):
           # Check that both length and hashes are not are not calculated
           self.assertIn('length', metadata_files_info_dict[stripped_filename])
           self.assertIn('hashes', metadata_files_info_dict[stripped_filename])

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -471,8 +471,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     temporary_directory = tempfile.mkdtemp(dir=self.temporary_directory)
     storage_backend = securesystemslib.storage.FilesystemBackend()
 
-    # Test building the tree one node at a time with identical nodes
-    # to verify the hashes
+    # Test building the tree one node at a time to verify the hashes
 
     test_nodes = {}
     test_nodes['file1'] = tuf.formats.make_metadata_fileinfo(5, None, None)

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -474,7 +474,9 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     test_nodes = {}
     test_nodes['file1'] = tuf.formats.make_metadata_fileinfo(5, None, None)
 
-    root_1 = repo_lib.build_merkle_tree(test_nodes, storage_backend,
+    root_1, leaves = repo_lib.build_merkle_tree(test_nodes)
+
+    repo_lib.write_merkle_paths(root_1, leaves, storage_backend,
         temporary_directory)
 
     file_path = os.path.join(temporary_directory, 'file1.json')
@@ -482,38 +484,40 @@ class TestRepositoryToolFunctions(unittest.TestCase):
 
     test_nodes['file2'] = tuf.formats.make_metadata_fileinfo(5, None, None)
 
-    root_2 = repo_lib.build_merkle_tree(test_nodes, storage_backend,
-        temporary_directory)
+    root_2, leaves = repo_lib.build_merkle_tree(test_nodes)
 
     digest_object = securesystemslib.hash.digest()
-    digest_object.update((root_1 + root_1).encode('utf-8'))
+    digest_object.update((root_1.hash() + root_1.hash()).encode('utf-8'))
 
-    self.assertEqual(root_2, digest_object.hexdigest())
+    self.assertEqual(root_2.hash(), digest_object.hexdigest())
 
     test_nodes['file3'] = tuf.formats.make_metadata_fileinfo(5, None, None)
     test_nodes['file4'] = tuf.formats.make_metadata_fileinfo(5, None, None)
 
-    root_3 = repo_lib.build_merkle_tree(test_nodes, storage_backend,
-        temporary_directory)
+    root_3, leaves = repo_lib.build_merkle_tree(test_nodes)
 
     digest_object = securesystemslib.hash.digest()
-    digest_object.update((root_2 + root_2).encode('utf-8'))
+    digest_object.update((root_2.hash()+ root_2.hash()).encode('utf-8'))
 
-    self.assertEqual(root_3, digest_object.hexdigest())
+    self.assertEqual(root_3.hash(), digest_object.hexdigest())
 
     test_nodes['file5'] = tuf.formats.make_metadata_fileinfo(5, None, None)
 
-    root_4 = repo_lib.build_merkle_tree(test_nodes, storage_backend,
+    root_4, leaves = repo_lib.build_merkle_tree(test_nodes)
+
+    repo_lib.write_merkle_paths(root_4, leaves, storage_backend,
         temporary_directory)
 
     digest_object = securesystemslib.hash.digest()
-    digest_object.update((root_3 + root_1).encode('utf-8'))
+    digest_object.update((root_3.hash() + root_1.hash()).encode('utf-8'))
 
-    self.assertEqual(root_4, digest_object.hexdigest())
+    self.assertEqual(root_4.hash(), digest_object.hexdigest())
 
     file_path = os.path.join(temporary_directory, 'file1.json')
 
     self.assertTrue(os.path.exists(file_path))
+
+    repo_lib.print_merkle_tree(root_4)
 
 
 

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -470,6 +470,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
   def test_build_merkle_tree(self):
     temporary_directory = tempfile.mkdtemp(dir=self.temporary_directory)
     storage_backend = securesystemslib.storage.FilesystemBackend()
+    version = 1
 
     # Test building the tree one node at a time to verify the hashes
 
@@ -478,9 +479,12 @@ class TestRepositoryToolFunctions(unittest.TestCase):
 
     root_1, leaves = repo_lib._build_merkle_tree(test_nodes)
     repo_lib._write_merkle_paths(root_1, leaves, storage_backend,
-        temporary_directory)
+        temporary_directory, version)
 
     file_path = os.path.join(temporary_directory, 'file1-snapshot.json')
+    self.assertTrue(os.path.exists(file_path))
+
+    file_path = os.path.join(temporary_directory, '1.file1-snapshot.json')
     self.assertTrue(os.path.exists(file_path))
 
     test_nodes['file2'] = tuf.formats.make_metadata_fileinfo(5, None, None)
@@ -500,13 +504,15 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     root_4, leaves = repo_lib._build_merkle_tree(test_nodes)
 
     repo_lib._write_merkle_paths(root_4, leaves, storage_backend,
-        temporary_directory)
+        temporary_directory, version + 1)
 
     self.assertEqual(root_4.left.digest, root_3.digest)
 
     # Ensure that the paths are written to the directory
     file_path = os.path.join(temporary_directory, 'file1-snapshot.json')
+    self.assertTrue(os.path.exists(file_path))
 
+    file_path = os.path.join(temporary_directory, '2.file1-snapshot.json')
     self.assertTrue(os.path.exists(file_path))
 
     # repo_lib.print_merkle_tree(root_4)

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -467,6 +467,56 @@ class TestRepositoryToolFunctions(unittest.TestCase):
                                          False, use_existing_fileinfo=True)
 
 
+  def test_build_merkle_tree(self):
+    temporary_directory = tempfile.mkdtemp(dir=self.temporary_directory)
+    storage_backend = securesystemslib.storage.FilesystemBackend()
+
+    test_nodes = {}
+    test_nodes['file1'] = tuf.formats.make_metadata_fileinfo(5, None, None)
+
+    root_1 = repo_lib.build_merkle_tree(test_nodes, storage_backend,
+        temporary_directory)
+
+    file_path = os.path.join(temporary_directory, 'file1.json')
+    self.assertTrue(os.path.exists(file_path))
+
+    test_nodes['file2'] = tuf.formats.make_metadata_fileinfo(5, None, None)
+
+    root_2 = repo_lib.build_merkle_tree(test_nodes, storage_backend,
+        temporary_directory)
+
+    digest_object = securesystemslib.hash.digest()
+    digest_object.update((root_1 + root_1).encode('utf-8'))
+
+    self.assertEqual(root_2, digest_object.hexdigest())
+
+    test_nodes['file3'] = tuf.formats.make_metadata_fileinfo(5, None, None)
+    test_nodes['file4'] = tuf.formats.make_metadata_fileinfo(5, None, None)
+
+    root_3 = repo_lib.build_merkle_tree(test_nodes, storage_backend,
+        temporary_directory)
+
+    digest_object = securesystemslib.hash.digest()
+    digest_object.update((root_2 + root_2).encode('utf-8'))
+
+    self.assertEqual(root_3, digest_object.hexdigest())
+
+    test_nodes['file5'] = tuf.formats.make_metadata_fileinfo(5, None, None)
+
+    root_4 = repo_lib.build_merkle_tree(test_nodes, storage_backend,
+        temporary_directory)
+
+    digest_object = securesystemslib.hash.digest()
+    digest_object.update((root_3 + root_1).encode('utf-8'))
+
+    self.assertEqual(root_4, digest_object.hexdigest())
+
+    file_path = os.path.join(temporary_directory, 'file1.json')
+
+    self.assertTrue(os.path.exists(file_path))
+
+
+
   def _setup_generate_snapshot_metadata_test(self):
     # Test normal case.
     temporary_directory = tempfile.mkdtemp(dir=self.temporary_directory)

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -259,10 +259,16 @@ class TestRepository(unittest.TestCase):
     repository.mark_dirty(['role1', 'targets', 'root', 'snapshot', 'timestamp'])
     repository.writeall(snapshot_merkle=True)
 
+    # Were the merkle snapshots written?
     targets_snapshot_filepath = os.path.join(metadata_directory,
         'targets-snapshot.json')
     targets_snapshot = securesystemslib.util.load_json_file(targets_snapshot_filepath)
     tuf.formats.SNAPSHOT_MERKLE_SCHEMA.check_match(targets_snapshot)
+
+    # Does timestamp have the root hash?
+    timestamp_filepath = os.path.join(metadata_directory, 'timestamp.json')
+    timestamp = securesystemslib.util.load_json_file(timestamp_filepath)
+    timestamp['signed']['merkle_root']
 
     # Verify that status() does not raise
     # 'tuf.exceptions.InsufficientKeysError' if a top-level role

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -260,7 +260,7 @@ class TestRepository(unittest.TestCase):
     repository.writeall(snapshot_merkle=True)
 
     targets_snapshot_filepath = os.path.join(metadata_directory,
-        'targets.json-snapshot.json')
+        'targets-snapshot.json')
     targets_snapshot = securesystemslib.util.load_json_file(targets_snapshot_filepath)
     tuf.formats.SNAPSHOT_MERKLE_SCHEMA.check_match(targets_snapshot)
 

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -255,6 +255,15 @@ class TestRepository(unittest.TestCase):
     # Verify that status() does not raise an exception.
     repository.status()
 
+    # Test writeall with generating a snapshot merkle tree
+    repository.mark_dirty(['role1', 'targets', 'root', 'snapshot', 'timestamp'])
+    repository.writeall(snapshot_merkle=True)
+
+    targets_snapshot_filepath = os.path.join(metadata_directory,
+        'targets.json-snapshot.json')
+    targets_snapshot = securesystemslib.util.load_json_file(targets_snapshot_filepath)
+    tuf.formats.SNAPSHOT_MERKLE_SCHEMA.check_match(targets_snapshot)
+
     # Verify that status() does not raise
     # 'tuf.exceptions.InsufficientKeysError' if a top-level role
     # does not contain a threshold of keys.
@@ -496,7 +505,9 @@ class TestRepository(unittest.TestCase):
     # Construct list of file paths expected, determining absolute paths.
     expected_files = []
     for filepath in ['1.root.json', 'root.json', 'targets.json',
-        'snapshot.json', 'timestamp.json', 'role1.json', 'role2.json']:
+        'snapshot.json', 'timestamp.json', 'role1.json', 'role2.json',
+        'targets-snapshot.json', 'timestamp-merkle.json',
+        'role1-snapshot.json', 'role2-snapshot.json']:
       expected_files.append(os.path.abspath(os.path.join(
           'repository_data', 'repository', 'metadata', filepath)))
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1791,15 +1791,15 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     repository_updater.refresh()
 
     # Test verify merkle path
-    snapshot_info = repository_updater._verify_merkle_path('targets')
+    snapshot_info = repository_updater.verify_merkle_path('targets')
     self.assertEqual(snapshot_info['version'], 1)
 
-    snapshot_info = repository_updater._verify_merkle_path('role1')
+    snapshot_info = repository_updater.verify_merkle_path('role1')
     self.assertEqual(snapshot_info['version'], 1)
 
     # verify merkle path with invalid role
     self.assertRaises(tuf.exceptions.NoWorkingMirrorError,
-        repository_updater._verify_merkle_path, 'foo')
+        repository_updater.verify_merkle_path, 'foo')
 
     # Test get_one_valid_targetinfo with snapshot merkle
     repository_updater.get_one_valid_targetinfo('file1.txt')

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1792,7 +1792,9 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # Test verify merkle path
     snapshot_info = repository_updater._verify_merkle_path('targets')
+    self.assertEqual(snapshot_info['version'], 1)
 
+    snapshot_info = repository_updater._verify_merkle_path('role1')
     self.assertEqual(snapshot_info['version'], 1)
 
     # verify merkle path with invalid role

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -709,6 +709,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
 
 
+
   def test_3__update_metadata(self):
     # Setup
     # _update_metadata() downloads, verifies, and installs the specified
@@ -848,7 +849,6 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
           'Expected a failure to verify metadata when the metadata had a '
           'specification version number that was unexpected.  '
           'No error was raised.')
-
 
 
 
@@ -1775,6 +1775,26 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     targets = [{'filepath': 'file1.txt', 'fileinfo': {'length': 1, 'hashes': {'sha256': 'abc'}}}]
     self.repository_updater._targets_of_role('targets',
         targets=targets, skip_refresh=False)
+
+
+
+
+  def test_snapshot_merkle(self):
+    # replace timestamp with a merkle timestamp and create the updater
+    merkle_timestamp = os.path.join(self.repository_directory, 'metadata', 'timestamp-merkle.json')
+    timestamp = os.path.join(self.repository_directory, 'metadata', 'timestamp.json')
+
+    shutil.move(merkle_timestamp, timestamp)
+
+    repository_updater = updater.Updater(self.repository_name,
+                                      self.repository_mirrors)
+    repository_updater.refresh()
+
+    # Test verify merkle path
+    snapshot_info = repository_updater._verify_merkle_path('targets')
+
+    self.assertEqual(snapshot_info['version'], 1)
+
 
 
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -833,7 +833,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     upperbound_filelength = tuf.settings.DEFAULT_TIMESTAMP_REQUIRED_LENGTH
     try:
       self.repository_updater._get_metadata_file('timestamp', 'timestamp.json',
-      upperbound_filelength, 1)
+      upperbound_filelength, 1, self.repository_updater.signable_verification)
 
     except tuf.exceptions.NoWorkingMirrorError as e:
       # Note that this test provides a piece of metadata which would fail to

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -709,7 +709,6 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
 
 
-
   def test_3__update_metadata(self):
     # Setup
     # _update_metadata() downloads, verifies, and installs the specified
@@ -849,6 +848,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
           'Expected a failure to verify metadata when the metadata had a '
           'specification version number that was unexpected.  '
           'No error was raised.')
+
 
 
 
@@ -1794,6 +1794,13 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     snapshot_info = repository_updater._verify_merkle_path('targets')
 
     self.assertEqual(snapshot_info['version'], 1)
+
+    # verify merkle path with invalid role
+    self.assertRaises(tuf.exceptions.NoWorkingMirrorError,
+        repository_updater._verify_merkle_path, 'foo')
+
+    # Test get_one_valid_targetinfo with snapshot merkle
+    repository_updater.get_one_valid_targetinfo('file1.txt')
 
 
 

--- a/tuf/client/auditor.py
+++ b/tuf/client/auditor.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+
+# Copyright 2012 - 2017, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+<Program Name>
+  auditor.py
+
+<Author>
+  Marina Moore <mnm678@gmail.com>
+<Started>
+  January 28, 2021
+<Copyright>
+  See LICENSE-MIT OR LICENSE for licensing information.
+<Purpose>
+  'auditor.py' provides an implementation of an auditor for
+  snapshot merkle metadata.
+
+"""
+
+import tuf
+import tuf.download
+import tuf.formats
+import tuf.client.updater
+
+import securesystemslib.hash
+
+
+
+class Auditor(object):
+  """
+  <Purpose>
+    Provide a class that downloads and verifies snapshot merkle metadata
+    from a repository.
+
+  <Arguments>
+    repository_name:
+      Name of the repository to be audited
+
+    repository_mirrors:
+      Dictionary holding repository mirror information, conformant to
+      `tuf.formats.MIRRORDICT_SCHEMA`.
+
+  <Exceptions>
+    securesystemslib.exceptions.FormatError:
+      If the arguments are improperly formatted.
+
+  <Side Effects>
+    None.
+
+  <Returns>
+    None.
+  """
+
+  def __init__(self, repository_name, repository_mirrors):
+    securesystemslib.formats.NAME_SCHEMA.check_match(repository_name)
+    tuf.formats.MIRRORDICT_SCHEMA.check_match(repository_mirrors)
+
+    self.repository_name = repository_name
+    self.mirrors = repository_mirrors
+
+    # Create a dictionary to store current version information
+    # for all targets metadata
+    self.version_info = {}
+
+    # Keep track of the last timestamp version number checked
+    self.last_version_verified = 0
+
+    # Updater will be used to update top-level metadata
+    self.updater = tuf.client.updater.Updater(repository_name, repository_mirrors)
+
+
+  def verify(self):
+    # download most recent top-level metadata, determine current timestamp key
+    self.updater.refresh()
+
+    cur_timestamp_keys = self.updater.metadata['current']['root']['roles']['timestamp']['keyids']
+
+    # Download all trees since last_version_verified that use cur_timestamp_key
+
+    next_version = self.last_version_verified + 1
+    version_exists = True
+
+    while(version_exists):
+      verification_fn = self.updater.signable_verification
+
+      # Attempt to download this version of timestamp. If it does not exist,
+      # break out of the loop
+      timestamp = self.updater.download_metadata_version_if_exists("timestamp",
+          next_version, verification_fn,
+          tuf.settings.DEFAULT_TIMESTAMP_REQUIRED_LENGTH)
+
+      if not timestamp:
+        version_exists = False
+        break
+
+
+      # Compare with the current timestamp keys. We only verify any trees
+      # that use the current keys for fast forward attack recovery
+      # Check if there are the same number of keys, and that the keyids match
+      # TODO: Should the auditor also verify older trees?
+      if len(timestamp['signatures']) != len(cur_timestamp_keys):
+        break
+
+      for s in timestamp['signatures']:
+        if s['keyid'] not in cur_timestamp_keys:
+          break
+
+      merkle_root = timestamp['signed']['merkle_root']
+
+      # Download and verify Merkle trees
+
+      # First, download snapshot to get a list of nodes
+      snapshot = self.updater.download_metadata_version_if_exists("snapshot",
+          next_version, verification_fn,
+          tuf.settings.DEFAULT_SNAPSHOT_REQUIRED_LENGTH)
+
+      for metadata_filename in snapshot['signed']['meta']:
+        # Download the node and verify its path
+        versioninfo = self.updater.verify_merkle_path(
+            metadata_filename[:-len('.json')], next_version, merkle_root)
+
+        # Have we seen this metadata file before?
+        # If yes, compare the version info
+        if metadata_filename in self.version_info:
+          if self.version_info[metadata_filename] > versioninfo['version']:
+            raise tuf.exceptions.RepositoryError('Rollback attack detected' +
+                'for ' + metadata_filename + '. Version ' +
+                str(versioninfo['version']) + ' is less than ' +
+                str(self.version_info[metadata_filename]))
+
+        # Update `version_info` with the latest seen version
+        self.version_info[metadata_filename] = versioninfo['version']
+
+
+      self.last_version_verified = next_version
+      next_version = next_version + 1
+
+
+

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1905,7 +1905,9 @@ class Updater(object):
 
     # Ensure the referenced metadata has been loaded.  The 'root' role may be
     # updated without having 'snapshot' available.
-    if referenced_metadata not in self.metadata['current']:
+    # When snapshot merkle trees are used, there will not be a snapshot file.
+    # Instead, if the snapshot merkle file is missing, this will error below.
+    if 'merkle_root' not in self.metadata['current']['timestamp'] and referenced_metadata not in self.metadata['current']:
       raise tuf.exceptions.RepositoryError('Cannot update'
         ' ' + repr(metadata_role) + ' because ' + referenced_metadata + ' is'
         ' missing.')
@@ -2499,7 +2501,11 @@ class Updater(object):
 
     roles_to_update = []
 
-    if rolename + '.json' in self.metadata['current']['snapshot']['meta']:
+    # Add the role if it is listed in snapshot. If snapshot merkle
+    # trees are used, the snaphot check will be done later when
+    # the merkle tree is verified
+    if 'merkle_root' in self.metadata['current']['timestamp'] or
+        rolename + '.json' in self.metadata['current']['snapshot']['meta']:
       roles_to_update.append(rolename)
 
     if refresh_all_delegated_roles:

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -2504,8 +2504,7 @@ class Updater(object):
     # Add the role if it is listed in snapshot. If snapshot merkle
     # trees are used, the snaphot check will be done later when
     # the merkle tree is verified
-    if 'merkle_root' in self.metadata['current']['timestamp'] or
-        rolename + '.json' in self.metadata['current']['snapshot']['meta']:
+    if 'merkle_root' in self.metadata['current']['timestamp'] or rolename + '.json' in self.metadata['current']['snapshot']['meta']:
       roles_to_update.append(rolename)
 
     if refresh_all_delegated_roles:

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1810,8 +1810,8 @@ class Updater(object):
 
       # Does the result match the merkle root?
       if node_hash != merkle_root:
-        raise tuf.exceptions.RepositoryError('The merkle root does not match ' +
-            'the hash for ' + metadata_role)
+        raise tuf.exceptions.RepositoryError('The merkle root ' + merkle_root +
+            ' does not match the hash ' + node_hash + ' for ' + metadata_role)
 
       # return the verified snapshot contents
       return contents

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1487,6 +1487,11 @@ class Updater(object):
         The expected and required version number of the 'metadata_role' file
         downloaded.  'expected_version' is an integer.
 
+      snapshot_merkle:
+        Is the metadata file a snapshot merkle file? Snapshot merkle files
+        are not signed and so should skip some of the verification steps here.
+        Instead, they must be verified using _verify_merkle_path.
+
     <Exceptions>
       tuf.exceptions.NoWorkingMirrorError:
         The metadata could not be fetched. This is raised only when all known
@@ -1644,6 +1649,11 @@ class Updater(object):
       version:
         The expected and required version number of the 'metadata_role' file
         downloaded.  'expected_version' is an integer.
+
+      snapshot_merkle:
+        Is the metadata to be updated for a snapshot merkle file?
+        Snapshot merkle metadata does not contain a signature, but must
+        instead be verified using _verify_merkle_path.
 
     <Exceptions>
       tuf.exceptions.NoWorkingMirrorError:

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1778,8 +1778,9 @@ class Updater(object):
 
       # hash the contents to determine the leaf hash in the merkle tree
       contents = snapshot_merkle['leaf_contents']
+      json_contents = securesystemslib.formats.encode_canonical(contents)
       digest_object = securesystemslib.hash.digest()
-      digest_object.update((metadata_role + str(contents) + '0').encode('utf-8'))
+      digest_object.update((json_contents).encode('utf-8'))
       node_hash = digest_object.hexdigest()
 
       # For each hash in the merkle_path, determine if the current node is

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -369,8 +369,8 @@ TARGETS_SCHEMA = SCHEMA.Object(
 SNAPSHOT_MERKLE_SCHEMA = SCHEMA.Object(
   leaf_contents = SCHEMA.OneOf([VERSIONINFO_SCHEMA,
                               METADATA_FILEINFO_SCHEMA]),
-  merkle_path = SCHEMA.ListOf(HASH_SCHEMA),
-  path_directions = SCHEMA.ListOf(SCHEMA.Integer()))
+  merkle_path = SCHEMA.DictOf(key_schema=SCHEMA.AnyString(), value_schema=HASH_SCHEMA),
+  path_directions = SCHEMA.DictOf(key_schema=SCHEMA.AnyString(), value_schema=SCHEMA.Integer()))
 
 # Snapshot role: indicates the latest versions of all metadata (except
 # timestamp).

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -395,7 +395,8 @@ TIMESTAMP_SCHEMA = SCHEMA.Object(
   spec_version = SPECIFICATION_VERSION_SCHEMA,
   version = METADATAVERSION_SCHEMA,
   expires = securesystemslib.formats.ISO8601_DATETIME_SCHEMA,
-  meta = FILEINFODICT_SCHEMA)
+  meta = FILEINFODICT_SCHEMA,
+  merkle_root = SCHEMA.Optional(HASH_SCHEMA))
 
 
 # project.cfg file: stores information about the project in a json dictionary

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -366,6 +366,12 @@ TARGETS_SCHEMA = SCHEMA.Object(
   targets = FILEDICT_SCHEMA,
   delegations = SCHEMA.Optional(DELEGATIONS_SCHEMA))
 
+SNAPSHOT_MERKLE_SCHEMA = SCHEMA.Object(
+  leaf_contents = SCHEMA.OneOf([VERSIONINFO_SCHEMA,
+                              METADATA_FILEINFO_SCHEMA]),
+  merkle_path = SCHEMA.ListOf(HASH_SCHEMA),
+  path_directions = SCHEMA.ListOf(SCHEMA.Integer()))
+
 # Snapshot role: indicates the latest versions of all metadata (except
 # timestamp).
 SNAPSHOT_SCHEMA = SCHEMA.Object(
@@ -375,6 +381,12 @@ SNAPSHOT_SCHEMA = SCHEMA.Object(
   expires = securesystemslib.formats.ISO8601_DATETIME_SCHEMA,
   spec_version = SPECIFICATION_VERSION_SCHEMA,
   meta = FILEINFODICT_SCHEMA)
+
+MERKLE_TIMESTAMP_SCHEMA = SCHEMA.Object(
+  spec_version = SPECIFICATION_VERSION_SCHEMA,
+  version = METADATAVERSION_SCHEMA,
+  expires = securesystemslib.formats.ISO8601_DATETIME_SCHEMA,
+  merkle_root = HASH_SCHEMA)
 
 # Timestamp role: indicates the latest version of the snapshot file.
 TIMESTAMP_SCHEMA = SCHEMA.Object(

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -382,12 +382,6 @@ SNAPSHOT_SCHEMA = SCHEMA.Object(
   spec_version = SPECIFICATION_VERSION_SCHEMA,
   meta = FILEINFODICT_SCHEMA)
 
-MERKLE_TIMESTAMP_SCHEMA = SCHEMA.Object(
-  spec_version = SPECIFICATION_VERSION_SCHEMA,
-  version = METADATAVERSION_SCHEMA,
-  expires = securesystemslib.formats.ISO8601_DATETIME_SCHEMA,
-  merkle_root = HASH_SCHEMA)
-
 # Timestamp role: indicates the latest version of the snapshot file.
 TIMESTAMP_SCHEMA = SCHEMA.Object(
   object_name = 'TIMESTAMP_SCHEMA',

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1654,7 +1654,6 @@ def _build_merkle_tree(fileinfodict):
   # We will build the merkle tree starting with the leaf nodes. Each
   # leaf contains snapshot information for a single metadata file.
   leaves = []
-  nodes = []
   for name, contents in sorted(fileinfodict.items()):
     if name.endswith(".json"):
       name = os.path.splitext(name)[0]
@@ -1680,9 +1679,8 @@ def _build_merkle_tree(fileinfodict):
       # Otherwise, use the next two nodes to build a new node.
       else:
         n = InternalNode(current_nodes[i], current_nodes[i+1])
-        # Add this node to the next level, and to a list of all nodes
+        # Add this node to the next level
         new_nodes.append(n)
-        nodes.append(n)
     current_nodes = new_nodes
 
   # The only node remaining in current_nodes will be the root node.

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -132,8 +132,6 @@ def _generate_and_write_metadata(rolename, metadata_filename,
           use_length=use_snapshot_length, use_hashes=use_snapshot_hashes,
           snapshot_merkle=True)
 
-      print_merkle_tree(root)
-
       # Add the merkle tree root hash to the timestamp roleinfo
       timestamp_roleinfo = tuf.roledb.get_roleinfo('timestamp', repository_name)
       timestamp_roleinfo['merkle_root'] = root.hash()
@@ -2027,17 +2025,14 @@ def generate_timestamp_metadata(snapshot_file_path, version, expiration_date,
       tuf.formats.make_metadata_fileinfo(snapshot_version['version'],
           length, hashes)
 
-  if(roleinfo):
-    try:
-      merkle_root = roleinfo['merkle_root']
-      return tuf.formats.build_dict_conforming_to_schema(
-          tuf.formats.TIMESTAMP_SCHEMA,
-          version=version,
-          expires=expiration_date,
-          meta=snapshot_fileinfo,
-          merkle_root=merkle_root)
-    except KeyError:
-      pass
+  if roleinfo and 'merkle_root' in roleinfo:
+    merkle_root = roleinfo['merkle_root']
+    return tuf.formats.build_dict_conforming_to_schema(
+        tuf.formats.TIMESTAMP_SCHEMA,
+        version=version,
+        expires=expiration_date,
+        meta=snapshot_fileinfo,
+        merkle_root=merkle_root)
 
   # Generate the timestamp metadata object.
   # Use generalized build_dict_conforming_to_schema func to produce a dict that

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1848,6 +1848,11 @@ def generate_snapshot_metadata(metadata_directory, version, expiration_date,
       Read more at section 5.6 from the Mercury paper:
       https://www.usenix.org/conference/atc17/technical-sessions/presentation/kuppusamy
 
+    snapshot_merkle:
+      Whether to generate snapshot merkle files in addition to snapshot.json
+      metadata. If this is true, this function will return the root and leaves
+      of the merkle tree in addition to the snapshot metadata.
+
   <Exceptions>
     securesystemslib.exceptions.FormatError, if the arguments are improperly
     formatted.
@@ -1992,6 +1997,10 @@ def generate_timestamp_metadata(snapshot_file_path, version, expiration_date,
       Whether to include the optional hashes attribute of the snapshot
       metadata file in the timestamp metadata.
       Default is True.
+
+    roleinfo:
+      The roleinfo for the timestamp role. This is used when a snapshot
+      merkle tree is used to access the merkle tree's root hash.
 
   <Exceptions>
     securesystemslib.exceptions.FormatError, if the generated timestamp metadata

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -1676,7 +1676,7 @@ def build_merkle_tree(fileinfodict):
   # leaf contains snapshot information for a single metadata file.
   leaves = []
   nodes = []
-  for name, contents in fileinfodict.items():
+  for name, contents in sorted(fileinfodict.items()):
     if name.endswith(".json"):
       name = os.path.splitext(name)[0]
     leaves.append(Leaf(name, contents))

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -296,6 +296,10 @@ class Repository(object):
         written as-is (True) or whether hashes should be generated (False,
         requires access to the targets files on-disk).
 
+      snapshot_merkle:
+        Whether to generate snapshot merkle metadata in addition to snapshot
+        metadata.
+
     <Exceptions>
       tuf.exceptions.UnsignedMetadataError, if any of the top-level
       and delegated roles do not have the minimum threshold of signatures.

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -266,7 +266,7 @@ class Repository(object):
 
 
 
-  def writeall(self, consistent_snapshot=False, use_existing_fileinfo=False):
+  def writeall(self, consistent_snapshot=False, use_existing_fileinfo=False, snapshot_merkle=False):
     """
     <Purpose>
       Write all the JSON Metadata objects to their corresponding files for
@@ -373,7 +373,8 @@ class Repository(object):
           consistent_snapshot, filenames,
           repository_name=self._repository_name,
           use_snapshot_length=self._use_snapshot_length,
-          use_snapshot_hashes=self._use_snapshot_hashes)
+          use_snapshot_hashes=self._use_snapshot_hashes,
+          snapshot_merkle=snapshot_merkle)
 
     # Generate the 'timestamp.json' metadata file.
     if 'timestamp' in dirty_rolenames:
@@ -382,7 +383,8 @@ class Repository(object):
           self._storage_backend, consistent_snapshot,
           filenames, repository_name=self._repository_name,
           use_timestamp_length=self._use_timestamp_length,
-          use_timestamp_hashes=self._use_timestamp_hashes)
+          use_timestamp_hashes=self._use_timestamp_hashes,
+          snapshot_merkle=snapshot_merkle)
 
     tuf.roledb.unmark_dirty(dirty_rolenames, self._repository_name)
 

--- a/tuf/settings.py
+++ b/tuf/settings.py
@@ -74,6 +74,8 @@ DEFAULT_SNAPSHOT_REQUIRED_LENGTH = 2000000 #bytes
 # download Targets metadata.
 DEFAULT_TARGETS_REQUIRED_LENGTH = 5000000 #bytes
 
+MERKLE_FILELENGTH = 10000
+
 # Set a timeout value in seconds (float) for non-blocking socket operations.
 SOCKET_TIMEOUT = 4 #seconds
 


### PR DESCRIPTION
This pr adds the ability to use a snapshot merkle tree instead of the snapshot.json metadata. More details about the snapshot merkle design are available in the Notary v2 design proposal: https://docs.google.com/document/d/1w8PFELVxt4p1aMk5oJv0RbDyd5J4OyvwguNSNZ1sJNw/edit# or the [TAP](https://github.com/theupdateframework/taps/pull/125).

This implementation includes creation and verification of snapshot merkle metadata, as well as an example auditor implementation.
