### PR TITLE
MANIFEST.in: Include LICENSE files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include LICENSE*
 include README.md
 include tox.ini
 include tests/repository_data/keystore/delegation_key


### PR DESCRIPTION
This seems to be a common way to handle license files. Also, vendoring
tool fails to handle tuf without a LICENSE file.

Fixes #1160

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>
