### PR TITLE
Fix unclosed socket warning caused by RequestsFetcher

### DIFF
--- a/tuf/requests_fetcher.py
+++ b/tuf/requests_fetcher.py
@@ -79,6 +79,7 @@ class RequestsFetcher(FetcherInterface):
     try:
       response.raise_for_status()
     except requests.HTTPError as e:
+      response.close()
       status = e.response.status_code
       raise tuf.exceptions.FetcherHTTPError(str(e), status)
 


### PR DESCRIPTION

**Description of the changes being introduced by the pull request**:

Close the Response object when an HTTP error is raised.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


