### PR TITLE
Abstract out the network IO

### DIFF
--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -124,7 +124,7 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://localhost:' \
+    url_prefix = 'http://127.0.0.1:' \
         + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -124,7 +124,7 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://127.0.0.1:' \
+    url_prefix = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
         + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -43,6 +43,7 @@ import warnings
 
 import tuf
 import tuf.download as download
+import tuf.fetcher
 import tuf.log
 import tuf.unittest_toolbox as unittest_toolbox
 import tuf.exceptions
@@ -85,6 +86,10 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     digest = m.hexdigest()
     self.target_hash = {'md5':digest}
 
+    # Initialize the default fetcher for the download
+    self.fetcher = tuf.fetcher.RequestsFetcher()
+
+
 
   # Stop server process and perform clean up.
   def tearDown(self):
@@ -100,7 +105,7 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
   def test_download_url_to_tempfileobj(self):
 
     download_file = download.safe_download
-    with download_file(self.url, self.target_data_length) as temp_fileobj:
+    with download_file(self.url, self.target_data_length, self.fetcher) as temp_fileobj:
       temp_fileobj.seek(0)
       temp_file_data = temp_fileobj.read().decode('utf-8')
       self.assertEqual(self.target_data, temp_file_data)
@@ -118,18 +123,18 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     # the server-reported length of the file does not match the
     # required_length.  'updater.py' *does* verify the hashes of downloaded
     # content.
-    download.safe_download(self.url, self.target_data_length - 4).close()
-    download.unsafe_download(self.url, self.target_data_length - 4).close()
+    download.safe_download(self.url, self.target_data_length - 4, self.fetcher).close()
+    download.unsafe_download(self.url, self.target_data_length - 4, self.fetcher).close()
 
     # We catch 'tuf.exceptions.DownloadLengthMismatchError' for safe_download()
     # because it will not download more bytes than requested (in this case, a
     # length greater than the size of the target file).
     self.assertRaises(tuf.exceptions.DownloadLengthMismatchError,
-        download.safe_download, self.url, self.target_data_length + 1)
+        download.safe_download, self.url, self.target_data_length + 1, self.fetcher)
 
     # Calling unsafe_download() with a mismatched length should not raise an
     # exception.
-    download.unsafe_download(self.url, self.target_data_length + 1).close()
+    download.unsafe_download(self.url, self.target_data_length + 1, self.fetcher).close()
 
 
 
@@ -165,31 +170,29 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     unsafe_download_file = download.unsafe_download
 
     self.assertRaises(securesystemslib.exceptions.FormatError,
-                      download_file, None, self.target_data_length)
-
-    self.assertRaises(tuf.exceptions.URLParsingError,
-                      download_file,
-                      self.random_string(), self.target_data_length)
+                      download_file, None, self.target_data_length, self.fetcher)
 
     url = 'http://localhost:' \
         + str(self.server_process_handler.port) + '/' + self.random_string()
     self.assertRaises(requests.exceptions.HTTPError,
                       download_file,
                       url,
-                      self.target_data_length)
+                      self.target_data_length,
+                      self.fetcher)
     url1 = 'http://localhost:' \
       + str(self.server_process_handler.port + 1) + '/' + self.random_string()
     self.assertRaises(requests.exceptions.ConnectionError,
                       download_file,
                       url1,
-                      self.target_data_length)
+                      self.target_data_length,
+                      self.fetcher)
 
     # Specify an unsupported URI scheme.
     url_with_unsupported_uri = self.url.replace('http', 'file')
     self.assertRaises(requests.exceptions.InvalidSchema, download_file, url_with_unsupported_uri,
-                      self.target_data_length)
+                      self.target_data_length, self.fetcher)
     self.assertRaises(requests.exceptions.InvalidSchema, unsafe_download_file,
-                      url_with_unsupported_uri, self.target_data_length)
+                      url_with_unsupported_uri, self.target_data_length, self.fetcher)
 
 
 
@@ -290,7 +293,7 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
       os.environ['REQUESTS_CA_BUNDLE'] = bad_cert_fname
       # Clear sessions to ensure that the certificate we just specified is used.
       # TODO: Confirm necessity of this session clearing and lay out mechanics.
-      tuf.download._sessions = {}
+      self.fetcher._sessions = {}
 
       # Try connecting to the server process with the bad cert while trusting
       # the bad cert. Expect failure because even though we trust it, the
@@ -302,9 +305,9 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
             category=urllib3.exceptions.SubjectAltNameWarning)
 
         with self.assertRaises(requests.exceptions.SSLError):
-          download.safe_download(bad_https_url, target_data_length)
+          download.safe_download(bad_https_url, target_data_length, self.fetcher)
         with self.assertRaises(requests.exceptions.SSLError):
-          download.unsafe_download(bad_https_url, target_data_length)
+          download.unsafe_download(bad_https_url, target_data_length, self.fetcher)
 
         # Try connecting to the server processes with the good certs while not
         # trusting the good certs (trusting the bad cert instead). Expect failure
@@ -312,31 +315,31 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
         # trust it.
         logger.info('Trying HTTPS download of target file: ' + good_https_url)
         with self.assertRaises(requests.exceptions.SSLError):
-          download.safe_download(good_https_url, target_data_length)
+          download.safe_download(good_https_url, target_data_length, self.fetcher)
         with self.assertRaises(requests.exceptions.SSLError):
-          download.unsafe_download(good_https_url, target_data_length)
+          download.unsafe_download(good_https_url, target_data_length, self.fetcher)
 
         logger.info('Trying HTTPS download of target file: ' + good2_https_url)
         with self.assertRaises(requests.exceptions.SSLError):
-          download.safe_download(good2_https_url, target_data_length)
+          download.safe_download(good2_https_url, target_data_length, self.fetcher)
         with self.assertRaises(requests.exceptions.SSLError):
-          download.unsafe_download(good2_https_url, target_data_length)
+          download.unsafe_download(good2_https_url, target_data_length, self.fetcher)
 
 
         # Configure environment to now trust the certfile that is expired.
         os.environ['REQUESTS_CA_BUNDLE'] = expired_cert_fname
         # Clear sessions to ensure that the certificate we just specified is used.
         # TODO: Confirm necessity of this session clearing and lay out mechanics.
-        tuf.download._sessions = {}
+        self.fetcher._sessions = {}
 
         # Try connecting to the server process with the expired cert while
         # trusting the expired cert. Expect failure because even though we trust
         # it, it is expired.
         logger.info('Trying HTTPS download of target file: ' + expired_https_url)
         with self.assertRaises(requests.exceptions.SSLError):
-          download.safe_download(expired_https_url, target_data_length)
+          download.safe_download(expired_https_url, target_data_length, self.fetcher)
         with self.assertRaises(requests.exceptions.SSLError):
-          download.unsafe_download(expired_https_url, target_data_length)
+          download.unsafe_download(expired_https_url, target_data_length, self.fetcher)
 
 
         # Try connecting to the server processes with the good certs while
@@ -346,18 +349,18 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
         os.environ['REQUESTS_CA_BUNDLE'] = good_cert_fname
         # Clear sessions to ensure that the certificate we just specified is used.
         # TODO: Confirm necessity of this session clearing and lay out mechanics.
-        tuf.download._sessions = {}
+        self.fetcher._sessions = {}
         logger.info('Trying HTTPS download of target file: ' + good_https_url)
-        download.safe_download(good_https_url, target_data_length).close()
-        download.unsafe_download(good_https_url, target_data_length).close()
+        download.safe_download(good_https_url, target_data_length, self.fetcher).close()
+        download.unsafe_download(good_https_url, target_data_length,self.fetcher).close()
 
         os.environ['REQUESTS_CA_BUNDLE'] = good2_cert_fname
         # Clear sessions to ensure that the certificate we just specified is used.
         # TODO: Confirm necessity of this session clearing and lay out mechanics.
-        tuf.download._sessions = {}
+        self.fetcher._sessions = {}
         logger.info('Trying HTTPS download of target file: ' + good2_https_url)
-        download.safe_download(good2_https_url, target_data_length).close()
-        download.unsafe_download(good2_https_url, target_data_length).close()
+        download.safe_download(good2_https_url, target_data_length, self.fetcher).close()
+        download.unsafe_download(good2_https_url, target_data_length, self.fetcher).close()
 
     finally:
       for proc_handler in [

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -43,7 +43,7 @@ import warnings
 
 import tuf
 import tuf.download as download
-import tuf.fetcher
+import tuf.requests_fetcher
 import tuf.log
 import tuf.unittest_toolbox as unittest_toolbox
 import tuf.exceptions
@@ -87,7 +87,7 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     self.target_hash = {'md5':digest}
 
     # Initialize the default fetcher for the download
-    self.fetcher = tuf.fetcher.RequestsFetcher()
+    self.fetcher = tuf.requests_fetcher.RequestsFetcher()
 
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -112,6 +112,29 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
       self.assertEqual(self.target_data_length, len(temp_file_data))
 
 
+  # Test: Download url in more than one chunk.
+  def test_download_url_in_chunks(self):
+
+    # Set smaller chunk size to ensure that the file will be downloaded
+    # in more than one chunk
+    default_chunk_size = tuf.settings.CHUNK_SIZE
+    tuf.settings.CHUNK_SIZE = 4
+    # We don't have access to chunks from  download_file()
+    # so we just confirm that the expectation of more than one chunk is
+    # correct and verify that no errors are raised during download
+    chunks_count = self.target_data_length/tuf.settings.CHUNK_SIZE
+    self.assertGreater(chunks_count, 1)
+
+    download_file = download.safe_download
+    with download_file(self.url, self.target_data_length, self.fetcher) as temp_fileobj:
+      temp_fileobj.seek(0)
+      temp_file_data = temp_fileobj.read().decode('utf-8')
+      self.assertEqual(self.target_data, temp_file_data)
+      self.assertEqual(self.target_data_length, len(temp_file_data))
+
+    # Restore default settings
+    tuf.settings.CHUNK_SIZE = default_chunk_size
+
 
   # Test: Incorrect lengths.
   def test_download_url_to_tempfileobj_and_lengths(self):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -77,7 +77,7 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     self.server_process_handler = utils.TestServerProcess(log=logger)
 
     rel_target_filepath = os.path.basename(target_filepath)
-    self.url = 'http://localhost:' \
+    self.url = 'http://127.0.0.1:' \
         + str(self.server_process_handler.port) + '/' + rel_target_filepath
 
     # Computing hash of target file data.
@@ -172,14 +172,14 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     self.assertRaises(securesystemslib.exceptions.FormatError,
                       download_file, None, self.target_data_length, self.fetcher)
 
-    url = 'http://localhost:' \
+    url = 'http://127.0.0.1:' \
         + str(self.server_process_handler.port) + '/' + self.random_string()
     self.assertRaises(requests.exceptions.HTTPError,
                       download_file,
                       url,
                       self.target_data_length,
                       self.fetcher)
-    url1 = 'http://localhost:' \
+    url1 = 'http://127.0.0.1:' \
       + str(self.server_process_handler.port + 1) + '/' + self.random_string()
     self.assertRaises(requests.exceptions.ConnectionError,
                       download_file,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -192,23 +192,19 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     download_file = download.safe_download
     unsafe_download_file = download.unsafe_download
 
-    self.assertRaises(securesystemslib.exceptions.FormatError,
-                      download_file, None, self.target_data_length, self.fetcher)
+    with self.assertRaises(securesystemslib.exceptions.FormatError):
+      download_file(None, self.target_data_length, self.fetcher)
 
     url = 'http://127.0.0.1:' \
         + str(self.server_process_handler.port) + '/' + self.random_string()
-    self.assertRaises(requests.exceptions.HTTPError,
-                      download_file,
-                      url,
-                      self.target_data_length,
-                      self.fetcher)
+    with self.assertRaises(tuf.exceptions.FetcherHTTPError) as cm:
+      download_file(url, self.target_data_length, self.fetcher)
+    self.assertEqual(cm.exception.status_code, 404)
+
     url1 = 'http://127.0.0.1:' \
       + str(self.server_process_handler.port + 1) + '/' + self.random_string()
-    self.assertRaises(requests.exceptions.ConnectionError,
-                      download_file,
-                      url1,
-                      self.target_data_length,
-                      self.fetcher)
+    with self.assertRaises(requests.exceptions.ConnectionError):
+      download_file(url1, self.target_data_length, self.fetcher)
 
     # Specify an unsupported URI scheme.
     url_with_unsupported_uri = self.url.replace('http', 'file')

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -77,7 +77,7 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     self.server_process_handler = utils.TestServerProcess(log=logger)
 
     rel_target_filepath = os.path.basename(target_filepath)
-    self.url = 'http://127.0.0.1:' \
+    self.url = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
         + str(self.server_process_handler.port) + '/' + rel_target_filepath
 
     # Computing hash of target file data.
@@ -195,13 +195,13 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
     with self.assertRaises(securesystemslib.exceptions.FormatError):
       download_file(None, self.target_data_length, self.fetcher)
 
-    url = 'http://127.0.0.1:' \
+    url = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
         + str(self.server_process_handler.port) + '/' + self.random_string()
     with self.assertRaises(tuf.exceptions.FetcherHTTPError) as cm:
       download_file(url, self.target_data_length, self.fetcher)
     self.assertEqual(cm.exception.status_code, 404)
 
-    url1 = 'http://127.0.0.1:' \
+    url1 = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
       + str(self.server_process_handler.port + 1) + '/' + self.random_string()
     with self.assertRaises(requests.exceptions.ConnectionError):
       download_file(url1, self.target_data_length, self.fetcher)

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -126,7 +126,7 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://localhost:' \
+    url_prefix = 'http://127.0.0.1:' \
         + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -126,7 +126,7 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://127.0.0.1:' \
+    url_prefix = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
         + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -133,7 +133,7 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://localhost:' \
+    url_prefix = 'http://127.0.0.1:' \
         + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -133,7 +133,7 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://127.0.0.1:' \
+    url_prefix = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
         + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -55,7 +55,7 @@ class TestFetcher(unittest_toolbox.Modified_TestCase):
     self.server_process_handler = utils.TestServerProcess(log=logger)
 
     rel_target_filepath = os.path.basename(target_filepath)
-    self.url = 'http://localhost:' \
+    self.url = 'http://127.0.0.1:' \
         + str(self.server_process_handler.port) + '/' + rel_target_filepath
 
     # Create a temporary file where the target file chunks are written

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -58,7 +58,7 @@ class TestFetcher(unittest_toolbox.Modified_TestCase):
     self.server_process_handler = utils.TestServerProcess(log=logger)
 
     rel_target_filepath = os.path.basename(target_filepath)
-    self.url = 'http://127.0.0.1:' \
+    self.url = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
         + str(self.server_process_handler.port) + '/' + rel_target_filepath
 
     # Create a temporary file where the target file chunks are written

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -30,7 +30,7 @@ import math
 
 import tuf
 import tuf.exceptions
-import tuf.fetcher
+import tuf.requests_fetcher
 import tuf.unittest_toolbox as unittest_toolbox
 
 from tests import utils
@@ -64,7 +64,7 @@ class TestFetcher(unittest_toolbox.Modified_TestCase):
     # Create a temporary file where the target file chunks are written
     # during fetching
     self.temp_file = tempfile.TemporaryFile()
-    self.fetcher = tuf.fetcher.RequestsFetcher()
+    self.fetcher = tuf.requests_fetcher.RequestsFetcher()
 
 
   # Stop server process and perform clean up.

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+
+"""
+<Program>
+  test_download.py
+
+<Author>
+  Teodora Sechkova tsechkova@vmware.com
+
+<Started>
+  December 18, 2020.
+
+<Copyright>
+  See LICENSE-MIT OR LICENSE for licensing information.
+
+<Purpose>
+  Unit test for RequestsFetcher.
+"""
+
+import logging
+import os
+import io
+import sys
+import unittest
+import tempfile
+
+import tuf
+import tuf.exceptions
+import tuf.fetcher
+import tuf.unittest_toolbox as unittest_toolbox
+
+from tests import utils
+
+
+logger = logging.getLogger(__name__)
+
+
+class TestFetcher(unittest_toolbox.Modified_TestCase):
+  def setUp(self):
+    """
+    Create a temporary file and launch a simple server in the
+    current working directory.
+    """
+
+    unittest_toolbox.Modified_TestCase.setUp(self)
+
+    # Making a temporary file.
+    current_dir = os.getcwd()
+    target_filepath = self.make_temp_data_file(directory=current_dir)
+    self.target_fileobj = open(target_filepath, 'r')
+    self.file_contents = self.target_fileobj.read()
+    self.file_length = len(self.file_contents)
+
+    # Launch a SimpleHTTPServer (serves files in the current dir).
+    self.server_process_handler = utils.TestServerProcess(log=logger)
+
+    rel_target_filepath = os.path.basename(target_filepath)
+    self.url = 'http://localhost:' \
+        + str(self.server_process_handler.port) + '/' + rel_target_filepath
+
+    # Create a temporary file where the target file chunks are written
+    # during fetching
+    self.temp_file = tempfile.TemporaryFile()
+    self.fetcher = tuf.fetcher.RequestsFetcher()
+
+
+  # Stop server process and perform clean up.
+  def tearDown(self):
+    unittest_toolbox.Modified_TestCase.tearDown(self)
+
+    # Cleans the resources and flush the logged lines (if any).
+    self.server_process_handler.clean()
+
+    self.target_fileobj.close()
+    self.temp_file.close()
+
+
+  # Test: Normal case.
+  def test_fetch(self):
+
+    for chunk in self.fetcher.fetch(self.url, self.file_length):
+        self.temp_file.write(chunk)
+
+    self.temp_file.seek(0)
+    temp_file_data = self.temp_file.read().decode('utf-8')
+    self.assertEqual(self.file_contents, temp_file_data)
+    self.assertEqual(self.file_length, len(temp_file_data))
+
+
+  # Test if fetcher downloads file up to a required length
+  def test_fetch_restricted_length(self):
+    for chunk in self.fetcher.fetch(self.url, self.file_length-4):
+        self.temp_file.write(chunk)
+
+    self.temp_file.seek(0, io.SEEK_END)
+    self.assertEqual(self.temp_file.tell(), self.file_length-4)
+
+
+  # Test if fetcher does not downlad more than actual file length
+  def test_fetch_upper_length(self):
+    for chunk in self.fetcher.fetch(self.url, self.file_length+4):
+        self.temp_file.write(chunk)
+
+    self.temp_file.seek(0, io.SEEK_END)
+    self.assertEqual(self.temp_file.tell(), self.file_length)
+
+
+  # Test incorrect URL parsing
+  def test_url_parsing(self):
+   with self.assertRaises(tuf.exceptions.URLParsingError) as cm:
+     for chunk in self.fetcher.fetch(self.random_string(), self.file_length):
+         self.temp_file.write(chunk)
+
+
+
+# Run unit test.
+if __name__ == '__main__':
+  utils.configure_test_logging(sys.argv)
+  unittest.main()

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,20 +1,9 @@
 #!/usr/bin/env python
 
-"""
-<Program>
-  test_download.py
+# Copyright 2021, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
 
-<Author>
-  Teodora Sechkova tsechkova@vmware.com
-
-<Started>
-  December 18, 2020.
-
-<Copyright>
-  See LICENSE-MIT OR LICENSE for licensing information.
-
-<Purpose>
-  Unit test for RequestsFetcher.
+"""Unit test for RequestsFetcher.
 """
 # Help with Python 2 compatibility, where the '/' operator performs
 # integer division.

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -146,7 +146,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://localhost:' \
+    url_prefix = 'http://127.0.0.1:' \
         + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -146,7 +146,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://127.0.0.1:' \
+    url_prefix = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
         + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -132,7 +132,7 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
 
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://localhost:' \
+    url_prefix = 'http://127.0.0.1:' \
       + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -132,7 +132,7 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
 
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://127.0.0.1:' \
+    url_prefix = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
       + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -132,7 +132,7 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://localhost:' \
+    url_prefix = 'http://127.0.0.1:' \
       + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -132,7 +132,7 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://127.0.0.1:' \
+    url_prefix = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
       + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -136,8 +136,8 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
 
     logger.debug('Server process 2 started.')
 
-    url_prefix = 'http://localhost:' + str(self.server_process_handler.port)
-    url_prefix2 = 'http://localhost:' + str(self.server_process_handler2.port)
+    url_prefix = 'http://127.0.0.1:' + str(self.server_process_handler.port)
+    url_prefix2 = 'http://127.0.0.1:' + str(self.server_process_handler2.port)
 
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
                                            'metadata_path': 'metadata',

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -136,8 +136,12 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
 
     logger.debug('Server process 2 started.')
 
-    url_prefix = 'http://127.0.0.1:' + str(self.server_process_handler.port)
-    url_prefix2 = 'http://127.0.0.1:' + str(self.server_process_handler2.port)
+    url_prefix = \
+        'http://' + utils.TEST_HOST_ADDRESS + ':' + \
+        str(self.server_process_handler.port)
+    url_prefix2 = \
+        'http://' + utils.TEST_HOST_ADDRESS + ':' + \
+        str(self.server_process_handler2.port)
 
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
                                            'metadata_path': 'metadata',

--- a/tests/test_proxy_use.py
+++ b/tests/test_proxy_use.py
@@ -121,6 +121,9 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
     # the type of connection used with the target server.
     cls.https_proxy_addr = 'https://localhost:' + str(cls.https_proxy_handler.port)
 
+    # Initialize the default fetcher for the download
+    self.fetcher = tuf.fetcher.RequestsFetcher()
+
 
 
   @classmethod
@@ -202,8 +205,8 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
     """
 
     logger.info('Trying HTTP download with no proxy: ' + self.url)
-    download.safe_download(self.url, self.target_data_length)
-    download.unsafe_download(self.url, self.target_data_length)
+    download.safe_download(self.url, self.target_data_length, self.fetcher)
+    download.unsafe_download(self.url, self.target_data_length, self.fetcher)
 
 
 
@@ -218,8 +221,8 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
     self.set_env_value('HTTP_PROXY', self.http_proxy_addr)
 
     logger.info('Trying HTTP download via HTTP proxy: ' + self.url)
-    download.safe_download(self.url, self.target_data_length)
-    download.unsafe_download(self.url, self.target_data_length)
+    download.safe_download(self.url, self.target_data_length, self.fetcher)
+    download.unsafe_download(self.url, self.target_data_length, self.fetcher)
 
 
 
@@ -243,11 +246,11 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
         os.path.join('ssl_certs', 'ssl_cert.crt'))
     # Clear sessions to ensure that the certificate we just specified is used.
     # TODO: Confirm necessity of this session clearing and lay out mechanics.
-    tuf.download._sessions = {}
+    self.fetcher._sessions = {}
 
     logger.info('Trying HTTPS download via HTTP proxy: ' + self.url_https)
-    download.safe_download(self.url_https, self.target_data_length)
-    download.unsafe_download(self.url_https, self.target_data_length)
+    download.safe_download(self.url_https, self.target_data_length, self.fetcher)
+    download.unsafe_download(self.url_https, self.target_data_length, self.fetcher)
 
 
 
@@ -267,11 +270,11 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
         os.path.join('ssl_certs', 'proxy_ca.crt'))
     # Clear sessions to ensure that the certificate we just specified is used.
     # TODO: Confirm necessity of this session clearing and lay out mechanics.
-    tuf.download._sessions = {}
+    self.fetcher._sessions = {}
 
     logger.info('Trying HTTP download via HTTPS proxy: ' + self.url_https)
-    download.safe_download(self.url, self.target_data_length)
-    download.unsafe_download(self.url, self.target_data_length)
+    download.safe_download(self.url, self.target_data_length, self.fetcher)
+    download.unsafe_download(self.url, self.target_data_length, self.fetcher)
 
 
 
@@ -293,11 +296,11 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
         os.path.join('ssl_certs', 'proxy_ca.crt'))
     # Clear sessions to ensure that the certificate we just specified is used.
     # TODO: Confirm necessity of this session clearing and lay out mechanics.
-    tuf.download._sessions = {}
+    self.fetcher._sessions = {}
 
     logger.info('Trying HTTPS download via HTTPS proxy: ' + self.url_https)
-    download.safe_download(self.url_https, self.target_data_length)
-    download.unsafe_download(self.url_https, self.target_data_length)
+    download.safe_download(self.url_https, self.target_data_length, self.fetcher)
+    download.unsafe_download(self.url_https, self.target_data_length, self.fetcher)
 
 
 

--- a/tests/test_proxy_use.py
+++ b/tests/test_proxy_use.py
@@ -167,10 +167,10 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
 
     suffix = '/' + os.path.basename(target_filepath)
     self.url = \
-        'http://localhost:' + str(self.http_server_handler.port) + suffix
+        'http://127.0.0.1:' + str(self.http_server_handler.port) + suffix
 
     self.url_https = \
-        'https://localhost:' + str(self.https_server_handler.port) + suffix
+        'https://127.0.0.1:' + str(self.https_server_handler.port) + suffix
 
 
 

--- a/tests/test_proxy_use.py
+++ b/tests/test_proxy_use.py
@@ -205,8 +205,8 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
     """
 
     logger.info('Trying HTTP download with no proxy: ' + self.url)
-    download.safe_download(self.url, self.target_data_length, self.fetcher)
-    download.unsafe_download(self.url, self.target_data_length, self.fetcher)
+    download.safe_download(self.url, self.target_data_length, self.fetcher).close()
+    download.unsafe_download(self.url, self.target_data_length, self.fetcher).close()
 
 
 
@@ -221,8 +221,8 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
     self.set_env_value('HTTP_PROXY', self.http_proxy_addr)
 
     logger.info('Trying HTTP download via HTTP proxy: ' + self.url)
-    download.safe_download(self.url, self.target_data_length, self.fetcher)
-    download.unsafe_download(self.url, self.target_data_length, self.fetcher)
+    download.safe_download(self.url, self.target_data_length, self.fetcher).close()
+    download.unsafe_download(self.url, self.target_data_length, self.fetcher).close()
 
 
 
@@ -249,8 +249,8 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
     self.fetcher._sessions = {}
 
     logger.info('Trying HTTPS download via HTTP proxy: ' + self.url_https)
-    download.safe_download(self.url_https, self.target_data_length, self.fetcher)
-    download.unsafe_download(self.url_https, self.target_data_length, self.fetcher)
+    download.safe_download(self.url_https, self.target_data_length, self.fetcher).close()
+    download.unsafe_download(self.url_https, self.target_data_length, self.fetcher).close()
 
 
 
@@ -273,8 +273,8 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
     self.fetcher._sessions = {}
 
     logger.info('Trying HTTP download via HTTPS proxy: ' + self.url_https)
-    download.safe_download(self.url, self.target_data_length, self.fetcher)
-    download.unsafe_download(self.url, self.target_data_length, self.fetcher)
+    download.safe_download(self.url, self.target_data_length, self.fetcher).close()
+    download.unsafe_download(self.url, self.target_data_length, self.fetcher).close()
 
 
 
@@ -299,8 +299,8 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
     self.fetcher._sessions = {}
 
     logger.info('Trying HTTPS download via HTTPS proxy: ' + self.url_https)
-    download.safe_download(self.url_https, self.target_data_length, self.fetcher)
-    download.unsafe_download(self.url_https, self.target_data_length, self.fetcher)
+    download.safe_download(self.url_https, self.target_data_length, self.fetcher).close()
+    download.unsafe_download(self.url_https, self.target_data_length, self.fetcher).close()
 
 
 

--- a/tests/test_proxy_use.py
+++ b/tests/test_proxy_use.py
@@ -97,7 +97,8 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
 
     # Note that the HTTP proxy server's address uses http://, regardless of the
     # type of connection used with the target server.
-    cls.http_proxy_addr = 'http://127.0.0.1:' + str(cls.http_proxy_handler.port)
+    cls.http_proxy_addr = 'http://' + utils.TEST_HOST_ADDRESS + ':' + \
+        str(cls.http_proxy_handler.port)
 
 
     # Launch an HTTPS proxy server, also derived from inaz2/proxy2.
@@ -167,10 +168,12 @@ class TestWithProxies(unittest_toolbox.Modified_TestCase):
 
     suffix = '/' + os.path.basename(target_filepath)
     self.url = \
-        'http://127.0.0.1:' + str(self.http_server_handler.port) + suffix
+        'http://' + utils.TEST_HOST_ADDRESS + ':' + \
+        str(self.http_server_handler.port) + suffix
 
     self.url_https = \
-        'https://127.0.0.1:' + str(self.https_server_handler.port) + suffix
+        'https://' + utils.TEST_HOST_ADDRESS + ':' + \
+         str(self.https_server_handler.port) + suffix
 
 
 

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -132,7 +132,7 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://localhost:' \
+    url_prefix = 'http://127.0.0.1:' \
       + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -132,7 +132,7 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
     # Set the url prefix required by the 'tuf/client/updater.py' updater.
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://127.0.0.1:' \
+    url_prefix = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
       + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -171,7 +171,7 @@ class TestSlowRetrieval(unittest_toolbox.Modified_TestCase):
 
     logger.info('Slow Retrieval Server process started.')
 
-    url_prefix = 'http://localhost:' \
+    url_prefix = 'http://127.0.0.1:' \
       + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -171,7 +171,7 @@ class TestSlowRetrieval(unittest_toolbox.Modified_TestCase):
 
     logger.info('Slow Retrieval Server process started.')
 
-    url_prefix = 'http://127.0.0.1:' \
+    url_prefix = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
       + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -167,7 +167,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://localhost:' \
+    url_prefix = 'http://127.0.0.1:' \
         + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client
@@ -1110,7 +1110,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://localhost:' \
+    url_prefix = 'http://127.0.0.1:' \
         + str(self.server_process_handler.port) + repository_basepath
 
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
@@ -1406,7 +1406,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://localhost:' \
+    url_prefix = 'http://127.0.0.1:' \
         + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client
@@ -1533,7 +1533,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://localhost:' \
+    url_prefix = 'http://127.0.0.1:' \
         + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client
@@ -1861,8 +1861,8 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
 
     logger.debug('Server process 2 started.')
 
-    url_prefix = 'http://localhost:' + str(self.server_process_handler.port)
-    url_prefix2 = 'http://localhost:' + str(self.server_process_handler2.port)
+    url_prefix = 'http://127.0.0.1:' + str(self.server_process_handler.port)
+    url_prefix2 = 'http://127.0.0.1:' + str(self.server_process_handler2.port)
 
     # We have all of the necessary information for two repository mirrors
     # in map.json, except for url prefixes.

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -167,7 +167,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://127.0.0.1:' \
+    url_prefix = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
         + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client
@@ -1110,7 +1110,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://127.0.0.1:' \
+    url_prefix = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
         + str(self.server_process_handler.port) + repository_basepath
 
     self.repository_mirrors = {'mirror1': {'url_prefix': url_prefix,
@@ -1406,7 +1406,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://127.0.0.1:' \
+    url_prefix = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
         + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client
@@ -1533,7 +1533,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://127.0.0.1:' \
+    url_prefix = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
         + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client
@@ -1861,8 +1861,12 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
 
     logger.debug('Server process 2 started.')
 
-    url_prefix = 'http://127.0.0.1:' + str(self.server_process_handler.port)
-    url_prefix2 = 'http://127.0.0.1:' + str(self.server_process_handler2.port)
+    url_prefix = \
+        'http://' + utils.TEST_HOST_ADDRESS + ':' + \
+        str(self.server_process_handler.port)
+    url_prefix2 = \
+        'http://' + utils.TEST_HOST_ADDRESS + ':' + \
+        str(self.server_process_handler2.port)
 
     # We have all of the necessary information for two repository mirrors
     # in map.json, except for url prefixes.

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -140,7 +140,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://localhost:' \
+    url_prefix = 'http://127.0.0.1:' \
         + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -140,7 +140,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     # 'path/to/tmp/repository' -> 'localhost:8001/tmp/repository'.
     repository_basepath = self.repository_directory[len(os.getcwd()):]
-    url_prefix = 'http://127.0.0.1:' \
+    url_prefix = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
         + str(self.server_process_handler.port) + repository_basepath
 
     # Setting 'tuf.settings.repository_directory' with the temporary client

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -39,6 +39,9 @@ import tuf.log
 
 logger = logging.getLogger(__name__)
 
+# Used when forming URLs on the client side
+TEST_HOST_ADDRESS = '127.0.0.1'
+
 try:
   # is defined in Python 3
   TimeoutError

--- a/tuf/client/fetcher.py
+++ b/tuf/client/fetcher.py
@@ -1,0 +1,53 @@
+"""
+<Program Name>
+  fetcher.py
+
+<Author>
+  Teodora Sechkova <tsechkova@vmware.com>
+
+<Started>
+  December 14, 2020
+
+<Copyright>
+  See LICENSE-MIT OR LICENSE for licensing information.
+
+<Purpose>
+  Provides an interface for network IO abstraction.
+"""
+
+import abc
+
+
+class FetcherInterface():
+  """
+  <Purpose>
+  Defines an interface for abstract network download which can be implemented
+  for a variety of network libraries and configurations.
+  """
+  __metaclass__ = abc.ABCMeta
+
+
+  @abc.abstractmethod
+  def fetch(self, url, required_length):
+    """
+    <Purpose>
+      Fetches the contents of HTTP/HTTPS url from a remote server up to
+      required_length and returns a bytes iterator.
+
+    <Arguments>
+      url:
+        A URL string that represents the location of the file.
+
+      required_length:
+        An integer value representing the length of the file in bytes.
+
+    <Exceptions>
+      tuf.exceptions.SlowRetrievalError, if a timeout occurs while receiving
+      data from a server
+
+      tuf.exceptions.FetcherHTTPError, if an HTTP error code was received
+    <Returns>
+      A bytes iterator
+    """
+    raise NotImplementedError # pragma: no cover
+

--- a/tuf/client/fetcher.py
+++ b/tuf/client/fetcher.py
@@ -1,53 +1,38 @@
-"""
-<Program Name>
-  fetcher.py
+# Copyright 2021, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
 
-<Author>
-  Teodora Sechkova <tsechkova@vmware.com>
-
-<Started>
-  December 14, 2020
-
-<Copyright>
-  See LICENSE-MIT OR LICENSE for licensing information.
-
-<Purpose>
-  Provides an interface for network IO abstraction.
+"""Provides an interface for network IO abstraction.
 """
 
+# Imports
 import abc
 
-
+# Classes
 class FetcherInterface():
-  """
-  <Purpose>
-  Defines an interface for abstract network download which can be implemented
-  for a variety of network libraries and configurations.
-  """
-  __metaclass__ = abc.ABCMeta
+  """Defines an interface for abstract network download.
 
+  By providing a concrete implementation of the abstract interface,
+  users of the framework can plug-in their preferred/customized
+  network stack.
+  """
+
+  __metaclass__ = abc.ABCMeta
 
   @abc.abstractmethod
   def fetch(self, url, required_length):
-    """
-    <Purpose>
-      Fetches the contents of HTTP/HTTPS url from a remote server up to
-      required_length and returns a bytes iterator.
+    """Fetches the contents of HTTP/HTTPS url from a remote server.
 
-    <Arguments>
-      url:
-        A URL string that represents the location of the file.
+    Ensures the length of the downloaded data is up to 'required_length'.
 
-      required_length:
-        An integer value representing the length of the file in bytes.
+    Arguments:
+      url: A URL string that represents a file location.
+      required_length: An integer value representing the file length in bytes.
 
-    <Exceptions>
-      tuf.exceptions.SlowRetrievalError, if a timeout occurs while receiving
-      data from a server
+    Raises:
+      tuf.exceptions.SlowRetrievalError: A timeout occurs while receiving data.
+      tuf.exceptions.FetcherHTTPError: An HTTP error code is received.
 
-      tuf.exceptions.FetcherHTTPError, if an HTTP error code was received
-    <Returns>
+    Returns:
       A bytes iterator
     """
     raise NotImplementedError # pragma: no cover
-

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -146,7 +146,6 @@ import securesystemslib.hash
 import securesystemslib.keys
 import securesystemslib.util
 import six
-import requests.exceptions
 
 # The Timestamp role does not have signed metadata about it; otherwise we
 # would need an infinite regress of metadata. Therefore, we use some
@@ -1125,8 +1124,8 @@ class Updater(object):
     """
 
     def neither_403_nor_404(mirror_error):
-      if isinstance(mirror_error, requests.exceptions.HTTPError):
-        if mirror_error.response.status_code in {403, 404}:
+      if isinstance(mirror_error, tuf.exceptions.FetcherHTTPError):
+        if mirror_error.status_code in {403, 404}:
           return False
       return True
 

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -131,7 +131,7 @@ import warnings
 
 import tuf
 import tuf.download
-import tuf.fetcher
+import tuf.requests_fetcher
 import tuf.formats
 import tuf.settings
 import tuf.keydb
@@ -696,7 +696,7 @@ class Updater(object):
     # Initialize Updater with an externally provided 'fetcher' implementing
     # the network download. By default tuf.fetcher.RequestsFetcher is used.
     if fetcher is None:
-      self.fetcher = tuf.fetcher.RequestsFetcher()
+      self.fetcher = tuf.requests_fetcher.RequestsFetcher()
     else:
       self.fetcher = fetcher
 

--- a/tuf/download.py
+++ b/tuf/download.py
@@ -40,7 +40,6 @@ import securesystemslib.util
 import six
 
 import tuf
-import tuf.fetcher
 import tuf.exceptions
 import tuf.formats
 

--- a/tuf/download.py
+++ b/tuf/download.py
@@ -192,32 +192,32 @@ def _download_file(url, required_length, fetcher, STRICT_REQUIRED_LENGTH=True):
   # This is the temporary file that we will return to contain the contents of
   # the downloaded file.
   temp_file = tempfile.TemporaryFile()
-  start_time = timeit.default_timer()
 
   average_download_speed = 0
   number_of_bytes_received = 0
 
   try:
-
-    for chunk in fetcher.fetch(url, required_length):
+    chunks = fetcher.fetch(url, required_length)
+    start_time = timeit.default_timer()
+    for chunk in chunks:
 
       stop_time = timeit.default_timer()
-      seconds_spent_receiving = stop_time - start_time
+      temp_file.write(chunk)
+
       # Measure the average download speed.
       number_of_bytes_received += len(chunk)
+      seconds_spent_receiving = stop_time - start_time
       average_download_speed = number_of_bytes_received / seconds_spent_receiving
 
       if average_download_speed < tuf.settings.MIN_AVERAGE_DOWNLOAD_SPEED:
         logger.debug('The average download speed dropped below the minimum'
-          ' average download speed set in tuf.settings.py.')
+          ' average download speed set in tuf.settings.py. Stopping the'
+          ' download!')
         break
 
       else:
         logger.debug('The average download speed has not dipped below the'
           ' minimum average download speed set in tuf.settings.py.')
-
-
-      temp_file.write(chunk)
 
     # Does the total number of downloaded bytes match the required length?
     _check_downloaded_length(number_of_bytes_received, required_length,

--- a/tuf/exceptions.py
+++ b/tuf/exceptions.py
@@ -335,3 +335,14 @@ class URLParsingError(Error):
 class InvalidConfigurationError(Error):
   """If a configuration object does not match the expected format."""
 
+class FetcherHTTPError(Exception):
+  """
+  Returned by FetcherInterface implementations for HTTP errors.
+
+  Args:
+    message (str): The HTTP error messsage
+    status_code (int): The HTTP status code
+  """
+  def __init__(self, message, status_code):
+    super(FetcherHTTPError, self).__init__(message)
+    self.status_code = status_code

--- a/tuf/fetcher.py
+++ b/tuf/fetcher.py
@@ -16,6 +16,16 @@
 """
 
 import abc
+import requests
+import six
+import logging
+import time
+
+import urllib3.exceptions
+import tuf.exceptions
+import tuf.settings
+
+logger = logging.getLogger(__name__)
 
 
 class FetcherInterface():
@@ -49,3 +59,126 @@ class FetcherInterface():
       A bytes iterator
     """
     raise NotImplementedError # pragma: no cover
+
+
+
+class RequestsFetcher(FetcherInterface):
+  """
+  <Purpose>
+    A concrete implementation of FetcherInterface based on the Requests
+    library.
+  """
+
+  def __init__(self):
+    # From http://docs.python-requests.org/en/master/user/advanced/#session-objects:
+    #
+    # "The Session object allows you to persist certain parameters across requests.
+    # It also persists cookies across all requests made from the Session instance,
+    # and will use urllib3's connection pooling. So if you're making several
+    # requests to the same host, the underlying TCP connection will be reused,
+    # which can result in a significant performance increase (see HTTP persistent
+    # connection)."
+    #
+    # NOTE: We use a separate requests.Session per scheme+hostname combination, in
+    # order to reuse connections to the same hostname to improve efficiency, but
+    # avoiding sharing state between different hosts-scheme combinations to
+    # minimize subtle security issues. Some cookies may not be HTTP-safe.
+    self._sessions = {}
+
+
+  def fetch(self, url, required_length):
+    # Get a customized session for each new schema+hostname combination.
+    session = self._get_session(url)
+
+    # Get the requests.Response object for this URL.
+    #
+    # Defer downloading the response body with stream=True.
+    # Always set the timeout. This timeout value is interpreted by requests as:
+    #  - connect timeout (max delay before first byte is received)
+    #  - read (gap) timeout (max delay between bytes received)
+    with session.get(url, stream=True,
+        timeout=tuf.settings.SOCKET_TIMEOUT) as response:
+
+      # Check response status.
+      response.raise_for_status()
+
+      try:
+        bytes_received = 0
+        while True:
+          # We download a fixed chunk of data in every round. This is so that we
+          # can defend against slow retrieval attacks. Furthermore, we do not wish
+          # to download an extremely large file in one shot.
+          # Before beginning the round, sleep (if set) for a short amount of time
+          # so that the CPU is not hogged in the while loop.
+          if tuf.settings.SLEEP_BEFORE_ROUND:
+            time.sleep(tuf.settings.SLEEP_BEFORE_ROUND)
+
+          read_amount = min(
+              tuf.settings.CHUNK_SIZE, required_length - bytes_received)
+
+          # NOTE: This may not handle some servers adding a Content-Encoding
+          # header, which may cause urllib3 to misbehave:
+          # https://github.com/pypa/pip/blob/404838abcca467648180b358598c597b74d568c9/src/pip/_internal/download.py#L547-L582
+          data = response.raw.read(read_amount)
+          bytes_received += len(data)
+
+          yield data
+
+          if bytes_received == required_length:
+            break
+
+          # We might have no more data to read. Check number of bytes downloaded.
+          if not data:
+            logger.debug('Downloaded ' + repr(bytes_received) + '/' +
+              repr(required_length) + ' bytes.')
+
+            # Finally, we signal that the download is complete.
+            break
+
+      except urllib3.exceptions.ReadTimeoutError as e:
+        raise tuf.exceptions.SlowRetrievalError(str(e))
+
+
+
+
+  def _get_session(self, url):
+    """
+    Returns a different customized requests.Session per schema+hostname
+    combination.
+    """
+    # Use a different requests.Session per schema+hostname combination, to
+    # reuse connections while minimizing subtle security issues.
+    parsed_url = six.moves.urllib.parse.urlparse(url)
+
+    if not parsed_url.scheme or not parsed_url.hostname:
+      raise tuf.exceptions.URLParsingError(
+          'Could not get scheme and hostname from URL: ' + url)
+
+    session_index = parsed_url.scheme + '+' + parsed_url.hostname
+
+    logger.debug('url: ' + url)
+    logger.debug('session index: ' + session_index)
+
+    session = self._sessions.get(session_index)
+
+    if not session:
+      session = requests.Session()
+      self._sessions[session_index] = session
+
+      # Attach some default headers to every Session.
+      requests_user_agent = session.headers['User-Agent']
+      # Follows the RFC: https://tools.ietf.org/html/rfc7231#section-5.5.3
+      tuf_user_agent = 'tuf/' + tuf.__version__ + ' ' + requests_user_agent
+      session.headers.update({
+          # Tell the server not to compress or modify anything.
+          # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding#Directives
+          'Accept-Encoding': 'identity',
+          # The TUF user agent.
+          'User-Agent': tuf_user_agent})
+
+      logger.debug('Made new session for ' + session_index)
+
+    else:
+      logger.debug('Reusing session for ' + session_index)
+
+    return session

--- a/tuf/fetcher.py
+++ b/tuf/fetcher.py
@@ -1,0 +1,51 @@
+"""
+<Program Name>
+  fetcher.py
+
+<Author>
+  Teodora Sechkova <tsechkova@vmware.com>
+
+<Started>
+  December 14, 2020
+
+<Copyright>
+  See LICENSE-MIT OR LICENSE for licensing information.
+
+<Purpose>
+  Provides an interface for network IO abstraction.
+"""
+
+import abc
+
+
+class FetcherInterface():
+  """
+  <Purpose>
+  Defines an interface for abstract network download which can be implemented
+  for a variety of network libraries and configurations.
+  """
+  __metaclass__ = abc.ABCMeta
+
+
+  @abc.abstractmethod
+  def fetch(self, url, required_length):
+    """
+    <Purpose>
+      Fetches the contents of HTTP/HTTPS url from a remote server up to
+      required_length and returns a bytes iterator.
+
+    <Arguments>
+      url:
+        A URL string that represents the location of the file.
+
+      required_length:
+        An integer value representing the length of the file in bytes.
+
+    <Exceptions>
+      tuf.exceptions.SlowRetrievalError, if a timeout occurs while receiving
+      data from a server
+
+    <Returns>
+      A bytes iterator
+    """
+    raise NotImplementedError # pragma: no cover

--- a/tuf/fetcher.py
+++ b/tuf/fetcher.py
@@ -101,6 +101,9 @@ class RequestsFetcher(FetcherInterface):
     # Check response status.
     response.raise_for_status()
 
+    # Define a generator function to be returned by fetch. This way the caller
+    # of fetch can differentiate between connection and actual data download
+    # and measure download times accordingly.
     def chunks():
       try:
         bytes_received = 0
@@ -132,7 +135,7 @@ class RequestsFetcher(FetcherInterface):
 
           yield data
 
-          if bytes_received == required_length:
+          if bytes_received >= required_length:
             break
 
       except urllib3.exceptions.ReadTimeoutError as e:

--- a/tuf/requests_fetcher.py
+++ b/tuf/requests_fetcher.py
@@ -12,10 +12,10 @@
   See LICENSE-MIT OR LICENSE for licensing information.
 
 <Purpose>
-  Provides an interface for network IO abstraction.
+  Provides an implementation of FetcherInterface using the requests HTTP
+  library.
 """
 
-import abc
 import requests
 import six
 import logging
@@ -24,46 +24,12 @@ import time
 import urllib3.exceptions
 import tuf.exceptions
 import tuf.settings
+import tuf.client.fetcher
 
 logger = logging.getLogger(__name__)
 
 
-class FetcherInterface():
-  """
-  <Purpose>
-  Defines an interface for abstract network download which can be implemented
-  for a variety of network libraries and configurations.
-  """
-  __metaclass__ = abc.ABCMeta
-
-
-  @abc.abstractmethod
-  def fetch(self, url, required_length):
-    """
-    <Purpose>
-      Fetches the contents of HTTP/HTTPS url from a remote server up to
-      required_length and returns a bytes iterator.
-
-    <Arguments>
-      url:
-        A URL string that represents the location of the file.
-
-      required_length:
-        An integer value representing the length of the file in bytes.
-
-    <Exceptions>
-      tuf.exceptions.SlowRetrievalError, if a timeout occurs while receiving
-      data from a server
-
-      tuf.exceptions.FetcherHTTPError, if an HTTP error code was received
-    <Returns>
-      A bytes iterator
-    """
-    raise NotImplementedError # pragma: no cover
-
-
-
-class RequestsFetcher(FetcherInterface):
+class RequestsFetcher(tuf.client.fetcher.FetcherInterface):
   """
   <Purpose>
     A concrete implementation of FetcherInterface based on the Requests


### PR DESCRIPTION

**Description of the changes being introduced by the pull request**:

Based on the discussion in #1213 and mainly the idea of @jku, implement an abstract `FetcherInterface` calss and
a concrete `RequestsFetcher` class .

The idea is to extract the network IO related code out of `tuf.download` and put it in `RequestsFetcher` class which is also the default `FetcherInterface` implementation which TUF uses if not given an external one.

`RequestsFetcher` implements only one public method '`fetch`' which returns a bytes iterator. All file handling and verification
logic remains in `tuf.download` which is now wrapper in a `FileDownload` class for convenience.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


