### PR TITLE
Fix root self verification to only count a keyid once towards the threshold

### DIFF
--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1385,7 +1385,7 @@ class Updater(object):
     signatures = signable['signatures']
     signed = securesystemslib.formats.encode_canonical(
         signable['signed']).encode('utf-8')
-    validated = 0
+    verified_sig_keyids = set()
 
     for signature in signatures:
       keyid = signature['keyid']
@@ -1403,9 +1403,9 @@ class Updater(object):
       valid_sig = securesystemslib.keys.verify_signature(key, signature, signed)
 
       if valid_sig:
-        validated = validated + 1
+        verified_sig_keyids.add(keyid)
 
-    if validated >= threshold:
+    if len(verified_sig_keyids) >= threshold:
       return True
     return False
 


### PR DESCRIPTION
Fixes #N/A

**Description of the changes being introduced by the pull request**:

@trishankatdatadog perceptively observed that `_verify_root_self_signed()`, introduced in #1101, will incorrectly count multiple signatures with the same keyid towards the threshold for new signatures listed inside an updated root metadata file.

This PR introduces:
1. a test to catch this issue, by having a root metadata file with a threshold of two list the same keyid:sig dict twice in the metadata file's signatures.
2. a fix to `_verify_root_self_signed()` to uniquify a list of keyids for which signatures have been verified, and compare only the number of unique keyids against the threshold.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


