### PR TITLE
Bump Cryptography, pin the py2 version separately

### DIFF
--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -1,7 +1,8 @@
 certifi==2020.12.5        # via requests
 cffi==1.14.4              # via cryptography, pynacl
 chardet==4.0.0            # via requests
-cryptography==3.3.1       # via securesystemslib
+cryptography==3.4.5       ; python_version >= '3' # via securesystemslib
+cryptography==3.3.2       ; python_version < '3' # via securesystemslib
 enum34==1.1.10            ; python_version < '3' # via cryptography
 idna==2.10                # via requests
 ipaddress==1.0.23         ; python_version < '3' # via cryptography


### PR DESCRIPTION
On Python3 bump cryptography from 3.3.1 to 3.4.5.

On python2 bump from 3.3.1 to 3.3.2 (3.3-branch is the last branch
with python2 support).

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

---

I think this is enough in TUF? -- once securesystemslib releases we can change TUF setup.py to require the new securesystemslib and that will bring in the correct cryptography for the binary packages?