### PR TITLE
Start to keep Architectural Decision Records (ADRs) for tuf reference implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ env/*
 tests/htmlcov/*
 .DS_Store
 .python-version
+*~

--- a/docs/adr/0000-use-markdown-architectural-decision-records.md
+++ b/docs/adr/0000-use-markdown-architectural-decision-records.md
@@ -1,0 +1,25 @@
+# Use Markdown Architectural Decision Records
+
+* Status: accepted
+* Date: 2020-10-20
+
+Technical Story: https://github.com/theupdateframework/tuf/issues/1141
+
+## Context and Problem Statement
+
+We want to record architectural decisions made in this project.
+Which format and structure should these records follow?
+
+## Considered Options
+
+* [MADR](https://adr.github.io/madr/) 2.1.2 – The Markdown Architectural Decision Records
+* Formless – No conventions for file format and structure
+
+## Decision Outcome
+
+Chosen option: "MADR 2.1.2", because
+
+* Implicit assumptions should be made explicit.
+  Design documentation is important to enable people understanding the decisions
+  later on.
+* The MADR structure is comprehensible and facilitates usage & maintenance.

--- a/docs/adr/0001-python-version-3-6-plus.md
+++ b/docs/adr/0001-python-version-3-6-plus.md
@@ -7,9 +7,11 @@ Technical Story: https://github.com/theupdateframework/tuf/issues/1125
 
 ## Context and Problem Statement
 
-We do not want to try and support end-of-life versions of the language.
-We want to use modern language features, such as typing.
-We want to ease maintainer burden, by reducing the major language versions supported.
+We are planning a refactor of tuf where:
+
+* We do not want to try and support end-of-life versions of the language.
+* We want to use modern language features, such as typing.
+* We want to ease maintainer burden, by reducing the major language versions supported.
 
 ## Decision Drivers
 
@@ -30,6 +32,8 @@ We want to ease maintainer burden, by reducing the major language versions suppo
 Chosen option: "Support only Python 3.6+", because we want modern features and lower
 maintainer effort as we work to improve our codebase through the refactor effort.
 
+New modules should target Python 3.6+.
+
 Using modules to polyfill standard library features from Python 3.6+ feels
 untenable as more libraries are dropping support for EOL Python releases.
 
@@ -37,3 +41,8 @@ untenable as more libraries are dropping support for EOL Python releases.
 
 * Leaves major adopter and contributor without an actively developed client for some of
   their customers stuck on older Python versions.
+
+## Links
+
+* [Discussion of how/where to develop the refactored codebase](https://github.com/theupdateframework/tuf/issues/1126)
+* [Discussion of deprecation policy for the pre-1.0, Python 2.7 supporting, code](https://github.com/theupdateframework/tuf/issues/1127)

--- a/docs/adr/0001-python-version-3-6-plus.md
+++ b/docs/adr/0001-python-version-3-6-plus.md
@@ -1,0 +1,39 @@
+# Default to Python 3.6 or newer for new development
+
+* Status: accepted
+* Date: 2020-10-20
+
+Technical Story: https://github.com/theupdateframework/tuf/issues/1125
+
+## Context and Problem Statement
+
+We do not want to try and support end-of-life versions of the language.
+We want to use modern language features, such as typing.
+We want to ease maintainer burden, by reducing the major language versions supported.
+
+## Decision Drivers
+
+* Python 2.7 is end-of-life
+* Python 3.5 is end-of-life
+* Modern Python allows use of desirable features such as type hints
+* Supporting end-of-life Python versions adds maintenance overhead
+
+## Considered Options
+
+* Support Python 2.7 and 3.5+
+* Support Python 2.7 and 3.6+
+* Support Python 2.7 and 3.6+ (with polyfill modules)
+* Support only Python 3.6+
+
+## Decision Outcome
+
+Chosen option: "Support only Python 3.6+", because we want modern features and lower
+maintainer effort as we work to improve our codebase through the refactor effort.
+
+Using modules to polyfill standard library features from Python 3.6+ feels
+untenable as more libraries are dropping support for EOL Python releases.
+
+### Negative Consequences
+
+* Leaves major adopter and contributor without an actively developed client for some of
+  their customers stuck on older Python versions.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,13 @@
+# Architectural Decision Log
+
+This log lists the architectural decisions for tuf.
+
+<!-- adrlog -- Regenerate the content by using "adr-log -i". You can install it via "npm install -g adr-log" -->
+
+- [ADR-0000](0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
+
+<!-- adrlogstop -->
+
+For new ADRs, please use [template.md](template.md) as basis.
+More information on MADR is available at <https://adr.github.io/madr/>.
+General information about architectural decision records is available at <https://adr.github.io/>.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -5,6 +5,7 @@ This log lists the architectural decisions for tuf.
 <!-- adrlog -- Regenerate the content by using "adr-log -i". You can install it via "npm install -g adr-log" -->
 
 - [ADR-0000](0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
+- [ADR-0001](0001-python-version-3-6-plus.md) - Default to Python 3.6 or newer for new development
 
 <!-- adrlogstop -->
 

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,72 @@
+# [short title of solved problem and solution]
+
+* Status: [proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)] <!-- optional -->
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
+
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* [option 1]
+* [option 2]
+* [option 3]
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+### Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->


### PR DESCRIPTION
Fixes #1141, #1125 

**Description of the changes being introduced by the pull request**:

Add initial Architectural Decision Records (ADRs) documenting some workflow decisions before the [refactor](https://github.com/theupdateframework/tuf/projects/2):
1. Use of MADR format to keep ADRs for the reference implementation
2. Decision to adopt Python 3.6+ moving forward (dropping Python 2.7)

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


