### PR TITLE
Make confined_target_dirs optional field

### DIFF
--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -132,8 +132,7 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
     tuf.settings.repositories_directory = self.client_directory
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
                                            'metadata_path': 'metadata',
-                                           'targets_path': 'targets',
-                                           'confined_target_dirs': ['']}}
+                                           'targets_path': 'targets'}}
 
     # Create the repository instance.  The test cases will use this client
     # updater to refresh metadata, fetch target files, etc.

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -134,8 +134,7 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
     tuf.settings.repositories_directory = self.client_directory
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
                                            'metadata_path': 'metadata',
-                                           'targets_path': 'targets',
-                                           'confined_target_dirs': ['']}}
+                                           'targets_path': 'targets'}}
 
     # Create the repository instance.  The test cases will use this client
     # updater to refresh metadata, fetch target files, etc.

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -141,8 +141,7 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
     tuf.settings.repositories_directory = self.client_directory
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
                                            'metadata_path': 'metadata',
-                                           'targets_path': 'targets',
-                                           'confined_target_dirs': ['']}}
+                                           'targets_path': 'targets'}}
 
     # Create the repository instance.  The test cases will use this client
     # updater to refresh metadata, fetch target files, etc.

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -261,6 +261,12 @@ class TestFormats(unittest.TestCase):
          'confined_target_dirs': ['path1/', 'path2/'],
          'custom': {'type': 'mirror'}}),
 
+      'MIRROR_SCHEMA_NO_CONFINED_TARGETS': (tuf.formats.MIRROR_SCHEMA,
+        {'url_prefix': 'http://localhost:8001',
+         'metadata_path': 'metadata/',
+         'targets_path': 'targets/',
+         'custom': {'type': 'mirror'}}),
+
       'MIRRORDICT_SCHEMA': (tuf.formats.MIRRORDICT_SCHEMA,
         {'mirror1': {'url_prefix': 'http://localhost:8001',
          'metadata_path': 'metadata/',

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -148,8 +148,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     tuf.settings.repositories_directory = self.client_directory
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
                                            'metadata_path': 'metadata',
-                                           'targets_path': 'targets',
-                                           'confined_target_dirs': ['']}}
+                                           'targets_path': 'targets'}}
 
     # Create the repository instance.  The test cases will use this client
     # updater to refresh metadata, fetch target files, etc.

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -141,8 +141,7 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
 
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
                                            'metadata_path': 'metadata',
-                                           'targets_path': 'targets',
-                                           'confined_target_dirs': ['']}}
+                                           'targets_path': 'targets'}}
 
     # Creating repository instance.  The test cases will use this client
     # updater to refresh metadata, fetch target files, etc.

--- a/tests/test_mirrors.py
+++ b/tests/test_mirrors.py
@@ -50,8 +50,7 @@ class TestMirrors(unittest_toolbox.Modified_TestCase):
     self.mirrors = \
     {'mirror1': {'url_prefix' : 'http://mirror1.com',
                  'metadata_path' : 'metadata',
-                 'targets_path' : 'targets',
-                 'confined_target_dirs' : ['']},
+                 'targets_path' : 'targets'},
      'mirror2': {'url_prefix' : 'http://mirror2.com',
                  'metadata_path' : 'metadata',
                  'targets_path' : 'targets',

--- a/tests/test_mirrors.py
+++ b/tests/test_mirrors.py
@@ -59,15 +59,47 @@ class TestMirrors(unittest_toolbox.Modified_TestCase):
      'mirror3': {'url_prefix' : 'http://mirror3.com',
                  'targets_path' : 'targets',
                  'confined_target_dirs' : ['targets/release/v2/']},
+     # confined_target_dirs = [] means that none of the targets on
+     # that mirror is available.
      'mirror4': {'url_prefix' : 'http://mirror4.com',
                  'metadata_path' : 'metadata',
                  'confined_target_dirs' : []},
+     # Make sure we are testing when confined_target_dirs is [''] which means
+     # that all targets are available on that mirror.
+     'mirror5': {'url_prefix' : 'http://mirror5.com',
+                 'targets_path' : 'targets',
+                 'confined_target_dirs' : ['']}
     }
 
 
 
   def test_get_list_of_mirrors(self):
     # Test: Normal case.
+
+    # 1 match: a mirror without target directory confinement
+    mirror_list = mirrors.get_list_of_mirrors('target', 'a.txt', self.mirrors)
+    self.assertEqual(len(mirror_list), 2)
+    self.assertTrue(self.mirrors['mirror1']['url_prefix']+'/targets/a.txt' in \
+                    mirror_list)
+    self.assertTrue(self.mirrors['mirror5']['url_prefix']+'/targets/a.txt' in \
+                    mirror_list)
+
+    mirror_list = mirrors.get_list_of_mirrors('target', 'a/b', self.mirrors)
+    self.assertEqual(len(mirror_list), 2)
+    self.assertTrue(self.mirrors['mirror1']['url_prefix']+'/targets/a/b' in \
+                    mirror_list)
+    self.assertTrue(self.mirrors['mirror5']['url_prefix']+'/targets/a/b' in \
+                    mirror_list)
+
+    # 2 matches: One with non-confined targets and one with matching confinement
+    mirror_list = mirrors.get_list_of_mirrors('target', 'release/v2/c', self.mirrors)
+    self.assertEqual(len(mirror_list), 3)
+    self.assertTrue(self.mirrors['mirror1']['url_prefix']+'/targets/release/v2/c' in \
+                    mirror_list)
+    self.assertTrue(self.mirrors['mirror3']['url_prefix']+'/targets/release/v2/c' in \
+                    mirror_list)
+    self.assertTrue(self.mirrors['mirror5']['url_prefix']+'/targets/release/v2/c' in \
+                    mirror_list)
 
     # 3 matches: Metadata found on 3 mirrors
     mirror_list = mirrors.get_list_of_mirrors('meta', 'release.txt', self.mirrors)
@@ -79,31 +111,12 @@ class TestMirrors(unittest_toolbox.Modified_TestCase):
     self.assertTrue(self.mirrors['mirror4']['url_prefix']+'/metadata/release.txt' in \
                     mirror_list)
 
-    # 1 match: a mirror without target directory confinement
-    mirror_list = mirrors.get_list_of_mirrors('target', 'a.txt', self.mirrors)
-    self.assertEqual(len(mirror_list), 1)
-    self.assertTrue(self.mirrors['mirror1']['url_prefix']+'/targets/a.txt' in \
-                    mirror_list)
-
-    mirror_list = mirrors.get_list_of_mirrors('target', 'a/b', self.mirrors)
-    self.assertEqual(len(mirror_list), 1)
-    self.assertTrue(self.mirrors['mirror1']['url_prefix']+'/targets/a/b' in \
-                    mirror_list)
-
     # No matches
-    mirror1 = self.mirrors['mirror1']
     del self.mirrors['mirror1']
+    del self.mirrors['mirror5']
     mirror_list = mirrors.get_list_of_mirrors('target', 'a/b', self.mirrors)
     self.assertFalse(mirror_list)
-    self.mirrors['mirror1'] = mirror1
 
-    # 2 matches: One with non-confined targets and one with matching confinement
-    mirror_list = mirrors.get_list_of_mirrors('target', 'release/v2/c', self.mirrors)
-    self.assertEqual(len(mirror_list), 2)
-    self.assertTrue(self.mirrors['mirror1']['url_prefix']+'/targets/release/v2/c' in \
-                    mirror_list)
-    self.assertTrue(self.mirrors['mirror3']['url_prefix']+'/targets/release/v2/c' in \
-                    mirror_list)
 
     # Test: Invalid 'file_type'.
     self.assertRaises(securesystemslib.exceptions.Error, mirrors.get_list_of_mirrors,

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -140,8 +140,7 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
     tuf.settings.repositories_directory = self.client_directory
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
                                            'metadata_path': 'metadata',
-                                           'targets_path': 'targets',
-                                           'confined_target_dirs': ['']}}
+                                           'targets_path': 'targets'}}
 
     # Create the repository instance.  The test cases will use this client
     # updater to refresh metadata, fetch target files, etc.

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -151,13 +151,11 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
 
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
                                            'metadata_path': 'metadata',
-                                           'targets_path': 'targets',
-                                           'confined_target_dirs': ['']}}
+                                           'targets_path': 'targets'}}
 
     self.repository_mirrors2 = {'mirror1': {'url_prefix': url_prefix2,
                                            'metadata_path': 'metadata',
-                                           'targets_path': 'targets',
-                                           'confined_target_dirs': ['']}}
+                                           'targets_path': 'targets'}}
 
     # Create the repository instances.  The test cases will use these client
     # updaters to refresh metadata, fetch target files, etc.

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -140,8 +140,7 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
     tuf.settings.repositories_directory = self.client_directory
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
                                            'metadata_path': 'metadata',
-                                           'targets_path': 'targets',
-                                           'confined_target_dirs': ['']}}
+                                           'targets_path': 'targets'}}
 
     # Create the repository instance.  The test cases will use this client
     # updater to refresh metadata, fetch target files, etc.

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -217,8 +217,7 @@ class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
     tuf.settings.repositories_directory = self.client_directory
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
                                            'metadata_path': 'metadata',
-                                           'targets_path': 'targets',
-                                           'confined_target_dirs': ['']}}
+                                           'targets_path': 'targets'}}
 
     # Create the repository instance.  The test cases will use this client
     # updater to refresh metadata, fetch target files, etc.

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -170,8 +170,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
                                            'metadata_path': 'metadata',
-                                           'targets_path': 'targets',
-                                           'confined_target_dirs': ['']}}
+                                           'targets_path': 'targets'}}
 
     # Creating a repository instance.  The test cases will use this client
     # updater to refresh metadata, fetch target files, etc.
@@ -1092,8 +1091,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         + str(self.server_process_handler.port) + repository_basepath
 
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
-        'metadata_path': 'metadata', 'targets_path': 'targets',
-        'confined_target_dirs': ['']}}
+        'metadata_path': 'metadata', 'targets_path': 'targets'}}
 
     # Creating a repository instance.  The test cases will use this client
     # updater to refresh metadata, fetch target files, etc.
@@ -1391,8 +1389,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     tuf.settings.repositories_directory = self.client_directory
 
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
-        'metadata_path': 'metadata', 'targets_path': 'targets',
-        'confined_target_dirs': ['']}}
+        'metadata_path': 'metadata', 'targets_path': 'targets'}}
 
     # Creating a repository instance.  The test cases will use this client
     # updater to refresh metadata, fetch target files, etc.
@@ -1519,8 +1516,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     tuf.settings.repositories_directory = self.client_directory
 
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
-        'metadata_path': 'metadata', 'targets_path': 'targets',
-        'confined_target_dirs': ['']}}
+        'metadata_path': 'metadata', 'targets_path': 'targets'}}
 
     # Creating a repository instance.  The test cases will use this client
     # updater to refresh metadata, fetch target files, etc.
@@ -1890,12 +1886,10 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     url_prefix2 = 'http://localhost:' + str(self.SERVER_PORT2)
 
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
-        'metadata_path': 'metadata', 'targets_path': 'targets',
-        'confined_target_dirs': ['']}}
+        'metadata_path': 'metadata', 'targets_path': 'targets'}}
 
     self.repository_mirrors2 = {'mirror1': {'url_prefix': url_prefix2,
-        'metadata_path': 'metadata', 'targets_path': 'targets',
-        'confined_target_dirs': ['']}}
+        'metadata_path': 'metadata', 'targets_path': 'targets'}}
 
     # Create the repository instances.  The test cases will use these client
     # updaters to refresh metadata, fetch target files, etc.

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -149,8 +149,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
                                            'metadata_path': 'metadata',
-                                           'targets_path': 'targets',
-                                           'confined_target_dirs': ['']}}
+                                           'targets_path': 'targets'}}
 
     # Creating a repository instance.  The test cases will use this client
     # updater to refresh metadata, fetch target files, etc.

--- a/tuf/client/README.md
+++ b/tuf/client/README.md
@@ -63,15 +63,14 @@ tuf.settings.repositories_directory = 'path/to/local_repository'
 # and targets files can be found in the 'metadata' and 'targets' directory,
 # respectively.  If the client wishes to only download target files from
 # specific directories on the mirror, the 'confined_target_dirs' field
-# should be set.  In the example, the client has chosen '', which is
-# interpreted as no confinement.  In other words, the client can download
+# should be set.  In this example, the client hasn't set confined_target_dirs,
+# which is interpreted as no confinement.  In other words, the client can download
 # targets from any directory or subdirectories.  If the client had chosen
 # 'targets1/', they would have been confined to the '/targets/targets1/'
 # directory on the 'http://localhost:8001' mirror.
 repository_mirrors = {'mirror1': {'url_prefix': 'http://localhost:8001',
                                   'metadata_path': 'metadata',
-                                  'targets_path': 'targets',
-                                  'confined_target_dirs': ['']}}
+                                  'targets_path': 'targets'}}
 
 # The updater may now be instantiated.  The Updater class of 'updater.py'
 # is called with two arguments.  The first argument assigns a name to this

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -68,15 +68,15 @@
   # and targets files can be found in the 'metadata' and 'targets' directory,
   # respectively.  If the client wishes to only download target files from
   # specific directories on the mirror, the 'confined_target_dirs' field
-  # should be set.  In the example, the client has chosen '', which is
-  # interpreted as no confinement.  In other words, the client can download
+  # should be set.  In this example, the client hasn't set confined_target_dirs,
+  # which is interpreted as no confinement.
+  # In other words, the client can download
   # targets from any directory or subdirectories.  If the client had chosen
   # 'targets1/', they would have been confined to the '/targets/targets1/'
   # directory on the 'http://localhost:8001' mirror.
   repository_mirrors = {'mirror1': {'url_prefix': 'http://localhost:8001',
                                     'metadata_path': 'metadata',
-                                    'targets_path': 'targets',
-                                    'confined_target_dirs': ['']}}
+                                    'targets_path': 'targets'}}
 
   # The updater may now be instantiated.  The Updater class of 'updater.py'
   # is called with two arguments.  The first argument assigns a name to this
@@ -504,8 +504,7 @@ class MultiRepoUpdater(object):
           mirrors[url] = {
             'url_prefix': url,
             'metadata_path': 'metadata',
-            'targets_path': 'targets',
-            'confined_target_dirs': ['']}
+            'targets_path': 'targets'}
 
         try:
           # NOTE: State (e.g., keys) should NOT be shared across different

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -405,7 +405,7 @@ MIRROR_SCHEMA = SCHEMA.Object(
   url_prefix = securesystemslib.formats.URL_SCHEMA,
   metadata_path = SCHEMA.Optional(RELPATH_SCHEMA),
   targets_path = SCHEMA.Optional(RELPATH_SCHEMA),
-  confined_target_dirs = RELPATHS_SCHEMA,
+  confined_target_dirs = SCHEMA.Optional(RELPATHS_SCHEMA),
   custom = SCHEMA.Optional(SCHEMA.Object()))
 
 # A dictionary of mirrors where the dict keys hold the mirror's name and

--- a/tuf/mirrors.py
+++ b/tuf/mirrors.py
@@ -112,8 +112,10 @@ def get_list_of_mirrors(file_type, file_path, mirrors_dict):
     # for targets, ensure directory confinement
     if path_key == 'targets_path':
       full_filepath = os.path.join(path, file_path)
-      if not in_confined_directory(full_filepath,
-          mirror_info['confined_target_dirs']):
+      confined_target_dirs = mirror_info.get('confined_target_dirs')
+      # confined_target_dirs is an optional field
+      if confined_target_dirs and not in_confined_directory(full_filepath,
+          confined_target_dirs):
         continue
 
     # urllib.quote(string) replaces special characters in string using the %xx

--- a/tuf/scripts/client.py
+++ b/tuf/scripts/client.py
@@ -117,8 +117,7 @@ def update_client(parsed_arguments):
   # Set the repository mirrors.  This dictionary is needed by the Updater
   # class of updater.py.
   repository_mirrors = {'mirror': {'url_prefix': parsed_arguments.repo,
-      'metadata_path': 'metadata', 'targets_path': 'targets',
-      'confined_target_dirs': ['']}}
+      'metadata_path': 'metadata', 'targets_path': 'targets'}}
 
   # Create the repository object using the repository name 'repository'
   # and the repository mirrors defined above.


### PR DESCRIPTION
Fixes: https://github.com/theupdateframework/tuf/issues/1155

**Description of the changes being introduced by the pull request**:

The field confined_target_dirs from the MIRROR_SCHEMA  is
a list of strings. Those strings define the accessible target
paths for that mirror. For one target to be available for that mirror,
its path should have as a prefix at least one of the strings defined
in confined_target_dirs.

That's why when confined_target_dirs is a list with one element empty
string (e.g. `['']`) this means all targets files on that mirror are
available and if confined_target_dirs is empty list (e.g. `[]`) this
would be interpreted as none of the target files is available.

This is a confusing API that could easily lead to mistakes.
That's why it's better we promote to not set confined_target_dirs
at all if a user wants targets to be available.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


