### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
   include:
     - python: "2.7"
       env: TOXENV=py27
-    - python: "3.5"
-      env: TOXENV=py35
     - python: "3.6"
       env: TOXENV=py36
     - python: "3.7"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,5 @@
 environment:
   matrix:
-    - PYTHON: "C:\\Python39"
-      PYTHON_VERSION: 3.9
-      PYTHON_ARCH: 32
-
     - PYTHON: "C:\\Python38"
       PYTHON_VERSION: 3.8
       PYTHON_ARCH: 32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,9 @@
 environment:
   matrix:
+    - PYTHON: "C:\\Python39"
+      PYTHON_VERSION: 3.9
+      PYTHON_ARCH: 32
+
     - PYTHON: "C:\\Python38"
       PYTHON_VERSION: 3.8
       PYTHON_ARCH: 32
@@ -10,10 +14,6 @@ environment:
 
     - PYTHON: "C:\\Python36"
       PYTHON_VERSION: 3.6
-      PYTHON_ARCH: 32
-
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: 3.5
       PYTHON_ARCH: 32
 
     - PYTHON: "C:\\Python27"

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -1,9 +1,9 @@
-certifi==2020.11.8       # via requests
+certifi==2020.12.5        # via requests
 cffi==1.14.4              # via cryptography, pynacl
 chardet==3.0.4            # via requests
-cryptography==3.2.1         # via securesystemslib
-enum34==1.1.6             ; python_version < '3' # via cryptography
-idna==2.10                 # via requests
+cryptography==3.3.1       # via securesystemslib
+enum34==1.1.10            ; python_version < '3' # via cryptography
+idna==2.10                # via requests
 ipaddress==1.0.23         ; python_version < '3' # via cryptography
 pycparser==2.20           # via cffi
 pynacl==1.4.0             # via securesystemslib

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@
 # 1. Use this script to create a pinned requirements file for each Python
 #    version
 # ```
-# for v in 2.7 3.5 3.6 3.7 3.8; do
+# for v in 2.7 3.6 3.7 3.8 3.9; do
 #   mkvirtualenv tuf-env-${v} -p python${v};
 #   pip install pip-tools;
 #   pip-compile --no-header -o requirements-${v}.txt requirements.txt;

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,6 @@ setup(
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
@@ -113,7 +112,7 @@ setup(
     'Source': 'https://github.com/theupdateframework/tuf',
     'Issues': 'https://github.com/theupdateframework/tuf/issues'
   },
-  python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
+  python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4",
   install_requires = [
     'requests>=2.19.1',
     'six>=1.11.0',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = lint,py{27,35,36,37,38,39}
+envlist = lint,py{27,36,37,38,39}
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

Fixes #<ISSUE NUMBER>

**Description of the changes being introduced by the pull request**:

Python 3.5 has now reached its end-of-life and has been retired:
 https://www.python.org/dev/peps/pep-0478/

The optional (but highly recommended) 'cryptography' dependency  has also just dropped support for 3.5. Continuing support for 3.5  in TUF does not seem worth the effort.

This PR also updates the test configuration accordingly and recomputes the pinned dependencies. 

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


