### PR TITLE
Add support for python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
       env: TOXENV=py37
     - python: "3.8"
       env: TOXENV=py38
+    - python: "3.9"
+      env: TOXENV=py39
     - python: "3.8"
       env: TOXENV=with-sslib-master
     - python: "3.8"

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ setup(
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: Security',
     'Topic :: Software Development'

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = lint,py{27,35,36,37,38}
+envlist = lint,py{27,35,36,37,38,39}
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
Python 3.9 is released on October 5-th 2020 and it seems
logical to add support for it.

For reference read:
https://docs.python.org/3/whatsnew/3.9.html

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


