### PR TITLE
experimental client: Add MetadataBundle

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -450,21 +450,23 @@ class TestMetadata(unittest.TestCase):
             with self.assertRaises(ValueError):
                 DelegatedRole.from_dict(role.copy())
 
-            # Test creating DelegatedRole only with "path_hash_prefixes"
+            # Test creating DelegatedRole only with "path_hash_prefixes" (an empty one)
             del role["paths"]
-            DelegatedRole.from_dict(role.copy())
-            role["paths"] = "foo"
+            role["path_hash_prefixes"] = []
+            role_obj = DelegatedRole.from_dict(role.copy())
+            self.assertEqual(role_obj.to_dict(), role)
 
-            # Test creating DelegatedRole only with "paths"
+            # Test creating DelegatedRole only with "paths" (now an empty one)
             del role["path_hash_prefixes"]
-            DelegatedRole.from_dict(role.copy())
-            role["path_hash_prefixes"] = "foo"
+            role["paths"] = []
+            role_obj = DelegatedRole.from_dict(role.copy())
+            self.assertEqual(role_obj.to_dict(), role)
 
             # Test creating DelegatedRole without "paths" and
             # "path_hash_prefixes" set
             del role["paths"]
-            del role["path_hash_prefixes"]
-            DelegatedRole.from_dict(role)
+            role_obj = DelegatedRole.from_dict(role.copy())
+            self.assertEqual(role_obj.to_dict(), role)
 
 
     def test_delegation_class(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -496,6 +496,21 @@ class TestMetadata(unittest.TestCase):
         delegations = Delegations.from_dict(copy.deepcopy(delegations_dict))
         self.assertEqual(delegations_dict, delegations.to_dict())
 
+        # empty keys and roles
+        delegations_dict = {"keys":{}, "roles":[]}
+        delegations = Delegations.from_dict(delegations_dict.copy())
+        self.assertEqual(delegations_dict, delegations.to_dict())
+
+        # Test some basic missing or broken input
+        invalid_delegations_dicts = [
+            {},
+            {"keys":None, "roles":None},
+            {"keys":{"foo":0}, "roles":[]},
+            {"keys":{}, "roles":["foo"]},
+        ]
+        for d in invalid_delegations_dicts:
+            with self.assertRaises((KeyError, AttributeError)):
+                Delegations.from_dict(d)
 
     def test_metadata_targets(self):
         targets_path = os.path.join(

--- a/tests/test_metadata_bundle.py
+++ b/tests/test_metadata_bundle.py
@@ -15,166 +15,108 @@ from tests import utils
 logger = logging.getLogger(__name__)
 
 class TestMetadataBundle(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.temp_dir = tempfile.mkdtemp(dir=os.getcwd())
-
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls.temp_dir)
-
-    def setUp(self):
-        # copy metadata to "local repo"
-        shutil.copytree(
-            os.path.join(os.getcwd(), 'repository_data', 'repository', 'metadata'),
-            self.temp_dir,
-            dirs_exist_ok=True
-        )
-
-    def test_local_load(self):
-
-        # test loading all local metadata succesfully
-        bundle = MetadataBundle(self.temp_dir)
-        bundle.root_update_finished()
-        bundle.load_local_timestamp()
-        bundle.load_local_snapshot()
-        bundle.load_local_targets()
-        bundle.load_local_delegated_targets('role1','targets')
-        bundle.load_local_delegated_targets('role2','role1')
-
-        # Make sure loading metadata without its "dependencies" fails
-        bundle = MetadataBundle(self.temp_dir)
-
-        with self.assertRaises(RuntimeError):
-            bundle.load_local_timestamp()
-        bundle.root_update_finished()
-        with self.assertRaises(RuntimeError):
-            bundle.load_local_snapshot()
-        bundle.load_local_timestamp()
-        with self.assertRaises(RuntimeError):
-            bundle.load_local_targets()
-        bundle.load_local_snapshot()
-        with self.assertRaises(RuntimeError):
-            bundle.load_local_delegated_targets('role1','targets')
-        bundle.load_local_targets()
-        with self.assertRaises(RuntimeError):
-            bundle.load_local_delegated_targets('role2','role1')
-        bundle.load_local_delegated_targets('role1','targets')
-        bundle.load_local_delegated_targets('role2','role1')
 
     def test_update(self):
-        remote_dir = os.path.join(os.getcwd(), 'repository_data', 'repository', 'metadata')
+        repo_dir = os.path.join(os.getcwd(), 'repository_data', 'repository', 'metadata')
 
-        # remove all but root.json from local repo
-        os.remove(os.path.join(self.temp_dir, "timestamp.json"))
-        os.remove(os.path.join(self.temp_dir, "snapshot.json"))
-        os.remove(os.path.join(self.temp_dir, "targets.json"))
-        os.remove(os.path.join(self.temp_dir, "role1.json"))
-        os.remove(os.path.join(self.temp_dir, "role2.json"))
-
-        bundle = MetadataBundle(self.temp_dir)
+        with open(os.path.join(repo_dir, "root.json"), "rb") as f:
+            bundle = MetadataBundle(f.read())
         bundle.root_update_finished()
 
-        # test local load failure, then updating metadata succesfully
-        with self.assertRaises(exceptions.RepositoryError):
-            bundle.load_local_timestamp()
-        with open(os.path.join(remote_dir, "timestamp.json"), "rb") as f:
+        with open(os.path.join(repo_dir, "timestamp.json"), "rb") as f:
             bundle.update_timestamp(f.read())
-        with open(os.path.join(remote_dir, "snapshot.json"), "rb") as f:
+        with open(os.path.join(repo_dir, "snapshot.json"), "rb") as f:
             bundle.update_snapshot(f.read())
-        with open(os.path.join(remote_dir, "targets.json"), "rb") as f:
+        with open(os.path.join(repo_dir, "targets.json"), "rb") as f:
             bundle.update_targets(f.read())
-        with open(os.path.join(remote_dir, "role1.json"), "rb") as f:
+        with open(os.path.join(repo_dir, "role1.json"), "rb") as f:
             bundle.update_delegated_targets(f.read(), "role1", "targets")
-        with open(os.path.join(remote_dir, "role2.json"), "rb") as f:
+        with open(os.path.join(repo_dir, "role2.json"), "rb") as f:
             bundle.update_delegated_targets(f.read(), "role2", "role1")
 
-        # test loading the metadata (that should now be locally available)
-        bundle = MetadataBundle(self.temp_dir)
+    def test_out_of_order_ops(self):
+        repo_dir = os.path.join(os.getcwd(), 'repository_data', 'repository', 'metadata')
+        data={}
+        for md in ["root", "timestamp", "snapshot", "targets", "role1"]:
+            with open(os.path.join(repo_dir, f"{md}.json"), "rb") as f:
+                data[md] = f.read()
+
+        bundle = MetadataBundle(data["root"])
+
+        # Update timestamp before root is finished
+        with self.assertRaises(RuntimeError):
+            bundle.update_timestamp(data["timestamp"])
+
         bundle.root_update_finished()
-        bundle.load_local_timestamp()
-        bundle.load_local_snapshot()
-        bundle.load_local_targets()
-        bundle.load_local_delegated_targets('role1','targets')
-        bundle.load_local_delegated_targets('role2','role1')
-
-        # TODO test loading one version, then updating to new versions of each metadata
-
-    def test_local_load_with_invalid_data(self):
-        # Test root and one of the top-level metadata files
-
-        with tempfile.TemporaryDirectory() as tempdir:
-            # Missing root.json
-            with self.assertRaises(exceptions.RepositoryError):
-                MetadataBundle(tempdir)
-
-            # root.json not a json file at all
-            with open(os.path.join(tempdir, "root.json"), "w") as f:
-                f.write("")
-            with self.assertRaises(exceptions.RepositoryError):
-                MetadataBundle(tempdir)
-
-            # root.json does not validate
-            md = Metadata.from_file(os.path.join(self.temp_dir, "root.json"))
-            md.signed.version += 1
-            md.to_file(os.path.join(tempdir, "root.json"))
-            with self.assertRaises(exceptions.RepositoryError):
-                MetadataBundle(tempdir)
-
-            md.signed.version -= 1
-            md.to_file(os.path.join(tempdir, "root.json"))
-            bundle = MetadataBundle(tempdir)
+        with self.assertRaises(RuntimeError):
             bundle.root_update_finished()
 
-            # Missing timestamp.json
-            with self.assertRaises(exceptions.RepositoryError):
-                bundle.load_local_timestamp()
+        # Update snapshot before timestamp
+        with self.assertRaises(RuntimeError):
+            bundle.update_snapshot(data["snapshot"])
 
-            # timestamp not a json file at all
-            with open(os.path.join(tempdir, "timestamp.json"), "w") as f:
-                f.write("")
-            with self.assertRaises(exceptions.RepositoryError):
-                bundle.load_local_timestamp()
+        bundle.update_timestamp(data["timestamp"])
 
-            # timestamp does not validate
-            md = Metadata.from_file(os.path.join(self.temp_dir, "timestamp.json"))
-            md.signed.version += 1
-            md.to_file(os.path.join(tempdir, "timestamp.json"))
-            with self.assertRaises(exceptions.RepositoryError):
-                bundle.load_local_timestamp()
+        # Update targets before snapshot
+        with self.assertRaises(RuntimeError):
+            bundle.update_targets(data["targets"])
 
-            md.signed.version -= 1
-            md.to_file(os.path.join(tempdir, "timestamp.json"))
-            bundle.load_local_timestamp()
+        bundle.update_snapshot(data["snapshot"])
 
-    def test_update_with_invalid_data(self):
-        # Test on of the top level metadata files
+        #update timestamp after snapshot
+        with self.assertRaises(RuntimeError):
+            bundle.update_timestamp(data["timestamp"])
 
-        timestamp_md = Metadata.from_file(os.path.join(self.temp_dir, "timestamp.json"))
+        # Update delegated targets before targets
+        with self.assertRaises(RuntimeError):
+            bundle.update_delegated_targets(data["role1"], "role1", "targets")
 
-        # remove all but root.json from local repo
-        os.remove(os.path.join(self.temp_dir, "timestamp.json"))
-        os.remove(os.path.join(self.temp_dir, "snapshot.json"))
-        os.remove(os.path.join(self.temp_dir, "targets.json"))
-        os.remove(os.path.join(self.temp_dir, "role1.json"))
-        os.remove(os.path.join(self.temp_dir, "role2.json"))
+        bundle.update_targets(data["targets"])
+        bundle.update_delegated_targets(data["role1"], "role1", "targets")
 
-        bundle = MetadataBundle(self.temp_dir)
+    def test_update_with_invalid_json(self):
+        repo_dir = os.path.join(os.getcwd(), 'repository_data', 'repository', 'metadata')
+        data={}
+        for md in ["root", "timestamp", "snapshot", "targets", "role1"]:
+            with open(os.path.join(repo_dir, f"{md}.json"), "rb") as f:
+                data[md] = f.read()
+
+        # root.json not a json file at all
+        with self.assertRaises(exceptions.RepositoryError):
+            MetadataBundle(b"")
+        # root.json is invalid
+        root = Metadata.from_bytes(data["root"])
+        root.signed.version += 1
+        with self.assertRaises(exceptions.RepositoryError):
+            MetadataBundle(json.dumps(root.to_dict()).encode())
+
+        bundle = MetadataBundle(data["root"])
         bundle.root_update_finished()
 
-        # timestamp not a json file at all
-        with self.assertRaises(exceptions.RepositoryError):
-            bundle.update_timestamp(b"")
+        top_level_md = [
+            (data["timestamp"], bundle.update_timestamp),
+            (data["snapshot"], bundle.update_snapshot),
+            (data["targets"], bundle.update_targets),
+        ]
+        for metadata, update_func in top_level_md:
+            # metadata is not json
+            with self.assertRaises(exceptions.RepositoryError):
+                update_func(b"")
+            # metadata is invalid
+            md = Metadata.from_bytes(metadata)
+            md.signed.version += 1
+            with self.assertRaises(exceptions.RepositoryError):
+                update_func(json.dumps(md.to_dict()).encode())
 
-        # timestamp does not validate
-        timestamp_md.signed.version += 1
-        data = timestamp_md.to_dict()
-        with self.assertRaises(exceptions.RepositoryError):
-            bundle.update_timestamp(json.dumps(data).encode())
+            # metadata is of wrong type
+            with self.assertRaises(exceptions.RepositoryError):
+                update_func(data["root"])
 
-        timestamp_md.signed.version -= 1
-        data = timestamp_md.to_dict()
-        bundle.update_timestamp(json.dumps(data).encode())
+            update_func(metadata)
+
+
+    # TODO test updating over initial metadata (new keys, newer timestamp, etc)
+    # TODO test the actual specification checks
 
 
 if __name__ == '__main__':

--- a/tests/test_metadata_bundle.py
+++ b/tests/test_metadata_bundle.py
@@ -1,6 +1,8 @@
 import logging
 import os
+import shutil
 import sys
+import tempfile
 import unittest
 
 from tuf.api import metadata
@@ -11,11 +13,26 @@ from tests import utils
 logger = logging.getLogger(__name__)
 
 class TestMetadataBundle(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.temporary_directory)
+
+    def setUp(self):
+        # copy metadata to "local repo"
+        shutil.copytree(
+            os.path.join(os.getcwd(), 'repository_data', 'repository', 'metadata'),
+            self.temporary_directory,
+            dirs_exist_ok=True
+        )
+
     def test_local_load(self):
-        repo_dir = os.path.join(os.getcwd(), 'repository_data', 'repository', 'metadata')
 
         # test loading all local metadata succesfully
-        bundle = MetadataBundle(repo_dir)
+        bundle = MetadataBundle(self.temporary_directory)
         bundle.root_update_finished()
         self.assertTrue(bundle.load_local_timestamp())
         self.assertTrue(bundle.load_local_snapshot())
@@ -24,7 +41,7 @@ class TestMetadataBundle(unittest.TestCase):
         self.assertTrue(bundle.load_local_delegated_targets('role2','role1'))
 
         # Make sure loading metadata without its "dependencies" fails
-        bundle = MetadataBundle(repo_dir)
+        bundle = MetadataBundle(self.temporary_directory)
 
         with self.assertRaises(RuntimeError):
             bundle.load_local_timestamp()
@@ -42,6 +59,42 @@ class TestMetadataBundle(unittest.TestCase):
             bundle.load_local_delegated_targets('role2','role1')
         self.assertTrue(bundle.load_local_delegated_targets('role1','targets'))
         self.assertTrue(bundle.load_local_delegated_targets('role2','role1'))
+
+    def test_update(self):
+        remote_dir = os.path.join(os.getcwd(), 'repository_data', 'repository', 'metadata')
+
+        # remove all but root.json from local repo
+        os.remove(os.path.join(self.temporary_directory, "timestamp.json"))
+        os.remove(os.path.join(self.temporary_directory, "snapshot.json"))
+        os.remove(os.path.join(self.temporary_directory, "targets.json"))
+        os.remove(os.path.join(self.temporary_directory, "role1.json"))
+        os.remove(os.path.join(self.temporary_directory, "role2.json"))
+
+        # test updating metadata succesfully
+        bundle = MetadataBundle(self.temporary_directory)
+        bundle.root_update_finished()
+
+        with open(os.path.join(remote_dir, "timestamp.json"), "rb") as f:
+            bundle.update_timestamp(f.read())
+        with open(os.path.join(remote_dir, "snapshot.json"), "rb") as f:
+            bundle.update_snapshot(f.read())
+        with open(os.path.join(remote_dir, "targets.json"), "rb") as f:
+            bundle.update_targets(f.read())
+        with open(os.path.join(remote_dir, "role1.json"), "rb") as f:
+            bundle.update_delegated_targets(f.read(), "role1", "targets")
+        with open(os.path.join(remote_dir, "role2.json"), "rb") as f:
+            bundle.update_delegated_targets(f.read(), "role2", "role1")
+
+        # test loading the metadata (that should now be locally available)
+        bundle = MetadataBundle(self.temporary_directory)
+        bundle.root_update_finished()
+        self.assertTrue(bundle.load_local_timestamp())
+        self.assertTrue(bundle.load_local_snapshot())
+        self.assertTrue(bundle.load_local_targets())
+        self.assertTrue(bundle.load_local_delegated_targets('role1','targets'))
+        self.assertTrue(bundle.load_local_delegated_targets('role2','role1'))
+
+        # TODO test loading one version, then updating to new versions of each metadata
 
 
 if __name__ == '__main__':

--- a/tests/test_metadata_bundle.py
+++ b/tests/test_metadata_bundle.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import shutil
@@ -5,7 +6,8 @@ import sys
 import tempfile
 import unittest
 
-from tuf.api import metadata
+from tuf import exceptions
+from tuf.api.metadata import Metadata
 from tuf.client_rework.metadata_bundle import MetadataBundle
 
 from tests import utils
@@ -15,65 +17,67 @@ logger = logging.getLogger(__name__)
 class TestMetadataBundle(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
+        cls.temp_dir = tempfile.mkdtemp(dir=os.getcwd())
 
     @classmethod
     def tearDownClass(cls):
-        shutil.rmtree(cls.temporary_directory)
+        shutil.rmtree(cls.temp_dir)
 
     def setUp(self):
         # copy metadata to "local repo"
         shutil.copytree(
             os.path.join(os.getcwd(), 'repository_data', 'repository', 'metadata'),
-            self.temporary_directory,
+            self.temp_dir,
             dirs_exist_ok=True
         )
 
     def test_local_load(self):
 
         # test loading all local metadata succesfully
-        bundle = MetadataBundle(self.temporary_directory)
+        bundle = MetadataBundle(self.temp_dir)
         bundle.root_update_finished()
-        self.assertTrue(bundle.load_local_timestamp())
-        self.assertTrue(bundle.load_local_snapshot())
-        self.assertTrue(bundle.load_local_targets())
-        self.assertTrue(bundle.load_local_delegated_targets('role1','targets'))
-        self.assertTrue(bundle.load_local_delegated_targets('role2','role1'))
+        bundle.load_local_timestamp()
+        bundle.load_local_snapshot()
+        bundle.load_local_targets()
+        bundle.load_local_delegated_targets('role1','targets')
+        bundle.load_local_delegated_targets('role2','role1')
 
         # Make sure loading metadata without its "dependencies" fails
-        bundle = MetadataBundle(self.temporary_directory)
+        bundle = MetadataBundle(self.temp_dir)
 
         with self.assertRaises(RuntimeError):
             bundle.load_local_timestamp()
         bundle.root_update_finished()
         with self.assertRaises(RuntimeError):
             bundle.load_local_snapshot()
-        self.assertTrue(bundle.load_local_timestamp())
+        bundle.load_local_timestamp()
         with self.assertRaises(RuntimeError):
             bundle.load_local_targets()
-        self.assertTrue(bundle.load_local_snapshot())
+        bundle.load_local_snapshot()
         with self.assertRaises(RuntimeError):
             bundle.load_local_delegated_targets('role1','targets')
-        self.assertTrue(bundle.load_local_targets())
+        bundle.load_local_targets()
         with self.assertRaises(RuntimeError):
             bundle.load_local_delegated_targets('role2','role1')
-        self.assertTrue(bundle.load_local_delegated_targets('role1','targets'))
-        self.assertTrue(bundle.load_local_delegated_targets('role2','role1'))
+        bundle.load_local_delegated_targets('role1','targets')
+        bundle.load_local_delegated_targets('role2','role1')
 
     def test_update(self):
         remote_dir = os.path.join(os.getcwd(), 'repository_data', 'repository', 'metadata')
 
         # remove all but root.json from local repo
-        os.remove(os.path.join(self.temporary_directory, "timestamp.json"))
-        os.remove(os.path.join(self.temporary_directory, "snapshot.json"))
-        os.remove(os.path.join(self.temporary_directory, "targets.json"))
-        os.remove(os.path.join(self.temporary_directory, "role1.json"))
-        os.remove(os.path.join(self.temporary_directory, "role2.json"))
+        os.remove(os.path.join(self.temp_dir, "timestamp.json"))
+        os.remove(os.path.join(self.temp_dir, "snapshot.json"))
+        os.remove(os.path.join(self.temp_dir, "targets.json"))
+        os.remove(os.path.join(self.temp_dir, "role1.json"))
+        os.remove(os.path.join(self.temp_dir, "role2.json"))
 
-        # test updating metadata succesfully
-        bundle = MetadataBundle(self.temporary_directory)
+        bundle = MetadataBundle(self.temp_dir)
         bundle.root_update_finished()
 
+        # test local load failure, then updating metadata succesfully
+        with self.assertRaises(exceptions.RepositoryError):
+            bundle.load_local_timestamp()
         with open(os.path.join(remote_dir, "timestamp.json"), "rb") as f:
             bundle.update_timestamp(f.read())
         with open(os.path.join(remote_dir, "snapshot.json"), "rb") as f:
@@ -86,15 +90,91 @@ class TestMetadataBundle(unittest.TestCase):
             bundle.update_delegated_targets(f.read(), "role2", "role1")
 
         # test loading the metadata (that should now be locally available)
-        bundle = MetadataBundle(self.temporary_directory)
+        bundle = MetadataBundle(self.temp_dir)
         bundle.root_update_finished()
-        self.assertTrue(bundle.load_local_timestamp())
-        self.assertTrue(bundle.load_local_snapshot())
-        self.assertTrue(bundle.load_local_targets())
-        self.assertTrue(bundle.load_local_delegated_targets('role1','targets'))
-        self.assertTrue(bundle.load_local_delegated_targets('role2','role1'))
+        bundle.load_local_timestamp()
+        bundle.load_local_snapshot()
+        bundle.load_local_targets()
+        bundle.load_local_delegated_targets('role1','targets')
+        bundle.load_local_delegated_targets('role2','role1')
 
         # TODO test loading one version, then updating to new versions of each metadata
+
+    def test_local_load_with_invalid_data(self):
+        # Test root and one of the top-level metadata files
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            # Missing root.json
+            with self.assertRaises(exceptions.RepositoryError):
+                MetadataBundle(tempdir)
+
+            # root.json not a json file at all
+            with open(os.path.join(tempdir, "root.json"), "w") as f:
+                f.write("")
+            with self.assertRaises(exceptions.RepositoryError):
+                MetadataBundle(tempdir)
+
+            # root.json does not validate
+            md = Metadata.from_file(os.path.join(self.temp_dir, "root.json"))
+            md.signed.version += 1
+            md.to_file(os.path.join(tempdir, "root.json"))
+            with self.assertRaises(exceptions.RepositoryError):
+                MetadataBundle(tempdir)
+
+            md.signed.version -= 1
+            md.to_file(os.path.join(tempdir, "root.json"))
+            bundle = MetadataBundle(tempdir)
+            bundle.root_update_finished()
+
+            # Missing timestamp.json
+            with self.assertRaises(exceptions.RepositoryError):
+                bundle.load_local_timestamp()
+
+            # timestamp not a json file at all
+            with open(os.path.join(tempdir, "timestamp.json"), "w") as f:
+                f.write("")
+            with self.assertRaises(exceptions.RepositoryError):
+                bundle.load_local_timestamp()
+
+            # timestamp does not validate
+            md = Metadata.from_file(os.path.join(self.temp_dir, "timestamp.json"))
+            md.signed.version += 1
+            md.to_file(os.path.join(tempdir, "timestamp.json"))
+            with self.assertRaises(exceptions.RepositoryError):
+                bundle.load_local_timestamp()
+
+            md.signed.version -= 1
+            md.to_file(os.path.join(tempdir, "timestamp.json"))
+            bundle.load_local_timestamp()
+
+    def test_update_with_invalid_data(self):
+        # Test on of the top level metadata files
+
+        timestamp_md = Metadata.from_file(os.path.join(self.temp_dir, "timestamp.json"))
+
+        # remove all but root.json from local repo
+        os.remove(os.path.join(self.temp_dir, "timestamp.json"))
+        os.remove(os.path.join(self.temp_dir, "snapshot.json"))
+        os.remove(os.path.join(self.temp_dir, "targets.json"))
+        os.remove(os.path.join(self.temp_dir, "role1.json"))
+        os.remove(os.path.join(self.temp_dir, "role2.json"))
+
+        bundle = MetadataBundle(self.temp_dir)
+        bundle.root_update_finished()
+
+        # timestamp not a json file at all
+        with self.assertRaises(exceptions.RepositoryError):
+            bundle.update_timestamp(b"")
+
+        # timestamp does not validate
+        timestamp_md.signed.version += 1
+        data = timestamp_md.to_dict()
+        with self.assertRaises(exceptions.RepositoryError):
+            bundle.update_timestamp(json.dumps(data).encode())
+
+        timestamp_md.signed.version -= 1
+        data = timestamp_md.to_dict()
+        bundle.update_timestamp(json.dumps(data).encode())
 
 
 if __name__ == '__main__':

--- a/tests/test_metadata_bundle.py
+++ b/tests/test_metadata_bundle.py
@@ -1,0 +1,29 @@
+import logging
+import os
+import sys
+import unittest
+
+from tuf.api import metadata
+from tuf.client_rework.metadata_bundle import MetadataBundle
+
+from tests import utils
+
+logger = logging.getLogger(__name__)
+
+class TestMetadataBundle(unittest.TestCase):
+    def test_local_load(self):
+        repo_dir = os.path.join(os.getcwd(), 'repository_data', 'repository', 'metadata')
+
+        bundle = MetadataBundle(repo_dir)
+        bundle.root_update_finished()
+
+        self.assertTrue(bundle.load_local_timestamp())
+        self.assertTrue(bundle.load_local_snapshot())
+        self.assertTrue(bundle.load_local_targets())
+        self.assertTrue(bundle.load_local_delegated_targets('role1','targets'))
+        self.assertTrue(bundle.load_local_delegated_targets('role2','role1'))
+
+
+if __name__ == '__main__':
+  utils.configure_test_logging(sys.argv)
+  unittest.main()

--- a/tests/test_metadata_bundle.py
+++ b/tests/test_metadata_bundle.py
@@ -14,12 +14,32 @@ class TestMetadataBundle(unittest.TestCase):
     def test_local_load(self):
         repo_dir = os.path.join(os.getcwd(), 'repository_data', 'repository', 'metadata')
 
+        # test loading all local metadata succesfully
         bundle = MetadataBundle(repo_dir)
         bundle.root_update_finished()
-
         self.assertTrue(bundle.load_local_timestamp())
         self.assertTrue(bundle.load_local_snapshot())
         self.assertTrue(bundle.load_local_targets())
+        self.assertTrue(bundle.load_local_delegated_targets('role1','targets'))
+        self.assertTrue(bundle.load_local_delegated_targets('role2','role1'))
+
+        # Make sure loading metadata without its "dependencies" fails
+        bundle = MetadataBundle(repo_dir)
+
+        with self.assertRaises(RuntimeError):
+            bundle.load_local_timestamp()
+        bundle.root_update_finished()
+        with self.assertRaises(RuntimeError):
+            bundle.load_local_snapshot()
+        self.assertTrue(bundle.load_local_timestamp())
+        with self.assertRaises(RuntimeError):
+            bundle.load_local_targets()
+        self.assertTrue(bundle.load_local_snapshot())
+        with self.assertRaises(RuntimeError):
+            bundle.load_local_delegated_targets('role1','targets')
+        self.assertTrue(bundle.load_local_targets())
+        with self.assertRaises(RuntimeError):
+            bundle.load_local_delegated_targets('role2','role1')
         self.assertTrue(bundle.load_local_delegated_targets('role1','targets'))
         self.assertTrue(bundle.load_local_delegated_targets('role2','role1'))
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -770,7 +770,7 @@ class DelegatedRole(Role):
         super().__init__(keyids, threshold, unrecognized_fields)
         self.name = name
         self.terminating = terminating
-        if paths and path_hash_prefixes:
+        if paths is not None and path_hash_prefixes is not None:
             raise ValueError(
                 "Only one of the attributes 'paths' and"
                 "'path_hash_prefixes' can be set!"
@@ -806,9 +806,9 @@ class DelegatedRole(Role):
             "terminating": self.terminating,
             **base_role_dict,
         }
-        if self.paths:
+        if self.paths is not None:
             res_dict["paths"] = self.paths
-        elif self.path_hash_prefixes:
+        elif self.path_hash_prefixes is not None:
             res_dict["path_hash_prefixes"] = self.path_hash_prefixes
         return res_dict
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -911,9 +911,12 @@ class Targets(Signed):
         """Creates Targets object from its dict representation."""
         common_args = cls._common_fields_from_dict(targets_dict)
         targets = targets_dict.pop("targets")
-        delegations = targets_dict.pop("delegations", None)
-        if delegations:
-            delegations = Delegations.from_dict(delegations)
+        try:
+            delegations_dict = targets_dict.pop("delegations")
+        except KeyError:
+            delegations = None
+        else:
+            delegations = Delegations.from_dict(delegations_dict)
         # All fields left in the targets_dict are unrecognized.
         return cls(*common_args, targets, delegations, targets_dict)
 
@@ -921,7 +924,7 @@ class Targets(Signed):
         """Returns the dict representation of self."""
         targets_dict = self._common_fields_to_dict()
         targets_dict["targets"] = self.targets
-        if self.delegations:
+        if self.delegations is not None:
             targets_dict["delegations"] = self.delegations.to_dict()
         return targets_dict
 

--- a/tuf/client_rework/metadata_bundle.py
+++ b/tuf/client_rework/metadata_bundle.py
@@ -1,0 +1,349 @@
+# Copyright the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""TUF client bundle-of-metadata
+
+MetadataBundle keeps track of current valid set of metadata for the client,
+and handles almost every step of the "Detailed client workflow" in the TUF
+specification (the remaining steps are download related). The bundle takes
+care of persisting valid metadata on disk, loading local metadata from disk
+and deleting invalid local metadata.
+
+New metadata (downloaded from a remote repository) can be loaded using
+'update_metadata()'. The type of accepted metadata depends on bundle state
+(states are "root"/"timestamp"/"snapshot"/"targets"/). Bundle states advances
+to next state on every successful metadata update, except for "root" where state
+only advances when 'root_update_finished()' is called. Exceptions will be thrown
+if metadata fails to load in any way.
+
+Example (with hypothetical download function):
+
+>>> # Load local root
+>>> bundle = MetadataBundle("path/to/metadata")
+>>>
+>>> # state: "root", load more root versions from remote
+>>> with download("root", bundle.root.signed.version + 1) as f:
+>>>     bundle.load_metadata(f.read())
+>>> with download("root", bundle.root.signed.version + 1) as f:
+>>>     bundle.load_metadata(f.read())
+>>>
+>>> # Finally, no more root from remote
+>>> bundle.root_update_finished()
+>>>
+>>> # state: "timestamp", load timestamp
+>>> with download("timestamp") as f:
+>>>     bundle.load_metadata(f.read())
+>>>
+>>> # state: "snapshot", load snapshot (consistent snapshot not shown)
+>>> with download("snapshot") as f:
+>>>     bundle.load_metadata(f.read())
+>>>
+>>> # state: "targets", load targets
+>>> version = bundle.snapshot.signed.meta["targets.json"]["version"]
+>>> with download("snapshot", version + 1) as f:
+>>>     bundle.load_metadata(f.read())
+>>>
+>>> # Top level metadata is now fully loaded and verified
+
+
+TODO:
+ * Delegated targets not implement yet
+ * exceptions are all over the place and not thought out at all
+ * a bit of repetition
+ * No tests!
+ * Naming maybe not final?
+ * some metadata interactions might work better in Metadata itself
+ * Progress through Specification update process should be documented
+   (not sure yet how)
+"""
+
+from collections import abc
+from datetime import datetime
+import logging
+import os
+from typing import Dict
+
+from securesystemslib import keys as sslib_hash
+from securesystemslib import keys as sslib_keys
+
+from tuf import exceptions
+from tuf.api.metadata import Metadata
+
+logger = logging.getLogger(__name__)
+
+# This is a placeholder until ...
+# TODO issue 1306: implement this in Metadata API
+def verify_with_threshold(root: Metadata, role: str, unverified: Metadata):
+    unique_keys = set()
+    for keyid in root.signed.roles[role]["keyids"]:
+        key_metadata = root.signed.keys[keyid]
+        key, _ = sslib_keys.format_metadata_to_key(key_metadata)
+
+        try:
+            if unverified.verify(key):
+                unique_keys.add(key["keyval"]["public"])
+        except:
+            pass
+
+    return len(unique_keys) >= root.signed.roles[role]["threshold"]
+
+
+# TODO issue 1336: implement in metadata api
+from tuf.api.serialization.json import JSONDeserializer
+
+
+def from_string(data: str) -> Metadata:
+    return JSONDeserializer().deserialize(data)
+
+
+class MetadataBundle(abc.Mapping):
+    def __init__(self, path: str):
+        """Initialize by loading existing metadata from disk
+
+        This includes root, timestamp, snapshot and _top-level_ targets .
+        """
+        self._path = path
+        self._bundle = {}  # type: Dict[str: Metadata]
+        self._state = "root"
+        self.reference_time = None
+
+        if not os.path.exists(path):
+            # TODO try to create dir instead?
+            raise exceptions.RepositoryError("Repository does not exist")
+
+        # Load and validate the local root metadata
+        # Valid root metadata is required (but invalid files are not removed)
+        try:
+            with open(os.path.join(self._path, "root.json"), "rb") as f:
+                self._load_intermediate_root(f.read())
+            logger.debug("Loaded local root.json")
+        except:
+            raise exceptions.RepositoryError("Failed to load local root metadata")
+
+    def update_metadata(self, metadata_str: str):
+        logger.debug("Updating %s", self._state)
+        if self._state == "root":
+            self._load_intermediate_root(metadata_str)
+            self.root.to_file(os.path.join(self._path, "root.json"))
+        elif self._state == "timestamp":
+            self._load_timestamp(metadata_str)
+            self.timestamp.to_file(os.path.join(self._path, "timestamp.json"))
+            self._state = "snapshot"
+        elif self._state == "snapshot":
+            self._load_snapshot(metadata_str)
+            self.snapshot.to_file(os.path.join(self._path, "snapshot.json"))
+            self._state = "targets"
+        elif self._state == "targets":
+            self._load_targets(metadata_str)
+            self.targets.to_file(os.path.join(self._path, "targets.json"))
+            self._state = ""
+        else:
+            raise NotImplementedError
+
+    def root_update_finished(self):
+        if self._state != "root":
+            # bundle does not support this order of ops
+            raise exceptions.RepositoryError
+
+        self._make_root_permanent(self)
+        self._state = "timestamp"
+
+    # Implement Mapping
+    def __getitem__(self, key: str):
+        return self._bundle[key]
+
+    def __len__(self):
+        return len(self._bundle)
+
+    def __iter__(self):
+        return iter(self._bundle)
+
+    # Helper properties for top level metadata
+    @property
+    def root(self):
+        return self._bundle.get("root")
+
+    @property
+    def timestamp(self):
+        return self._bundle.get("timestamp")
+
+    @property
+    def snapshot(self):
+        return self._bundle.get("snapshot")
+
+    @property
+    def targets(self):
+        return self._bundle.get("targets")
+
+    def _load_intermediate_root(self, data: str):
+        """Verify the new root using current root (if any) and use it as current root
+
+        Raises if root fails verification
+        """
+        new_root = from_string(data)
+        if new_root.signed._type != "root":
+            raise exceptions.RepositoryError
+
+        if self.root is not None:
+            if not verify_with_threshold(self.root, "root", new_root):
+                raise exceptions.UnsignedMetadataError(
+                    "New root is not signed by root", new_root.signed
+                )
+
+            if new_root.signed.version != self.root.signed.version + 1:
+                # TODO not a "Replayed Metadata attack": the version is just not what we expected
+                raise exceptions.ReplayedMetadataError(
+                    "root", new_root.signed.version, self.root.signed.version
+                )
+
+        if not verify_with_threshold(new_root, "root", new_root):
+            raise exceptions.UnsignedMetadataError(
+                "New root is not signed by itself", new_root.signed
+            )
+
+        self._bundle["root"] = new_root
+
+    def _make_root_permanent(self):
+        # Store our reference "now", verify root expiry
+        self.reference_time = datetime.utcnow()
+        if self.root.signed.is_expired(self.reference_time):
+            raise exceptions.ExpiredMetadataError
+
+        logger.debug("Verified final root.json")
+
+        # Load remaning local metadata: this ensures invalid
+        # metadata gets wiped from disk
+        try:
+            with open(os.path.join(self._path, "timestamp.json"), "rb") as f:
+                self._load_timestamp(f.read())
+            logger.debug("Loaded local timestamp.json")
+        except Exception as e:
+            # TODO only handle specific errors
+            logger.debug("Failed to load local timestamp.json")
+            # TODO delete local file
+
+        try:
+            with open(os.path.join(self._path, "snapshot.json"), "rb") as f:
+                self._load_snapshot(f.read())
+            logger.debug("Loaded local snapshot.json")
+        except Exception as e:
+            # TODO only handle specific errors
+            logger.debug("Failed to load local snapshot.json")
+            # TODO delete local file
+
+        try:
+            with open(os.path.join(self._path, "targets.json"), "rb") as f:
+                self._load_targets(f.read())
+            logger.debug("Loaded local targets.json")
+        except Exception as e:
+            # TODO only handle specific errors
+            logger.debug("Failed to load local targets.json")
+            # TODO delete local file
+
+    def _load_timestamp(self, data: str):
+        """Verifies the new timestamp and uses it as current timestamp
+
+        Raises if verification fails
+        """
+        new_timestamp = from_string(data)
+        if new_timestamp.signed._type != "timestamp":
+            raise exceptions.RepositoryError
+
+        if not verify_with_threshold(self.root, "timestamp", new_timestamp):
+            raise exceptions.UnsignedMetadataError(
+                "New timestamp is not signed by root", new_timestamp.signed
+            )
+
+        if self.timestamp is not None:
+            # Prevent rolling back timestamp version
+            if new_timestamp.signed.version < self.timestamp.signed.version:
+                raise exceptions.ReplayedMetadataError(
+                    "timestamp",
+                    new_timestamp.signed.version,
+                    self.timestamp.signed.version,
+                )
+            # Prevent rolling back snapshot version
+            if (
+                new_timestamp.signed.meta["snapshot.json"]["version"]
+                < self.timestamp.signed.meta["snapshot.json"]["version"]
+            ):
+                # TODO not sure about the
+                raise exceptions.ReplayedMetadataError(
+                    "snapshot",
+                    new_timestamp.signed.meta["snapshot.json"]["version"],
+                    self.timestamp.signed.meta["snapshot.json"]["version"],
+                )
+
+        if new_timestamp.signed.is_expired(self.reference_time):
+            raise exceptions.ExpiredMetadataError
+
+        self._bundle["timestamp"] = new_timestamp
+
+    def _load_snapshot(self, data: str):
+        # Verify against the hashes in timestamp, if any
+        meta = self.timestamp.signed.meta["snapshot.json"]
+        hashes = meta.get("hashes") or {}
+        for algo, _hash in meta["hashes"].items():
+            digest_object = sslib_hash.digest(algo)
+            digest_object.update(data)
+            if digest_object.hexdigest() != _hash:
+                raise exceptions.BadHashError()
+        new_snapshot = from_string(data)
+        if new_snapshot.signed._type != "snapshot":
+            raise exceptions.RepositoryError
+
+        if not verify_with_threshold(self.root, "snapshot", new_snapshot):
+            raise exceptions.UnsignedMetadataError(
+                "New snapshot is not signed by root", new_snapshot.signed
+            )
+
+        if (
+            new_snapshot.signed.version
+            != self.timestamp.signed.meta["snapshot.json"]["version"]
+        ):
+            raise exceptions.BadVersionNumberError
+
+        if self.snapshot:
+            for filename, fileinfo in self.snapshot.signed.meta.items():
+                new_fileinfo = new_snapshot.signed.meta.get(filename)
+
+                # Prevent removal of any metadata in meta
+                if new_fileinfo is None:
+                    raise exceptions.ReplayedMetadataError
+
+                # Prevent rollback of any metadata versions
+                if new_fileinfo["version"] < fileinfo["version"]:
+                    raise exceptions.ReplayedMetadataError
+
+        if new_snapshot.signed.is_expired(self.reference_time):
+            raise exceptions.ExpiredMetadataError
+
+        self._bundle["snapshot"] = new_snapshot
+
+    def _load_targets(self, data: str):
+        # Verify against the hashes in snapshot, if any
+        meta = self.snapshot.signed.meta["targets.json"]
+
+        hashes = meta.get("hashes") or {}
+        for algo, _hash in hashes.items():
+            digest_object = sslib_hash.digest(algo)
+            digest_object.update(data)
+            if digest_object.hexdigest() != _hash:
+                raise exceptions.BadHashError()
+
+        new_targets = from_string(data)
+        if new_targets.signed._type != "targets":
+            raise exceptions.RepositoryError
+
+        if not verify_with_threshold(self.root, "targets", new_targets):
+            raise exceptions.UnsignedMetadataError(
+                "New targets is not signed by root", new_targets.signed
+            )
+
+        if new_targets.signed.version != meta["version"]:
+            raise exceptions.BadVersionNumberError
+
+        if new_targets.signed.is_expired(self.reference_time):
+            raise exceptions.ExpiredMetadataError
+
+        self._bundle["targets"] = new_targets

--- a/tuf/client_rework/metadata_bundle.py
+++ b/tuf/client_rework/metadata_bundle.py
@@ -233,6 +233,10 @@ class MetadataBundle(abc.Mapping):
         self.update_delegated_targets(data, "targets", "root")
 
     def load_local_delegated_targets(self, role_name: str, delegator_name: str):
+        if self.get(role_name):
+            logger.debug("Local %s already loaded", role_name)
+            return True
+
         logger.debug("Loading local %s", role_name)
 
         try:

--- a/tuf/client_rework/metadata_bundle.py
+++ b/tuf/client_rework/metadata_bundle.py
@@ -62,10 +62,6 @@ Example (with hypothetical download function):
 
 
 TODO:
- * Delegated targets are implemented but they are not covered
-   by same immutability guarantees: the top-level metadata is handled
-   by hard-coded rules (can't update root if snapshot is loaded)
-   but delegations would require storing the delegation tree ...
  * exceptions are all over the place and not thought out at all
  * usefulness of root_update_finished() can be debated: it could be done
    in the beginning of _load_timestamp()...
@@ -129,14 +125,14 @@ def verify_with_threshold(delegator: Metadata, role_name: str, unverified: Metad
 
 
 class MetadataBundle(abc.Mapping):
-    def __init__(self, path: str):
+    def __init__(self, repository_path: str):
         """Initialize by loading root metadata from disk"""
-        self._path = path
+        self._path = repository_path
         self._bundle = {}  # type: Dict[str: Metadata]
         self._local_load_attempted = {}
         self.reference_time = None
 
-        if not os.path.exists(path):
+        if not os.path.exists(self._path):
             # TODO try to create dir instead?
             raise exceptions.RepositoryError("Repository does not exist")
 
@@ -353,7 +349,7 @@ class MetadataBundle(abc.Mapping):
                 new_timestamp.signed.meta["snapshot.json"]["version"]
                 < self.timestamp.signed.meta["snapshot.json"]["version"]
             ):
-                # TODO not sure about the
+                # TODO not sure about the correct exception here
                 raise exceptions.ReplayedMetadataError(
                     "snapshot",
                     new_timestamp.signed.meta["snapshot.json"]["version"],

--- a/tuf/client_rework/metadata_bundle.py
+++ b/tuf/client_rework/metadata_bundle.py
@@ -86,7 +86,7 @@ import logging
 import os
 from typing import Dict
 
-from securesystemslib import keys as sslib_hash
+from securesystemslib import hash as sslib_hash
 from securesystemslib import keys as sslib_keys
 
 from tuf import exceptions
@@ -358,7 +358,7 @@ class MetadataBundle(abc.Mapping):
 
         # Verify against the hashes in timestamp, if any
         hashes = meta.get("hashes") or {}
-        for algo, _hash in meta["hashes"].items():
+        for algo, _hash in hashes.items():
             digest_object = sslib_hash.digest(algo)
             digest_object.update(data)
             observed_hash = digest_object.hexdigest()

--- a/tuf/client_rework/metadata_bundle.py
+++ b/tuf/client_rework/metadata_bundle.py
@@ -98,9 +98,7 @@ def from_string(data: str) -> Metadata:
 
 class MetadataBundle(abc.Mapping):
     def __init__(self, path: str):
-        """Initialize by loading existing metadata from disk
-
-        This includes root, timestamp, snapshot and _top-level_ targets .
+        """Initialize by loading root metadata from disk
         """
         self._path = path
         self._bundle = {}  # type: Dict[str: Metadata]

--- a/tuf/client_rework/metadata_bundle.py
+++ b/tuf/client_rework/metadata_bundle.py
@@ -134,10 +134,6 @@ class MetadataBundle(abc.Mapping):
         self._bundle = {}  # type: Dict[str: Metadata]
         self.reference_time = None
 
-        if not os.path.exists(self._path):
-            # TODO try to create dir instead?
-            raise exceptions.RepositoryError("Repository does not exist")
-
         # Load and validate the local root metadata
         # Valid root metadata is required
         logger.debug("Loading local root")

--- a/tuf/client_rework/metadata_bundle.py
+++ b/tuf/client_rework/metadata_bundle.py
@@ -204,6 +204,9 @@ class MetadataBundle(abc.Mapping):
         if self.root.signed.is_expired(self.reference_time):
             raise exceptions.ExpiredMetadataError("New root.json is expired")
 
+        # We skip specification step 5.3.11: deleting timestamp and snapshot
+        # with rotated keys is not needed as they will be invalid, are not
+        # loaded and cannot be loaded
         self._root_update_finished = True
         logger.debug("Verified final root.json")
 
@@ -316,6 +319,7 @@ class MetadataBundle(abc.Mapping):
             )
 
         if self.root is not None:
+            # We are not loading initial trusted root: verify the new one
             if not verify_with_threshold(self.root, "root", new_root):
                 raise exceptions.UnsignedMetadataError(
                     "New root is not signed by root", new_root.signed

--- a/tuf/client_rework/metadata_bundle.py
+++ b/tuf/client_rework/metadata_bundle.py
@@ -204,7 +204,7 @@ class MetadataBundle(abc.Mapping):
     def root_update_finished(self):
         """Mark root metadata as final."""
         if self.reference_time is not None:
-            raise ValueError("Root update is already finished")
+            raise RuntimeError("Root update is already finished")
 
         # Store our reference "now", verify root expiry
         self.reference_time = datetime.utcnow()
@@ -306,7 +306,7 @@ class MetadataBundle(abc.Mapping):
         Note that an expired intermediate root is considered valid: expiry is
         only checked for the final root in root_update_finished()."""
         if self.reference_time is not None:
-            raise ValueError("Cannot update root after root update is finished")
+            raise RuntimeError("Cannot update root after root update is finished")
 
         try:
             new_root = Metadata.from_bytes(data)
@@ -341,9 +341,9 @@ class MetadataBundle(abc.Mapping):
         """Verifies and loads 'data' as new timestamp metadata."""
         if self.reference_time is None:
             # root_update_finished() not called
-            raise ValueError("Cannot update timestamp before root")
+            raise RuntimeError("Cannot update timestamp before root")
         if self.snapshot is not None:
-            raise ValueError("Cannot update timestamp after snapshot")
+            raise RuntimeError("Cannot update timestamp after snapshot")
 
         try:
             new_timestamp = Metadata.from_bytes(data)
@@ -391,9 +391,9 @@ class MetadataBundle(abc.Mapping):
         """Verifies and loads 'data' as new snapshot metadata."""
 
         if self.timestamp is None:
-            raise ValueError("Cannot update snapshot before timestamp")
+            raise RuntimeError("Cannot update snapshot before timestamp")
         if self.targets is not None:
-            raise ValueError("Cannot update snapshot after targets")
+            raise RuntimeError("Cannot update snapshot after targets")
 
         meta = self.timestamp.signed.meta["snapshot.json"]
 
@@ -462,11 +462,11 @@ class MetadataBundle(abc.Mapping):
         Raises if verification fails
         """
         if self.snapshot is None:
-            raise ValueError("Cannot load targets before snapshot")
+            raise RuntimeError("Cannot load targets before snapshot")
 
         delegator = self.get(delegator_name)
         if delegator is None:
-            raise ValueError("Cannot load targets before delegator")
+            raise RuntimeError("Cannot load targets before delegator")
 
         # Verify against the hashes in snapshot, if any
         meta = self.snapshot.signed.meta.get(f"{role_name}.json")

--- a/tuf/client_rework/metadata_bundle.py
+++ b/tuf/client_rework/metadata_bundle.py
@@ -199,7 +199,8 @@ class MetadataBundle(abc.Mapping):
         logger.debug("Updating root")
 
         self._load_intermediate_root(data)
-        self.root.to_file(os.path.join(self._path, "root.json"))
+        with open(os.path.join(self._path, "root.json"), "wb") as f:
+            f.write(data)
 
     def root_update_finished(self):
         """Mark root metadata as final."""
@@ -232,7 +233,8 @@ class MetadataBundle(abc.Mapping):
         logger.debug("Updating timestamp")
 
         self._load_timestamp(data)
-        self.timestamp.to_file(os.path.join(self._path, "timestamp.json"))
+        with open(os.path.join(self._path, "timestamp.json"), "wb") as f:
+            f.write(data)
 
     def load_local_snapshot(self) -> bool:
         """Load cached snapshot metadata from local storage.
@@ -253,7 +255,8 @@ class MetadataBundle(abc.Mapping):
         logger.debug("Updating snapshot")
 
         self._load_snapshot(data)
-        self.snapshot.to_file(os.path.join(self._path, "snapshot.json"))
+        with open(os.path.join(self._path, "snapshot.json"), "wb") as f:
+            f.write(data)
 
     def load_local_targets(self) -> bool:
         """Load cached targets metadata from local storage.
@@ -298,7 +301,8 @@ class MetadataBundle(abc.Mapping):
         logger.debug("Updating %s", role_name)
 
         self._load_delegated_targets(data, role_name, delegator_name)
-        self[role_name].to_file(os.path.join(self._path, f"{role_name}.json"))
+        with open(os.path.join(self._path, f"{role_name}.json"), "wb") as f:
+            f.write(data)
 
     def _load_intermediate_root(self, data: bytes):
         """Verifies and loads 'data' as new root metadata.

--- a/tuf/client_rework/metadata_bundle.py
+++ b/tuf/client_rework/metadata_bundle.py
@@ -4,10 +4,11 @@
 """TUF client bundle-of-metadata
 
 MetadataBundle keeps track of current valid set of metadata for the client,
-and handles almost every step of the "Detailed client workflow" in the TUF
-specification (the remaining steps are download related). The bundle takes
-care of persisting valid metadata on disk, loading local metadata from disk
-and deleting invalid local metadata.
+and handles almost every step of the "Detailed client workflow" (
+https://theupdateframework.github.io/specification/latest#detailed-client-workflow)
+in the TUF specification (the remaining steps are download related). The
+bundle takes care of persisting valid metadata on disk and loading local
+metadata from disk.
 
 Loaded metadata can be accessed via the index access with rolename as key
 or, in the case of top-level metadata using the helper properties like
@@ -16,9 +17,12 @@ or, in the case of top-level metadata using the helper properties like
 The rules for top-level metadata are
  * Metadata is loadable only if metadata it depends on is loaded
  * Metadata is immutable if any metadata depending on it has been loaded
- * Caller must load/update these in order:
+ * Metadata must be loaded/updated in order:
    root -> timestamp -> snapshot -> targets -> (other delegated targets)
- * Caller should try loading local file before updating metadata from remote
+ * For each metadata either local load or the remote update must succeed
+ * Caller should try loading local version before updating metadata from remote
+   (the exception is root where local data is loaded at MetadataBundle
+   initialization: the initialization fails if local data cannot be loaded)
 
 Exceptions are raised if metadata fails to load in any way. The exception
 to this is local loads -- only local root metadata needs to be valid:
@@ -104,7 +108,7 @@ logger = logging.getLogger(__name__)
 def verify_with_threshold(
     delegator: Metadata, role_name: str, unverified: Metadata
 ) -> bool:
-    """Verify 'unverified' with keys and treshold defined in delegator"""
+    """Verify 'unverified' with keys and threshold defined in delegator"""
     if delegator.signed._type == "root":
         keys = delegator.signed.keys
         role = delegator.signed.roles.get(role_name)

--- a/tuf/client_rework/metadata_bundle.py
+++ b/tuf/client_rework/metadata_bundle.py
@@ -92,7 +92,7 @@ from securesystemslib import keys as sslib_keys
 
 from tuf import exceptions
 from tuf.api.metadata import Metadata, Root, Targets
-from tuf.api.serialization import SerializationError
+from tuf.api.serialization import DeserializationError
 
 logger = logging.getLogger(__name__)
 
@@ -310,7 +310,7 @@ class MetadataBundle(abc.Mapping):
 
         try:
             new_root = Metadata.from_bytes(data)
-        except SerializationError as e:
+        except DeserializationError as e:
             raise exceptions.RepositoryError("Failed to load root") from e
 
         if new_root.signed.type != "root":
@@ -348,7 +348,7 @@ class MetadataBundle(abc.Mapping):
 
         try:
             new_timestamp = Metadata.from_bytes(data)
-        except SerializationError as e:
+        except DeserializationError as e:
             raise exceptions.RepositoryError("Failed to load timestamp") from e
 
         if new_timestamp.signed.type != "timestamp":
@@ -409,7 +409,7 @@ class MetadataBundle(abc.Mapping):
 
         try:
             new_snapshot = Metadata.from_bytes(data)
-        except SerializationError as e:
+        except DeserializationError as e:
             raise exceptions.RepositoryError("Failed to load snapshot") from e
 
         if new_snapshot.signed.type != "snapshot":
@@ -486,7 +486,7 @@ class MetadataBundle(abc.Mapping):
 
         try:
             new_delegate = Metadata.from_bytes(data)
-        except SerializationError as e:
+        except DeserializationError as e:
             raise exceptions.RepositoryError("Failed to load snapshot") from e
 
         if new_delegate.signed.type != "targets":

--- a/tuf/client_rework/metadata_bundle.py
+++ b/tuf/client_rework/metadata_bundle.py
@@ -94,13 +94,6 @@ from tuf import exceptions
 from tuf.api.metadata import Metadata, Root, Targets
 from tuf.api.serialization import SerializationError
 
-# TODO: Either enaable old-style logging in pylintc (issue #1334)
-# or change this file to use f-strings for logging
-# pylint: disable=logging-too-many-args
-
-# TODO: signed._type really does not work issue #1375:
-# pylint: disable=protected-access
-
 logger = logging.getLogger(__name__)
 
 # This is a placeholder until ...
@@ -317,9 +310,9 @@ class MetadataBundle(abc.Mapping):
         except SerializationError as e:
             raise exceptions.RepositoryError("Failed to load root") from e
 
-        if new_root.signed._type != "root":
+        if new_root.signed.type != "root":
             raise exceptions.RepositoryError(
-                f"Expected 'root', got '{new_root.signed._type}'"
+                f"Expected 'root', got '{new_root.signed.type}'"
             )
 
         if self.root is not None:
@@ -354,9 +347,9 @@ class MetadataBundle(abc.Mapping):
         except SerializationError as e:
             raise exceptions.RepositoryError("Failed to load timestamp") from e
 
-        if new_timestamp.signed._type != "timestamp":
+        if new_timestamp.signed.type != "timestamp":
             raise exceptions.RepositoryError(
-                f"Expected 'timestamp', got '{new_timestamp.signed._type}'"
+                f"Expected 'timestamp', got '{new_timestamp.signed.type}'"
             )
 
         if not verify_with_threshold(self.root, "timestamp", new_timestamp):
@@ -415,9 +408,9 @@ class MetadataBundle(abc.Mapping):
         except SerializationError as e:
             raise exceptions.RepositoryError("Failed to load snapshot") from e
 
-        if new_snapshot.signed._type != "snapshot":
+        if new_snapshot.signed.type != "snapshot":
             raise exceptions.RepositoryError(
-                f"Expected 'snapshot', got '{new_snapshot.signed._type}'"
+                f"Expected 'snapshot', got '{new_snapshot.signed.type}'"
             )
 
         if not verify_with_threshold(self.root, "snapshot", new_snapshot):
@@ -492,9 +485,9 @@ class MetadataBundle(abc.Mapping):
         except SerializationError as e:
             raise exceptions.RepositoryError("Failed to load snapshot") from e
 
-        if new_delegate.signed._type != "targets":
+        if new_delegate.signed.type != "targets":
             raise exceptions.RepositoryError(
-                f"Expected 'targets', got '{new_delegate.signed._type}'"
+                f"Expected 'targets', got '{new_delegate.signed.type}'"
             )
 
         if not verify_with_threshold(delegator, role_name, new_delegate):

--- a/tuf/client_rework/metadata_bundle.py
+++ b/tuf/client_rework/metadata_bundle.py
@@ -117,7 +117,7 @@ def verify_with_threshold(
         raise ValueError("Call is valid only on delegator metadata")
 
     if role is None:
-        raise exceptions.UnknownRoleError
+        raise ValueError(f"Delegated role {role_name} not found")
 
     # verify that delegate is signed by correct threshold of unique keys
     unique_keys = set()

--- a/tuf/exceptions.py
+++ b/tuf/exceptions.py
@@ -89,12 +89,6 @@ class BadHashError(Error):
     #     repr(self.observed_hash) + ')')
 
 
-
-
-class BadVersionNumberError(Error):
-  """Indicate an error for metadata that contains an invalid version number."""
-
-
 class BadPasswordError(Error):
   """Indicate an error after encountering an invalid password."""
 
@@ -105,6 +99,10 @@ class UnknownKeyError(Error):
 
 class RepositoryError(Error):
   """Indicate an error with a repository's state, such as a missing file."""
+
+
+class BadVersionNumberError(RepositoryError):
+  """Indicate an error for metadata that contains an invalid version number."""
 
 
 class MissingLocalRepositoryError(RepositoryError):
@@ -119,35 +117,28 @@ class ForbiddenTargetError(RepositoryError):
   """Indicate that a role signed for a target that it was not delegated to."""
 
 
-class ExpiredMetadataError(Error):
+class ExpiredMetadataError(RepositoryError):
   """Indicate that a TUF Metadata file has expired."""
 
 
 class ReplayedMetadataError(RepositoryError):
   """Indicate that some metadata has been replayed to the client."""
 
-  def __init__(self, metadata_role, previous_version, current_version):
+  def __init__(self, metadata_role, downloaded_version, current_version):
     super(ReplayedMetadataError, self).__init__()
 
     self.metadata_role = metadata_role
-    self.previous_version = previous_version
+    self.downloaded_version = downloaded_version
     self.current_version = current_version
-
 
   def __str__(self):
     return (
         'Downloaded ' + repr(self.metadata_role) + ' is older (' +
-        repr(self.previous_version) + ') than the version currently '
+        repr(self.downloaded_version) + ') than the version currently '
         'installed (' + repr(self.current_version) + ').')
 
   def __repr__(self):
     return self.__class__.__name__ + ' : ' + str(self)
-
-    # # Directly instance-reproducing:
-    # return (
-    #     self.__class__.__name__ + '(' + repr(self.metadata_role) + ', ' +
-    #     repr(self.previous_version) + ', ' + repr(self.current_version) + ')')
-
 
 
 class CryptoError(Error):
@@ -250,7 +241,7 @@ class InvalidNameError(Error):
   """Indicate an error while trying to validate any type of named object."""
 
 
-class UnsignedMetadataError(Error):
+class UnsignedMetadataError(RepositoryError):
   """Indicate metadata object with insufficient threshold of signatures."""
 
   def __init__(self, message, signable):

--- a/tuf/exceptions.py
+++ b/tuf/exceptions.py
@@ -66,7 +66,11 @@ class UnsupportedAlgorithmError(Error):
   """Indicate an error while trying to identify a user-specified algorithm."""
 
 
-class BadHashError(Error):
+class RepositoryError(Error):
+  """Indicate an error with a repository's state, such as a missing file."""
+
+
+class BadHashError(RepositoryError):
   """Indicate an error while checking the value of a hash object."""
 
   def __init__(self, expected_hash, observed_hash):
@@ -95,10 +99,6 @@ class BadPasswordError(Error):
 
 class UnknownKeyError(Error):
   """Indicate an error while verifying key-like objects (e.g., keyids)."""
-
-
-class RepositoryError(Error):
-  """Indicate an error with a repository's state, such as a missing file."""
 
 
 class BadVersionNumberError(RepositoryError):


### PR DESCRIPTION
MetadataBundle keeps track of current valid set of metadata for the
client, and handles almost every step of the "Detailed client workflow"
in the TUF specification (the remaining steps are I/O related).

It also
verifies any new metadata (local or downloaded from remote repository).

**EDIT** this bit is no longer true in the newest version: _The bundle takes care of persisting valid metadata on disk, loading
local metadata from disk and deleting invalid local metadata._ 

