### PR TITLE
build: Add keys to sdist archive for tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,10 +2,12 @@ include LICENSE*
 include README.md
 include tox.ini
 include tests/repository_data/keystore/delegation_key
-include tests/repository_data/keystore/root_key
+include tests/repository_data/keystore/root_key*
 include tests/repository_data/keystore/snapshot_key
 include tests/repository_data/keystore/targets_key
 include tests/repository_data/keystore/timestamp_key
+include tests/ssl_certs/*.crt
+include tests/ssl_certs/*.key
 
 recursive-include docs *.txt
 recursive-include docs *.md


### PR DESCRIPTION
While packaging latest release for debian from pypi tarball
I noticed some tests' files were not shipped, let's add them.

Relate-to: https://github.com/theupdateframework/tuf/issues/263
Signed-off-by: Philippe Coval <rzr@users.sf.net>

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

Fixes #<ISSUE NUMBER>

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


