### PR TITLE
Bump securesystemslib to 0.20.0

### DIFF
--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -9,7 +9,7 @@ ipaddress==1.0.23         ; python_version < '3' # via cryptography
 pycparser==2.20           # via cffi
 pynacl==1.4.0             # via securesystemslib
 requests==2.25.1
-securesystemslib[crypto,pynacl]==0.19.0
+securesystemslib[crypto,pynacl]==0.20.0
 six==1.15.0
 subprocess32==3.5.4       ; python_version < '3' # via securesystemslib
 urllib3==1.26.3           # via requests


### PR DESCRIPTION
https://github.com/secure-systems-lab/securesystemslib/releases/tag/v0.20.0
https://pypi.org/project/securesystemslib/0.20.0/

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>


