### PR TITLE
Add MissingLocalRepositoryError

### DIFF
--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -224,6 +224,9 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # directory.
     tuf.settings.repositories_directory = self.client_directory
 
+    # Test: repository does not exist
+    self.assertRaises(tuf.exceptions.MissingLocalRepositoryError, updater.Updater,
+                      'test_non_existing_repository', self.repository_mirrors)
 
     # Test: empty client repository (i.e., no metadata directory).
     metadata_backup = self.client_metadata + '.backup'

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -733,6 +733,12 @@ class Updater(object):
     # Set the path for the current set of metadata files.
     repositories_directory = tuf.settings.repositories_directory
     repository_directory = os.path.join(repositories_directory, self.repository_name)
+
+    # raise MissingLocalRepository if the repo does not exist at all.
+    if not os.path.exists(repository_directory):
+      raise tuf.exceptions.MissingLocalRepositoryError('Local repository ' +
+        repr(repository_directory) + ' does not exist.')
+
     current_path = os.path.join(repository_directory, 'metadata', 'current')
 
     # Ensure the current path is valid/exists before saving it.

--- a/tuf/exceptions.py
+++ b/tuf/exceptions.py
@@ -115,6 +115,10 @@ class RepositoryError(Error):
   """Indicate an error with a repository's state, such as a missing file."""
 
 
+class MissingLocalRepositoryError(RepositoryError):
+  """Raised when a local repository could not be found."""
+
+
 class InsufficientKeysError(Error):
   """Indicate that metadata role lacks a threshold of pubic or private keys."""
 


### PR DESCRIPTION
This allows clients to separate
a) missing local repository and
b) error while loading local repository

This is fully backwards-compliant: MissingLocalRepositoryError derives
from RepositoryError and every situation that now results in
MissingLocalRepositoryError used to result in a RepositoryError.

Fixes #1063

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

---

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


