### PR TITLE
tests: don't delete open files

### DIFF
--- a/tests/test_arbitrary_package_attack.py
+++ b/tests/test_arbitrary_package_attack.py
@@ -134,15 +134,15 @@ class TestArbitraryPackageAttack(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
     # updater.Updater() populates the roledb with the name "test_repository1"
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
     # Logs stdout and stderr from the sever subprocess.
     self.server_process_handler.flush_log()
+
+    # Remove temporary directory
+    unittest_toolbox.Modified_TestCase.tearDown(self)
 
 
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -85,12 +85,13 @@ class TestDownload(unittest_toolbox.Modified_TestCase):
 
   # Stop server process and perform clean up.
   def tearDown(self):
-    unittest_toolbox.Modified_TestCase.tearDown(self)
-
     # Cleans the resources and flush the logged lines (if any).
     self.server_process_handler.clean()
 
     self.target_fileobj.close()
+
+    # Remove temp directory
+    unittest_toolbox.Modified_TestCase.tearDown(self)
 
 
   # Test: Normal case.

--- a/tests/test_endless_data_attack.py
+++ b/tests/test_endless_data_attack.py
@@ -135,15 +135,14 @@ class TestEndlessDataAttack(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
     # Logs stdout and stderr from the sever subprocess.
     self.server_process_handler.flush_log()
 
+    # Remove temporary directory
+    unittest_toolbox.Modified_TestCase.tearDown(self)
 
 
   def test_without_tuf(self):

--- a/tests/test_extraneous_dependencies_attack.py
+++ b/tests/test_extraneous_dependencies_attack.py
@@ -141,14 +141,14 @@ class TestExtraneousDependenciesAttack(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
     # Logs stdout and stderr from the sever subprocess.
     self.server_process_handler.flush_log()
+
+    # Remove temporary directory
+    unittest_toolbox.Modified_TestCase.tearDown(self)
 
 
   def test_with_tuf(self):

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -55,13 +55,14 @@ class TestFetcher(unittest_toolbox.Modified_TestCase):
 
   # Stop server process and perform clean up.
   def tearDown(self):
-    unittest_toolbox.Modified_TestCase.tearDown(self)
-
     # Cleans the resources and flush the logged lines (if any).
     self.server_process_handler.clean()
 
     self.target_fileobj.close()
     self.temp_file.close()
+
+    # Remove temporary directory
+    unittest_toolbox.Modified_TestCase.tearDown(self)
 
 
   # Test: Normal case.

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -155,14 +155,14 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
     # Logs stdout and stderr from the sever subprocess.
     self.server_process_handler.flush_log()
+
+    # Remove temporary directory
+    unittest_toolbox.Modified_TestCase.tearDown(self)
 
 
   def test_without_tuf(self):

--- a/tests/test_key_revocation_integration.py
+++ b/tests/test_key_revocation_integration.py
@@ -147,13 +147,14 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
     # Logs stdout and stderr from the sever subprocess.
     self.server_process_handler.flush_log()
+
+    # Remove temporary directory
+    unittest_toolbox.Modified_TestCase.tearDown(self)
 
 
   # UNIT TESTS.

--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -140,14 +140,14 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
     # Logs stdout and stderr from the sever subprocess.
     self.server_process_handler.flush_log()
+
+    # Remove temporary directory
+    unittest_toolbox.Modified_TestCase.tearDown(self)
 
 
   def test_with_tuf(self):

--- a/tests/test_multiple_repositories_integration.py
+++ b/tests/test_multiple_repositories_integration.py
@@ -49,18 +49,16 @@ repo_tool.disable_console_log_messages()
 class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
 
   def setUp(self):
-    # We are inheriting from custom class.
+    # Modified_Testcase can handle temp dir removal
     unittest_toolbox.Modified_TestCase.setUp(self)
-
-    self.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
+    self.temporary_directory = self.make_temp_directory(directory=os.getcwd())
 
     # Copy the original repository files provided in the test folder so that
     # any modifications made to repository files are restricted to the copies.
     # The 'repository_data' directory is expected to exist in 'tuf/tests/'.
     original_repository_files = os.path.join(os.getcwd(), 'repository_data')
 
-    self.temporary_repository_root = self.make_temp_directory(directory=
-        self.temporary_directory)
+    self.temporary_repository_root = tempfile.mkdtemp(dir=self.temporary_directory)
 
     # The original repository, keystore, and client directories will be copied
     # for each test case.
@@ -151,10 +149,6 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
-
     # Cleans the resources and flush the logged lines (if any).
     self.server_process_handler.clean()
     self.server_process_handler2.clean()
@@ -163,7 +157,8 @@ class TestMultipleRepositoriesIntegration(unittest_toolbox.Modified_TestCase):
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
-    shutil.rmtree(self.temporary_directory)
+    # Remove top-level temporary directory
+    unittest_toolbox.Modified_TestCase.tearDown(self)
 
 
   def test_update(self):

--- a/tests/test_replay_attack.py
+++ b/tests/test_replay_attack.py
@@ -142,15 +142,14 @@ class TestReplayAttack(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
     # Logs stdout and stderr from the sever subprocess.
     self.server_process_handler.flush_log()
 
+    # Remove temporary directory
+    unittest_toolbox.Modified_TestCase.tearDown(self)
 
 
   def test_without_tuf(self):

--- a/tests/test_slow_retrieval_attack.py
+++ b/tests/test_slow_retrieval_attack.py
@@ -60,22 +60,17 @@ repo_tool.disable_console_log_messages()
 class TestSlowRetrieval(unittest_toolbox.Modified_TestCase):
 
   def setUp(self):
-    # We are inheriting from custom class.
+    # Modified_Testcase can handle temp dir removal
     unittest_toolbox.Modified_TestCase.setUp(self)
+    self.temporary_directory = self.make_temp_directory(directory=os.getcwd())
 
     self.repository_name = 'test_repository1'
-
-    # Create a temporary directory to store the repository, metadata, and target
-    # files.  'temporary_directory' must be deleted in TearDownModule() so that
-    # temporary files are always removed, even when exceptions occur.
-    self.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
 
     # Copy the original repository files provided in the test folder so that
     # any modifications made to repository files are restricted to the copies.
     # The 'repository_data' directory is expected to exist in 'tuf/tests/'.
     original_repository_files = os.path.join(os.getcwd(), 'repository_data')
-    temporary_repository_root = \
-      self.make_temp_directory(directory=self.temporary_directory)
+    temporary_repository_root = tempfile.mkdtemp(dir=self.temporary_directory)
 
     # The original repository, keystore, and client directories will be copied
     # for each test case.
@@ -179,19 +174,14 @@ class TestSlowRetrieval(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
     # Cleans the resources and flush the logged lines (if any).
     self.server_process_handler.clean()
 
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated of all the test cases.
-    shutil.rmtree(self.temporary_directory)
-
+    # Remove temporary directory
+    unittest_toolbox.Modified_TestCase.tearDown(self)
 
 
   def test_delay_before_send(self):

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1773,18 +1773,16 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
 
   def setUp(self):
-    # We are inheriting from custom class.
+    # Modified_Testcase can handle temp dir removal
     unittest_toolbox.Modified_TestCase.setUp(self)
-
-    self.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
+    self.temporary_directory = self.make_temp_directory(directory=os.getcwd())
 
     # Copy the original repository files provided in the test folder so that
     # any modifications made to repository files are restricted to the copies.
     # The 'repository_data' directory is expected to exist in 'tuf/tests/'.
     original_repository_files = os.path.join(os.getcwd(), 'repository_data')
 
-    self.temporary_repository_root = self.make_temp_directory(directory=
-        self.temporary_directory)
+    self.temporary_repository_root = tempfile.mkdtemp(dir=self.temporary_directory)
 
     # Needed because in some tests simple_server.py cannot be found.
     # The reason is that the current working directory
@@ -1899,9 +1897,6 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # Modified_TestCase.tearDown() automatically deletes temporary files and
-    # directories that may have been created during each test case.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
 
     # Cleans the resources and flush the logged lines (if any).
     self.server_process_handler.clean()
@@ -1911,9 +1906,8 @@ class TestMultiRepoUpdater(unittest_toolbox.Modified_TestCase):
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
-    # Remove the temporary repository directory, which should contain all the
-    # metadata, targets, and key files generated of all the test cases
-    shutil.rmtree(self.temporary_directory)
+    # Remove top-level temporary directory
+    unittest_toolbox.Modified_TestCase.tearDown(self)
 
 
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -182,13 +182,14 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
     # Logs stdout and stderr from the sever subprocess.
     self.server_process_handler.flush_log()
+
+    # Remove temporary directory
+    unittest_toolbox.Modified_TestCase.tearDown(self)
 
 
   # UNIT TESTS.

--- a/tests/test_updater_root_rotation_integration.py
+++ b/tests/test_updater_root_rotation_integration.py
@@ -155,13 +155,14 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
 
   def tearDown(self):
-    # We are inheriting from custom class.
-    unittest_toolbox.Modified_TestCase.tearDown(self)
     tuf.roledb.clear_roledb(clear_all=True)
     tuf.keydb.clear_keydb(clear_all=True)
 
     # Logs stdout and stderr from the sever subprocess.
     self.server_process_handler.flush_log()
+
+    # Remove temporary directory
+    unittest_toolbox.Modified_TestCase.tearDown(self)
 
 
   # UNIT TESTS.


### PR DESCRIPTION
All three commits are basically the same thing: make sure tests remove temporary directories after any other teardown (most importantly: kill test servers before removing temp directories). First commit should actually fix a visible bug on windows CI (#1344), second is just good practice, third commit fixes a bug that is currently hidden by Modified_Testcase.

Long term thoughts:
* having a helper that handles server process and tempdir cleanup might be a good idea but I'm not sure Modified_Testcase is helping more than it's obfuscating? I'm not sure if the temp dir stuff is even directly needed in the tests, the common needs are these I think:
  * class must be able to serve repository that all its tests run against
  * test instance must be able to serve it's own repository (because it wants to modify the contents)
  * the served repository paths must be exposed so the content can be modified during test
  * So we could just always have one test server per class, and the repos are just copied in the served directory: either a repo dir per class or test-specific ones
* creating temp directories in current working directory is a bit obnoxious...