### PR TITLE
test: Start coverage from python module

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@ changedir = tests
 
 commands =
     python --version
-    coverage run aggregate_tests.py
-    coverage report -m --fail-under 97
+    python -m coverage run aggregate_tests.py
+    python -m coverage report -m --fail-under 97
 
 deps =
     -r{toxinidir}/requirements-test.txt
@@ -35,8 +35,8 @@ deps =
     --editable {toxinidir}
 
 commands =
-    coverage run aggregate_tests.py
-    coverage report -m
+    python -m coverage run aggregate_tests.py
+    python -m coverage report -m
 
 [testenv:lint]
 commands =


### PR DESCRIPTION
Runing module from python will help
portability between systems.

Those scripts may be renamed by distros,
for instance Debian provides python3-converage.

Signed-off-by: Philippe Coval <rzr@users.sf.net>

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

Fixes #<ISSUE NUMBER>

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


