### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Files that will always have LF line endings on checkout.
+tests/repository_data/** text eol=lf
+


### PR DESCRIPTION

**Description of the changes being introduced by the pull request**:

For compatibility with Windows systems, declare repository_data files to always have LF line endings on checkout.

The pattern `tests/repository_data/**` matches everything inside the directory `tests/repository_data `relative to the `.gitattributes `file, with infinite depth.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


