### PR TITLE
Make metadata signatures ordered by keyid

### DIFF
--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -112,7 +112,7 @@ def _generate_and_write_metadata(rolename, metadata_filename,
   roleinfo = tuf.roledb.get_roleinfo(rolename, repository_name)
   previous_keyids = roleinfo.get('previous_keyids', [])
   previous_threshold = roleinfo.get('previous_threshold', 1)
-  signing_keyids = list(set(roleinfo['signing_keyids']))
+  signing_keyids = sorted(set(roleinfo['signing_keyids']))
 
   # Generate the appropriate role metadata for 'rolename'.
   if rolename == 'root':


### PR DESCRIPTION
Fixes #1154 and parts of #1211.

**Description of the changes being introduced by the pull request**:
In `repository_lib._generate_and_write_metadata` sort the set of signing key keyids alphabetically before passing them on to signing functions, to make the order in which signatures are added deterministic. This is above all beneficial for testing.

This commit also adds an exemplary test for signatures on root metadata using the `repository_tool` interface to setup all the state that is required to test _generate_and_write_metadata.

Kudos to @erickt for proposing this fix, and to him and @davidstrauss for bringing the issue to our attention.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


