### PR TITLE
New metadata API: add MetaFile and TargetFile classes

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -306,13 +306,6 @@ class TestMetadata(unittest.TestCase):
             snapshot.signed.meta['role1.json'].to_dict(), fileinfo.to_dict()
         )
 
-        # Update only version. Length and hashes are optional.
-        fileinfo = MetaFile(3)
-        snapshot.signed.update('role2', fileinfo)
-        self.assertEqual(
-            snapshot.signed.meta['role2.json'].to_dict(), fileinfo.to_dict()
-        )
-
         # Test from_dict and to_dict without hashes and length.
         snapshot_dict = snapshot.to_dict()
         del snapshot_dict['signed']['meta']['role1.json']['length']
@@ -365,13 +358,6 @@ class TestMetadata(unittest.TestCase):
         test_dict = copy.deepcopy(timestamp_dict['signed'])
         timestamp_test = Timestamp.from_dict(test_dict)
         self.assertEqual(timestamp_dict['signed'], timestamp_test.to_dict())
-
-        # Update only version. Length and hashes are optional.
-        fileinfo = MetaFile(version=3)
-        timestamp.signed.update(fileinfo)
-        self.assertEqual(
-            timestamp.signed.meta['snapshot.json'].to_dict(), fileinfo.to_dict()
-        )
 
     def test_key_class(self):
         keys = {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,6 +30,7 @@ from tuf.api.metadata import (
     Key,
     Role,
     MetaFile,
+    TargetFile,
     Delegations,
     DelegatedRole,
 )
@@ -540,22 +541,23 @@ class TestMetadata(unittest.TestCase):
             "sha512": "ef5beafa16041bcdd2937140afebd485296cd54f7348ecd5a4d035c09759608de467a7ac0eb58753d0242df873c305e8bffad2454aa48f44480f15efae1cacd0"
         },
 
-        fileinfo = {
-            'hashes': hashes,
-            'length': 28
-        }
+        fileinfo = TargetFile(length=28, hashes=hashes)
 
         # Assert that data is not aleady equal
-        self.assertNotEqual(targets.signed.targets[filename], fileinfo)
+        self.assertNotEqual(
+            targets.signed.targets[filename].to_dict(), fileinfo.to_dict()
+        )
         # Update an already existing fileinfo
-        targets.signed.update(filename, fileinfo)
+        targets.signed.update(filename, fileinfo.to_dict())
         # Verify that data is updated
-        self.assertEqual(targets.signed.targets[filename], fileinfo)
+        self.assertEqual(
+            targets.signed.targets[filename].to_dict(), fileinfo.to_dict()
+        )
 
         # Test from_dict/to_dict Targets without delegations
         targets_dict = targets.to_dict()
         del targets_dict["signed"]["delegations"]
-        tmp_dict = targets_dict["signed"].copy()
+        tmp_dict = copy.deepcopy(targets_dict["signed"])
         targets_obj = Targets.from_dict(tmp_dict)
         self.assertEqual(targets_dict["signed"], targets_obj.to_dict())
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -243,6 +243,51 @@ class TestMetadata(unittest.TestCase):
         self.assertFalse(is_expired)
         md.signed.expires = expires
 
+
+    def test_metafile_class(self):
+        # Test from_dict and to_dict with all attributes.
+        data = {
+            "hashes": {
+                "sha256": "8f88e2ba48b412c3843e9bb26e1b6f8fc9e98aceb0fbaa97ba37b4c98717d7ab"
+            },
+            "length": 515,
+            "version": 1
+        }
+        metafile_obj = MetaFile.from_dict(copy.copy(data))
+        self.assertEqual(metafile_obj.to_dict(), data)
+
+        # Test from_dict and to_dict without length.
+        del data["length"]
+        metafile_obj = MetaFile.from_dict(copy.copy(data))
+        self.assertEqual(metafile_obj.to_dict(), data)
+
+        # Test from_dict and to_dict without length and hashes.
+        del data["hashes"]
+        metafile_obj = MetaFile.from_dict(copy.copy(data))
+        self.assertEqual(metafile_obj.to_dict(), data)
+
+
+    def test_targetfile_class(self):
+        # Test from_dict and to_dict with all attributes.
+        data = {
+            "custom": {
+                "file_permissions": "0644"
+            },
+            "hashes": {
+                "sha256": "65b8c67f51c993d898250f40aa57a317d854900b3a04895464313e48785440da",
+                "sha512": "467430a68afae8e9f9c0771ea5d78bf0b3a0d79a2d3d3b40c69fde4dd42c461448aef76fcef4f5284931a1ffd0ac096d138ba3a0d6ca83fa8d7285a47a296f77"
+            },
+            "length": 31
+        }
+        targetfile_obj = TargetFile.from_dict(copy.copy(data))
+        self.assertEqual(targetfile_obj.to_dict(), data)
+
+        # Test from_dict and to_dict without custom.
+        del data["custom"]
+        targetfile_obj = TargetFile.from_dict(copy.copy(data))
+        self.assertEqual(targetfile_obj.to_dict(), data)
+
+
     def test_metadata_snapshot(self):
         snapshot_path = os.path.join(
                 self.repo_dir, 'metadata', 'snapshot.json')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -301,14 +301,14 @@ class TestMetadata(unittest.TestCase):
         self.assertNotEqual(
             snapshot.signed.meta['role1.json'].to_dict(), fileinfo.to_dict()
         )
-        snapshot.signed.update('role1', 2, 123, hashes)
+        snapshot.signed.update('role1', fileinfo)
         self.assertEqual(
             snapshot.signed.meta['role1.json'].to_dict(), fileinfo.to_dict()
         )
 
         # Update only version. Length and hashes are optional.
-        snapshot.signed.update('role2', 3)
         fileinfo = MetaFile(3)
+        snapshot.signed.update('role2', fileinfo)
         self.assertEqual(
             snapshot.signed.meta['role2.json'].to_dict(), fileinfo.to_dict()
         )
@@ -353,7 +353,7 @@ class TestMetadata(unittest.TestCase):
         self.assertNotEqual(
             timestamp.signed.meta['snapshot.json'].to_dict(), fileinfo.to_dict()
         )
-        timestamp.signed.update(2, 520, hashes)
+        timestamp.signed.update(fileinfo)
         self.assertEqual(
             timestamp.signed.meta['snapshot.json'].to_dict(), fileinfo.to_dict()
         )
@@ -367,8 +367,8 @@ class TestMetadata(unittest.TestCase):
         self.assertEqual(timestamp_dict['signed'], timestamp_test.to_dict())
 
         # Update only version. Length and hashes are optional.
-        timestamp.signed.update(3)
         fileinfo = MetaFile(version=3)
+        timestamp.signed.update(fileinfo)
         self.assertEqual(
             timestamp.signed.meta['snapshot.json'].to_dict(), fileinfo.to_dict()
         )
@@ -593,7 +593,7 @@ class TestMetadata(unittest.TestCase):
             targets.signed.targets[filename].to_dict(), fileinfo.to_dict()
         )
         # Update an already existing fileinfo
-        targets.signed.update(filename, fileinfo.to_dict())
+        targets.signed.update(filename, fileinfo)
         # Verify that data is updated
         self.assertEqual(
             targets.signed.targets[filename].to_dict(), fileinfo.to_dict()

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -700,14 +700,9 @@ class Timestamp(Signed):
         return res_dict
 
     # Modification.
-    def update(
-        self,
-        version: int,
-        length: Optional[int] = None,
-        hashes: Optional[Dict[str, Any]] = None,
-    ) -> None:
+    def update(self, snapshot_meta: MetaFile) -> None:
         """Assigns passed info about snapshot metadata to meta dict."""
-        self.meta["snapshot.json"] = MetaFile(version, length, hashes)
+        self.meta["snapshot.json"] = snapshot_meta
 
 
 class Snapshot(Signed):
@@ -759,16 +754,10 @@ class Snapshot(Signed):
         return snapshot_dict
 
     # Modification.
-    def update(
-        self,
-        rolename: str,
-        version: int,
-        length: Optional[int] = None,
-        hashes: Optional[Dict[str, Any]] = None,
-    ) -> None:
+    def update(self, rolename: str, role_info: MetaFile) -> None:
         """Assigns passed (delegated) targets role info to meta dict."""
         metadata_fn = f"{rolename}.json"
-        self.meta[metadata_fn] = MetaFile(version, length, hashes)
+        self.meta[metadata_fn] = role_info
 
 
 class DelegatedRole(Role):
@@ -1010,6 +999,6 @@ class Targets(Signed):
         return targets_dict
 
     # Modification.
-    def update(self, filename: str, fileinfo: Dict[str, Any]) -> None:
+    def update(self, filename: str, fileinfo: TargetFile) -> None:
         """Assigns passed target file info to meta dict."""
-        self.targets[filename] = TargetFile.from_dict(fileinfo)
+        self.targets[filename] = fileinfo

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -31,6 +31,11 @@ from tuf.api.serialization import (
     SignedSerializer,
 )
 
+# Disable the "C0302: Too many lines in module" warning which warns for modules
+# with more 1000 lines, because all of the code here is logically connected
+# and currently, we are above 1000 lines by a small margin.
+# pylint: disable=C0302
+
 
 class Metadata:
     """A container for signed TUF metadata.


### PR DESCRIPTION
This pr is a continuation from pr https://github.com/theupdateframework/tuf/pull/1223

This is the final pr planned for https://github.com/theupdateframework/tuf/issues/1139, 

**Description of the changes being introduced by the pull request**:

In the top-level metadata classes, there are complex attributes such as
"meta" in Targets and Snapshot, "key" and "roles" in Root etc.
We want to represent those complex attributes with a class to allow
easier verification and support for metadata with unrecognized fields.
For more context read ADR 0004 and ADR 0008 in the docs/adr folder.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


