### PR TITLE
tox: Don't use pre-release tools

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     # installation (see `skipsdist`), to get relative paths in coverage reports
     --editable {toxinidir}
 
-install_command = pip install --pre {opts} {packages}
+install_command = pip install {opts} {packages}
 
 # Develop test env to run tests against securesystemslib's master branch
 # Must to be invoked explicitly with, e.g. `tox -e with-sslib-master`


### PR DESCRIPTION
Keep using newest versions of build tools, but don't use pre-releases:
* less downloading (with chances of failures) happens in the CI because
  versions change less often
* tools are less likely to break the build (or at least it happens less
  often)

This change should not affect the software under test as we install
pinned versions of those.

Note that this also doesn't affect black: tox still ends up with a
pre-release version of black because that project has never made an
actual release.

Fixes #1350

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>
