### PR TITLE
Updater: close file object

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -299,7 +299,7 @@ class TestServerProcess():
         break
 
     if len(self.__logged_messages) > 0:
-      title = "Test server (" + self.server + ") output:"
+      title = "Test server (" + self.server + ") output:\n"
       message = [title] + self.__logged_messages
       self.__logger.info('| '.join(message))
       self.__logged_messages = []

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1320,10 +1320,12 @@ class Updater(object):
         return file_object
 
       except Exception as exception:
-        # Remember the error from this mirror, and "reset" the target file.
+        # Remember the error from this mirror, close tempfile if one was opened
         logger.debug('Update failed from ' + file_mirror + '.')
         file_mirror_errors[file_mirror] = exception
-        file_object = None
+        if file_object is not None:
+          file_object.close()
+          file_object = None
 
     logger.debug('Failed to update ' + repr(target_filepath) + ' from'
         ' all mirrors: ' + repr(file_mirror_errors))


### PR DESCRIPTION
Fix a tiny issue in test server output and close a dangling tempfile in Updater. This is the last unclosed fileobject that our tests find so:
Fixes #1123

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


