### PR TITLE
Reinstate publishing coverage on coveralls.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,39 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install tox
+          pip install --upgrade tox coveralls
 
       - name: Run tox
         run: tox -e ${{ matrix.toxenv }}
+
+      - name: Publish on coveralls.io
+        # TODO: Maybe make 'lint' a separate job instead of case handling here
+        if: ${{ matrix.toxenv != 'lint' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_FLAG_NAME: ${{ runner.os }} / Python ${{ matrix.python-version }} / ${{ matrix.toxenv }}
+          COVERALLS_PARALLEL: true
+        # Use cp workaround to publish coverage reports with relative paths
+        # FIXME: Consider refactoring the tests to not require the test
+        # aggregation script being invoked from the `tests` directory, so
+        # that `.coverage` is written to and .coveragrc can also reside in
+        # the project root directory as is the convention.
+        run: |
+          cp tests/.coverage .
+          coveralls --service=github --rcfile=tests/.coveragerc
+
+  coveralls-fin:
+    # Always run when all 'build' jobs have finished even if they failed
+    # TODO: Replace always() with a 'at least one job succeeded' expression
+    if: always()
+    needs: build
+    runs-on: ubuntu-latest
+    container: python:3-slim
+    steps:
+      - name: Finalize publishing on coveralls.io
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade coveralls
+          coveralls --finish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,13 @@ jobs:
             os: ubuntu-latest
             toxenv: lint
 
+    env:
+      # Set TOXENV env var to tell tox which testenv (see tox.ini) to use
+      # NOTE: The Python 2.7 runner has two Python versions on the path (see
+      # setup-python below), so we tell tox explicitly to use the 'py27'
+      # testenv. For all other runners the toxenv configured above suffices.
+      TOXENV: ${{ matrix.python-version == '2.7' && 'py27' || matrix.toxenv }}
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -32,6 +39,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Set up service Python 3.x (on 2.7 only)
+        uses: actions/setup-python@v2
+        if: ${{ matrix.python-version == 2.7 }}
+        with:
+          python-version: 3.x
 
       - name: Find pip cache dir
         id: pip-cache
@@ -52,8 +65,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade tox coveralls
 
-      - name: Run tox
-        run: tox -e ${{ matrix.toxenv }}
+      - name: Run tox (${{ env.TOXENV }})
+        # See TOXENV environment variable for the testenv to be executed here
+        run: tox
 
       - name: Publish on coveralls.io
         # TODO: Maybe make 'lint' a separate job instead of case handling here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,10 @@ jobs:
 
       - name: Publish on coveralls.io
         # TODO: Maybe make 'lint' a separate job instead of case handling here
-        if: ${{ matrix.toxenv != 'lint' }}
+        if: ${{ env.TOXENV != 'lint' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: ${{ runner.os }} / Python ${{ matrix.python-version }} / ${{ matrix.toxenv }}
+          COVERALLS_FLAG_NAME: ${{ runner.os }} / Python ${{ matrix.python-version }} / ${{ env.TOXENV }}
           COVERALLS_PARALLEL: true
         # Use cp workaround to publish coverage reports with relative paths
         # FIXME: Consider refactoring the tests to not require the test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # <img src="https://cdn.rawgit.com/theupdateframework/artwork/3a649fa6/tuf-logo.svg" height="100" valign="middle" alt="TUF"/> A Framework for Securing Software Update Systems
 
 ![Build](https://github.com/theupdateframework/tuf/workflows/Run%20TUF%20tests%20and%20linter/badge.svg)
+[![Coveralls](https://coveralls.io/repos/theupdateframework/tuf/badge.svg?branch=develop)](https://coveralls.io/r/theupdateframework/tuf?branch=develop)
 ![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=theupdateframework/tuf)
 [![CII](https://bestpractices.coreinfrastructure.org/projects/1351/badge)](https://bestpractices.coreinfrastructure.org/projects/1351)
 [![PyPI](https://img.shields.io/pypi/v/tuf)](https://pypi.org/project/tuf/)

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ skipsdist = true
 changedir = tests
 
 commands =
+    python --version
     coverage run aggregate_tests.py
     coverage report -m --fail-under 97
 


### PR DESCRIPTION
Fixes #1243

**Description of the changes being introduced by the pull request**:
Re-instates publishing coverage on coveralls.io using the `coveralls` command line tool, which works better than the official, and a popular unofficial coveralls GitHub action and seems preferable for the security reasons outlined in #1246. 

This PR also configures the Python 2.7 runner to setup an additional 3.x service Python version to run tox and coveralls tools (only inside tox Python 2.7 is used).

See commit messages for more details.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


