### PR TITLE
CI: Allow failure when publishing on coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
         run: tox
 
       - name: Publish on coveralls.io
+        # A failure to publish coverage results on coveralls should not
+        # be a reason for a job failure.
+        continue-on-error: true
         # TODO: Maybe make 'lint' a separate job instead of case handling here
         if: ${{ env.TOXENV != 'lint' }}
         env:


### PR DESCRIPTION

**Description of the changes being introduced by the pull request**:

A failure during publishing of the coverage results on coveralls should not fail the whole build job.
Allow the step to fail.

A side effect of this change is that failures in this step will be unnoticed by PR authors unless intentionally looking at the CI run log.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


