### PR TITLE
Remove accidentally introduced uses of keyid_hash_algorithms

### DIFF
--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -952,8 +952,7 @@ class Updater(object):
         # We specify the keyid to ensure that it's the correct keyid
         # for the key.
         try:
-          key, _ = securesystemslib.keys.format_metadata_to_key(keyinfo, keyid,
-              keyid_hash_algorithms=keyinfo['keyid_hash_algorithms'])
+          key, _ = securesystemslib.keys.format_metadata_to_key(keyinfo, keyid)
 
           tuf.keydb.add_key(key, repository_name=self.repository_name)
 

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -123,7 +123,7 @@ def create_keydb_from_root_metadata(root_metadata, repository_name='default'):
       # All other keyids returned are ignored.
 
       key_dict, _ = securesystemslib.keys.format_metadata_to_key(key_metadata,
-          keyid, keyid_hash_algorithms=key_metadata['keyid_hash_algorithms'])
+          keyid)
 
       # Make sure to update key_dict['keyid'] to use one of the other valid
       # keyids, otherwise add_key() will have no reference to it.

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -652,7 +652,7 @@ def _load_top_level_metadata(repository, top_level_filenames, repository_name):
 
       # Use the keyid found in the delegation
       key_object, _ = securesystemslib.keys.format_metadata_to_key(key_metadata,
-          keyid, keyid_hash_algorithms=key_metadata['keyid_hash_algorithms'])
+          keyid)
 
       # Add 'key_object' to the list of recognized keys.  Keys may be shared,
       # so do not raise an exception if 'key_object' has already been loaded.


### PR DESCRIPTION
**Fixes issue #**: N/A

**Description of the changes being introduced by the pull request**:

PR #1014 removed uses of `keyid_hash_algorithms`, but a couple of uses were re-introduced in PR #1016. This PR removes uses of `keyid_hash_algorithms` to match #1014

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


