### PR TITLE
CI: Limit build-on-push to develop branch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: Run TUF tests and linter
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Dependabot pushes to main repository and ends up triggering two builds
every time (one for PR, one for push): limit the rule for build-on-push
to apply to develop branch only.

If release branches are used later on they should be added to list here.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>
