### PR TITLE
api: Add Metadata.from_bytes()

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -105,8 +105,7 @@ class TestMetadata(unittest.TestCase):
             path = os.path.join(self.repo_dir, 'metadata', metadata + '.json')
             metadata_obj = Metadata.from_file(path)
             with open(path, 'rb') as f:
-                metadata_str = f.read()
-            metadata_obj2 = JSONDeserializer().deserialize(metadata_str)
+                metadata_obj2 = Metadata.from_bytes(f.read())
 
             # Assert that both methods instantiate the right inner class for
             # each metadata type and ...
@@ -119,15 +118,17 @@ class TestMetadata(unittest.TestCase):
             self.assertDictEqual(
                     metadata_obj.to_dict(), metadata_obj2.to_dict())
 
-
         # Assert that it chokes correctly on an unknown metadata type
         bad_metadata_path = 'bad-metadata.json'
         bad_metadata = {'signed': {'_type': 'bad-metadata'}}
+        bad_string = json.dumps(bad_metadata).encode('utf-8')
         with open(bad_metadata_path, 'wb') as f:
-            f.write(json.dumps(bad_metadata).encode('utf-8'))
+            f.write(bad_string)
 
         with self.assertRaises(DeserializationError):
             Metadata.from_file(bad_metadata_path)
+        with self.assertRaises(DeserializationError):
+            Metadata.from_bytes(bad_string)
 
         os.remove(bad_metadata_path)
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -128,6 +128,32 @@ class Metadata:
             A TUF Metadata object.
 
         """
+        if storage_backend is None:
+            storage_backend = FilesystemBackend()
+
+        with storage_backend.get(filename) as file_obj:
+            return cls.from_bytes(file_obj.read(), deserializer)
+
+    @staticmethod
+    def from_bytes(
+        data: bytes,
+        deserializer: Optional[MetadataDeserializer] = None,
+    ) -> "Metadata":
+        """Loads TUF metadata from raw data.
+
+        Arguments:
+            data: metadata content as bytes.
+            deserializer: Optional; A MetadataDeserializer instance that
+                implements deserialization. Default is JSONDeserializer.
+
+        Raises:
+            tuf.api.serialization.DeserializationError:
+                The file cannot be deserialized.
+
+        Returns:
+            A TUF Metadata object.
+        """
+
         if deserializer is None:
             # Use local scope import to avoid circular import errors
             # pylint: disable=import-outside-toplevel
@@ -135,13 +161,7 @@ class Metadata:
 
             deserializer = JSONDeserializer()
 
-        if storage_backend is None:
-            storage_backend = FilesystemBackend()
-
-        with storage_backend.get(filename) as file_obj:
-            raw_data = file_obj.read()
-
-        return deserializer.deserialize(raw_data)
+        return deserializer.deserialize(data)
 
     def to_dict(self) -> Dict[str, Any]:
         """Returns the dict representation of self. """


### PR DESCRIPTION
This is essentially short-hand for

    JSONDeserializer().deserialize(data)

but seems easier for the API user so may be worth it.

Metadata.from_file() now uses Metadata.from_bytes() internally.

--- 
_(message and title edited later to replace string with bytes)_

Fixes #1336

I think adding this makes sense in that we're trying to "hide" serialization details from the default use case and currently that wasn't possible if you just have a string (and not a file).

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature