### PR TITLE
Temporarily remove broken Dependabot badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ![Build](https://github.com/theupdateframework/tuf/workflows/Run%20TUF%20tests%20and%20linter/badge.svg)
 [![Coveralls](https://coveralls.io/repos/theupdateframework/tuf/badge.svg?branch=develop)](https://coveralls.io/r/theupdateframework/tuf?branch=develop)
-![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=theupdateframework/tuf)
 [![CII](https://bestpractices.coreinfrastructure.org/projects/1351/badge)](https://bestpractices.coreinfrastructure.org/projects/1351)
 [![PyPI](https://img.shields.io/pypi/v/tuf)](https://pypi.org/project/tuf/)
 


### PR DESCRIPTION
Fixes #<ISSUE NUMBER>

**Description of the changes being introduced by the pull request**:
The Dependabot status badge no longer works, since having migrated from stand-alone to GitHub native in #1258.

The issue is tracked upstream in dependabot/dependabot-core#1912.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


