### PR TITLE
Delegate port generation for the tests to the OS

### DIFF
--- a/tests/fast_server_exit.py
+++ b/tests/fast_server_exit.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+# Copyright 2020, TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+<Program Name>
+  fast_server_exit.py
+
+<Author>
+  Martin Vrachev.
+
+<Started>
+  October 29, 2020.
+
+<Copyright>
+  See LICENSE-MIT OR LICENSE for licensing information.
+
+<Purpose>
+  Used for tests in tests/test_utils.py.
+"""
+
+import sys
+
+sys.exit(0)

--- a/tests/proxy_server.py
+++ b/tests/proxy_server.py
@@ -462,25 +462,21 @@ def test(HandlerClass=ProxyRequestHandler, ServerClass=ThreadingHTTPServer, prot
     global INTERCEPT
     global TARGET_SERVER_CA_FILEPATH
 
-    if sys.argv[1:]:
-        port = int(sys.argv[1])
-    else:
-        port = 8080
-    server_address = ('localhost', port)
+    server_address = ('localhost', 0)
 
     # MODIFIED: Argument added, conditional below added to control INTERCEPT
     # setting.
-    if len(sys.argv) > 2:
-      if sys.argv[2].lower() == 'intercept':
+    if len(sys.argv) > 1:
+      if sys.argv[1].lower() == 'intercept':
         INTERCEPT = True
 
     # MODIFIED: Argument added to control certificate(s) the proxy expects of
     # the target server(s), and added default value.
-    if len(sys.argv) > 3:
-      if os.path.exists(sys.argv[3]):
-        TARGET_SERVER_CA_FILEPATH = sys.argv[3]
+    if len(sys.argv) > 2:
+      if os.path.exists(sys.argv[2]):
+        TARGET_SERVER_CA_FILEPATH = sys.argv[2]
       else:
-        raise Exception('Target server cert file not found: ' + sys.argv[3])
+        raise Exception('Target server cert file not found: ' + sys.argv[2])
 
     # MODIFIED: Create the target-host-specific proxy certificates directory if
     # it doesn't already exist.
@@ -489,11 +485,16 @@ def test(HandlerClass=ProxyRequestHandler, ServerClass=ThreadingHTTPServer, prot
 
 
     HandlerClass.protocol_version = protocol
-    httpd = ServerClass(server_address, HandlerClass)
+    try:
+      httpd = ServerClass(server_address, HandlerClass)
+      sa = httpd.socket.getsockname()
+      port_message = 'bind succeeded, server port is: ' + str(sa[1])
+      print(port_message)
+      print("Serving HTTP Proxy on", sa[0], "port", sa[1], "...")
+      httpd.serve_forever()
+    except:
+      print("bind failed")
 
-    sa = httpd.socket.getsockname()
-    print "Serving HTTP Proxy on", sa[0], "port", sa[1], "..."
-    httpd.serve_forever()
 
 
 if __name__ == '__main__':

--- a/tests/proxy_server.py
+++ b/tests/proxy_server.py
@@ -485,15 +485,12 @@ def test(HandlerClass=ProxyRequestHandler, ServerClass=ThreadingHTTPServer, prot
 
 
     HandlerClass.protocol_version = protocol
-    try:
-      httpd = ServerClass(server_address, HandlerClass)
-      sa = httpd.socket.getsockname()
-      port_message = 'bind succeeded, server port is: ' + str(sa[1])
-      print(port_message)
-      print("Serving HTTP Proxy on", sa[0], "port", sa[1], "...")
-      httpd.serve_forever()
-    except:
-      print("bind failed")
+    httpd = ServerClass(server_address, HandlerClass)
+    sa = httpd.socket.getsockname()
+    port_message = 'bind succeeded, server port is: ' + str(sa[1])
+    print(port_message)
+    print("Serving HTTP Proxy on", sa[0], "port", sa[1], "...")
+    httpd.serve_forever()
 
 
 

--- a/tests/repository_data/map.json
+++ b/tests/repository_data/map.json
@@ -23,11 +23,7 @@
   }
  ],
  "repositories": {
-  "test_repository1": [
-   "http://localhost:30001"
-  ],
-  "test_repository2": [
-   "http://localhost:30002"
-  ]
+  "test_repository1": [],
+  "test_repository2": []
  }
 }

--- a/tests/simple_https_server.py
+++ b/tests/simple_https_server.py
@@ -38,7 +38,6 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import sys
-import random
 import ssl
 import os
 import six

--- a/tests/simple_https_server.py
+++ b/tests/simple_https_server.py
@@ -53,16 +53,13 @@ if len(sys.argv) > 1:
     print('simple_https_server: cert file not found: ' + sys.argv[1] +
         '; using default: ' + certfile)
 
-try:
-  httpd = six.moves.BaseHTTPServer.HTTPServer(('localhost', 0),
-      six.moves.SimpleHTTPServer.SimpleHTTPRequestHandler)
+httpd = six.moves.BaseHTTPServer.HTTPServer(('localhost', 0),
+    six.moves.SimpleHTTPServer.SimpleHTTPRequestHandler)
 
-  httpd.socket = ssl.wrap_socket(
-      httpd.socket, keyfile=keyfile, certfile=certfile, server_side=True)
+httpd.socket = ssl.wrap_socket(
+    httpd.socket, keyfile=keyfile, certfile=certfile, server_side=True)
 
-  port_message = 'bind succeeded, server port is: ' \
-      + str(httpd.server_address[1])
-  print(port_message)
-  httpd.serve_forever()
-except:
-  print("bind failed")
+port_message = 'bind succeeded, server port is: ' \
+    + str(httpd.server_address[1])
+print(port_message)
+httpd.serve_forever()

--- a/tests/simple_https_server.py
+++ b/tests/simple_https_server.py
@@ -43,30 +43,27 @@ import ssl
 import os
 import six
 
-PORT = 0
-
 keyfile = os.path.join('ssl_certs', 'ssl_cert.key')
 certfile = os.path.join('ssl_certs', 'ssl_cert.crt')
 
+
 if len(sys.argv) > 1:
-  PORT = int(sys.argv[1])
-
-else:
-  PORT = random.randint(30000, 45000)
-
-if len(sys.argv) > 2:
-
-  if os.path.exists(sys.argv[2]):
-    certfile = sys.argv[2]
+  if os.path.exists(sys.argv[1]):
+    certfile = sys.argv[1]
   else:
-    print('simple_https_server: cert file not found: ' + sys.argv[2] +
+    print('simple_https_server: cert file not found: ' + sys.argv[1] +
         '; using default: ' + certfile)
 
-httpd = six.moves.BaseHTTPServer.HTTPServer(('localhost', PORT),
-                            six.moves.SimpleHTTPServer.SimpleHTTPRequestHandler)
+try:
+  httpd = six.moves.BaseHTTPServer.HTTPServer(('localhost', 0),
+      six.moves.SimpleHTTPServer.SimpleHTTPRequestHandler)
 
-httpd.socket = ssl.wrap_socket(
-    httpd.socket, keyfile=keyfile, certfile=certfile, server_side=True)
+  httpd.socket = ssl.wrap_socket(
+      httpd.socket, keyfile=keyfile, certfile=certfile, server_side=True)
 
-#print('Starting https server on port: ' + str(PORT))
-httpd.serve_forever()
+  port_message = 'bind succeeded, server port is: ' \
+      + str(httpd.server_address[1])
+  print(port_message)
+  httpd.serve_forever()
+except:
+  print("bind failed")

--- a/tests/simple_server.py
+++ b/tests/simple_server.py
@@ -39,14 +39,6 @@ import random
 import six
 from six.moves.SimpleHTTPServer import SimpleHTTPRequestHandler
 
-PORT = 0
-
-if len(sys.argv) > 1:
-  PORT = int(sys.argv[1])
-
-else:
-  PORT = random.randint(30000, 45000)
-
 
 class QuietHTTPRequestHandler(SimpleHTTPRequestHandler):
   """A SimpleHTTPRequestHandler that does not write incoming requests to
@@ -73,6 +65,12 @@ else:
 # Allow re-use so you can re-run tests as often as you want even if the
 # tests re-use ports. Otherwise TCP TIME-WAIT prevents reuse for ~1 minute
 six.moves.socketserver.TCPServer.allow_reuse_address = True
-httpd = six.moves.socketserver.TCPServer(('', PORT), handler)
 
-httpd.serve_forever()
+try:
+  httpd = six.moves.socketserver.TCPServer(('localhost', 0), handler)
+  port_message = 'bind succeeded, server port is: ' \
+      + str(httpd.server_address[1])
+  print(port_message)
+  httpd.serve_forever()
+except:
+  print("bind failed")

--- a/tests/simple_server.py
+++ b/tests/simple_server.py
@@ -66,11 +66,8 @@ else:
 # tests re-use ports. Otherwise TCP TIME-WAIT prevents reuse for ~1 minute
 six.moves.socketserver.TCPServer.allow_reuse_address = True
 
-try:
-  httpd = six.moves.socketserver.TCPServer(('localhost', 0), handler)
-  port_message = 'bind succeeded, server port is: ' \
-      + str(httpd.server_address[1])
-  print(port_message)
-  httpd.serve_forever()
-except:
-  print("bind failed")
+httpd = six.moves.socketserver.TCPServer(('localhost', 0), handler)
+port_message = 'bind succeeded, server port is: ' \
+    + str(httpd.server_address[1])
+print(port_message)
+httpd.serve_forever()

--- a/tests/slow_retrieval_server.py
+++ b/tests/slow_retrieval_server.py
@@ -32,7 +32,6 @@ from __future__ import unicode_literals
 import os
 import sys
 import time
-import random
 
 import six
 

--- a/tests/slow_retrieval_server.py
+++ b/tests/slow_retrieval_server.py
@@ -65,7 +65,13 @@ class Handler(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):
 
 
 if __name__ == '__main__':
-  port = int(sys.argv[1])
-  server_address = ('localhost', port)
-  httpd = six.moves.BaseHTTPServer.HTTPServer(server_address, Handler)
-  httpd.handle_request()
+  server_address = ('localhost', 0)
+
+  try:
+    httpd = six.moves.BaseHTTPServer.HTTPServer(server_address, Handler)
+    port_message = 'bind succeeded, server port is: ' \
+        + str(httpd.server_address[1])
+    print(port_message)
+    httpd.serve_forever()
+  except:
+    print("bind failed")

--- a/tests/slow_retrieval_server.py
+++ b/tests/slow_retrieval_server.py
@@ -37,14 +37,6 @@ import random
 import six
 
 
-# Modify the HTTPServer class to pass the 'test_mode' argument to
-# do_GET() function.
-class HTTPServer_Test(six.moves.BaseHTTPServer.HTTPServer):
-  def __init__(self, server_address, Handler, test_mode):
-    six.moves.BaseHTTPServer.HTTPServer.__init__(self, server_address, Handler)
-    self.test_mode = test_mode
-
-
 
 # HTTP request handler.
 class Handler(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):
@@ -62,38 +54,18 @@ class Handler(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):
       self.send_header('Content-length', str(len(data)))
       self.end_headers()
 
-      if self.server.test_mode == 'mode_1':
-        # Before sending any data, the server does nothing for a long time.
-        DELAY = 40
-        time.sleep(DELAY)
-        self.wfile.write(data)
-
-        return
-
-      # 'mode_2'
-      else:
-        DELAY = 1
-        # Throttle the file by sending a character every DELAY seconds.
-        for i in range(len(data)):
-          self.wfile.write(data[i].encode('utf-8'))
-          time.sleep(DELAY)
-
-        return
+      # Before sending any data, the server does nothing for a long time.
+      DELAY = 40
+      time.sleep(DELAY)
+      self.wfile.write((data.encode('utf-8')))
 
     except IOError as e:
       self.send_error(404, 'File Not Found!')
 
 
 
-def run(port, test_mode):
-  server_address = ('localhost', port)
-  httpd = HTTPServer_Test(server_address, Handler, test_mode)
-  httpd.handle_request()
-
-
-
 if __name__ == '__main__':
   port = int(sys.argv[1])
-  test_mode = sys.argv[2]
-  assert test_mode in ('mode_1', 'mode_2')
-  run(port, test_mode)
+  server_address = ('localhost', port)
+  httpd = six.moves.BaseHTTPServer.HTTPServer(server_address, Handler)
+  httpd.handle_request()

--- a/tests/slow_retrieval_server.py
+++ b/tests/slow_retrieval_server.py
@@ -66,11 +66,8 @@ class Handler(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):
 if __name__ == '__main__':
   server_address = ('localhost', 0)
 
-  try:
-    httpd = six.moves.BaseHTTPServer.HTTPServer(server_address, Handler)
-    port_message = 'bind succeeded, server port is: ' \
-        + str(httpd.server_address[1])
-    print(port_message)
-    httpd.serve_forever()
-  except:
-    print("bind failed")
+  httpd = six.moves.BaseHTTPServer.HTTPServer(server_address, Handler)
+  port_message = 'bind succeeded, server port is: ' \
+      + str(httpd.server_address[1])
+  print(port_message)
+  httpd.serve_forever()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -258,29 +258,29 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     # 4: run with an HTTPS certificate that is expired
     # Be sure to offset from the port used in setUp to avoid collision.
 
-    port1 = self.server_process_handler.port + 1
-    port2 = self.server_process_handler.port + 2
-    port3 = self.server_process_handler.port + 3
-    port4 = self.server_process_handler.port + 4
 
     good_https_server_handler = utils.TestServerProcess(log=logger,
-        server='simple_https_server.py', port=port1,
+        server='simple_https_server.py',
         extra_cmd_args=[good_cert_fname])
     good2_https_server_handler = utils.TestServerProcess(log=logger,
-        server='simple_https_server.py', port=port2,
+        server='simple_https_server.py',
         extra_cmd_args=[good2_cert_fname])
     bad_https_server_handler = utils.TestServerProcess(log=logger,
-        server='simple_https_server.py', port=port3,
+        server='simple_https_server.py',
         extra_cmd_args=[bad_cert_fname])
     expd_https_server_handler = utils.TestServerProcess(log=logger,
-        server='simple_https_server.py', port=port4,
+        server='simple_https_server.py',
         extra_cmd_args=[expired_cert_fname])
 
     suffix = '/' +  os.path.basename(target_filepath)
-    good_https_url = 'https://localhost:' + str(port1) + suffix
-    good2_https_url = 'https://localhost:' + str(port2) + suffix
-    bad_https_url = 'https://localhost:' + str(port3) + suffix
-    expired_https_url = 'https://localhost:' + str(port4) + suffix
+    good_https_url = 'https://localhost:' \
+        + str(good_https_server_handler.port) + suffix
+    good2_https_url = 'https://localhost:' \
+        + str(good2_https_server_handler.port) + suffix
+    bad_https_url = 'https://localhost:' \
+        + str(bad_https_server_handler.port) + suffix
+    expired_https_url = 'https://localhost:' \
+        + str(expd_https_server_handler.port) + suffix
 
     # Download the target file using an HTTPS connection.
 

--- a/tests/test_mirrors.py
+++ b/tests/test_mirrors.py
@@ -38,7 +38,6 @@ import utils
 
 import securesystemslib
 import securesystemslib.util
-import six
 
 
 class TestMirrors(unittest_toolbox.Modified_TestCase):

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -119,13 +119,6 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
     # the pre-generated metadata files have a specific structure, such
     # as a delegated role 'targets/role1', three target files, five key files,
     # etc.
-    self.SERVER_PORT = random.SystemRandom().randint(30000, 45000)
-    self.SERVER_PORT2 = random.SystemRandom().randint(30000, 45000)
-
-    # Avoid duplicate port numbers, to prevent multiple localhosts from
-    # listening on the same port.
-    while self.SERVER_PORT == self.SERVER_PORT2:
-      self.SERVER_PORT2 = random.SystemRandom().randint(30000, 45000)
 
     # Needed because in some tests simple_server.py cannot be found.
     # The reason is that the current working directory
@@ -134,20 +127,18 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
 
     # Creates a subprocess running server and uses temp file for logging.
     self.server_process_handler = utils.TestServerProcess(log=logger,
-        port=self.SERVER_PORT, server=SIMPLE_SERVER_PATH,
-        popen_cwd=self.repository_directory)
+        server=SIMPLE_SERVER_PATH, popen_cwd=self.repository_directory)
 
     logger.debug('Server process started.')
 
     # Creates a subprocess running server and uses temp file for logging.
     self.server_process_handler2 = utils.TestServerProcess(log=logger,
-        port=self.SERVER_PORT2, server=SIMPLE_SERVER_PATH,
-        popen_cwd=self.repository_directory2)
+        server=SIMPLE_SERVER_PATH, popen_cwd=self.repository_directory2)
 
     logger.debug('Server process 2 started.')
 
-    url_prefix = 'http://localhost:' + str(self.SERVER_PORT)
-    url_prefix2 = 'http://localhost:' + str(self.SERVER_PORT2)
+    url_prefix = 'http://localhost:' + str(self.server_process_handler.port)
+    url_prefix2 = 'http://localhost:' + str(self.server_process_handler2.port)
 
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
                                            'metadata_path': 'metadata',
@@ -265,8 +256,10 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
 
     # Test the behavior of the multi-repository updater.
     map_file = securesystemslib.util.load_json_file(self.map_file)
-    map_file['repositories'][self.repository_name] = ['http://localhost:' + str(self.SERVER_PORT)]
-    map_file['repositories'][self.repository_name2] = ['http://localhost:' + str(self.SERVER_PORT2)]
+    map_file['repositories'][self.repository_name] = ['http://localhost:' \
+        + str(self.server_process_handler.port)]
+    map_file['repositories'][self.repository_name2] = ['http://localhost:' \
+        + str(self.server_process_handler2.port)]
     with open(self.map_file, 'w') as file_object:
       file_object.write(json.dumps(map_file))
 

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -31,7 +31,6 @@ from __future__ import unicode_literals
 
 import os
 import tempfile
-import random
 import logging
 import shutil
 import unittest

--- a/tests/test_proxy_use.py
+++ b/tests/test_proxy_use.py
@@ -80,15 +80,13 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
 
     # Launch an HTTPS server (serves files in the current dir).
     cls.https_server_handler = utils.TestServerProcess(log=logger,
-        server='simple_https_server.py',
-        port=cls.http_server_handler.port + 1)
+        server='simple_https_server.py')
 
     # Launch an HTTP proxy server derived from inaz2/proxy2.
     # This one is able to handle HTTP CONNECT requests, and so can pass HTTPS
     # requests on to the target server.
     cls.http_proxy_handler = utils.TestServerProcess(log=logger,
-        server='proxy_server.py',
-        port=cls.http_server_handler.port + 2)
+        server='proxy_server.py')
 
     # Note that the HTTP proxy server's address uses http://, regardless of the
     # type of connection used with the target server.
@@ -109,9 +107,8 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
     #   This is only relevant if the proxy is in intercept mode.
     good_cert_fpath = os.path.join('ssl_certs', 'ssl_cert.crt')
     cls.https_proxy_handler = utils.TestServerProcess(log=logger,
-        server='proxy_server.py',
-        port=cls.http_server_handler.port + 3,
-        extra_cmd_args=['intercept', good_cert_fpath])
+        server='proxy_server.py', extra_cmd_args=['intercept',
+        good_cert_fpath])
 
     # Note that the HTTPS proxy server's address uses https://, regardless of
     # the type of connection used with the target server.

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -169,7 +169,7 @@ class TestSlowRetrieval(unittest_toolbox.Modified_TestCase):
     repository_basepath = self.repository_directory[len(os.getcwd()):]
 
     self.server_process_handler = utils.TestServerProcess(log=logger,
-        server='slow_retrieval_server.py', timeout=0)
+        server='slow_retrieval_server.py')
 
     logger.info('Slow Retrieval Server process started.')
 

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -46,7 +46,6 @@ from __future__ import unicode_literals
 
 import os
 import tempfile
-import random
 import time
 import shutil
 import logging
@@ -222,7 +221,6 @@ class TestSlowRetrieval(unittest_toolbox.Modified_TestCase):
 
     # Verify that the TUF client detects replayed metadata and refuses to
     # continue the update process.
-    client_filepath = os.path.join(self.client_directory, 'file1.txt')
     try:
       file1_target = self.repository_updater.get_one_valid_targetinfo('file1.txt')
       self.repository_updater.download_target(file1_target, self.client_directory)

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -172,14 +172,6 @@ class TestSlowRetrieval(unittest_toolbox.Modified_TestCase):
 
     logger.info('Slow Retrieval Server process started.')
 
-    # NOTE: Following error is raised if a delay is not long enough:
-    # <urlopen error [Errno 111] Connection refused>
-    # or, on Windows:
-    # Failed to establish a new connection: [Errno 111] Connection refused'
-    # 1s led to occasional failures in automated builds on AppVeyor, so
-    # increasing this to 3s, sadly.
-    time.sleep(3)
-
     url_prefix = 'http://localhost:' \
       + str(self.server_process_handler.port) + repository_basepath
 

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -208,7 +208,7 @@ class TestSlowRetrieval(unittest_toolbox.Modified_TestCase):
 
   def test_delay_before_send(self):
     # Simulate a slow retrieval attack.
-    # 'mode_1': When download begins,the server blocks the download for a long
+    # When download begins,the server blocks the download for a long
     # time by doing nothing before it sends the first byte of data.
 
     # Verify that the TUF client detects replayed metadata and refuses to

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -68,61 +68,19 @@ logger = logging.getLogger(__name__)
 repo_tool.disable_console_log_messages()
 
 
-class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
 
-  @classmethod
-  def setUpClass(cls):
-    # Create a temporary directory to store the repository, metadata, and target
-    # files.  'temporary_directory' must be deleted in TearDownModule() so that
-    # temporary files are always removed, even when exceptions occur.
-    cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
-    cls.SERVER_PORT = random.randint(30000, 45000)
-
-
-
-  @classmethod
-  def tearDownClass(cls):
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated of all the test cases.
-    shutil.rmtree(cls.temporary_directory)
-
-
-
-  def _start_slow_server(self, mode):
-    # Launch a SimpleHTTPServer (serves files in the current directory).
-    # Test cases will request metadata and target files that have been
-    # pre-generated in 'tuf/tests/repository_data', which will be served by the
-    # SimpleHTTPServer launched here.  The test cases of this unit test assume
-    # the pre-generated metadata files have a specific structure, such
-    # as a delegated role 'targets/role1', three target files, five key files,
-    # etc.
-    self.server_process_handler = utils.TestServerProcess(log=logger,
-        server='slow_retrieval_server.py', port=self.SERVER_PORT,
-        timeout=0, extra_cmd_args=[mode])
-
-    logger.info('Slow Retrieval Server process started.')
-
-    # NOTE: Following error is raised if a delay is not long enough:
-    # <urlopen error [Errno 111] Connection refused>
-    # or, on Windows:
-    # Failed to establish a new connection: [Errno 111] Connection refused'
-    # 1s led to occasional failures in automated builds on AppVeyor, so
-    # increasing this to 3s, sadly.
-    time.sleep(3)
-
-
-
-  def _stop_slow_server(self):
-    # Logs stdout and stderr from the server subprocess and then it
-    # kills it and closes the temp file used for logging.
-    self.server_process_handler.clean()
-
+class TestSlowRetrieval(unittest_toolbox.Modified_TestCase):
 
   def setUp(self):
     # We are inheriting from custom class.
     unittest_toolbox.Modified_TestCase.setUp(self)
 
     self.repository_name = 'test_repository1'
+
+    # Create a temporary directory to store the repository, metadata, and target
+    # files.  'temporary_directory' must be deleted in TearDownModule() so that
+    # temporary files are always removed, even when exceptions occur.
+    self.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
 
     # Copy the original repository files provided in the test folder so that
     # any modifications made to repository files are restricted to the copies.
@@ -209,8 +167,22 @@ class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = \
-      'http://localhost:' + str(self.SERVER_PORT) + repository_basepath
+
+    self.server_process_handler = utils.TestServerProcess(log=logger,
+        server='slow_retrieval_server.py', timeout=0)
+
+    logger.info('Slow Retrieval Server process started.')
+
+    # NOTE: Following error is raised if a delay is not long enough:
+    # <urlopen error [Errno 111] Connection refused>
+    # or, on Windows:
+    # Failed to establish a new connection: [Errno 111] Connection refused'
+    # 1s led to occasional failures in automated builds on AppVeyor, so
+    # increasing this to 3s, sadly.
+    time.sleep(3)
+
+    url_prefix = 'http://localhost:' \
+      + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client
     # directory copied from the original repository files.
@@ -233,15 +205,20 @@ class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
+    # Logs stdout and stderr from the server subprocess and then it
+    # kills it and closes the temp file used for logging.
+    self.server_process_handler.clean()
+
+    # Remove the temporary repository directory, which should contain all the
+    # metadata, targets, and key files generated of all the test cases.
+    shutil.rmtree(self.temporary_directory)
 
 
 
-  def test_with_tuf_mode_1(self):
+  def test_delay_before_send(self):
     # Simulate a slow retrieval attack.
     # 'mode_1': When download begins,the server blocks the download for a long
     # time by doing nothing before it sends the first byte of data.
-
-    self._start_slow_server('mode_1')
 
     # Verify that the TUF client detects replayed metadata and refuses to
     # continue the update process.
@@ -264,53 +241,6 @@ class TestSlowRetrievalAttack(unittest_toolbox.Modified_TestCase):
     else:
       self.fail('TUF did not prevent a slow retrieval attack.')
 
-    finally:
-      self._stop_slow_server()
-
-
-
-  # The following test fails as a result of a change to TUF's download code.
-  # Rather than constructing urllib2 requests, we now use the requests library.
-  # This solves an HTTPS proxy issue, but has for the moment deprived us of a
-  # way to prevent certain this kind of slow retrieval attack.
-  # See conversation in PR: https://github.com/theupdateframework/tuf/pull/781
-  # TODO: Update download code to resolve the slow retrieval vulnerability.
-  @unittest.expectedFailure
-  def test_with_tuf_mode_2(self):
-    # Simulate a slow retrieval attack.
-    # 'mode_2': During the download process, the server blocks the download
-    # by sending just several characters every few seconds.
-
-    self._start_slow_server('mode_2')
-    client_filepath = os.path.join(self.client_directory, 'file1.txt')
-    original_average_download_speed = tuf.settings.MIN_AVERAGE_DOWNLOAD_SPEED
-    tuf.settings.MIN_AVERAGE_DOWNLOAD_SPEED = 3
-
-    try:
-      file1_target = self.repository_updater.get_one_valid_targetinfo('file1.txt')
-      self.repository_updater.download_target(file1_target, self.client_directory)
-
-    # Verify that the specific 'tuf.exceptions.SlowRetrievalError' exception is
-    # raised by each mirror.  'file1.txt' should be large enough to trigger a
-    # slow retrieval attack, otherwise the expected exception may not be
-    # consistently raised.
-    except tuf.exceptions.NoWorkingMirrorError as exception:
-      for mirror_url, mirror_error in six.iteritems(exception.mirror_errors):
-        url_prefix = self.repository_mirrors['mirror1']['url_prefix']
-        url_file = os.path.join(url_prefix, 'targets', 'file1.txt')
-
-        # Verify that 'file1.txt' is the culprit.
-        self.assertEqual(url_file.replace('\\', '/'), mirror_url)
-        self.assertTrue(isinstance(mirror_error, tuf.exceptions.SlowRetrievalError))
-
-    else:
-      # Another possibility is to check for a successfully downloaded
-      # 'file1.txt' at this point.
-      self.fail('TUF did not prevent a slow retrieval attack.')
-
-    finally:
-      self._stop_slow_server()
-      tuf.settings.MIN_AVERAGE_DOWNLOAD_SPEED = original_average_download_speed
 
 
 if __name__ == '__main__':

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -58,6 +58,7 @@ import logging
 import errno
 import sys
 import unittest
+import json
 
 import tuf
 import tuf.exceptions
@@ -1863,27 +1864,35 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     # as a delegated role 'targets/role1', three target files, five key files,
     # etc.
 
-    # The ports are harcoded because the urls to the repositories are harcoded
-    # in map.json.
-    self.SERVER_PORT = 30001
-    self.SERVER_PORT2 = 30002
-
     # Creates a subprocess running server and uses temp file for logging.
     self.server_process_handler = utils.TestServerProcess(log=logger,
-        server=self.SIMPLE_SERVER_PATH, port=self.SERVER_PORT,
-        popen_cwd=self.repository_directory)
+        server=self.SIMPLE_SERVER_PATH, popen_cwd=self.repository_directory)
 
     logger.debug('Server process started.')
 
     # Creates a subprocess running server and uses temp file for logging.
     self.server_process_handler2 = utils.TestServerProcess(log=logger,
-        server=self.SIMPLE_SERVER_PATH, port=self.SERVER_PORT2,
-        popen_cwd=self.repository_directory2)
+        server=self.SIMPLE_SERVER_PATH, popen_cwd=self.repository_directory2)
 
     logger.debug('Server process 2 started.')
 
-    url_prefix = 'http://localhost:' + str(self.SERVER_PORT)
-    url_prefix2 = 'http://localhost:' + str(self.SERVER_PORT2)
+    url_prefix = 'http://localhost:' + str(self.server_process_handler.port)
+    url_prefix2 = 'http://localhost:' + str(self.server_process_handler2.port)
+
+    # We have all of the necessary information for two repository mirrors
+    # in map.json, except for url prefixes.
+    # For the url prefixes, we create subprocesses that run a server script.
+    # In server scripts we get a free port from the OS which is sent
+    # back to the father process.
+    # That's why we dynamically add the ports to the url prefixes
+    # and changing the content of map.json.
+    self.map_file_path = os.path.join(self.client_directory, 'map.json')
+    data = securesystemslib.util.load_json_file(self.map_file_path)
+
+    data['repositories']['test_repository1'] = [url_prefix]
+    data['repositories']['test_repository2'] = [url_prefix2]
+    with open(self.map_file_path, 'w') as f:
+      json.dump(data, f)
 
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
         'metadata_path': 'metadata', 'targets_path': 'targets'}}
@@ -1957,14 +1966,12 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
         updater.MultiRepoUpdater, root_filepath)
 
     # Test for a valid instantiation.
-    map_file = os.path.join(self.client_directory, 'map.json')
-    multi_repo_updater = updater.MultiRepoUpdater(map_file)
+    multi_repo_updater = updater.MultiRepoUpdater(self.map_file_path)
 
 
 
   def test__target_matches_path_pattern(self):
-    map_file = os.path.join(self.client_directory, 'map.json')
-    multi_repo_updater = updater.MultiRepoUpdater(map_file)
+    multi_repo_updater = updater.MultiRepoUpdater(self.map_file_path)
     paths = ['foo*.tgz', 'bar*.tgz', 'file1.txt']
     self.assertTrue(
         multi_repo_updater._target_matches_path_pattern('bar-1.0.tgz', paths))
@@ -1976,8 +1983,7 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
 
 
   def test_get_valid_targetinfo(self):
-    map_file = os.path.join(self.client_directory, 'map.json')
-    multi_repo_updater = updater.MultiRepoUpdater(map_file)
+    multi_repo_updater = updater.MultiRepoUpdater(self.map_file_path)
 
     # Verify the multi repo updater refuses to save targetinfo if
     # required local repositories are missing.
@@ -2084,8 +2090,7 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
 
 
   def test_get_updater(self):
-    map_file = os.path.join(self.client_directory, 'map.json')
-    multi_repo_updater = updater.MultiRepoUpdater(map_file)
+    multi_repo_updater = updater.MultiRepoUpdater(self.map_file_path)
 
     # Test for a non-existent repository name.
     self.assertEqual(None, multi_repo_updater.get_updater('bad_repo_name'))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -113,12 +113,11 @@ class TestServerProcess(unittest_toolbox.Modified_TestCase):
 
 
   def test_server_exit_before_timeout(self):
-    # Test starting a non existing server file."
-    self.assertRaises(ChildProcessError, utils.TestServerProcess, logger,
+    self.assertRaises(utils.ChildProcessError, utils.TestServerProcess, logger,
         server='non_existing_server.py')
 
     # Test starting a server which immediately exits."
-    self.assertRaises(ChildProcessError, utils.TestServerProcess, logger,
+    self.assertRaises(utils.ChildProcessError, utils.TestServerProcess, logger,
         server='fast_server_exit.py')
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,6 +112,16 @@ class TestServerProcess(unittest_toolbox.Modified_TestCase):
     self.assertFalse(self.server_process_handler.is_process_running())
 
 
+  def test_server_exit_before_timeout(self):
+    # Test starting a non existing server file."
+    self.assertRaises(ChildProcessError, utils.TestServerProcess, logger,
+        server='non_existing_server.py')
+
+    # Test starting a server which immediately exits."
+    self.assertRaises(ChildProcessError, utils.TestServerProcess, logger,
+        server='fast_server_exit.py')
+
+
 if __name__ == '__main__':
   utils.configure_test_logging(sys.argv)
   unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+
+# Copyright 2020, TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+<Program Name>
+  test_utils.py
+
+<Author>
+  Martin Vrachev.
+
+<Started>
+  October 21, 2020.
+
+<Copyright>
+  See LICENSE-MIT OR LICENSE for licensing information.
+
+<Purpose>
+  Provide tests for some of the functions in utils.py module.
+"""
+
+import os
+import logging
+import unittest
+import socket
+import sys
+
+import tuf.unittest_toolbox as unittest_toolbox
+
+import utils
+
+logger = logging.getLogger(__name__)
+
+class TestServerProcess(unittest_toolbox.Modified_TestCase):
+
+  def tearDown(self):
+    # Make sure we are calling clean on existing attribute.
+    if hasattr(self, 'server_process_handler'):
+      self.server_process_handler.clean()
+
+
+  def can_connect(self):
+    succeed = False
+    try:
+      sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+      sock.connect(('localhost', self.server_process_handler.port))
+      succeed = True
+    except:
+      pass
+    finally:
+      if sock:
+        sock.close()
+    return succeed
+
+
+  def test_simple_server_startup(self):
+    # Test normal case
+    self.server_process_handler = utils.TestServerProcess(log=logger)
+
+    # Make sure we can connect to the server
+    self.assertTrue(self.can_connect())
+
+
+  def test_simple_https_server_startup(self):
+    # Test normal case
+    good_cert_path = os.path.join('ssl_certs', 'ssl_cert.crt')
+    self.server_process_handler = utils.TestServerProcess(log=logger,
+        server='simple_https_server.py', extra_cmd_args=[good_cert_path])
+
+    # Make sure we can connect to the server
+    self.assertTrue(self.can_connect())
+
+
+  @unittest.skipIf(sys.version_info.major != 2, "Test for Python 2.X")
+  def test_proxy_server_startup(self):
+    # Test normal case
+    self.server_process_handler = utils.TestServerProcess(log=logger,
+        server='proxy_server.py')
+
+    # Make sure we can connect to the server.
+    self.assertTrue(self.can_connect())
+
+    self.server_process_handler.clean()
+
+    # Test start proxy_server using certificate files.
+    good_cert_fpath = os.path.join('ssl_certs', 'ssl_cert.crt')
+    self.server_process_handler = utils.TestServerProcess(log=logger,
+        server='proxy_server.py', extra_cmd_args=['intercept',
+        good_cert_fpath])
+
+    # Make sure we can connect to the server.
+    self.assertTrue(self.can_connect())
+
+
+  def test_slow_retrieval_server_startup(self):
+    # Test normal case
+    self.server_process_handler = utils.TestServerProcess(log=logger,
+        server='slow_retrieval_server.py')
+
+    # Make sure we can connect to the server
+    self.assertTrue(self.can_connect())
+
+
+  def test_cleanup(self):
+    # Test normal case
+    self.server_process_handler = utils.TestServerProcess(log=logger,
+        server='simple_server.py')
+
+    self.server_process_handler.clean()
+
+    # Check if the process has successfully been killed.
+    self.assertFalse(self.server_process_handler.is_process_running())
+
+
+if __name__ == '__main__':
+  utils.configure_test_logging(sys.argv)
+  unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,17 +41,16 @@ class TestServerProcess(unittest_toolbox.Modified_TestCase):
 
 
   def can_connect(self):
-    succeed = False
     try:
       sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
       sock.connect(('localhost', self.server_process_handler.port))
-      succeed = True
+      return True
     except:
-      pass
+      return False
     finally:
+      # The process will always enter in finally even we return.
       if sock:
         sock.close()
-    return succeed
 
 
   def test_simple_server_startup(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -181,9 +181,8 @@ class TestServerProcess():
     # loop until bind succeeds, server exits or we timeout
     while elapsed < timeout:
       if not self.is_process_running():
-        raise ChildProcessError('Child process running ' + self.server \
-            + ' exited before the timeout has expired with code ' \
-            + str(self.__server_process.poll()) + '!')
+        raise ChildProcessError(self.server + ' exited unexpectedly ' \
+            + 'with code ' + str(self.__server_process.poll()) + '!')
 
       elif self._set_port_if_in_logs():
         # If the port is in the log, then the bind was successful.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -37,11 +37,21 @@ logger = logging.getLogger(__name__)
 try:
   # is defined in Python 3
   TimeoutError
+  ChildProcessError
 except NameError:
   # Define for Python 2
   class TimeoutError(Exception):
 
     def __init__(self, value="Timeout"):
+      self.value = value
+
+    def __str__(self):
+      return repr(self.value)
+
+
+  class ChildProcessError(Exception):
+
+    def __init__(self, value="ChidProcess"):
       self.value = value
 
     def __str__(self):


### PR DESCRIPTION
Fixes https://github.com/theupdateframework/tuf/issues/1124, Fixes https://github.com/theupdateframework/tuf/issues/1111

**Description of the changes being introduced by the pull request**:

This pr aims to make the creation of new server subprocesses more stable.
It fixes issues related to the usage of ports already in use like 
`[Errno 98] Address already in use` or `ConnectionRefusedError: [Errno 111]`

By using `0` as a port argument when we start the servers we ask the OS to give us
an arbitrary unused port. 
This method is much better than if we generate a port, because
instead of us generating a port, verifying that it's not busy, and use a retry mechanism (if the port is busy)
we can simply rely on the OS to do that job for us.

This means that the server scripts receive their ports when they are created and then send it back to the 
father process which had created them.

Other changes/cleanups in this pr include 
- remove test_slow_retrieval expected failure test
-  make sure there is no place where we are generating server ports outside the server scripts.
- remove port argument from TestServerProcess in `tests/utils.py`
- remove unused imports
- remove try/except at server test files 

This pr is related to the closed https://github.com/theupdateframework/tuf/pull/1169 pr but because 
I decided to use a whole different approach I thought it made more sense to close that one and create this one.

PS: Great thanks to @jku with whom we had discussions about this pr on regular occasions!

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature

