### PR TITLE
fix the outdate link in docs/tuf-spec.0.9.txt

### DIFF
--- a/docs/tuf-spec.0.9.txt
+++ b/docs/tuf-spec.0.9.txt
@@ -1,1 +1,1 @@
-The TUF specification file has been moved to https://github.com/theupdateframework/specification/blob/master/historical/tuf-spec.md
+The TUF specification file has been moved to https://github.com/theupdateframework/specification/blob/master/historical/tuf-spec.0.9.txt


### PR DESCRIPTION
I find the link in docs/tuf-spec.0.9.txt has outdate,so I fix it 