### PR TITLE
Potential fix for imports

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,7 +29,7 @@ def setUpModule():
 
 # Since setUpModule is called after imports we need to import conditionally.
 if IS_PY_VERSION_SUPPORTED:
-    import tuf.exceptions
+    import tuf
     from tuf.api.metadata import (
         Metadata,
         Snapshot,

--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -45,12 +45,9 @@ import unittest
 import sys
 
 import tuf
-import tuf.formats
-import tuf.roledb
-import tuf.keydb
 import tuf.log
-import tuf.client.updater as updater
-import tuf.unittest_toolbox as unittest_toolbox
+from tuf.client import updater
+from tuf import unittest_toolbox
 
 import utils
 

--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -45,7 +45,6 @@ import unittest
 import sys
 
 import tuf
-import tuf.log
 from tuf.client import updater
 from tuf import unittest_toolbox
 

--- a/tests/test_developer_tool.py
+++ b/tests/test_developer_tool.py
@@ -30,10 +30,7 @@ import sys
 
 import tuf
 import tuf.log
-import tuf.roledb
-import tuf.keydb
-import tuf.developer_tool as developer_tool
-import tuf.exceptions
+from tuf import developer_tool
 
 import securesystemslib
 import securesystemslib.exceptions

--- a/tests/test_developer_tool.py
+++ b/tests/test_developer_tool.py
@@ -29,7 +29,6 @@ import shutil
 import sys
 
 import tuf
-import tuf.log
 from tuf import developer_tool
 
 import securesystemslib

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -40,7 +40,6 @@ import sys
 import unittest
 
 import tuf
-import tuf.log
 from tuf import download
 from tuf import unittest_toolbox
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -40,10 +40,9 @@ import sys
 import unittest
 
 import tuf
-import tuf.download as download
 import tuf.log
-import tuf.unittest_toolbox as unittest_toolbox
-import tuf.exceptions
+from tuf import download
+from tuf import unittest_toolbox
 
 import utils
 

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -48,7 +48,6 @@ import unittest
 import sys
 
 import tuf
-import tuf.log
 from tuf.client import updater
 from tuf import unittest_toolbox
 

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -48,11 +48,9 @@ import unittest
 import sys
 
 import tuf
-import tuf.formats
 import tuf.log
-import tuf.client.updater as updater
-import tuf.unittest_toolbox as unittest_toolbox
-import tuf.roledb
+from tuf.client import updater
+from tuf import unittest_toolbox
 
 import utils
 

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -50,12 +50,10 @@ import logging
 import unittest
 import sys
 
-import tuf.formats
+import tuf
 import tuf.log
-import tuf.client.updater as updater
-import tuf.roledb
-import tuf.keydb
-import tuf.unittest_toolbox as unittest_toolbox
+from tuf.client import updater
+from tuf import unittest_toolbox
 
 import utils
 

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -51,7 +51,6 @@ import unittest
 import sys
 
 import tuf
-import tuf.log
 from tuf.client import updater
 from tuf import unittest_toolbox
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -34,7 +34,6 @@ import sys
 import os
 
 import tuf
-import tuf.formats
 
 import utils
 

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -54,7 +54,6 @@ import unittest
 import sys
 
 import tuf
-import tuf.log
 from tuf.client import updater
 from tuf import repository_tool as repo_tool
 from tuf import unittest_toolbox

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -53,14 +53,11 @@ import logging
 import unittest
 import sys
 
-import tuf.formats
+import tuf
 import tuf.log
-import tuf.client.updater as updater
-import tuf.repository_tool as repo_tool
-import tuf.unittest_toolbox as unittest_toolbox
-import tuf.roledb
-import tuf.keydb
-import tuf.exceptions
+from tuf.client import updater
+from tuf import repository_tool as repo_tool
+from tuf import unittest_toolbox
 
 import utils
 

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -46,11 +46,9 @@ import sys
 
 import tuf
 import tuf.log
-import tuf.roledb
-import tuf.keydb
-import tuf.repository_tool as repo_tool
-import tuf.unittest_toolbox as unittest_toolbox
-import tuf.client.updater as updater
+from tuf import repository_tool as repo_tool
+from tuf import unittest_toolbox
+from tuf.client import updater
 
 import utils
 

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -45,7 +45,6 @@ import unittest
 import sys
 
 import tuf
-import tuf.log
 from tuf import repository_tool as repo_tool
 from tuf import unittest_toolbox
 from tuf.client import updater

--- a/tests/test_keydb.py
+++ b/tests/test_keydb.py
@@ -33,11 +33,8 @@ import logging
 import sys
 
 import tuf
-import tuf.formats
 import securesystemslib.keys
 import securesystemslib.settings
-import tuf.keydb
-import tuf.log
 
 import utils
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -28,7 +28,6 @@ import sys
 
 import tuf
 import tuf.log
-import tuf.settings
 
 import securesystemslib
 import securesystemslib.util

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -27,7 +27,7 @@ import shutil
 import sys
 
 import tuf
-import tuf.log
+from tuf import log as tuf_log
 
 import securesystemslib
 import securesystemslib.util
@@ -53,8 +53,8 @@ class TestLog(unittest.TestCase):
     self._initial_level = logging.getLogger('tuf').level
 
   def tearDown(self):
-    tuf.log.remove_console_handler()
-    tuf.log.disable_file_logging()
+    tuf_log.remove_console_handler()
+    tuf_log.disable_file_logging()
     logging.getLogger('tuf').level = self._initial_level
 
 
@@ -65,18 +65,18 @@ class TestLog(unittest.TestCase):
     global log_levels
     global logger
 
-    tuf.log.set_log_level()
+    tuf_log.set_log_level()
     self.assertTrue(logger.isEnabledFor(logging.DEBUG))
 
     for level in log_levels:
-      tuf.log.set_log_level(level)
+      tuf_log.set_log_level(level)
       self.assertTrue(logger.isEnabledFor(level))
 
     # Test for improperly formatted argument.
-    self.assertRaises(securesystemslib.exceptions.FormatError, tuf.log.set_log_level, '123')
+    self.assertRaises(securesystemslib.exceptions.FormatError, tuf_log.set_log_level, '123')
 
     # Test for invalid argument.
-    self.assertRaises(securesystemslib.exceptions.FormatError, tuf.log.set_log_level, 51)
+    self.assertRaises(securesystemslib.exceptions.FormatError, tuf_log.set_log_level, 51)
 
 
 
@@ -84,44 +84,44 @@ class TestLog(unittest.TestCase):
     # Normal case.  Default log level.
     # A file handler is not set by default.  Add one now before attempting to
     # set the log level.
-    self.assertRaises(tuf.exceptions.Error, tuf.log.set_filehandler_log_level)
-    tuf.log.enable_file_logging()
-    tuf.log.set_filehandler_log_level()
+    self.assertRaises(tuf.exceptions.Error, tuf_log.set_filehandler_log_level)
+    tuf_log.enable_file_logging()
+    tuf_log.set_filehandler_log_level()
 
     # Expected log levels.
     for level in log_levels:
-      tuf.log.set_log_level(level)
+      tuf_log.set_log_level(level)
 
     # Test that the log level of the file handler cannot be set because
     # file logging is disabled (via tuf.settings.ENABLE_FILE_LOGGING).
     tuf.settings.ENABLE_FILE_LOGGING = False
-    reload_module(tuf.log)
+    reload_module(tuf_log)
 
     # Test for improperly formatted argument.
-    self.assertRaises(securesystemslib.exceptions.FormatError, tuf.log.set_filehandler_log_level, '123')
+    self.assertRaises(securesystemslib.exceptions.FormatError, tuf_log.set_filehandler_log_level, '123')
 
     # Test for invalid argument.
-    self.assertRaises(securesystemslib.exceptions.FormatError, tuf.log.set_filehandler_log_level, 51)
+    self.assertRaises(securesystemslib.exceptions.FormatError, tuf_log.set_filehandler_log_level, 51)
 
 
   def test_set_console_log_level(self):
     # Test setting a console log level without first adding one.
-    self.assertRaises(securesystemslib.exceptions.Error, tuf.log.set_console_log_level)
+    self.assertRaises(securesystemslib.exceptions.Error, tuf_log.set_console_log_level)
 
     # Normal case.  Default log level.  Setting the console log level first
     # requires adding a console logger.
-    tuf.log.add_console_handler()
-    tuf.log.set_console_log_level()
+    tuf_log.add_console_handler()
+    tuf_log.set_console_log_level()
 
     # Expected log levels.
     for level in log_levels:
-      tuf.log.set_console_log_level(level)
+      tuf_log.set_console_log_level(level)
 
     # Test for improperly formatted argument.
-    self.assertRaises(securesystemslib.exceptions.FormatError, tuf.log.set_console_log_level, '123')
+    self.assertRaises(securesystemslib.exceptions.FormatError, tuf_log.set_console_log_level, '123')
 
     # Test for invalid argument.
-    self.assertRaises(securesystemslib.exceptions.FormatError, tuf.log.set_console_log_level, 51)
+    self.assertRaises(securesystemslib.exceptions.FormatError, tuf_log.set_console_log_level, 51)
 
 
 
@@ -129,20 +129,20 @@ class TestLog(unittest.TestCase):
 
   def test_add_console_handler(self):
     # Normal case.  Default log level.
-    tuf.log.add_console_handler()
+    tuf_log.add_console_handler()
 
     # Adding a console handler when one has already been added.
-    tuf.log.add_console_handler()
+    tuf_log.add_console_handler()
 
     # Expected log levels.
     for level in log_levels:
-      tuf.log.set_console_log_level(level)
+      tuf_log.set_console_log_level(level)
 
     # Test for improperly formatted argument.
-    self.assertRaises(securesystemslib.exceptions.FormatError, tuf.log.add_console_handler, '123')
+    self.assertRaises(securesystemslib.exceptions.FormatError, tuf_log.add_console_handler, '123')
 
     # Test for invalid argument.
-    self.assertRaises(securesystemslib.exceptions.FormatError, tuf.log.add_console_handler, 51)
+    self.assertRaises(securesystemslib.exceptions.FormatError, tuf_log.add_console_handler, 51)
 
     # Test that an exception is printed to the console.  Note: A stack trace
     # is not included in the exception output because 'log.py' applies a filter
@@ -156,10 +156,10 @@ class TestLog(unittest.TestCase):
 
   def test_remove_console_handler(self):
     # Normal case.
-    tuf.log.remove_console_handler()
+    tuf_log.remove_console_handler()
 
     # Removing a console handler that has not been added.  Logs a warning.
-    tuf.log.remove_console_handler()
+    tuf_log.remove_console_handler()
 
 
   def test_enable_file_logging(self):
@@ -168,39 +168,39 @@ class TestLog(unittest.TestCase):
       shutil.move(
           tuf.settings.LOG_FILENAME, tuf.settings.LOG_FILENAME + '.backup')
 
-    tuf.log.enable_file_logging()
+    tuf_log.enable_file_logging()
     self.assertTrue(os.path.exists(tuf.settings.LOG_FILENAME))
     if os.path.exists(tuf.settings.LOG_FILENAME + '.backup'):
       shutil.move(
           tuf.settings.LOG_FILENAME + '.backup', tuf.settings.LOG_FILENAME)
 
     # The file logger must first be unset before attempting to re-add it.
-    self.assertRaises(tuf.exceptions.Error, tuf.log.enable_file_logging)
+    self.assertRaises(tuf.exceptions.Error, tuf_log.enable_file_logging)
 
-    tuf.log.disable_file_logging()
-    tuf.log.enable_file_logging('my_log_file.log')
+    tuf_log.disable_file_logging()
+    tuf_log.enable_file_logging('my_log_file.log')
     logger.debug('testing file logging')
     self.assertTrue(os.path.exists('my_log_file.log'))
 
     # Test for an improperly formatted argument.
-    tuf.log.disable_file_logging()
+    tuf_log.disable_file_logging()
     self.assertRaises(securesystemslib.exceptions.FormatError,
-        tuf.log.enable_file_logging, 1)
+        tuf_log.enable_file_logging, 1)
 
 
   def test_disable_file_logging(self):
     # Normal case.
-    tuf.log.enable_file_logging('my.log')
+    tuf_log.enable_file_logging('my.log')
     logger.debug('debug message')
     junk, hashes = securesystemslib.util.get_file_details('my.log')
-    tuf.log.disable_file_logging()
+    tuf_log.disable_file_logging()
     logger.debug('new debug message')
     junk, hashes2 = securesystemslib.util.get_file_details('my.log')
     self.assertEqual(hashes, hashes2)
 
     # An exception should not be raised if an attempt is made to disable
     # the file logger if it has already been disabled.
-    tuf.log.disable_file_logging()
+    tuf_log.disable_file_logging()
 
 
 # Run unit test.

--- a/tests/test_mirrors.py
+++ b/tests/test_mirrors.py
@@ -31,8 +31,8 @@ from __future__ import unicode_literals
 import unittest
 import sys
 
-import tuf.mirrors as mirrors
-import tuf.unittest_toolbox as unittest_toolbox
+from tuf import mirrors
+from tuf import unittest_toolbox
 
 import utils
 

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -45,13 +45,11 @@ import logging
 import unittest
 import sys
 
-import tuf.exceptions
+import tuf
 import tuf.log
-import tuf.client.updater as updater
-import tuf.repository_tool as repo_tool
-import tuf.unittest_toolbox as unittest_toolbox
-import tuf.roledb
-import tuf.keydb
+from tuf.client import updater
+from tuf import repository_tool as repo_tool
+from tuf import unittest_toolbox
 
 import utils
 

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -46,7 +46,6 @@ import unittest
 import sys
 
 import tuf
-import tuf.log
 from tuf.client import updater
 from tuf import repository_tool as repo_tool
 from tuf import unittest_toolbox

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -40,11 +40,9 @@ import sys
 
 import tuf
 import tuf.log
-import tuf.roledb
-import tuf.client.updater as updater
-import tuf.settings
-import tuf.unittest_toolbox as unittest_toolbox
-import tuf.repository_tool as repo_tool
+from tuf.client import updater
+from tuf import unittest_toolbox
+from tuf import repository_tool as repo_tool
 
 import utils
 

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -39,7 +39,6 @@ import json
 import sys
 
 import tuf
-import tuf.log
 from tuf.client import updater
 from tuf import unittest_toolbox
 from tuf import repository_tool as repo_tool

--- a/tests/test_proxy_use.py
+++ b/tests/test_proxy_use.py
@@ -41,10 +41,9 @@ import unittest
 import sys
 
 import tuf
-import tuf.download as download
 import tuf.log
-import tuf.unittest_toolbox as unittest_toolbox
-import tuf.exceptions
+from tuf import download
+from tuf import unittest_toolbox
 
 import utils
 

--- a/tests/test_proxy_use.py
+++ b/tests/test_proxy_use.py
@@ -41,7 +41,6 @@ import unittest
 import sys
 
 import tuf
-import tuf.log
 from tuf import download
 from tuf import unittest_toolbox
 

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -46,11 +46,11 @@ import logging
 import unittest
 import sys
 
-import tuf.formats
+import tuf
 import tuf.log
-import tuf.client.updater as updater
-import tuf.repository_tool as repo_tool
-import tuf.unittest_toolbox as unittest_toolbox
+from tuf.client import updater
+from tuf import repository_tool as repo_tool
+from tuf import unittest_toolbox
 
 import utils
 

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -47,7 +47,6 @@ import unittest
 import sys
 
 import tuf
-import tuf.log
 from tuf.client import updater
 from tuf import repository_tool as repo_tool
 from tuf import unittest_toolbox

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -40,7 +40,6 @@ import copy
 import sys
 
 import tuf
-import tuf.log
 from tuf import repository_lib as repo_lib
 from tuf import repository_tool as repo_tool
 

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -40,15 +40,9 @@ import copy
 import sys
 
 import tuf
-import tuf.formats
 import tuf.log
-import tuf.formats
-import tuf.roledb
-import tuf.keydb
-import tuf.settings
-
-import tuf.repository_lib as repo_lib
-import tuf.repository_tool as repo_tool
+from tuf import repository_lib as repo_lib
+from tuf import repository_tool as repo_tool
 
 import utils
 

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -39,10 +39,7 @@ import sys
 
 import tuf
 import tuf.log
-import tuf.formats
-import tuf.roledb
-import tuf.keydb
-import tuf.repository_tool as repo_tool
+from tuf import repository_tool as repo_tool
 
 import utils
 

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -38,7 +38,6 @@ import shutil
 import sys
 
 import tuf
-import tuf.log
 from tuf import repository_tool as repo_tool
 
 import utils

--- a/tests/test_roledb.py
+++ b/tests/test_roledb.py
@@ -33,9 +33,6 @@ import logging
 import sys
 
 import tuf
-import tuf.formats
-import tuf.roledb
-import tuf.exceptions
 import tuf.log
 
 import utils

--- a/tests/test_roledb.py
+++ b/tests/test_roledb.py
@@ -33,7 +33,6 @@ import logging
 import sys
 
 import tuf
-import tuf.log
 
 import utils
 

--- a/tests/test_root_versioning_integration.py
+++ b/tests/test_root_versioning_integration.py
@@ -33,7 +33,6 @@ import unittest
 import sys
 
 import tuf
-import tuf.log
 from tuf import repository_tool as repo_tool
 
 import utils

--- a/tests/test_root_versioning_integration.py
+++ b/tests/test_root_versioning_integration.py
@@ -34,11 +34,7 @@ import sys
 
 import tuf
 import tuf.log
-import tuf.formats
-import tuf.exceptions
-import tuf.roledb
-import tuf.keydb
-import tuf.repository_tool as repo_tool
+from tuf import repository_tool as repo_tool
 
 import utils
 

--- a/tests/test_sig.py
+++ b/tests/test_sig.py
@@ -35,7 +35,6 @@ import copy
 import sys
 
 import tuf
-import tuf.log
 
 import utils
 

--- a/tests/test_sig.py
+++ b/tests/test_sig.py
@@ -36,11 +36,6 @@ import sys
 
 import tuf
 import tuf.log
-import tuf.formats
-import tuf.keydb
-import tuf.roledb
-import tuf.sig
-import tuf.exceptions
 
 import utils
 

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -54,7 +54,6 @@ import unittest
 import sys
 
 import tuf
-import tuf.log
 from tuf.client import updater
 from tuf import unittest_toolbox
 from tuf import repository_tool as repo_tool

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -53,12 +53,11 @@ import logging
 import unittest
 import sys
 
+import tuf
 import tuf.log
-import tuf.client.updater as updater
-import tuf.unittest_toolbox as unittest_toolbox
-import tuf.repository_tool as repo_tool
-import tuf.roledb
-import tuf.keydb
+from tuf.client import updater
+from tuf import unittest_toolbox
+from tuf import repository_tool as repo_tool
 
 import utils
 

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -37,7 +37,7 @@ import tempfile
 import sys
 
 if sys.version_info >= (3, 3):
-  import unittest.mock as mock
+  from unittest import mock
 
 else:
   import mock

--- a/tests/test_unittest_toolbox.py
+++ b/tests/test_unittest_toolbox.py
@@ -33,7 +33,7 @@ import logging
 import shutil
 import sys
 
-import tuf.unittest_toolbox as unittest_toolbox
+from tuf import unittest_toolbox
 
 import utils
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -60,15 +60,11 @@ import sys
 import unittest
 
 import tuf
-import tuf.exceptions
 import tuf.log
-import tuf.formats
-import tuf.keydb
-import tuf.roledb
-import tuf.repository_tool as repo_tool
-import tuf.repository_lib as repo_lib
-import tuf.unittest_toolbox as unittest_toolbox
-import tuf.client.updater as updater
+from tuf import repository_tool as repo_tool
+from tuf import repository_lib as repo_lib
+from tuf import unittest_toolbox
+from tuf.client import updater
 
 import utils
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -60,7 +60,6 @@ import sys
 import unittest
 
 import tuf
-import tuf.log
 from tuf import repository_tool as repo_tool
 from tuf import repository_lib as repo_lib
 from tuf import unittest_toolbox

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -51,13 +51,9 @@ import sys
 
 import tuf
 import tuf.log
-import tuf.keydb
-import tuf.roledb
-import tuf.exceptions
-import tuf.repository_tool as repo_tool
-import tuf.unittest_toolbox as unittest_toolbox
-import tuf.client.updater as updater
-import tuf.settings
+from tuf import repository_tool as repo_tool
+from tuf import unittest_toolbox
+from tuf.client import updater
 
 import utils
 

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -50,7 +50,6 @@ import filecmp
 import sys
 
 import tuf
-import tuf.log
 from tuf import repository_tool as repo_tool
 from tuf import unittest_toolbox
 from tuf.client import updater

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,7 +29,7 @@ import subprocess
 import tempfile
 import random
 
-import tuf.log
+from tuf import log as tuf_log
 
 logger = logging.getLogger(__name__)
 
@@ -100,7 +100,7 @@ def configure_test_logging(argv):
     loglevel = logging.DEBUG
 
   logging.basicConfig(level=loglevel)
-  tuf.log.set_log_level(loglevel)
+  tuf_log.set_log_level(loglevel)
 
 
 class TestServerProcess():

--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -11,3 +11,11 @@ __version__ = "0.14.0"
 # For example, "1.4.3" and "1.0.0" are supported.  "2.0.0" is not supported.
 # See https://github.com/theupdateframework/specification
 SPECIFICATION_VERSION = '1.0.0'
+
+from . import exceptions
+from . import formats
+from . import keydb
+from . import roledb
+from . import settings
+from . import sig
+

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -22,8 +22,7 @@ from securesystemslib.util import (
 from securesystemslib.storage import StorageBackendInterface
 from securesystemslib.keys import create_signature, verify_signature
 
-import tuf.formats
-import tuf.exceptions
+import tuf
 
 
 # Types

--- a/tuf/client/README.md
+++ b/tuf/client/README.md
@@ -48,13 +48,13 @@ can decide how to proceed rather than automatically downloading a new Root file.
 # The client first imports the 'updater.py' module, the only module the
 # client is required to import.  The client will utilize a single class
 # from this module.
-import tuf.client.updater
-import tuf.settings
+from tuf import client
 
 # The only other module the client interacts with is 'settings'.  The
 # client accesses this module solely to set the repository directory.
 # This directory will hold the files downloaded from a remote repository.
-tuf.settings.repositories_directory = 'path/to/local_repository'
+from tuf import settings
+settings.repositories_directory = 'path/to/local_repository'
 
 # Next, the client creates a dictionary object containing the repository
 # mirrors.  The client may download content from any one of these mirrors.
@@ -77,7 +77,7 @@ repository_mirrors = {'mirror1': {'url_prefix': 'http://localhost:8001',
 # is called with two arguments.  The first argument assigns a name to this
 # particular updater and the second argument the repository mirrors defined
 # above.
-updater = tuf.client.updater.Updater('updater', repository_mirrors)
+updater = client.updater.Updater('updater', repository_mirrors)
 
 # The client calls the refresh() method to ensure it has the latest
 # copies of the top-level metadata files (i.e., Root, Targets, Snapshot,

--- a/tuf/client/__init__.py
+++ b/tuf/client/__init__.py
@@ -1,0 +1,2 @@
+from .. import download
+from .. import mirrors

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -51,10 +51,8 @@
 
 <Example Client>
 
-  # The client first imports the 'updater.py' module, the only module the
-  # client is required to import.  The client will utilize a single class
-  # from this module.
-  from tuf import client
+  # The client first imports the Updater class:
+  from tuf.client.updater import Updater
 
   # The only other module the client interacts with is 'tuf.settings'.  The
   # client accesses this module solely to set the repository directory.
@@ -83,7 +81,7 @@
   # is called with two arguments.  The first argument assigns a name to this
   # particular updater and the second argument the repository mirrors defined
   # above.
-  updater = client.updater.Updater('updater', repository_mirrors)
+  updater = Updater('updater', repository_mirrors)
 
   # The client next calls the refresh() method to ensure it has the latest
   # copies of the metadata files.
@@ -495,7 +493,7 @@ class MultiRepoUpdater(object):
 
       else:
         # Create repository mirrors object needed by the
-        # client.updater.Updater().  Each 'repository_name' can have more
+        # Updater().  Each 'repository_name' can have more
         # than one mirror.
         mirrors = {}
 
@@ -510,7 +508,7 @@ class MultiRepoUpdater(object):
           # NOTE: State (e.g., keys) should NOT be shared across different
           # updater instances.
           logger.debug('Adding updater for ' + repr(repository_name))
-          updater = client.updater.Updater(repository_name, mirrors)
+          updater = Updater(repository_name, mirrors)
 
         except Exception:
           return None

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -54,11 +54,12 @@
   # The client first imports the 'updater.py' module, the only module the
   # client is required to import.  The client will utilize a single class
   # from this module.
-  import tuf.client.updater
+  from tuf import client
 
   # The only other module the client interacts with is 'tuf.settings'.  The
   # client accesses this module solely to set the repository directory.
   # This directory will hold the files downloaded from a remote repository.
+  import tuf
   tuf.settings.repositories_directory = 'local-repository'
 
   # Next, the client creates a dictionary object containing the repository
@@ -82,7 +83,7 @@
   # is called with two arguments.  The first argument assigns a name to this
   # particular updater and the second argument the repository mirrors defined
   # above.
-  updater = tuf.client.updater.Updater('updater', repository_mirrors)
+  updater = client.updater.Updater('updater', repository_mirrors)
 
   # The client next calls the refresh() method to ensure it has the latest
   # copies of the metadata files.
@@ -130,15 +131,7 @@ import copy
 import warnings
 
 import tuf
-import tuf.download
-import tuf.formats
-import tuf.settings
-import tuf.keydb
-import tuf.log
-import tuf.mirrors
-import tuf.roledb
-import tuf.sig
-import tuf.exceptions
+from tuf import client
 
 import securesystemslib.exceptions
 import securesystemslib.hash
@@ -502,7 +495,7 @@ class MultiRepoUpdater(object):
 
       else:
         # Create repository mirrors object needed by the
-        # tuf.client.updater.Updater().  Each 'repository_name' can have more
+        # client.updater.Updater().  Each 'repository_name' can have more
         # than one mirror.
         mirrors = {}
 
@@ -517,7 +510,7 @@ class MultiRepoUpdater(object):
           # NOTE: State (e.g., keys) should NOT be shared across different
           # updater instances.
           logger.debug('Adding updater for ' + repr(repository_name))
-          updater = tuf.client.updater.Updater(repository_name, mirrors)
+          updater = client.updater.Updater(repository_name, mirrors)
 
         except Exception:
           return None
@@ -1225,7 +1218,7 @@ class Updater(object):
       Non-public method that ensures the length of 'file_object' is strictly
       equal to 'trusted_file_length'.  This is a deliberately redundant
       implementation designed to complement
-      tuf.download._check_downloaded_length().
+      client.download._check_downloaded_length().
 
     <Arguments>
       file_object:
@@ -1271,7 +1264,7 @@ class Updater(object):
       Non-public method that checks the trusted file length of a file object.
       The length of the file must be less than or equal to the expected
       length. This is a deliberately redundant implementation designed to
-      complement tuf.download._check_downloaded_length().
+      complement client.download._check_downloaded_length().
 
     <Arguments>
       file_object:
@@ -1540,7 +1533,7 @@ class Updater(object):
       A file object containing the metadata.
     """
 
-    file_mirrors = tuf.mirrors.get_list_of_mirrors('meta', remote_filename,
+    file_mirrors = client.mirrors.get_list_of_mirrors('meta', remote_filename,
         self.mirrors)
 
     # file_mirror (URL): error (Exception)
@@ -1549,7 +1542,7 @@ class Updater(object):
 
     for file_mirror in file_mirrors:
       try:
-        file_object = tuf.download.unsafe_download(file_mirror,
+        file_object = client.download.unsafe_download(file_mirror,
             upperbound_filelength)
         file_object.seek(0)
 
@@ -1699,7 +1692,7 @@ class Updater(object):
       A file object containing the metadata or target.
     """
 
-    file_mirrors = tuf.mirrors.get_list_of_mirrors(file_type, filepath,
+    file_mirrors = client.mirrors.get_list_of_mirrors(file_type, filepath,
         self.mirrors)
 
     # file_mirror (URL): error (Exception)
@@ -1713,10 +1706,10 @@ class Updater(object):
         # other one for "unsafe" download? This should induce safer and more
         # readable code.
         if download_safely:
-          file_object = tuf.download.safe_download(file_mirror, file_length)
+          file_object = client.download.safe_download(file_mirror, file_length)
 
         else:
-          file_object = tuf.download.unsafe_download(file_mirror, file_length)
+          file_object = client.download.unsafe_download(file_mirror, file_length)
 
         # Verify 'file_object' according to the callable function.
         # 'file_object' is also verified if decompressed above (i.e., the

--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -39,7 +39,6 @@ import tempfile
 import json
 
 import tuf
-import tuf.log
 from tuf import repository_lib as repo_lib
 
 import securesystemslib

--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -39,13 +39,8 @@ import tempfile
 import json
 
 import tuf
-import tuf.formats
-import tuf.keydb
-import tuf.roledb
-import tuf.sig
 import tuf.log
-import tuf.repository_lib as repo_lib
-import tuf.repository_tool
+from tuf import repository_lib as repo_lib
 
 import securesystemslib
 import securesystemslib.util

--- a/tuf/download.py
+++ b/tuf/download.py
@@ -43,9 +43,6 @@ import securesystemslib
 import securesystemslib.util
 import six
 
-import tuf.exceptions
-import tuf.formats
-
 import urllib3.exceptions
 
 # See 'log.py' to learn how logging is handled in TUF.

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -44,7 +44,7 @@ from __future__ import unicode_literals
 import logging
 import copy
 
-import tuf.formats
+import tuf
 
 import six
 import securesystemslib

--- a/tuf/log.py
+++ b/tuf/log.py
@@ -73,8 +73,6 @@ import logging
 import time
 
 import tuf
-import tuf.settings
-import tuf.exceptions
 
 import securesystemslib.formats
 

--- a/tuf/mirrors.py
+++ b/tuf/mirrors.py
@@ -33,7 +33,6 @@ from __future__ import unicode_literals
 import os
 
 import tuf
-import tuf.formats
 
 import securesystemslib
 import six

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -40,7 +40,7 @@ import json
 import tempfile
 
 import tuf
-import tuf.log
+from tuf import log as tuf_log
 
 import securesystemslib
 import securesystemslib.hash
@@ -2261,14 +2261,14 @@ def disable_console_log_messages():
     None.
 
   <Side Effects>
-    Removes the 'tuf.log' console handler, added by default when
+    Removes the console handler, added by default when
     'tuf.repository_tool.py' is imported.
 
   <Returns>
     None.
   """
 
-  tuf.log.remove_console_handler()
+  tuf_log.remove_console_handler()
 
 
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -40,13 +40,7 @@ import json
 import tempfile
 
 import tuf
-import tuf.formats
-import tuf.exceptions
-import tuf.keydb
-import tuf.roledb
-import tuf.sig
 import tuf.log
-import tuf.settings
 
 import securesystemslib
 import securesystemslib.hash

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -43,7 +43,7 @@ import json
 from collections import deque
 
 import tuf
-import tuf.log
+from tuf import log as tuf_log
 from tuf import repository_lib as repo_lib
 
 import securesystemslib.keys
@@ -91,8 +91,8 @@ logger = logging.getLogger(__name__)
 
 # Add a console handler so that users are aware of potentially unintended
 # states, such as multiple roles that share keys.
-tuf.log.add_console_handler()
-tuf.log.set_console_log_level(logging.INFO)
+tuf_log.add_console_handler()
+tuf_log.set_console_log_level(logging.INFO)
 
 # Recommended RSA key sizes:
 # https://en.wikipedia.org/wiki/Key_size#Asymmetric_algorithm_key_lengths

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -43,12 +43,8 @@ import json
 from collections import deque
 
 import tuf
-import tuf.formats
-import tuf.roledb
-import tuf.sig
 import tuf.log
-import tuf.exceptions
-import tuf.repository_lib as repo_lib
+from tuf import repository_lib as repo_lib
 
 import securesystemslib.keys
 import securesystemslib.formats

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -53,8 +53,6 @@ import logging
 import copy
 
 import tuf
-import tuf.log
-import tuf.formats
 
 import securesystemslib
 import six

--- a/tuf/scripts/client.py
+++ b/tuf/scripts/client.py
@@ -73,7 +73,7 @@ import logging
 
 import tuf
 from tuf import client
-import tuf.log
+from tuf import log as tuf_log
 
 # See 'log.py' to learn how logging is handled in TUF.
 logger = logging.getLogger(__name__)
@@ -203,22 +203,22 @@ def parse_arguments():
 
   # Set the logging level.
   if parsed_arguments.verbose == 5:
-    tuf.log.set_log_level(logging.CRITICAL)
+    tuf_log.set_log_level(logging.CRITICAL)
 
   elif parsed_arguments.verbose == 4:
-    tuf.log.set_log_level(logging.ERROR)
+    tuf_log.set_log_level(logging.ERROR)
 
   elif parsed_arguments.verbose == 3:
-    tuf.log.set_log_level(logging.WARNING)
+    tuf_log.set_log_level(logging.WARNING)
 
   elif parsed_arguments.verbose == 2:
-    tuf.log.set_log_level(logging.INFO)
+    tuf_log.set_log_level(logging.INFO)
 
   elif parsed_arguments.verbose == 1:
-    tuf.log.set_log_level(logging.DEBUG)
+    tuf_log.set_log_level(logging.DEBUG)
 
   else:
-    tuf.log.set_log_level(logging.NOTSET)
+    tuf_log.set_log_level(logging.NOTSET)
 
   # Return the repository mirror containing the metadata and target files.
   return parsed_arguments

--- a/tuf/scripts/client.py
+++ b/tuf/scripts/client.py
@@ -72,8 +72,7 @@ import argparse
 import logging
 
 import tuf
-import tuf.client.updater
-import tuf.settings
+from tuf import client
 import tuf.log
 
 # See 'log.py' to learn how logging is handled in TUF.
@@ -122,7 +121,7 @@ def update_client(parsed_arguments):
 
   # Create the repository object using the repository name 'repository'
   # and the repository mirrors defined above.
-  updater = tuf.client.updater.Updater('tufrepo', repository_mirrors)
+  updater = client.updater.Updater('tufrepo', repository_mirrors)
 
   # The local destination directory to save the target files.
   destination_directory = './tuftargets'

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -148,7 +148,7 @@ import time
 import fnmatch
 
 import tuf
-import tuf.log
+from tuf import log as tuf_log
 from tuf import repository_tool as repo_tool
 
 # 'pip install securesystemslib[crypto,pynacl]' is required for the CLI,
@@ -1115,7 +1115,7 @@ def parse_arguments():
   logging_levels = [logging.NOTSET, logging.DEBUG,
       logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL]
 
-  tuf.log.set_log_level(logging_levels[parsed_args.verbose])
+  tuf_log.set_log_level(logging_levels[parsed_args.verbose])
 
   return parsed_args
 

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -149,8 +149,7 @@ import fnmatch
 
 import tuf
 import tuf.log
-import tuf.formats
-import tuf.repository_tool as repo_tool
+from tuf import repository_tool as repo_tool
 
 # 'pip install securesystemslib[crypto,pynacl]' is required for the CLI,
 # which installs the cryptography, pynacl, and colorama dependencies.

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -51,9 +51,6 @@ from __future__ import unicode_literals
 import logging
 
 import tuf
-import tuf.keydb
-import tuf.roledb
-import tuf.formats
 
 import securesystemslib
 


### PR DESCRIPTION
Maybe fixes issue #1165 ?

This style of import:
`import tuf.download`
is incompatible with vendoring tool (typically vendoring modifies `from X import Y` into `from vendored.path.X import Y` but this can't be succesfully done with our style).

So I'd like to talk about changing the import style. Unfortunately just switching to the style `from tuf import download` means massive code churn as the local name changes from `tuf.download` to `download`: at least 700 lines of change and significant chance of namespace collision.

This PR is a exploration of another way: using package imports to keep the code mostly as is.

**Description of the changes being introduced by the pull request**:

* Removes all cases of `import tuf.something`
* Introduces package level default imports tuf and tuf.client, so a plain "import tuf" or "from tuf import client" is enough to get the basic imports in place with minimal changes to source code
* Leaves repository_tool, repository_lib, developer_tool and unittest_toolbox as they are: not part of a default import set
* leaves log out of the default import set because importing it has side-effects, and fixes the local naming issues resulting from that

This should be 100% backwards compatible: all import styles still work.
The important changes in functionality are:
* importing any tuf module typically ends up importing one or both default sets
* tuf.log is no longer imported uselessly in a lot of places (this should be a good thing)

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


