### PR TITLE
Make colorama dependency optional

### DIFF
--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -1,7 +1,6 @@
 certifi==2020.6.20       # via requests
 cffi==1.14.3              # via cryptography, pynacl
 chardet==3.0.4            # via requests
-colorama==0.4.3           # via securesystemslib
 cryptography==3.1.1         # via securesystemslib
 enum34==1.1.6             ; python_version < '3' # via cryptography
 idna==2.10                 # via requests
@@ -10,7 +9,7 @@ pycparser==2.20           # via cffi
 pynacl==1.4.0             # via securesystemslib
 python-dateutil==2.8.1    # via securesystemslib
 requests==2.24.0
-securesystemslib[colors,crypto,pynacl]==0.16.0
+securesystemslib[crypto,pynacl]==0.16.0
 six==1.15.0
 subprocess32==3.5.4       ; python_version < '3' # via securesystemslib
 urllib3==1.25.10           # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,6 @@
 # 3. Use this command to remove per-version files
 #    `rm requirements-?.?.txt`
 #
-securesystemslib[colors, crypto, pynacl]
+securesystemslib[crypto, pynacl]
 requests
 six

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -24,7 +24,7 @@
 
   Note:
   'pip install securesystemslib[crypto,pynacl]' is required by the CLI,
-  which installs the 3rd-party dependencies: cryptography, pynacl, and colorama.
+  which installs the 3rd-party dependencies: cryptography and pynacl.
 
 <Usage>
   Note: arguments within brackets are optional.
@@ -153,9 +153,9 @@ import tuf.formats
 import tuf.repository_tool as repo_tool
 
 # 'pip install securesystemslib[crypto,pynacl]' is required for the CLI,
-# which installs the cryptography, pynacl, and colorama dependencies.
+# which installs the cryptography and pynacl.
 import securesystemslib
-from colorama import Fore
+from securesystemslib import interface
 import six
 
 
@@ -428,7 +428,7 @@ def import_privatekey_from_file(keypath, password=None):
     # However, care should be taken when including the full path in exceptions
     # and log files.
     password = securesystemslib.interface.get_password('Enter a password for'
-        ' the encrypted key (' + Fore.RED + repr(keypath) + Fore.RESET + '): ',
+        ' the encrypted key (' + interface.TERM_RED + repr(keypath) + interface.TERM_RED + '): ',
         confirm=False)
 
   # Does 'password' have the correct format?


### PR DESCRIPTION
Fixes N/A

**Description of the changes being introduced by the pull request**:
* Switch repo script from using colorama directly to using the `TERM_` values defined in `securesystemslib.interface`. These values are set automatically depending on whether colorama is importable, and therefore make the colorama dependency an optional/soft dependency
* Remove colorama from the requirements

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


