### PR TITLE
Remove future module

### DIFF
--- a/tests/aggregate_tests.py
+++ b/tests/aggregate_tests.py
@@ -26,14 +26,6 @@
   'tuf/tests'.  Use --random to run the tests in random order.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import sys
 import unittest
 

--- a/tests/simple_https_server.py
+++ b/tests/simple_https_server.py
@@ -29,14 +29,6 @@
     http://docs.python.org/library/simplehttpserver.html#module-SimpleHTTPServer
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import sys
 import ssl
 import os

--- a/tests/simple_server.py
+++ b/tests/simple_server.py
@@ -25,14 +25,6 @@
     http://docs.python.org/library/simplehttpserver.html#module-SimpleHTTPServer
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import sys
 import random
 import socketserver

--- a/tests/slow_retrieval_server.py
+++ b/tests/slow_retrieval_server.py
@@ -21,14 +21,6 @@
   interval 'DELAY').  The server is used in 'test_slow_retrieval_attack.py'.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import sys
 import time

--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -28,14 +28,6 @@
   There is no difference between 'updates' and 'target' files.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import tempfile
 import shutil

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -25,14 +25,6 @@
   TODO: Adopt the environment variable management from test_proxy_use.py here.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import hashlib
 import logging
 import os

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -31,14 +31,6 @@
   There is no difference between 'updates' and 'target' files.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import tempfile
 import shutil

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -34,14 +34,6 @@
   There is no difference between 'updates' and 'target' files.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import tempfile
 import shutil

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -5,9 +5,6 @@
 
 """Unit test for RequestsFetcher.
 """
-# Help with Python 2 compatibility, where the '/' operator performs
-# integer division.
-from __future__ import division
 
 import logging
 import os

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -20,14 +20,6 @@
   Unit test for 'formats.py'
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import unittest
 import datetime
 import sys

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -36,14 +36,6 @@
   metadata without the client being aware.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import datetime
 import os
 import time

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -29,14 +29,6 @@
   'tests/unittest_toolbox.py'.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import shutil
 import tempfile

--- a/tests/test_keydb.py
+++ b/tests/test_keydb.py
@@ -20,14 +20,6 @@
   Unit test for 'keydb.py'.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import unittest
 import logging
 import sys

--- a/tests/test_mirrors.py
+++ b/tests/test_mirrors.py
@@ -20,14 +20,6 @@
   Unit test for 'mirrors.py'.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import unittest
 import sys
 

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -30,14 +30,6 @@
   Note: There is no difference between 'updates' and 'target' files.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import tempfile
 import shutil

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -21,14 +21,6 @@
   multiple repositories and separate sets of metadata for each.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import tempfile
 import logging

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -30,14 +30,6 @@
   Note: There is no difference between 'updates' and 'target' files.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import tempfile
 import datetime

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -20,14 +20,6 @@
   Unit test for 'repository_lib.py'.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import time
 import datetime

--- a/tests/test_repository_tool.py
+++ b/tests/test_repository_tool.py
@@ -20,14 +20,6 @@
   Unit test for 'repository_tool.py'.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import time
 import datetime

--- a/tests/test_roledb.py
+++ b/tests/test_roledb.py
@@ -20,14 +20,6 @@
   Unit test for 'roledb.py'.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import unittest
 import logging
 import sys

--- a/tests/test_root_versioning_integration.py
+++ b/tests/test_root_versioning_integration.py
@@ -20,10 +20,6 @@
   Test root versioning for efficient root key rotation.
 """
 
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 import os
 import logging

--- a/tests/test_sig.py
+++ b/tests/test_sig.py
@@ -21,14 +21,6 @@
   Test cases for sig.py.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import unittest
 import logging
 import copy

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -36,14 +36,6 @@
   use slow target download.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import tempfile
 import shutil

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -21,13 +21,6 @@
 
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 import unittest
 import datetime # part of TUTORIAL.md

--- a/tests/test_unittest_toolbox.py
+++ b/tests/test_unittest_toolbox.py
@@ -20,14 +20,6 @@
   Test cases for unittest_toolbox.py.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import unittest
 import logging
 import shutil

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -41,14 +41,6 @@
   less dependent than 2.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import time
 import shutil

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -33,14 +33,6 @@
   less dependent than 2.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import shutil
 import tempfile

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -113,14 +113,6 @@
     target_custom_data = target['fileinfo']['custom']
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import errno
 import logging
 import os

--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -24,13 +24,6 @@
   'developer_tool.py'.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 import os
 import errno
 import logging

--- a/tuf/download.py
+++ b/tuf/download.py
@@ -23,14 +23,6 @@
   metadata of that file.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import logging
 import timeit
 import tempfile

--- a/tuf/exceptions.py
+++ b/tuf/exceptions.py
@@ -22,14 +22,6 @@
   there is a good reason not to, and provide that reason in those cases.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 from urllib import parse
 
 import logging

--- a/tuf/formats.py
+++ b/tuf/formats.py
@@ -55,14 +55,6 @@
   signable_object = make_signable(unsigned_object)
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import binascii
 import calendar
 import datetime

--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -33,14 +33,6 @@
   dictionary's 'keyid' key (i.e., rsakey['keyid']).
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import logging
 import copy
 

--- a/tuf/log.py
+++ b/tuf/log.py
@@ -61,14 +61,6 @@
   http://docs.python.org/2/howto/logging-cookbook.html
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import logging
 import time
 

--- a/tuf/mirrors.py
+++ b/tuf/mirrors.py
@@ -22,14 +22,6 @@
   of the file with respect to the base url.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 from urllib import parse
 

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -23,14 +23,6 @@
   complete guide to using 'tuf.repository_tool.py'.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import errno
 import time

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -24,14 +24,6 @@
   'tuf.repository_tool.py'.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import time
 import datetime

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -41,14 +41,6 @@
   optional.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import logging
 import copy
 

--- a/tuf/scripts/client.py
+++ b/tuf/scripts/client.py
@@ -59,14 +59,6 @@
     $ client.py --repo http://localhost:8001 README.txt
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import sys
 import argparse
 import logging

--- a/tuf/scripts/repo.py
+++ b/tuf/scripts/repo.py
@@ -131,14 +131,6 @@
     Delete repo in current working or specified directory.
 """
 
-# Help with Python 2+3 compatibility, where the print statement is a function,
-# an implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import sys
 import logging

--- a/tuf/settings.py
+++ b/tuf/settings.py
@@ -23,14 +23,6 @@
  behavior.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 
 # Set a directory that should be used for all temporary files. If this
 # is None, then the system default will be used. The system default

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -40,14 +40,6 @@
   is also a function for that.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import logging
 
 import securesystemslib # pylint: disable=unused-import

--- a/tuf/unittest_toolbox.py
+++ b/tuf/unittest_toolbox.py
@@ -22,14 +22,6 @@
   Specifically, Modified_TestCase is a derived class from unittest.TestCase.
 """
 
-# Help with Python 3 compatibility, where the print statement is a function, an
-# implicit relative import is invalid, and the '/' operator performs true
-# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import shutil
 import unittest


### PR DESCRIPTION
Fixes #1297

**Description of the changes being introduced by the pull request**:
Removes 168 occurrences of pattern `from_future_import` from 43 files. 

With the release of tuf 0.17.0, Python2 is not supported. Therefore, backward compatibility of Python2 by importing future module is not required. 

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


