### PR TITLE
Fix imports and default value for function arg

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,7 +18,7 @@ import copy
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 
-import utils
+from tests import utils
 
 # TODO: Remove case handling when fully dropping support for versions >= 3.6
 IS_PY_VERSION_SUPPORTED = sys.version_info >= (3, 6)

--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -52,7 +52,7 @@ import tuf.log
 import tuf.client.updater as updater
 import tuf.unittest_toolbox as unittest_toolbox
 
-import utils
+from tests import utils
 
 import securesystemslib
 import six

--- a/tests/test_developer_tool.py
+++ b/tests/test_developer_tool.py
@@ -41,7 +41,7 @@ import securesystemslib.exceptions
 from tuf.developer_tool import METADATA_DIRECTORY_NAME
 from tuf.developer_tool import TARGETS_DIRECTORY_NAME
 
-import utils
+from tests import utils
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -47,7 +47,7 @@ import tuf.log
 import tuf.unittest_toolbox as unittest_toolbox
 import tuf.exceptions
 
-import utils
+from tests import utils
 
 import requests.exceptions
 

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -54,7 +54,7 @@ import tuf.client.updater as updater
 import tuf.unittest_toolbox as unittest_toolbox
 import tuf.roledb
 
-import utils
+from tests import utils
 
 import securesystemslib
 import six

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -57,7 +57,7 @@ import tuf.roledb
 import tuf.keydb
 import tuf.unittest_toolbox as unittest_toolbox
 
-import utils
+from tests import utils
 
 import securesystemslib
 import six

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -36,7 +36,7 @@ import os
 import tuf
 import tuf.formats
 
-import utils
+from tests import utils
 
 import securesystemslib
 import securesystemslib.util

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -68,7 +68,7 @@ import tuf.roledb
 import tuf.keydb
 import tuf.exceptions
 
-import utils
+from tests import utils
 
 import securesystemslib
 import six

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -52,7 +52,7 @@ import tuf.repository_tool as repo_tool
 import tuf.unittest_toolbox as unittest_toolbox
 import tuf.client.updater as updater
 
-import utils
+from tests import utils
 
 import securesystemslib
 import six

--- a/tests/test_keydb.py
+++ b/tests/test_keydb.py
@@ -39,7 +39,7 @@ import securesystemslib.settings
 import tuf.keydb
 import tuf.log
 
-import utils
+from tests import utils
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -33,7 +33,7 @@ import tuf.settings
 import securesystemslib
 import securesystemslib.util
 
-import utils
+from tests import utils
 
 from six.moves import reload_module
 

--- a/tests/test_mirrors.py
+++ b/tests/test_mirrors.py
@@ -34,7 +34,7 @@ import sys
 import tuf.mirrors as mirrors
 import tuf.unittest_toolbox as unittest_toolbox
 
-import utils
+from tests import utils
 
 import securesystemslib
 import securesystemslib.util

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -53,7 +53,7 @@ import tuf.unittest_toolbox as unittest_toolbox
 import tuf.roledb
 import tuf.keydb
 
-import utils
+from tests import utils
 
 import six
 

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -45,7 +45,7 @@ import tuf.settings
 import tuf.unittest_toolbox as unittest_toolbox
 import tuf.repository_tool as repo_tool
 
-import utils
+from tests import utils
 
 import six
 import securesystemslib

--- a/tests/test_proxy_use.py
+++ b/tests/test_proxy_use.py
@@ -46,7 +46,7 @@ import tuf.log
 import tuf.unittest_toolbox as unittest_toolbox
 import tuf.exceptions
 
-import utils
+from tests import utils
 
 import six
 

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -52,7 +52,7 @@ import tuf.client.updater as updater
 import tuf.repository_tool as repo_tool
 import tuf.unittest_toolbox as unittest_toolbox
 
-import utils
+from tests import utils
 
 import securesystemslib
 import six

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -50,7 +50,7 @@ import tuf.settings
 import tuf.repository_lib as repo_lib
 import tuf.repository_tool as repo_tool
 
-import utils
+from tests import utils
 
 import securesystemslib
 import securesystemslib.exceptions

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -44,7 +44,7 @@ import tuf.roledb
 import tuf.keydb
 import tuf.repository_tool as repo_tool
 
-import utils
+from tests import utils
 
 import securesystemslib
 import securesystemslib.exceptions

--- a/tests/test_roledb.py
+++ b/tests/test_roledb.py
@@ -38,7 +38,7 @@ import tuf.roledb
 import tuf.exceptions
 import tuf.log
 
-import utils
+from tests import utils
 
 import securesystemslib
 import securesystemslib.keys

--- a/tests/test_root_versioning_integration.py
+++ b/tests/test_root_versioning_integration.py
@@ -40,7 +40,7 @@ import tuf.roledb
 import tuf.keydb
 import tuf.repository_tool as repo_tool
 
-import utils
+from tests import utils
 
 import securesystemslib
 import securesystemslib.storage

--- a/tests/test_sig.py
+++ b/tests/test_sig.py
@@ -42,7 +42,7 @@ import tuf.roledb
 import tuf.sig
 import tuf.exceptions
 
-import utils
+from tests import utils
 
 import securesystemslib
 import securesystemslib.keys

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -58,7 +58,7 @@ import tuf.repository_tool as repo_tool
 import tuf.roledb
 import tuf.keydb
 
-import utils
+from tests import utils
 
 import six
 

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -44,7 +44,7 @@ else:
 
 from tuf.repository_tool import *   # part of TUTORIAL.md
 
-import utils
+from tests import utils
 
 import securesystemslib.exceptions
 

--- a/tests/test_unittest_toolbox.py
+++ b/tests/test_unittest_toolbox.py
@@ -35,7 +35,7 @@ import sys
 
 import tuf.unittest_toolbox as unittest_toolbox
 
-import utils
+from tests import utils
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -71,7 +71,7 @@ import tuf.repository_lib as repo_lib
 import tuf.unittest_toolbox as unittest_toolbox
 import tuf.client.updater as updater
 
-import utils
+from tests import utils
 
 import securesystemslib
 import six

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -59,7 +59,7 @@ import tuf.unittest_toolbox as unittest_toolbox
 import tuf.client.updater as updater
 import tuf.settings
 
-import utils
+from tests import utils
 
 import securesystemslib
 import six

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,7 +28,7 @@ import sys
 
 import tuf.unittest_toolbox as unittest_toolbox
 
-import utils
+from tests import utils
 
 logger = logging.getLogger(__name__)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -156,17 +156,19 @@ class TestServerProcess():
         List of additional arguments for the command
         which will start the subprocess.
         More precisely "python -u <path_to_server> <port> <extra_cmd_args>".
-        Default is empty list.
+        When no list is provided, an empty list ("[]") will be assigned to it.
   """
 
 
   def __init__(self, log, server='simple_server.py',
-      timeout=10, popen_cwd=".", extra_cmd_args=[]):
+      timeout=10, popen_cwd=".", extra_cmd_args=None):
 
     self.server = server
     self.__logger = log
     # Stores popped messages from the queue.
     self.__logged_messages = []
+    if extra_cmd_args is None:
+      extra_cmd_args = []
 
     try:
       self._start_server(timeout, extra_cmd_args, popen_cwd)


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:
This quote from the Google Python style guide made me realize
why empty list as a default value for an argument could be
dangerous:

`Default arguments are evaluated once at module load time.
This may cause problems if the argument is a mutable object
such as a list or a dictionary. If the function modifies the object
(e.g., by appending an item to a list), the default value is modified.`

Read more here:
https://google.github.io/styleguide/pyguide.html#2123-cons

Also, currently, we are importing the "utils" module in tests/utils
with "import utils".
This could become a problem when there is another module with
the same general name "utils" and could lead to import mistakes.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


