### PR TITLE
ci: Remove workaround for pip resolver issue

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,9 +24,7 @@ deps =
     # installation (see `skipsdist`), to get relative paths in coverage reports
     --editable {toxinidir}
 
-# FIXME: use legacy resolver because https://github.com/pypa/pip/issues/9215
-install_command = pip install --use-deprecated=legacy-resolver --pre {opts} {packages}
-
+install_command = pip install --pre {opts} {packages}
 
 # Develop test env to run tests against securesystemslib's master branch
 # Must to be invoked explicitly with, e.g. `tox -e with-sslib-master`

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ install_command = pip install --use-deprecated=legacy-resolver --pre {opts} {pac
 # Must to be invoked explicitly with, e.g. `tox -e with-sslib-master`
 [testenv:with-sslib-master]
 deps =
-    git+http://github.com/secure-systems-lab/securesystemslib.git@master#egg=securesystemslib
+    git+https://github.com/secure-systems-lab/securesystemslib.git@master#egg=securesystemslib[crypto,pynacl]
     -r{toxinidir}/requirements-test.txt
     --editable {toxinidir}
 


### PR DESCRIPTION
* Remove the workaround that was added for pip issue 9215 and does not _seem_ to appear anymore with pip 21.0.1.
* Add the "extras" requirements for the with-sslib-master case (which pip now requires)
* do not accept plain http for anything

Fixes #1290 