### PR TITLE
tuf/api: Expose tuf.api as a package (take 2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ matrix:
       env: TOXENV=py37
     - python: "3.8"
       env: TOXENV=py38
-    - python: "3.6"
+    - python: "3.8"
       env: TOXENV=with-sslib-master
     - python: "3.8"
       env: TOXENV=lint
 
   allow_failures:
-    - python: "3.6"
+    - python: "3.8"
       env: TOXENV=with-sslib-master
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
       env: TOXENV=py38
     - python: "3.6"
       env: TOXENV=with-sslib-master
+    - python: "3.8"
+      env: TOXENV=lint
 
   allow_failures:
     - python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
       env: TOXENV=with-sslib-master
     - python: "3.8"
       env: TOXENV=lint
+      before_script: skip
+      after_success: skip
 
   allow_failures:
     - python: "3.8"
@@ -37,9 +39,9 @@ before_script:
 
 script:
   - tox
-  - fossa
 
 after_success:
+  - fossa
   # Workaround to get coverage reports with relative paths.
   # FIXME: Consider refactoring the tests to not require the test aggregation
   # script being invoked from the `tests` directory, so that `.coverage` is

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,8 @@ skipsdist = true
 changedir = tests
 
 commands =
-    pylint {toxinidir}/tuf
+    pylint {toxinidir}/tuf --ignore={toxinidir}/tuf/api
+    pylint {toxinidir}/tuf/api --rcfile={toxinidir}/tuf/api/pylintrc
     bandit -r {toxinidir}/tuf
     coverage run aggregate_tests.py
     coverage report -m --fail-under 97

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36, py37, py38
+envlist = lint,py{27,35,36,37,38}
 skipsdist = true
 
 [testenv]
@@ -14,9 +14,6 @@ skipsdist = true
 changedir = tests
 
 commands =
-    pylint {toxinidir}/tuf --ignore={toxinidir}/tuf/api
-    pylint {toxinidir}/tuf/api --rcfile={toxinidir}/tuf/api/pylintrc
-    bandit -r {toxinidir}/tuf
     coverage run aggregate_tests.py
     coverage report -m --fail-under 97
 
@@ -40,3 +37,9 @@ deps =
 commands =
     coverage run aggregate_tests.py
     coverage report -m
+
+[testenv:lint]
+commands =
+    pylint {toxinidir}/tuf --ignore={toxinidir}/tuf/api
+    pylint {toxinidir}/tuf/api --rcfile={toxinidir}/tuf/api/pylintrc
+    bandit -r {toxinidir}/tuf

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -10,7 +10,6 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
 import json
-import logging
 import tempfile
 
 from securesystemslib.formats import encode_canonical

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -179,9 +179,9 @@ class Metadata():
                 The file cannot be written.
 
         """
-        with tempfile.TemporaryFile() as f:
-            f.write(self.to_json(compact).encode('utf-8'))
-            persist_temp_file(f, filename, storage_backend)
+        with tempfile.TemporaryFile() as temp_file:
+            temp_file.write(self.to_json(compact).encode('utf-8'))
+            persist_temp_file(temp_file, filename, storage_backend)
 
 
     # Signatures.

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -239,14 +239,14 @@ class Metadata():
             raise tuf.exceptions.Error(
                     f'no signature for key {key["keyid"]}.')
 
-        elif len(signatures_for_keyid) > 1:
+        if len(signatures_for_keyid) > 1:
             raise tuf.exceptions.Error(
                     f'{len(signatures_for_keyid)} signatures for key '
                     f'{key["keyid"]}, not sure which one to verify.')
-        else:
-            return verify_signature(
-                    key, signatures_for_keyid[0],
-                    self.signed.to_canonical_bytes())
+
+        return verify_signature(
+            key, signatures_for_keyid[0],
+            self.signed.to_canonical_bytes())
 
 
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -493,6 +493,10 @@ class Targets(Signed):
             }
 
     """
+    # TODO: determine an appropriate value for max-args and fix places where
+    # we violate that. This __init__ function takes 7 arguments, whereas the
+    # default max-args value for pylint is 5
+    # pylint: disable=too-many-arguments
     def __init__(
             self, _type: str, version: int, spec_version: str,
             expires: datetime, targets: JsonDict, delegations: JsonDict

--- a/tuf/api/pylintrc
+++ b/tuf/api/pylintrc
@@ -1,0 +1,6 @@
+[MESSAGE_CONTROL]
+disable=fixme
+
+[FORMAT]
+indent-string="    "
+max-line-length=79


### PR DESCRIPTION
Taking over from #1157 

**Description of the changes being introduced by the pull request**:
* add tuf/api/__init__.py, turning tuf/api into a full package for distribution purposes
* add a pylintrc for tuf/api and update tox to use it (and ignore tuf/api with the default pylintrc)
* minor stylistic changes to tuf/api/metadata.py to resolve some pylint warnings

Note: ac8d273 disables a single pylintrc check in a code comment. I was loath to do this, but I think it's better to explicitly disable that site than disable the message for all code before we've decided on coding style.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


