### PR TITLE
Add a method of Signed metadata class returning information about metadata expiration 

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -219,7 +219,25 @@ class TestMetadata(unittest.TestCase):
         md.signed.bump_expiration(timedelta(days=365))
         self.assertEqual(md.signed.expires, datetime(2031, 1, 2, 0, 0))
 
+        # Test is_expired with reference_time provided
+        is_expired = md.signed.is_expired(md.signed.expires)
+        self.assertTrue(is_expired)
+        is_expired = md.signed.is_expired(md.signed.expires + timedelta(days=1))
+        self.assertTrue(is_expired)
+        is_expired = md.signed.is_expired(md.signed.expires - timedelta(days=1))
+        self.assertFalse(is_expired)
 
+        # Test is_expired without reference_time, 
+        # manipulating md.signed.expires
+        expires = md.signed.expires
+        md.signed.expires = datetime.utcnow()
+        is_expired = md.signed.is_expired()
+        self.assertTrue(is_expired)
+        md.signed.expires = datetime.utcnow() + timedelta(days=1)
+        is_expired = md.signed.is_expired()
+        self.assertFalse(is_expired)
+        md.signed.expires = expires
+        
     def test_metadata_snapshot(self):
         snapshot_path = os.path.join(
                 self.repo_dir, 'metadata', 'snapshot.json')

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -351,6 +351,22 @@ class Signed:
             "expires": self.expires.isoformat() + "Z",
         }
 
+    def is_expired(self, reference_time: datetime = None) -> bool:
+        """Checks metadata expiration against a reference time.
+
+        Args:
+            reference_time: Optional; The time to check expiration date against.
+                A naive datetime in UTC expected.
+                If not provided, checks against the current UTC date and time.
+
+        Returns:
+            True if expiration time is less than the reference time.
+        """
+        if reference_time is None:
+            reference_time = datetime.utcnow()
+
+        return reference_time >= self.expires
+
     # Modification.
     def bump_expiration(self, delta: timedelta = timedelta(days=1)) -> None:
         """Increments the expires attribute by the passed timedelta. """


### PR DESCRIPTION
Adds the **is_expired** method to the **Signed** metadata class that checks the **expires** attribute against a reference time and returns information about metadata expiration 

Signed-off-by: Velichka Atanasova <avelichka@vmware.com>

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

Fixes #1305

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


