### PR TITLE
tests: Use current python interpreter for sub tests

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -25,6 +25,7 @@ from contextlib import contextmanager
 import errno
 import logging
 import socket
+import sys
 import time
 import subprocess
 import threading
@@ -186,7 +187,7 @@ class TestServerProcess():
     """Starts the process running the server."""
 
     # The "-u" option forces stdin, stdout and stderr to be unbuffered.
-    command = ['python', '-u', self.server] + extra_cmd_args
+    command = [sys.executable, '-u', self.server] + extra_cmd_args
 
     # Reusing one subprocess in multiple tests, but split up the logs for each.
     self.__server_process = subprocess.Popen(command,


### PR DESCRIPTION
Can be useful to run tests using distro runtimes,
(like python3 on Debian).

Relate-to: https://github.com/theupdateframework/tuf/issues/263
Signed-off-by: Philippe Coval <rzr@users.sf.net>

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

Fixes #<ISSUE NUMBER>

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


