### PR TITLE
Docs: change the editable venv installation order

### DIFF
--- a/docs/CONTRIBUTORS.rst
+++ b/docs/CONTRIBUTORS.rst
@@ -155,13 +155,13 @@ via PyPI).
 
 To develop and test ``tuf`` with above commands alongside its in-house dependency
 `securesystemslib <https://github.com/secure-systems-lab/securesystemslib>`_,
-it is recommended to first make an editable install of ``securesystemslib`` (in
-a *venv*), and then install ``tuf`` in editable mode too (in the same *venv*).
+it is recommended to first make an editable install of ``tuf`` (in
+a *venv*), and then install ``securesystemslib`` in editable mode too (in the same *venv*).
 ::
 
-    $ cd path/to/securesystemslib
-    $ pip install -r requirements-dev.txt
     $ cd path/to/tuf
+    $ pip install -r requirements-dev.txt
+    $ cd path/to/securesystemslib
     $ pip install -r requirements-dev.txt
 
 


### PR DESCRIPTION
Fixes NA

**Description of the changes being introduced by the pull request**:

If you follow the instructions we provide for our contributors in
docs/CONTRIBUTORS.rst your sys.path (used to search for imports)
will put securesystemlib project directory first and tuf directory
second.
This creates a problem with imports from tuf modules because we can
import the wrong file or on relative imports (as currently we
use in the tests when we import utils), the imports cannot be resolved.

If we change the installation order, then tuf directory will be the
first in the import resolution path and those problems will be fixed.

PS: I want to express my gratitude towards Jussi who helped me find
this problem.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


