### PR TITLE
Re-raise exceptions explicitly using the 'from' keyword

### DIFF
--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1585,9 +1585,10 @@ class Updater(object):
                 str(metadata_spec_version) +
                 ". The update will continue as the major versions match.")
 
-        except (ValueError, TypeError):
-          raise securesystemslib.exceptions.FormatError('Improperly'
-            ' formatted spec_version, which must be in major.minor.fix format')
+        except (ValueError, TypeError) as error:
+          six.raise_from(securesystemslib.exceptions.FormatError('Improperly'
+              ' formatted spec_version, which must be in major.minor.fix format'),
+              error)
 
         # If the version number is unspecified, ensure that the version number
         # downloaded is greater than the currently trusted version number for

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -954,15 +954,16 @@ def check_signable_object_format(signable):
   try:
     role_type = signable['signed']['_type']
 
-  except (KeyError, TypeError):
-    raise securesystemslib.exceptions.FormatError('Untyped signable object.')
+  except (KeyError, TypeError) as error:
+    six.raise_from(securesystemslib.exceptions.FormatError(
+        'Untyped signable object.'), error)
 
   try:
     schema = SCHEMAS_BY_TYPE[role_type]
 
-  except KeyError:
-    raise securesystemslib.exceptions.FormatError('Unrecognized'
-      ' type ' + repr(role_type))
+  except KeyError as error:
+    six.raise_from(securesystemslib.exceptions.FormatError(
+        'Unrecognized type ' + repr(role_type)), error)
 
   # 'securesystemslib.exceptions.FormatError' raised if 'signable' does not
   # have a properly formatted role schema.

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -341,8 +341,8 @@ def get_key(keyid, repository_name='default'):
   try:
     return copy.deepcopy(_keydb_dict[repository_name][keyid])
 
-  except KeyError:
-    raise tuf.exceptions.UnknownKeyError('Key: ' + keyid)
+  except KeyError as error:
+    six.raise_from(tuf.exceptions.UnknownKeyError('Key: ' + keyid), error)
 
 
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -534,9 +534,9 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
     # Ensure the 'consistent_snapshot' field is extracted.
     consistent_snapshot = root_metadata['consistent_snapshot']
 
-  except securesystemslib.exceptions.StorageError:
-    raise tuf.exceptions.RepositoryError('Cannot load the required'
-        ' root file: ' + repr(root_filename))
+  except securesystemslib.exceptions.StorageError as error:
+    six.raise_from(tuf.exceptions.RepositoryError('Cannot load the required'
+        ' root file: ' + repr(root_filename)), error)
 
   # Load 'timestamp.json'.  A Timestamp role file without a version number is
   # always written.
@@ -563,9 +563,9 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
     tuf.roledb.update_roleinfo('timestamp', roleinfo, mark_role_as_dirty=False,
         repository_name=repository_name)
 
-  except securesystemslib.exceptions.StorageError:
-    raise tuf.exceptions.RepositoryError('Cannot load the Timestamp file: '
-        + repr(timestamp_filename))
+  except securesystemslib.exceptions.StorageError as error:
+    six.raise_from(tuf.exceptions.RepositoryError('Cannot load the Timestamp '
+        'file: ' + repr(timestamp_filename)), error)
 
   # Load 'snapshot.json'.  A consistent snapshot.json must be calculated if
   # 'consistent_snapshot' is True.
@@ -603,9 +603,9 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
     tuf.roledb.update_roleinfo('snapshot', roleinfo, mark_role_as_dirty=False,
         repository_name=repository_name)
 
-  except securesystemslib.exceptions.StorageError:
-    raise tuf.exceptions.RepositoryError('The Snapshot file cannot be loaded: '
-        + repr(snapshot_filename))
+  except securesystemslib.exceptions.StorageError as error:
+    six.raise_from(tuf.exceptions.RepositoryError('The Snapshot file '
+        'cannot be loaded: '+ repr(snapshot_filename)), error)
 
   # Load 'targets.json'.  A consistent snapshot of the Targets role must be
   # calculated if 'consistent_snapshot' is True.
@@ -659,9 +659,9 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
       except tuf.exceptions.KeyAlreadyExistsError:
         pass
 
-  except securesystemslib.exceptions.StorageError:
-    raise tuf.exceptions.RepositoryError('The Targets file can not be loaded: '
-        + repr(targets_filename))
+  except securesystemslib.exceptions.StorageError as error:
+    six.raise_from(tuf.exceptions.RepositoryError('The Targets file '
+        'can not be loaded: ' + repr(targets_filename)), error)
 
   return repository, consistent_snapshot
 

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -454,10 +454,10 @@ def import_privatekey_from_file(keypath, password=None):
       key_object = securesystemslib.keys.import_rsakey_from_private_pem(
           encrypted_key, 'rsassa-pss-sha256', password)
 
-    except securesystemslib.exceptions.CryptoError:
-      raise tuf.exceptions.Error(repr(keypath) + ' cannot be imported, possibly'
-          ' because an invalid key file is given or the decryption password is'
-          ' incorrect.')
+    except securesystemslib.exceptions.CryptoError as error:
+      six.raise_from(tuf.exceptions.Error(repr(keypath) + ' cannot be '
+          ' imported, possibly because an invalid key file is given or '
+          ' the decryption password is incorrect.'), error)
 
   if key_object['keytype'] not in SUPPORTED_KEY_TYPES:
     raise tuf.exceptions.Error('Trying to import an unsupported key'


### PR DESCRIPTION

**Fixes issue #**: #1115

**Description of the changes being introduced by the pull request**:

Versions 2.6.0 and later of pylint adhere to PEP 3134 and trigger a 'raise-missing-from' warning (W0707) when chained exceptions are raised implicitly.

The 'from' keyword is a Python3.x feature, that is why six.raise_from is used for Python2.x compatibility.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


