### PR TITLE
build: Lint install_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,8 +113,8 @@ setup(
   python_requires="~=3.6",
   install_requires = [
     'requests>=2.19.1',
-    'six>=1.11.0',
-    'securesystemslib>=0.18.0'
+    'securesystemslib>=0.18.0',
+    'six>=1.11.0'
   ],
   packages = find_packages(exclude=['tests']),
   scripts = [


### PR DESCRIPTION
While doing packaging works I noticed that
pypi file 'tuf.egg-info/requires.txt' was modified on build.

Let's sort dependencies alphabetically to avoid lint to change sources files.

Change-Id: I009810877681afe9b84a3c4f9bed14553327105b
Signed-off-by: Philippe Coval <rzr@users.sf.net>

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

Fixes #<ISSUE NUMBER>

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


