### PR TITLE
Configure dependabot to ignore 'idna'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
     interval: daily
     time: "10:00"
   open-pull-requests-limit: 10
+  ignore:
+    # New 'idna' (see 'requests') releases break Python 2.7 builds. Ignore here
+    # to avoid listing/pinning transitive dependencies in requirements.txt.
+    # FIXME: Un-ignore when dropping Python 2.7 or resolving #1249
+    - dependency-name: "idna"


### PR DESCRIPTION

Fixes -
Related to #1256 

**Description of the changes being introduced by the pull request**:
New releases of the transitive (via 'requests') dependency 'idna' break Python 2.7 builds. To fix this we configure dependabot to not bump 'idna' in requirements-pinned.txt, which lists and auto-updates all immediate and transitive dependencies for CI/CD testing.

An alternative would be to add and restrict 'idna' in 'requirements.txt' but this is less preferable because 'requirements.txt' should only have direct dependencies.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


