### PR TITLE
mirrors: Make targets_path and metadata_path optional

### DIFF
--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -403,8 +403,8 @@ PROJECT_CFG_SCHEMA = SCHEMA.Object(
 MIRROR_SCHEMA = SCHEMA.Object(
   object_name = 'MIRROR_SCHEMA',
   url_prefix = securesystemslib.formats.URL_SCHEMA,
-  metadata_path = RELPATH_SCHEMA,
-  targets_path = RELPATH_SCHEMA,
+  metadata_path = SCHEMA.Optional(RELPATH_SCHEMA),
+  targets_path = SCHEMA.Optional(RELPATH_SCHEMA),
   confined_target_dirs = RELPATHS_SCHEMA,
   custom = SCHEMA.Optional(SCHEMA.Object()))
 


### PR DESCRIPTION
Now clients can leave out targets_path or metadata_path if the
client knows the mirror does not have that type of targets.

This is backwards compatible: old mirror configs continue to work.

Fixes #1079.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

--- 

**PR notes:**

This is a minor improvement in the warehouse case where one mirror has metadata and targets, and the other mirror has only targets.

Note that this leaves the issue of using os.path.join() on URLs as is: Fixing #1077 in a provably backwards compatible way seems tricky.

I believe this is a good if minor change... but I'll make the case against merging as well:
* the usefulness in pip/warehouse is minimal: the directory confinement is not expressive enough to be useful so pip has to use two separate mirror configurations anyway -- this should mean that in normal operation no requests will be made to the 'wrong' mirror: I believe they would only happen if the metadata mirror does not respond to a request for e.g. a specific targets bin file. In that case the wrong mirror would be asked as well -- this would be an annoyance, not a security issue
* it can be argued that the correct solution is to make directory confinement more powerful instead:
  * it should work on both metadata and targets
  * it should be expressive enough to say "allow everything under this directory"

Unfortunately improving directory confinement is likely to be a breaking change.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


