### PR TITLE
client: update expiration check to match spec

### DIFF
--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -2266,7 +2266,7 @@ class Updater(object):
     expires_timestamp = tuf.formats.datetime_to_unix_timestamp(expires_datetime)
 
     current_time = int(time.time())
-    if expires_timestamp < current_time:
+    if expires_timestamp <= current_time:
       message = 'Metadata '+repr(metadata_rolename)+' expired on ' + \
         expires_datetime.ctime() + ' (UTC).'
       raise tuf.exceptions.ExpiredMetadataError(message)


### PR DESCRIPTION
Fixes #1231

**Description of the changes being introduced by the pull request**:

The specification, as of 1.0.16, describes an update expiration check as:

> The expiration timestamp in the trusted $ROLE metadata file MUST be
  higher than the fixed update expiration time.

Having done some research into how other security providers are comparing
expiration equivalents (i.e. OpenSSL x509 certificate checking code, and
GnuPG expiration checks), and how other TUF implementations are performing
the same check (rust-tuf, go-tuf), we came to a consensus that the correct
way to implement expiration comparisons is:

    expiration <= now

Where:
  expiration: is the metadata's expiration datetime
  now: is the current system time, or the fixed notion of time in the
       detailed client workflow (introduced in 1.0.16 of the spec)

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


