### PR TITLE
New API: Add Key and Role classes

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -306,21 +306,21 @@ class TestMetadata(unittest.TestCase):
             root_key2['keytype'], root_key2['scheme'], root_key2['keyval'])
 
         # Assert that root does not contain the new key
-        self.assertNotIn(keyid, root.signed.roles['root']['keyids'])
+        self.assertNotIn(keyid, root.signed.roles['root'].keyids)
         self.assertNotIn(keyid, root.signed.keys)
 
         # Add new root key
         root.signed.add_key('root', keyid, key_metadata)
 
         # Assert that key is added
-        self.assertIn(keyid, root.signed.roles['root']['keyids'])
+        self.assertIn(keyid, root.signed.roles['root'].keyids)
         self.assertIn(keyid, root.signed.keys)
 
         # Remove the key
         root.signed.remove_key('root', keyid)
 
         # Assert that root does not contain the new key anymore
-        self.assertNotIn(keyid, root.signed.roles['root']['keyids'])
+        self.assertNotIn(keyid, root.signed.roles['root'].keyids)
         self.assertNotIn(keyid, root.signed.keys)
 
 
@@ -369,6 +369,9 @@ class TestMetadata(unittest.TestCase):
             if metadata == "root":
                 for keyid in dict1["signed"]["keys"].keys():
                     dict1["signed"]["keys"][keyid]["d"] = "c"
+                for role_str in dict1["signed"]["roles"].keys():
+                    dict1["signed"]["roles"][role_str]["e"] = "g"
+
             temp_copy = copy.deepcopy(dict1)
             metadata_obj = Metadata.from_dict(temp_copy)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -365,6 +365,10 @@ class TestMetadata(unittest.TestCase):
             # Test that the metadata classes store unrecognized fields when
             # initializing and passes them when casting the instance to a dict.
 
+            # Add unrecognized fields to all metadata sub (helper) classes.
+            if metadata == "root":
+                for keyid in dict1["signed"]["keys"].keys():
+                    dict1["signed"]["keys"][keyid]["d"] = "c"
             temp_copy = copy.deepcopy(dict1)
             metadata_obj = Metadata.from_dict(temp_copy)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -381,6 +381,11 @@ class TestMetadata(unittest.TestCase):
         self.assertIn(keyid, root.signed.roles['root'].keyids)
         self.assertIn(keyid, root.signed.keys)
 
+        # Try adding the same key again and assert its ignored.
+        pre_add_keyid = root.signed.roles['root'].keyids.copy()
+        root.signed.add_key('root', keyid, key_metadata)
+        self.assertEqual(pre_add_keyid, root.signed.roles['root'].keyids)
+
         # Remove the key
         root.signed.remove_key('root', keyid)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -25,7 +25,9 @@ from tuf.api.metadata import (
     Metadata,
     Snapshot,
     Timestamp,
-    Targets
+    Targets,
+    Key,
+    Role
 )
 
 from tuf.api.serialization import (
@@ -290,6 +292,69 @@ class TestMetadata(unittest.TestCase):
         self.assertNotEqual(timestamp.signed.meta['snapshot.json'], fileinfo)
         timestamp.signed.update(2, 520, hashes)
         self.assertEqual(timestamp.signed.meta['snapshot.json'], fileinfo)
+
+
+    def test_key_class(self):
+        keys = {
+            "59a4df8af818e9ed7abe0764c0b47b4240952aa0d179b5b78346c470ac30278d":{
+                "keytype": "ed25519",
+                "keyval": {
+                    "public": "edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd"
+                },
+                "scheme": "ed25519"
+                        },
+        }
+        for key_dict in keys.values():
+            # Testing that the workflow of deserializing and serializing
+            # a key dictionary doesn't change the content.
+            test_key_dict = key_dict.copy()
+            key_obj = Key.from_dict(test_key_dict)
+            self.assertEqual(key_dict, key_obj.to_dict())
+            # Test creating an instance without a required attribute.
+            for key in key_dict.keys():
+                test_key_dict = key_dict.copy()
+                del test_key_dict[key]
+                with self.assertRaises(KeyError):
+                    Key.from_dict(test_key_dict)
+            # Test creating a Key instance with wrong keyval format.
+            key_dict["keyval"] = {}
+            with self.assertRaises(ValueError):
+                Key.from_dict(key_dict)
+
+
+    def test_role_class(self):
+        roles = {
+            "root": {
+                "keyids": [
+                    "4e777de0d275f9d28588dd9a1606cc748e548f9e22b6795b7cb3f63f98035fcb"
+                ],
+                "threshold": 1
+            },
+            "snapshot": {
+                "keyids": [
+                    "59a4df8af818e9ed7abe0764c0b47b4240952aa0d179b5b78346c470ac30278d"
+                ],
+                "threshold": 1
+            },
+        }
+        for role_dict in roles.values():
+            # Testing that the workflow of deserializing and serializing
+            # a role dictionary doesn't change the content.
+            test_role_dict = role_dict.copy()
+            role_obj = Role.from_dict(test_role_dict)
+            self.assertEqual(role_dict, role_obj.to_dict())
+            # Test creating an instance without a required attribute.
+            for role_attr in role_dict.keys():
+                test_role_dict = role_dict.copy()
+                del test_role_dict[role_attr]
+                with self.assertRaises(KeyError):
+                    Key.from_dict(test_role_dict)
+            # Test creating a Role instance with keyid dublicates.
+            # for keyid in role_dict["keyids"]:
+            role_dict["keyids"].append(role_dict["keyids"][0])
+            test_role_dict = role_dict.copy()
+            with self.assertRaises(ValueError):
+                Role.from_dict(test_role_dict)
 
 
     def test_metadata_root(self):

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -425,6 +425,8 @@ class Key:
         keyval: Mapping[str, str],
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ) -> None:
+        if not keyval.get("public"):
+            raise ValueError("keyval doesn't follow the specification format!")
         self.keytype = keytype
         self.scheme = scheme
         self.keyval = keyval

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -430,6 +430,15 @@ class Key:
         self.keyval = keyval
         self.unrecognized_fields = unrecognized_fields or {}
 
+    @classmethod
+    def from_dict(cls, key_dict: Mapping[str, Any]) -> "Key":
+        """Creates Key object from its dict representation."""
+        keytype = key_dict.pop("keytype")
+        scheme = key_dict.pop("scheme")
+        keyval = key_dict.pop("keyval")
+        # All fields left in the key_dict are unrecognized.
+        return cls(keytype, scheme, keyval, key_dict)
+
     def to_dict(self) -> Dict:
         """Returns the dictionary representation of self."""
         return {
@@ -461,6 +470,14 @@ class Role:
         self.keyids = keyids
         self.threshold = threshold
         self.unrecognized_fields = unrecognized_fields or {}
+
+    @classmethod
+    def from_dict(cls, role_dict: Mapping[str, Any]) -> "Role":
+        """Creates Role object from its dict representation."""
+        keyids = role_dict.pop("keyids")
+        threshold = role_dict.pop("threshold")
+        # All fields left in the role_dict are unrecognized.
+        return cls(keyids, threshold, role_dict)
 
     def to_dict(self) -> Dict:
         """Returns the dictionary representation of self."""
@@ -523,18 +540,9 @@ class Root(Signed):
         roles = root_dict.pop("roles")
 
         for keyid, key_dict in keys.items():
-            keytype = key_dict.pop("keytype")
-            scheme = key_dict.pop("scheme")
-            keyval = key_dict.pop("keyval")
-            # All fields left in the key_dict are unrecognized.
-            keys[keyid] = Key(keytype, scheme, keyval, key_dict)
-
-        for role_str, role_dict in roles.items():
-            keyids = role_dict.pop("keyids")
-            threshold = role_dict.pop("threshold")
-            # All fields left in the role_dict are unrecognized.
-            unrecognized_role_fields = role_dict
-            roles[role_str] = Role(keyids, threshold, unrecognized_role_fields)
+            keys[keyid] = Key.from_dict(key_dict)
+        for role_name, role_dict in roles.items():
+            roles[role_name] = Role.from_dict(role_dict)
 
         # All fields left in the root_dict are unrecognized.
         return cls(*common_args, consistent_snapshot, keys, roles, root_dict)

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -463,11 +463,17 @@ class Role:
 
     def __init__(
         self,
-        keyids: set,
+        keyids: list,
         threshold: int,
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ) -> None:
-        self.keyids = keyids
+        keyids_set = set(keyids)
+        if len(keyids_set) != len(keyids):
+            raise ValueError(
+                f"keyids should be a list of unique strings,"
+                f" instead got {keyids}"
+            )
+        self.keyids = keyids_set
         self.threshold = threshold
         self.unrecognized_fields = unrecognized_fields or {}
 
@@ -482,7 +488,7 @@ class Role:
     def to_dict(self) -> Dict:
         """Returns the dictionary representation of self."""
         return {
-            "keyids": self.keyids,
+            "keyids": list(self.keyids),
             "threshold": self.threshold,
             **self.unrecognized_fields,
         }
@@ -570,7 +576,7 @@ class Root(Signed):
     ) -> None:
         """Adds new key for 'role' and updates the key store."""
         if keyid not in self.roles[role].keyids:
-            self.roles[role].keyids.append(keyid)
+            self.roles[role].keyids.add(keyid)
             self.keys[keyid] = key_metadata
 
     # Remove key for a role.

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -577,9 +577,8 @@ class Root(Signed):
         self, role: str, keyid: str, key_metadata: Mapping[str, Any]
     ) -> None:
         """Adds new key for 'role' and updates the key store."""
-        if keyid not in self.roles[role].keyids:
-            self.roles[role].keyids.add(keyid)
-            self.keys[keyid] = key_metadata
+        self.roles[role].keyids.add(keyid)
+        self.keys[keyid] = key_metadata
 
     # Remove key for a role.
     def remove_key(self, role: str, keyid: str) -> None:


### PR DESCRIPTION
Addresses, but doesn't fix: #1139

**Description of the changes being introduced by the pull request**:

  In the top level metadata classes, there are complex attributes such as
  `meta` in Targets and Snapshot, `key` and `roles` in Root etc.
  We want to represent those complex attributes with a class to allow
  easier verification and support for metadata with unrecognized fields.
  For more context read ADR 0004 and ADR 0008 in the docs/adr folder.

The changes in this pr include:
- addition of a new `Key` class  integrated into Root
- addition of a new `Roles` class integrated into 
- added support for unrecognized fields
- added tests for unrecognized fields in `Key` and `Roles`

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


