### PR TITLE
TOX: Install securesystemslib in non-editable mode

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ install_command = pip install --pre {opts} {packages}
 # Must to be invoked explicitly with, e.g. `tox -e with-sslib-master`
 [testenv:with-sslib-master]
 deps =
-    --editable git+http://github.com/secure-systems-lab/securesystemslib.git@master#egg=securesystemslib
+    git+http://github.com/secure-systems-lab/securesystemslib.git@master#egg=securesystemslib
     -r{toxinidir}/requirements-test.txt
     --editable {toxinidir}
 


### PR DESCRIPTION
Fixes #1227 

**Description of the changes being introduced by the pull request**:

Installing securesystemslib in editable mode leads to a problem
in sys.path where we have two "tests" packages.
By not installing securesystemslib in an editable mode we are not
adding the securesystemslib tests to sys.path.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


