### PR TITLE
tox: Workaround double dep in with-sslib-master

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ install_command = pip install --pre {opts} {packages}
 # Must to be invoked explicitly with, e.g. `tox -e with-sslib-master`
 [testenv:with-sslib-master]
 deps =
-    --editable git+http://github.com/secure-systems-lab/securesystemslib.git@master#egg=securesystemslib[crypto,pynacl]
+    --editable git+http://github.com/secure-systems-lab/securesystemslib.git@master#egg=securesystemslib
     -r{toxinidir}/requirements-test.txt
     --editable {toxinidir}
 


### PR DESCRIPTION
Commit eb00d14 modified requirements-pinned.txt so that sslib specifiers
are now "[crypto,pynacl]". This happens to match the exact specifiers
used for the sslib git master dependency in tox.ini. This triggers pip
to say:
>   ERROR: Double requirement given: securesystemslib[crypto,pynacl]==0.16.0
>   (from -r /home/jku/src/tuf/requirements-pinned.txt (line 12)) (already
>   in securesystemslib[crypto,pynacl] from
>   git+http://github.com/secure-systems-lab/securesystemslib.git@master#egg=securesystemslib[crypto,pynacl],
>   name='securesystemslib')
> 

Avoid this by not setting any specifiers for the sslib git master
dependency in tox.ini: This makes pip happy and we get the git master
version installed. pynacl and crypto are still installed because they
are in requirements-pinned.txt.

Fixes #1184.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


