### PR TITLE
Update Travis CI build badge/docs after migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="https://cdn.rawgit.com/theupdateframework/artwork/3a649fa6/tuf-logo.svg" height="100" valign="middle" alt="TUF"/> A Framework for Securing Software Update Systems
 
-[![Travis-CI](https://travis-ci.org/theupdateframework/tuf.svg?branch=develop)](https://travis-ci.org/theupdateframework/tuf)
+[![Travis-CI](https://travis-ci.com/theupdateframework/tuf.svg?branch=develop)](https://travis-ci.com/theupdateframework/tuf)
 [![Coveralls](https://coveralls.io/repos/theupdateframework/tuf/badge.svg?branch=develop)](https://coveralls.io/r/theupdateframework/tuf?branch=develop)
 ![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=theupdateframework/tuf)
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B162%2Fgithub.com%2Ftheupdateframework%2Ftuf.svg?type=shield)](https://app.fossa.com/projects/custom%2B162%2Fgithub.com%2Ftheupdateframework%2Ftuf?ref=badge_shield)

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -27,7 +27,7 @@ guidelines](https://github.com/secure-systems-lab/code-style-guidelines), and
 must unit test any new software feature or change.  Submitted pull requests
 undergo review and automated testing, including, but not limited to:
 
-* Unit and build testing via [Travis CI](https://travis-ci.org/) and
+* Unit and build testing via [Travis CI](https://travis-ci.com/) and
 [Tox](https://tox.readthedocs.io/en/latest/).
 * Static code analysis via [Pylint](https://www.pylint.org/) and
 [Bandit](https://wiki.openstack.org/wiki/Security/Projects/Bandit).


### PR DESCRIPTION
Update badge URL in readme after migrating from travis-ci.org to travis-ci.com, due to brownout on the former.

Migration was performed via Travis Web UI:
https://docs.travis-ci.com/user/migrate/open-source-repository-migration

NOTE: This is a quick fix to speed up Travis builds until we switch to GitHub Actions (#1195)
