### PR TITLE
Remove redundant temp folder and unused imports

### DIFF
--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -37,7 +37,6 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import os
-import tempfile
 import shutil
 import json
 import logging
@@ -50,7 +49,7 @@ import tuf.roledb
 import tuf.keydb
 import tuf.log
 import tuf.client.updater as updater
-import tuf.unittest_toolbox as unittest_toolbox
+from tuf import unittest_toolbox
 
 from tests import utils
 
@@ -64,11 +63,6 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # Create a temporary directory to store the repository, metadata, and target
-    # files.  'temporary_directory' must be deleted in TearDownModule() so that
-    # temporary files are always removed, even when exceptions occur.
-    cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
-
     # Launch a SimpleHTTPServer (serves files in the current directory).
     # Test cases will request metadata and target files that have been
     # pre-generated in 'tuf/tests/repository_data', which will be served by the
@@ -85,16 +79,11 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
     # Cleans the resources and flush the logged lines (if any).
     cls.server_process_handler.clean()
 
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated of all the test cases.
-    shutil.rmtree(cls.temporary_directory)
-
 
 
 
   def setUp(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.setUp(self)
+    super().setUp()
 
     self.repository_name = 'test_repository1'
 
@@ -103,7 +92,7 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
     # The 'repository_data' directory is expected to exist in 'tuf/tests/'.
     original_repository_files = os.path.join(os.getcwd(), 'repository_data')
     temporary_repository_root = \
-      self.make_temp_directory(directory=self.temporary_directory)
+        self.make_temp_directory(directory=os.getcwd())
 
     # The original repository, keystore, and client directories will be copied
     # for each test case.
@@ -142,9 +131,7 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
+    super().tearDown()
     # updater.Updater() populates the roledb with the name "test_repository1"
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -45,8 +45,8 @@ import tuf
 import tuf.download as download
 import tuf.requests_fetcher
 import tuf.log
-import tuf.unittest_toolbox as unittest_toolbox
 import tuf.exceptions
+from tuf import unittest_toolbox
 
 from tests import utils
 
@@ -64,7 +64,7 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     current working directory.
     """
 
-    unittest_toolbox.Modified_TestCase.setUp(self)
+    super().setUp()
 
     # Making a temporary file.
     current_dir = os.getcwd()
@@ -93,7 +93,7 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
 
   # Stop server process and perform clean up.
   def tearDown(self):
-    unittest_toolbox.Modified_TestCase.tearDown(self)
+    super().tearDown()
 
     # Cleans the resources and flush the logged lines (if any).
     self.server_process_handler.clean()

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -40,7 +40,6 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import os
-import tempfile
 import shutil
 import json
 import logging
@@ -51,8 +50,8 @@ import tuf
 import tuf.formats
 import tuf.log
 import tuf.client.updater as updater
-import tuf.unittest_toolbox as unittest_toolbox
 import tuf.roledb
+from tuf import unittest_toolbox
 
 from tests import utils
 
@@ -66,10 +65,6 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # Create a temporary directory to store the repository, metadata, and target
-    # files.  'temporary_directory' must be deleted in TearDownModule() so that
-    # temporary files are always removed, even when exceptions occur.
-    cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
 
     # Launch a SimpleHTTPServer (serves files in the current directory).
     # Test cases will request metadata and target files that have been
@@ -87,16 +82,11 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
     # Cleans the resources and flush the logged lines (if any).
     cls.server_process_handler.clean()
 
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated of all the test cases.
-    shutil.rmtree(cls.temporary_directory)
-
 
 
 
   def setUp(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.setUp(self)
+    super().setUp()
 
     self.repository_name = 'test_repository1'
 
@@ -105,7 +95,7 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
     # The 'repository_data' directory is expected to exist in 'tuf/tests/'.
     original_repository_files = os.path.join(os.getcwd(), 'repository_data')
     temporary_repository_root = \
-      self.make_temp_directory(directory=self.temporary_directory)
+        self.make_temp_directory(directory=os.getcwd())
 
     # The original repository, keystore, and client directories will be copied
     # for each test case.
@@ -143,9 +133,7 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
+    super().tearDown()
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -43,7 +43,6 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import os
-import tempfile
 import shutil
 import json
 import logging
@@ -55,7 +54,7 @@ import tuf.log
 import tuf.client.updater as updater
 import tuf.roledb
 import tuf.keydb
-import tuf.unittest_toolbox as unittest_toolbox
+from tuf import unittest_toolbox
 
 from tests import utils
 
@@ -70,10 +69,6 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # Create a temporary directory to store the repository, metadata, and target
-    # files.  'temporary_directory' must be deleted in TearDownModule() so that
-    # temporary files are always removed, even when exceptions occur.
-    cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
 
     # Launch a SimpleHTTPServer (serves files in the current directory).
     # Test cases will request metadata and target files that have been
@@ -91,16 +86,11 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
     # Cleans the resources and flush the logged lines (if any).
     cls.server_process_handler.clean()
 
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated of all the test cases.
-    shutil.rmtree(cls.temporary_directory)
-
 
 
 
   def setUp(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.setUp(self)
+    super().setUp()
 
     self.repository_name = 'test_repository1'
 
@@ -109,7 +99,7 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
     # The 'repository_data' directory is expected to exist in 'tuf/tests/'.
     original_repository_files = os.path.join(os.getcwd(), 'repository_data')
     temporary_repository_root = \
-      self.make_temp_directory(directory=self.temporary_directory)
+        self.make_temp_directory(directory=os.getcwd())
 
     # The original repository, keystore, and client directories will be copied
     # for each test case.
@@ -150,9 +140,7 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
+    super().tearDown()
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -47,7 +47,6 @@ from __future__ import unicode_literals
 import datetime
 import os
 import time
-import tempfile
 import shutil
 import json
 import logging
@@ -63,10 +62,10 @@ import tuf.formats
 import tuf.log
 import tuf.client.updater as updater
 import tuf.repository_tool as repo_tool
-import tuf.unittest_toolbox as unittest_toolbox
 import tuf.roledb
 import tuf.keydb
 import tuf.exceptions
+from tuf import unittest_toolbox
 
 from tests import utils
 
@@ -84,10 +83,6 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # Create a temporary directory to store the repository, metadata, and target
-    # files.  'temporary_directory' must be deleted in TearDownModule() so that
-    # temporary files are always removed, even when exceptions occur.
-    cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
 
     # Launch a SimpleHTTPServer (serves files in the current directory).
     # Test cases will request metadata and target files that have been
@@ -105,16 +100,11 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # Cleans the resources and flush the logged lines (if any).
     cls.server_process_handler.clean()
 
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated of all the test cases.
-    shutil.rmtree(cls.temporary_directory)
-
 
 
 
   def setUp(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.setUp(self)
+    super().setUp()
     self.repository_name = 'test_repository1'
 
     # Copy the original repository files provided in the test folder so that
@@ -122,7 +112,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # The 'repository_data' directory is expected to exist in 'tuf/tests/'.
     original_repository_files = os.path.join(os.getcwd(), 'repository_data')
     temporary_repository_root = \
-      self.make_temp_directory(directory=self.temporary_directory)
+        self.make_temp_directory(directory=os.getcwd())
 
     # The original repository, keystore, and client directories will be copied
     # for each test case.
@@ -163,9 +153,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
+    super().tearDown()
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -39,7 +39,6 @@ from __future__ import unicode_literals
 
 import os
 import shutil
-import tempfile
 import logging
 import unittest
 import sys
@@ -49,8 +48,8 @@ import tuf.log
 import tuf.roledb
 import tuf.keydb
 import tuf.repository_tool as repo_tool
-import tuf.unittest_toolbox as unittest_toolbox
 import tuf.client.updater as updater
+from tuf import unittest_toolbox
 
 from tests import utils
 
@@ -65,11 +64,6 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # Create a temporary directory to store the repository, metadata, and target
-    # files.  'temporary_directory' must be deleted in TearDownModule() so that
-    # temporary files are always removed, even when exceptions occur.
-    cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
-
     # Launch a SimpleHTTPServer (serves files in the current directory).  Test
     # cases will request metadata and target files that have been pre-generated
     # in 'tuf/tests/repository_data', which will be served by the
@@ -86,16 +80,11 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
     # Cleans the resources and flush the logged lines (if any).
     cls.server_process_handler.clean()
 
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated for the test cases.
-    shutil.rmtree(cls.temporary_directory)
-
 
 
 
   def setUp(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.setUp(self)
+    super().setUp()
 
     self.repository_name = 'test_repository1'
 
@@ -104,7 +93,7 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
     # The 'repository_data' directory is expected to exist in 'tuf.tests/'.
     original_repository_files = os.path.join(os.getcwd(), 'repository_data')
     temporary_repository_root = \
-      self.make_temp_directory(directory=self.temporary_directory)
+        self.make_temp_directory(directory=os.getcwd())
 
     # The original repository, keystore, and client directories will be copied
     # for each test case.
@@ -156,8 +145,7 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
+    super().tearDown()
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 

--- a/tests/test_mirrors.py
+++ b/tests/test_mirrors.py
@@ -32,7 +32,7 @@ import unittest
 import sys
 
 import tuf.mirrors as mirrors
-import tuf.unittest_toolbox as unittest_toolbox
+from tuf import unittest_toolbox
 
 from tests import utils
 
@@ -43,8 +43,7 @@ import securesystemslib.util
 class TestMirrors(unittest_toolbox.Modified_TestCase):
 
   def setUp(self):
-
-    unittest_toolbox.Modified_TestCase.setUp(self)
+    super().setUp()
 
     self.mirrors = \
     {'mirror1': {'url_prefix' : 'http://mirror1.com',

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -39,7 +39,6 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import os
-import tempfile
 import shutil
 import logging
 import unittest
@@ -49,9 +48,9 @@ import tuf.exceptions
 import tuf.log
 import tuf.client.updater as updater
 import tuf.repository_tool as repo_tool
-import tuf.unittest_toolbox as unittest_toolbox
 import tuf.roledb
 import tuf.keydb
+from tuf import unittest_toolbox
 
 from tests import utils
 
@@ -69,11 +68,6 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # Create a temporary directory to store the repository, metadata, and
-    # target files.  'temporary_directory' must be deleted in TearDownModule()
-    # so that temporary files are always removed, even when exceptions occur.
-    cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
-
     # Launch a SimpleHTTPServer (serves files in the current directory).
     # Test cases will request metadata and target files that have been
     # pre-generated in 'tuf/tests/repository_data', which will be served by the
@@ -90,16 +84,11 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
     # Cleans the resources and flush the logged lines (if any).
     cls.server_process_handler.clean()
 
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated of all the test cases.
-    shutil.rmtree(cls.temporary_directory)
-
 
 
 
   def setUp(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.setUp(self)
+    super().setUp()
 
     self.repository_name = 'test_repository1'
 
@@ -108,7 +97,7 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
     # The 'repository_data' directory is expected to exist in 'tuf/tests/'.
     original_repository_files = os.path.join(os.getcwd(), 'repository_data')
     temporary_repository_root = \
-      self.make_temp_directory(directory=self.temporary_directory)
+        self.make_temp_directory(directory=os.getcwd())
 
     # The original repository, keystore, and client directories will be copied
     # for each test case.
@@ -149,9 +138,7 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
+    super().tearDown()
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -30,7 +30,6 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import os
-import tempfile
 import logging
 import shutil
 import unittest
@@ -42,8 +41,9 @@ import tuf.log
 import tuf.roledb
 import tuf.client.updater as updater
 import tuf.settings
-import tuf.unittest_toolbox as unittest_toolbox
 import tuf.repository_tool as repo_tool
+
+from tuf import unittest_toolbox
 
 from tests import utils
 
@@ -58,18 +58,14 @@ repo_tool.disable_console_log_messages()
 class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
 
   def setUp(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.setUp(self)
-
-    self.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
-
+    super().setUp()
     # Copy the original repository files provided in the test folder so that
     # any modifications made to repository files are restricted to the copies.
     # The 'repository_data' directory is expected to exist in 'tuf/tests/'.
     original_repository_files = os.path.join(os.getcwd(), 'repository_data')
 
-    self.temporary_repository_root = self.make_temp_directory(directory=
-        self.temporary_directory)
+    self.temporary_repository_root = self.make_temp_directory(
+        directory=os.getcwd())
 
     # The original repository, keystore, and client directories will be copied
     # for each test case.
@@ -160,9 +156,7 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
+    super().tearDown()
 
     # Cleans the resources and flush the logged lines (if any).
     self.server_process_handler.clean()
@@ -171,8 +165,6 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
     # updater.Updater() populates the roledb with the name "test_repository1"
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
-
-    shutil.rmtree(self.temporary_directory)
 
 
   def test_update(self):
@@ -272,8 +264,10 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
     valid_targetinfo = multi_repo_updater.get_valid_targetinfo('file3.txt')
 
     for my_updater, my_targetinfo in six.iteritems(valid_targetinfo):
-      my_updater.download_target(my_targetinfo, self.temporary_directory)
-      self.assertTrue(os.path.exists(os.path.join(self.temporary_directory, 'file3.txt')))
+      my_updater.download_target(my_targetinfo,
+          self.temporary_repository_root)
+      self.assertTrue(os.path.exists(os.path.join(
+          self.temporary_repository_root, 'file3.txt')))
 
 
 

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -39,7 +39,6 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import os
-import tempfile
 import datetime
 import shutil
 import logging
@@ -50,7 +49,7 @@ import tuf.formats
 import tuf.log
 import tuf.client.updater as updater
 import tuf.repository_tool as repo_tool
-import tuf.unittest_toolbox as unittest_toolbox
+from tuf import unittest_toolbox
 
 from tests import utils
 
@@ -69,11 +68,6 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # Create a temporary directory to store the repository, metadata, and target
-    # files.  'temporary_directory' must be deleted in TearDownModule() so that
-    # temporary files are always removed, even when exceptions occur.
-    cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
-
     # Launch a SimpleHTTPServer (serves files in the current directory).
     # Test cases will request metadata and target files that have been
     # pre-generated in 'tuf/tests/repository_data', which will be served by the
@@ -90,16 +84,10 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
     # Cleans the resources and flush the logged lines (if any).
     cls.server_process_handler.clean()
 
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated of all the test cases.
-    shutil.rmtree(cls.temporary_directory)
-
-
 
 
   def setUp(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.setUp(self)
+    super().setUp()
 
     self.repository_name = 'test_repository1'
 
@@ -108,7 +96,7 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
     # The 'repository_data' directory is expected to exist in 'tuf/tests/'.
     original_repository_files = os.path.join(os.getcwd(), 'repository_data')
     temporary_repository_root = \
-      self.make_temp_directory(directory=self.temporary_directory)
+        self.make_temp_directory(directory=os.getcwd())
 
     # The original repository, keystore, and client directories will be copied
     # for each test case.
@@ -149,9 +137,7 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
+    super().tearDown()
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -44,6 +44,8 @@ import tuf.roledb
 import tuf.keydb
 import tuf.repository_tool as repo_tool
 
+from tuf import unittest_toolbox
+
 from tests import utils
 
 import securesystemslib
@@ -55,33 +57,20 @@ logger = logging.getLogger(__name__)
 repo_tool.disable_console_log_messages()
 
 
-class TestRepository(unittest.TestCase):
-  @classmethod
-  def setUpClass(cls):
-    # Create a temporary directory to store the repository, metadata, and target
-    # files.  'temporary_directory' must be deleted in TearDownClass() so that
-    # temporary files are always removed, even when exceptions occur.
-    cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
-
-
-  @classmethod
-  def tearDownClass(cls):
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated for the test cases.
-    shutil.rmtree(cls.temporary_directory)
-
+class TestRepository(unittest_toolbox.Modified_TestCase):
 
 
   def setUp(self):
+    super().setUp()
     tuf.roledb.create_roledb('test_repository')
     tuf.keydb.create_keydb('test_repository')
-
+    self.temporary_directory = self.make_temp_directory(directory=os.getcwd())
 
 
   def tearDown(self):
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
-
+    super().tearDown()
 
   def test_init(self):
     # Test normal case.

--- a/tests/test_root_versioning_integration.py
+++ b/tests/test_root_versioning_integration.py
@@ -40,6 +40,8 @@ import tuf.roledb
 import tuf.keydb
 import tuf.repository_tool as repo_tool
 
+from tuf import unittest_toolbox
+
 from tests import utils
 
 import securesystemslib
@@ -50,19 +52,18 @@ logger = logging.getLogger(__name__)
 repo_tool.disable_console_log_messages()
 
 
-class TestRepository(unittest.TestCase):
+class TestRepository(unittest_toolbox.Modified_TestCase):
 
-  @classmethod
-  def setUpClass(cls):
-    cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
+  def setUp(self):
+    super().setUp()
+    self.temporary_directory = self.make_temp_directory(directory=os.getcwd())
 
-  @classmethod
-  def tearDownClass(cls):
-    shutil.rmtree(cls.temporary_directory)
 
   def tearDown(self):
     tuf.roledb.clear_roledb()
     tuf.keydb.clear_keydb()
+    super().tearDown()
+
 
   def test_init(self):
     # Test normal case.
@@ -98,8 +99,7 @@ class TestRepository(unittest.TestCase):
     #
     # Copy the target files from 'tuf/tests/repository_data' so that writeall()
     # has target fileinfo to include in metadata.
-    temporary_directory = tempfile.mkdtemp(dir=self.temporary_directory)
-    targets_directory = os.path.join(temporary_directory, 'repository',
+    targets_directory = os.path.join(self.temporary_directory, 'repository',
                                      repo_tool.TARGETS_DIRECTORY_NAME)
     original_targets_directory = os.path.join('repository_data',
                                               'repository', 'targets')
@@ -107,7 +107,7 @@ class TestRepository(unittest.TestCase):
 
     # In this case, create_new_repository() creates the 'repository/'
     # sub-directory in 'temporary_directory' if it does not exist.
-    repository_directory = os.path.join(temporary_directory, 'repository')
+    repository_directory = os.path.join(self.temporary_directory, 'repository')
     metadata_directory = os.path.join(repository_directory,
                                       repo_tool.METADATA_STAGED_DIRECTORY_NAME)
     repository = repo_tool.create_new_repository(repository_directory)

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -53,10 +53,11 @@ import sys
 
 import tuf.log
 import tuf.client.updater as updater
-import tuf.unittest_toolbox as unittest_toolbox
 import tuf.repository_tool as repo_tool
 import tuf.roledb
 import tuf.keydb
+
+from tuf import unittest_toolbox
 
 from tests import utils
 
@@ -70,8 +71,7 @@ repo_tool.disable_console_log_messages()
 class TestSlowRetrieval(unittest_toolbox.Modified_TestCase):
 
   def setUp(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.setUp(self)
+    super().setUp()
 
     self.repository_name = 'test_repository1'
 
@@ -189,9 +189,7 @@ class TestSlowRetrieval(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
+    super().tearDown()
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 

--- a/tests/test_unittest_toolbox.py
+++ b/tests/test_unittest_toolbox.py
@@ -33,7 +33,7 @@ import logging
 import shutil
 import sys
 
-import tuf.unittest_toolbox as unittest_toolbox
+from tuf import unittest_toolbox
 
 from tests import utils
 
@@ -41,11 +41,13 @@ logger = logging.getLogger(__name__)
 
 
 class TestUnittestToolbox(unittest_toolbox.Modified_TestCase):
+
   def setUp(self):
-    unittest_toolbox.Modified_TestCase.setUp(self)
+    super().setUp()
+
 
   def tearDown(self):
-    unittest_toolbox.Modified_TestCase.tearDown(self)
+    super().tearDown()
 
 
   def test_tear_down_already_deleted_dir(self):

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -73,8 +73,9 @@ import tuf.keydb
 import tuf.roledb
 import tuf.repository_tool as repo_tool
 import tuf.repository_lib as repo_lib
-import tuf.unittest_toolbox as unittest_toolbox
 import tuf.client.updater as updater
+
+from tuf import unittest_toolbox
 
 from tests import utils
 
@@ -89,11 +90,6 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # Create a temporary directory to store the repository, metadata, and target
-    # files.  'temporary_directory' must be deleted in TearDownModule() so that
-    # temporary files are always removed, even when exceptions occur.
-    cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
-
     # Needed because in some tests simple_server.py cannot be found.
     # The reason is that the current working directory
     # has been changed when executing a subprocess.
@@ -116,15 +112,10 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # Cleans the resources and flush the logged lines (if any).
     cls.server_process_handler.clean()
 
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated for the test cases
-    shutil.rmtree(cls.temporary_directory)
-
 
 
   def setUp(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.setUp(self)
+    super().setUp()
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
@@ -135,7 +126,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # The 'repository_data' directory is expected to exist in 'tuf.tests/'.
     original_repository_files = os.path.join(os.getcwd(), 'repository_data')
     temporary_repository_root = \
-      self.make_temp_directory(directory=self.temporary_directory)
+      self.make_temp_directory(directory=os.getcwd())
 
     # The original repository, keystore, and client directories will be copied
     # for each test case.
@@ -191,8 +182,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
+    super().tearDown()
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
@@ -1782,18 +1772,15 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
 
   def setUp(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.setUp(self)
+    super().setUp()
 
-    self.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
+    self.temporary_repository_root = \
+      self.make_temp_directory(directory=os.getcwd())
 
     # Copy the original repository files provided in the test folder so that
     # any modifications made to repository files are restricted to the copies.
     # The 'repository_data' directory is expected to exist in 'tuf/tests/'.
     original_repository_files = os.path.join(os.getcwd(), 'repository_data')
-
-    self.temporary_repository_root = self.make_temp_directory(directory=
-        self.temporary_directory)
 
     # Needed because in some tests simple_server.py cannot be found.
     # The reason is that the current working directory
@@ -1908,9 +1895,7 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
+    super().tearDown()
 
     # Cleans the resources and flush the logged lines (if any).
     self.server_process_handler.clean()
@@ -1919,10 +1904,6 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     # updater.Updater() populates the roledb with the name "test_repository1"
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
-
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated of all the test cases
-    shutil.rmtree(self.temporary_directory)
 
 
 

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -55,9 +55,10 @@ import tuf.keydb
 import tuf.roledb
 import tuf.exceptions
 import tuf.repository_tool as repo_tool
-import tuf.unittest_toolbox as unittest_toolbox
 import tuf.client.updater as updater
 import tuf.settings
+
+from tuf import unittest_toolbox
 
 from tests import utils
 
@@ -72,11 +73,6 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
   @classmethod
   def setUpClass(cls):
-    # Create a temporary directory to store the repository, metadata, and target
-    # files.  'temporary_directory' must be deleted in TearDownModule() so that
-    # temporary files are always removed, even when exceptions occur.
-    cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
-
     # Launch a SimpleHTTPServer (serves files in the current directory).  Test
     # cases will request metadata and target files that have been pre-generated
     # in 'tuf/tests/repository_data', which will be served by the
@@ -94,16 +90,11 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # Cleans the resources and flush the logged lines (if any).
     cls.server_process_handler.clean()
 
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated for the test cases.
-    shutil.rmtree(cls.temporary_directory)
-
 
 
 
   def setUp(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.setUp(self)
+    super().setUp()
 
     self.repository_name = 'test_repository1'
 
@@ -112,7 +103,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
     # The 'repository_data' directory is expected to exist in 'tuf.tests/'.
     original_repository_files = os.path.join(os.getcwd(), 'repository_data')
     temporary_repository_root = \
-      self.make_temp_directory(directory=self.temporary_directory)
+      self.make_temp_directory(directory=os.getcwd())
 
     # The original repository, keystore, and client directories will be copied
     # for each test case.
@@ -164,8 +155,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
+    super().tearDown()
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,7 +26,7 @@ import unittest
 import socket
 import sys
 
-import tuf.unittest_toolbox as unittest_toolbox
+from tuf import unittest_toolbox
 
 from tests import utils
 


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

In many of the tests classes, we are creating two
temporary directories: one with the name "temp_<random_string>"
and inside it, we generate a new directory for each test with the name
`Test<Class_Name>_<random_string>`.

I think we don't need the "temp_<random_string>" directory.
The only benefit I can think of is that it could contain multiple
temp folders from failing tests from a particular test run.
But even then, this is not a big bonus because the name
`temp_<random_string>` is not really descriptive from which test
run this directory was created.

PS: Thanks to Jussi Kukkonen who noticed we are using two temp
folders per class in our tests.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


