### PR TITLE
Add >=Py3.5 constraint for bandit test dependency

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -12,4 +12,4 @@ python-dateutil
 # additional test tools for linting and coverage measurement
 coverage
 pylint
-bandit
+bandit; python_version >= "3.5"


### PR DESCRIPTION

Fixes #<ISSUE NUMBER>

**Description of the changes being introduced by the pull request**:
Bandit just dropped support for Python <3.5. This PR adds a corresponding constraint to requirements-test.txt.

Note, we run bandit in a dedicated 'lint' tox environment, which uses Python3.8 on Travis.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


