### PR TITLE
New metadata API: add MetadataInfo and TargetFile classes

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -232,6 +232,10 @@ class TestMetadata(unittest.TestCase):
         self.assertNotEqual(snapshot.signed.meta, fileinfo)
         snapshot.signed.update('role1', 2, 123, hashes)
         self.assertEqual(snapshot.signed.meta, fileinfo)
+        # Update only version. Length and hashes are optional.
+        snapshot.signed.update('role1', 3)
+        fileinfo['role1.json'] = {'version': 3}
+        self.assertEqual(snapshot.signed.meta, fileinfo)
 
 
     def test_metadata_timestamp(self):
@@ -266,6 +270,10 @@ class TestMetadata(unittest.TestCase):
 
         self.assertNotEqual(timestamp.signed.meta['snapshot.json'], fileinfo)
         timestamp.signed.update(2, 520, hashes)
+        self.assertEqual(timestamp.signed.meta['snapshot.json'], fileinfo)
+        # Update only version. Length and hashes are optional.
+        timestamp.signed.update(3)
+        fileinfo = {'version': 3}
         self.assertEqual(timestamp.signed.meta['snapshot.json'], fileinfo)
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,6 +33,7 @@ if IS_PY_VERSION_SUPPORTED:
     import tuf.exceptions
     from tuf.api.metadata import (
         Metadata,
+        MetadataInfo,
         Root,
         Snapshot,
         Timestamp,
@@ -224,17 +225,18 @@ class TestMetadata(unittest.TestCase):
         # Create a dict representing what we expect the updated data to be
         fileinfo = copy.deepcopy(snapshot.signed.meta)
         hashes = {'sha256': 'c2986576f5fdfd43944e2b19e775453b96748ec4fe2638a6d2f32f1310967095'}
-        fileinfo['role1.json']['version'] = 2
-        fileinfo['role1.json']['hashes'] = hashes
-        fileinfo['role1.json']['length'] = 123
+        fileinfo['role1.json'].version = 2
+        fileinfo['role1.json'].hashes = hashes
+        fileinfo['role1.json'].length = 123
 
 
         self.assertNotEqual(snapshot.signed.meta, fileinfo)
         snapshot.signed.update('role1', 2, 123, hashes)
         self.assertEqual(snapshot.signed.meta, fileinfo)
+
         # Update only version. Length and hashes are optional.
         snapshot.signed.update('role1', 3)
-        fileinfo['role1.json'] = {'version': 3}
+        fileinfo['role1.json'] = MetadataInfo(3)
         self.assertEqual(snapshot.signed.meta, fileinfo)
 
 
@@ -263,18 +265,18 @@ class TestMetadata(unittest.TestCase):
         self.assertEqual(timestamp.signed.expires, datetime(2036, 1, 3, 0, 0))
 
         hashes = {'sha256': '0ae9664468150a9aa1e7f11feecb32341658eb84292851367fea2da88e8a58dc'}
-        fileinfo = copy.deepcopy(timestamp.signed.meta['snapshot.json'])
-        fileinfo['hashes'] = hashes
-        fileinfo['version'] = 2
-        fileinfo['length'] = 520
-
-        self.assertNotEqual(timestamp.signed.meta['snapshot.json'], fileinfo)
+        fileinfo = copy.deepcopy(timestamp.signed.meta)
+        fileinfo['snapshot.json'].hashes = hashes
+        fileinfo['snapshot.json'].version = 2
+        fileinfo['snapshot.json'].length = 520
+        self.assertNotEqual(timestamp.signed.meta, fileinfo)
         timestamp.signed.update(2, 520, hashes)
-        self.assertEqual(timestamp.signed.meta['snapshot.json'], fileinfo)
+        self.assertEqual(timestamp.signed.meta, fileinfo)
+
         # Update only version. Length and hashes are optional.
         timestamp.signed.update(3)
-        fileinfo = {'version': 3}
-        self.assertEqual(timestamp.signed.meta['snapshot.json'], fileinfo)
+        fileinfo['snapshot.json'] = MetadataInfo(version=3)
+        self.assertEqual(timestamp.signed.meta, fileinfo)
 
 
     def test_metadata_root(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,7 +37,8 @@ if IS_PY_VERSION_SUPPORTED:
         Root,
         Snapshot,
         Timestamp,
-        Targets
+        Targets,
+        TargetInfo
     )
 
     from securesystemslib.interface import (
@@ -324,15 +325,12 @@ class TestMetadata(unittest.TestCase):
             "sha512": "ef5beafa16041bcdd2937140afebd485296cd54f7348ecd5a4d035c09759608de467a7ac0eb58753d0242df873c305e8bffad2454aa48f44480f15efae1cacd0"
         },
 
-        fileinfo = {
-            'hashes': hashes,
-            'length': 28
-        }
+        fileinfo = TargetInfo(length=28, hashes=hashes)
 
         # Assert that data is not aleady equal
         self.assertNotEqual(targets.signed.targets[filename], fileinfo)
         # Update an already existing fileinfo
-        targets.signed.update(filename, fileinfo)
+        targets.signed.update(filename, fileinfo.to_dict())
         # Verify that data is updated
         self.assertEqual(targets.signed.targets[filename], fileinfo)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,6 +33,7 @@ if IS_PY_VERSION_SUPPORTED:
     import tuf.exceptions
     from tuf.api.metadata import (
         Metadata,
+        Root,
         Snapshot,
         Timestamp,
         Targets
@@ -92,6 +93,7 @@ class TestMetadata(unittest.TestCase):
 
     def test_generic_read(self):
         for metadata, inner_metadata_cls in [
+                ('root', Root),
                 ('snapshot', Snapshot),
                 ('timestamp', Timestamp),
                 ('targets', Targets)]:
@@ -137,7 +139,7 @@ class TestMetadata(unittest.TestCase):
 
 
     def test_read_write_read_compare(self):
-        for metadata in ['snapshot', 'timestamp', 'targets']:
+        for metadata in ['root', 'snapshot', 'timestamp', 'targets']:
             path = os.path.join(self.repo_dir, 'metadata', metadata + '.json')
             metadata_obj = Metadata.from_json_file(path)
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -381,6 +381,10 @@ class Root(Signed):
             self, _type: str=None, version: int=None, spec_version: str=None,
             expires: datetime=None, consistent_snapshot: bool=None,
             keys: JsonDict=None, roles: JsonDict=None) -> None:
+
+        # TODO: Add sensible defaults when we have input validation.
+        # See issue https://github.com/theupdateframework/tuf/issues/1140
+        # We need default values to create empty objects in Signed.from_dict()
         super().__init__(_type, version, spec_version, expires)
         # TODO: Add classes for keys and roles
         self.consistent_snapshot = consistent_snapshot
@@ -493,6 +497,10 @@ class Timestamp(Signed):
             self, _type: str=None, version: int=None, spec_version: str=None,
             expires: datetime=None, meta: Dict[str, MetadataInfo]=None
             ) -> None:
+
+        # TODO: Add sensible defaults when we have input validation.
+        # See issue https://github.com/theupdateframework/tuf/issues/1140
+        # We need default values to create empty objects in Signed.from_dict()
         super().__init__(_type, version, spec_version, expires)
         self.meta = meta
 
@@ -528,6 +536,8 @@ class Timestamp(Signed):
             hashes: Optional[JsonDict] = None) -> None:
         """Assigns passed info about snapshot metadata to meta dict. """
 
+        # TODO: Consider renaming this function:
+        # see: https://github.com/theupdateframework/tuf/issues/1230
         self.meta['snapshot.json'] = MetadataInfo(version, length, hashes)
 
 
@@ -549,6 +559,10 @@ class Snapshot(Signed):
             self, _type: str=None, version: int=None, spec_version: str=None,
             expires: datetime=None, meta: Dict[str, MetadataInfo]=None
             ) -> None:
+
+        # TODO: Add sensible defaults when we have input validation.
+        # See issue https://github.com/theupdateframework/tuf/issues/1140
+        # We need default values to create empty objects in Signed.from_dict()
         super().__init__(_type, version, spec_version, expires)
         self.meta = meta
 
@@ -587,6 +601,9 @@ class Snapshot(Signed):
             self, rolename: str, version: int, length: Optional[int] = None,
             hashes: Optional[JsonDict] = None) -> None:
         """Assigns passed (delegated) targets role info to meta dict. """
+
+        # TODO: Consider renaming this function:
+        # see: https://github.com/theupdateframework/tuf/issues/1230
         metadata_fn = f'{rolename}.json'
 
         self.meta[metadata_fn] = MetadataInfo(version, length, hashes)
@@ -697,6 +714,10 @@ class Targets(Signed):
             self, _type: str=None, version: int=None, spec_version: str=None,
             expires: datetime=None, targets: Dict[str, TargetInfo]=None,
             delegations: JsonDict=None) -> None:
+
+        # TODO: Add sensible defaults when we have input validation.
+        # See issue https://github.com/theupdateframework/tuf/issues/1140
+        # We need default values to create empty objects in Signed.from_dict()
         super().__init__(_type, version, spec_version, expires)
         self.targets = targets
 
@@ -737,5 +758,8 @@ class Targets(Signed):
     # Modification.
     def update(self, filename: str, fileinfo: JsonDict) -> None:
         """Assigns passed target file info to meta dict. """
+
+        # TODO: Consider renaming this function:
+        # see: https://github.com/theupdateframework/tuf/issues/1230
         self.targets[filename] = TargetInfo(fileinfo['length'],
             fileinfo['hashes'], fileinfo.get('custom'))

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -431,7 +431,7 @@ class Timestamp(Signed):
                         '<HASH ALGO 1>': '<SNAPSHOT METADATA FILE HASH 1>',
                         '<HASH ALGO 2>': '<SNAPSHOT METADATA FILE HASH 2>',
                         ...
-                    }
+                    } // optional
                 }
             }
 
@@ -455,13 +455,16 @@ class Timestamp(Signed):
 
 
     # Modification.
-    def update(self, version: int, length: int, hashes: JsonDict) -> None:
+    def update(self, version: int, length: Optional[int] = None,
+            hashes: Optional[JsonDict] = None) -> None:
         """Assigns passed info about snapshot metadata to meta dict. """
-        self.meta['snapshot.json'] = {
-            'version': version,
-            'length': length,
-            'hashes': hashes
-        }
+
+        self.meta['snapshot.json'] = {'version': version}
+        if length is not None:
+            self.meta['snapshot.json']['length'] = length
+
+        if hashes is not None:
+            self.meta['snapshot.json']['hashes'] = hashes
 
 
 class Snapshot(Signed):

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1,3 +1,5 @@
+# pylint: disable=E1101
+
 """TUF role metadata model.
 
 This module provides container classes for TUF role metadata, including methods
@@ -291,8 +293,11 @@ class Signed:
 
         # Create empty object with default or parametrized constructor with
         # default arguments.
-        obj = cls()
-        obj._type = signed_dict['_type']
+        # Warnings about rules E1120 (no-value-for-parameter) and W0212
+        # (protected-access) are not relevant here because cls is most likely
+        # a descendant of "Signed" and we need to setup the appropriate fields.
+        obj = cls() # pylint: disable=E1120
+        obj._type = signed_dict['_type'] # pylint: disable=W0212
         obj.version = signed_dict['version']
         obj.spec_version = signed_dict['spec_version']
         # Convert 'expires' TUF metadata string to a datetime object, which is

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -342,30 +342,33 @@ class Root(Signed):
             supports consistent snapshots.
         keys: A dictionary that contains a public key store used to verify
             top level roles metadata signatures::
-            {
-                '<KEYID>': {
-                    'keytype': '<KEY TYPE>',
-                    'scheme': '<KEY SCHEME>',
-                    'keyid_hash_algorithms': [
-                        '<HASH ALGO 1>',
-                        '<HASH ALGO 2>'
-                        ...
-                    ],
-                    'keyval': {
-                        'public': '<PUBLIC KEY HEX REPRESENTATION>'
-                    }
+
+                {
+                    '<KEYID>': {
+                        'keytype': '<KEY TYPE>',
+                        'scheme': '<KEY SCHEME>',
+                        'keyid_hash_algorithms': [
+                            '<HASH ALGO 1>',
+                            '<HASH ALGO 2>'
+                            ...
+                        ],
+                        'keyval': {
+                            'public': '<PUBLIC KEY HEX REPRESENTATION>'
+                        }
+                    },
+                    ...
                 },
-                ...
-            },
+
         roles: A dictionary that contains a list of signing keyids and
             a signature threshold for each top level role::
-            {
-                '<ROLE>': {
-                    'keyids': ['<SIGNING KEY KEYID>', ...],
-                    'threshold': <SIGNATURE THRESHOLD>,
-                },
-                ...
-            }
+
+                {
+                    '<ROLE>': {
+                        'keyids': ['<SIGNING KEY KEYID>', ...],
+                        'threshold': <SIGNATURE THRESHOLD>,
+                    },
+                    ...
+                }
 
     """
     # TODO: determine an appropriate value for max-args and fix places where
@@ -548,34 +551,34 @@ class Targets(Signed):
             roles and public key store used to verify their metadata
             signatures::
 
-            {
-                'keys' : {
-                    '<KEYID>': {
-                        'keytype': '<KEY TYPE>',
-                        'scheme': '<KEY SCHEME>',
-                        'keyid_hash_algorithms': [
-                            '<HASH ALGO 1>',
-                            '<HASH ALGO 2>'
-                            ...
-                        ],
-                        'keyval': {
-                            'public': '<PUBLIC KEY HEX REPRESENTATION>'
-                        }
+                {
+                    'keys' : {
+                        '<KEYID>': {
+                            'keytype': '<KEY TYPE>',
+                            'scheme': '<KEY SCHEME>',
+                            'keyid_hash_algorithms': [
+                                '<HASH ALGO 1>',
+                                '<HASH ALGO 2>'
+                                ...
+                            ],
+                            'keyval': {
+                                'public': '<PUBLIC KEY HEX REPRESENTATION>'
+                            }
+                        },
+                        ...
                     },
+                    'roles': [
+                        {
+                            'name': '<ROLENAME>',
+                            'keyids': ['<SIGNING KEY KEYID>', ...],
+                            'threshold': <SIGNATURE THRESHOLD>,
+                            'terminating': <TERMINATING BOOLEAN>,
+                            'path_hash_prefixes': ['<HEX DIGEST>', ... ], // or
+                            'paths' : ['PATHPATTERN', ... ],
+                        },
                     ...
-                },
-                'roles': [
-                    {
-                        'name': '<ROLENAME>',
-                        'keyids': ['<SIGNING KEY KEYID>', ...],
-                        'threshold': <SIGNATURE THRESHOLD>,
-                        'terminating': <TERMINATING BOOLEAN>,
-                        'path_hash_prefixes': ['<HEX DIGEST>', ... ], // or
-                        'paths' : ['PATHPATTERN', ... ],
-                    },
-                ...
-                ]
-            }
+                    ]
+                }
 
     """
     # TODO: determine an appropriate value for max-args and fix places where

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -273,6 +273,8 @@ class Signed:
             self, _type: str, version: int, spec_version: str,
             expires: datetime) -> None:
 
+        # "_type" is not actually meant to be "protected" in the OOP sense
+        # but rather is a workaround to not shadow the built-in "type" name.
         self._type = _type
         self.version = version
         self.spec_version = spec_version


### PR DESCRIPTION
This pr addresses https://github.com/theupdateframework/tuf/issues/1139, but doesn't fix it yet.

I will add a separate pr which will handle `Roles` and `Keys` classes.

**Description of the changes being introduced by the pull request**:
It includes the following changes:
- Add a missing root use case in a couple of our tests
- Make `length` and `hashes` optional in `Timestamp` as it is in our specification
- Add `MetaFile` class and use it in the `Timestamp` and `Snapshot` classes
- Add `TargetFile` class and use it in the `Targets` class
- Rename a few instances of the `update` method in our classes and use a more verbose name.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


