### PR TITLE
PoC: Let user download targets

### DIFF
--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1782,10 +1782,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
       self.repository_updater._check_hashes(targets_path, file_hashes)
 
     self.repository_updater._get_file('targets.json', verify_target_file,
-        file_type, file_size, download_safely=True).close()
-
-    self.repository_updater._get_file('targets.json', verify_target_file,
-        file_type, file_size, download_safely=False).close()
+        file_type, file_size).close()
 
   def test_13__targets_of_role(self):
     # Test case where a list of targets is given.  By default, the 'targets'

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -3261,6 +3261,14 @@ class Updater(object):
         Also ensure the length of the downloaded file matches 'required_length'
         exactly'
 
+        Raise 'securesystemslib.exceptions.DownloadLengthMismatchError', if
+        STRICT_REQUIRED_LENGTH is True and total_downloaded is not equal
+        required_length.
+
+        Raise 'tuf.exceptions.SlowRetrievalError', if the total downloaded was
+        done in less than the acceptable download speed (as set in
+        tuf.settings.py).
+
         If None, tuf.download.safe_download is used.
 
     <Exceptions>

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -3249,25 +3249,36 @@ class Updater(object):
 
      custom_download_handler:
         A user provided function performing the actual target file download.
-        In order to comply with the TUF specification, the function signature
-        should have the form:
+        In order to comply with the TUF specification, the function implementation
+        should match the following description:
 
-        'def download_handler_func(url, required_length)'
+        def download_handler_func(url, required_length)
+          <Purpose>
+            Given the 'url' and 'required_length' of the desired file, open a connection
+            to 'url', download it, and return the contents of the file.  Also ensure
+            the length of the downloaded file matches 'required_length' exactly.
 
-        The function implementation should provide the following functionality:
+          <Arguments>
+            url:
+              A URL string that represents the location of the file.
 
-        'Given the 'url' and 'required_length' of the desired file, open a
-        connection to 'url', download it, and return the contents of the file.
-        Also ensure the length of the downloaded file matches 'required_length'
-        exactly'
+            required_length:
+              An integer value representing the length of the file.  This is an exact
+              limit.
 
-        Raise 'securesystemslib.exceptions.DownloadLengthMismatchError', if
-        STRICT_REQUIRED_LENGTH is True and total_downloaded is not equal
-        required_length.
+          <Side Effects>
+            A temprorary file object is created to store the contents of 'url'.
 
-        Raise 'tuf.exceptions.SlowRetrievalError', if the total downloaded was
-        done in less than the acceptable download speed (as set in
-        tuf.settings.py).
+          <Exceptions>
+            DownloadLengthMismatchError, if there was a
+            mismatch of observed vs expected lengths while downloading the file.
+
+            SlowRetrievalError, if the total downloaded was
+            done in less than the acceptable download speed (as set in
+             tuf.settings.py).
+
+          <Returns>
+            A temporay file object that points to the contents of 'url'.
 
         If None, tuf.download.safe_download is used.
 

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1370,7 +1370,7 @@ class Updater(object):
       target_filepath = os.path.join(dirname, target_digest + '.' + basename)
 
     return self._get_file(target_filepath, verify_target_file,
-        'target', file_length, download_safely=True)
+        'target', file_length)
 
 
 
@@ -1654,8 +1654,7 @@ class Updater(object):
 
 
 
-  def _get_file(self, filepath, verify_file_function, file_type, file_length,
-      download_safely=True):
+  def _get_file(self, filepath, verify_file_function, file_type, file_length):
     """
     <Purpose>
       Non-public method that tries downloading, up to a certain length, a
@@ -1682,9 +1681,6 @@ class Updater(object):
         The expected length, or upper bound, of the target or metadata file to
         be downloaded.
 
-      download_safely:
-        A boolean switch to toggle safe or unsafe download of the file.
-
     <Exceptions>
       tuf.exceptions.NoWorkingMirrorError:
         The metadata could not be fetched. This is raised only when all known
@@ -1708,15 +1704,9 @@ class Updater(object):
 
     for file_mirror in file_mirrors:
       try:
-        # TODO: Instead of the more fragile 'download_safely' switch, unroll
-        # the function into two separate ones: one for "safe" download, and the
-        # other one for "unsafe" download? This should induce safer and more
-        # readable code.
-        if download_safely:
-          file_object = tuf.download.safe_download(file_mirror, file_length)
-
-        else:
-          file_object = tuf.download.unsafe_download(file_mirror, file_length)
+        # Eensure the length of the downloaded file matches 'file_length'
+        # exactly.
+        file_object = tuf.download.safe_download(file_mirror, file_length)
 
         # Verify 'file_object' according to the callable function.
         # 'file_object' is also verified if decompressed above (i.e., the


### PR DESCRIPTION

**Fixes issue #**: #1142 

**Description of the changes being introduced by the pull request**:

Give client-side users the option to provide their own custom download function
performing the actual target files download.

The user has to ensure that the function has the following signature and functionality:
```

def download_handler_func(url, required_length)
""" 
  Given the 'url' and 'required_length' of the desired file, open a
  connection to 'url', download it, and return the contents of the file.
  Also ensure the length of the downloaded file matches 'required_length'
  exactly
"""
```
By default `tuf.download.safe_download `is still used.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


