### PR TITLE
New API: Add DelegationRole and Delegations classes

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -477,6 +477,15 @@ class TestMetadata(unittest.TestCase):
                     dict1["signed"]["keys"][keyid]["d"] = "c"
                 for role_str in dict1["signed"]["roles"].keys():
                     dict1["signed"]["roles"][role_str]["e"] = "g"
+            elif metadata == "targets" and dict1["signed"].get("delegations"):
+                for keyid in dict1["signed"]["delegations"]["keys"].keys():
+                    dict1["signed"]["delegations"]["keys"][keyid]["d"] = "c"
+                new_roles = []
+                for role in dict1["signed"]["delegations"]["roles"]:
+                    role["e"] = "g"
+                    new_roles.append(role)
+                dict1["signed"]["delegations"]["roles"] = new_roles
+                dict1["signed"]["delegations"]["foo"] = "bar"
 
             temp_copy = copy.deepcopy(dict1)
             metadata_obj = Metadata.from_dict(temp_copy)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,7 +28,9 @@ from tuf.api.metadata import (
     Timestamp,
     Targets,
     Key,
-    Role
+    Role,
+    Delegations,
+    DelegatedRole,
 )
 
 from tuf.api.serialization import (
@@ -328,7 +330,7 @@ class TestMetadata(unittest.TestCase):
                     "public": "edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd"
                 },
                 "scheme": "ed25519"
-                        },
+            },
         }
         for key_dict in keys.values():
             # Testing that the workflow of deserializing and serializing
@@ -421,6 +423,76 @@ class TestMetadata(unittest.TestCase):
 
         with self.assertRaises(KeyError):
             root.signed.remove_key('root', 'nosuchkey')
+
+    def test_delegated_role_class(self):
+        roles = [
+            {
+                "keyids": [
+                    "c8022fa1e9b9cb239a6b362bbdffa9649e61ad2cb699d2e4bc4fdf7930a0e64a"
+                ],
+                "name": "role1",
+                "paths": [
+                    "file3.txt"
+                ],
+                "terminating": False,
+                "threshold": 1
+            }
+        ]
+        for role in roles:
+            # Testing that the workflow of deserializing and serializing
+            # a delegation role dictionary doesn't change the content.
+            key_obj = DelegatedRole.from_dict(role.copy())
+            self.assertEqual(role, key_obj.to_dict())
+
+            # Test creating a DelegatedRole object with both "paths" and
+            # "path_hash_prefixes" set.
+            role["path_hash_prefixes"] = "foo"
+            with self.assertRaises(ValueError):
+                DelegatedRole.from_dict(role.copy())
+
+            # Test creating DelegatedRole only with "path_hash_prefixes"
+            del role["paths"]
+            DelegatedRole.from_dict(role.copy())
+            role["paths"] = "foo"
+
+            # Test creating DelegatedRole only with "paths"
+            del role["path_hash_prefixes"]
+            DelegatedRole.from_dict(role.copy())
+            role["path_hash_prefixes"] = "foo"
+
+            # Test creating DelegatedRole without "paths" and
+            # "path_hash_prefixes" set
+            del role["paths"]
+            del role["path_hash_prefixes"]
+            DelegatedRole.from_dict(role)
+
+
+    def test_delegation_class(self):
+        roles = [
+                {
+                    "keyids": [
+                        "c8022fa1e9b9cb239a6b362bbdffa9649e61ad2cb699d2e4bc4fdf7930a0e64a"
+                    ],
+                    "name": "role1",
+                    "paths": [
+                        "file3.txt"
+                    ],
+                    "terminating": False,
+                    "threshold": 1
+                }
+            ]
+        keys = {
+                "59a4df8af818e9ed7abe0764c0b47b4240952aa0d179b5b78346c470ac30278d":{
+                    "keytype": "ed25519",
+                    "keyval": {
+                        "public": "edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd"
+                    },
+                    "scheme": "ed25519"
+                },
+            }
+        delegations_dict = {"keys": keys, "roles": roles}
+        delegations = Delegations.from_dict(copy.deepcopy(delegations_dict))
+        self.assertEqual(delegations_dict, delegations.to_dict())
 
 
     def test_metadata_targets(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -524,7 +524,6 @@ class TestMetadata(unittest.TestCase):
         del targets_dict["signed"]["delegations"]
         tmp_dict = targets_dict["signed"].copy()
         targets_obj = Targets.from_dict(tmp_dict)
-        tar_d = targets_obj.to_dict()
         self.assertEqual(targets_dict["signed"], targets_obj.to_dict())
 
     def setup_dict_with_unrecognized_field(self, file_path, field, value):

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -836,7 +836,7 @@ class Delegations:
         self.unrecognized_fields = unrecognized_fields or {}
 
     @classmethod
-    def from_dict(cls, delegations_dict: Mapping[str, Any]) -> "Delegations":
+    def from_dict(cls, delegations_dict: Dict[str, Any]) -> "Delegations":
         """Creates Delegations object from its dict representation."""
         keys = delegations_dict.pop("keys")
         keys_res = {}

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -775,10 +775,8 @@ class DelegatedRole(Role):
                 "Only one of the attributes 'paths' and"
                 "'path_hash_prefixes' can be set!"
             )
-        if paths:
-            self.paths = paths
-        elif path_hash_prefixes:
-            self.path_hash_prefixes = path_hash_prefixes
+        self.paths = paths
+        self.path_hash_prefixes = path_hash_prefixes
 
     @classmethod
     def from_dict(cls, role_dict: Mapping[str, Any]) -> "Role":


### PR DESCRIPTION
Addresses #1139

**Description of the changes being introduced by the pull request**:

  
  In the top-level metadata classes, there are complex attributes such as
  "meta" in Targets and Snapshot, "key" and "roles" in Root etc.
  We want to represent those complex attributes with a class to allow
  easier verification and support for metadata with unrecognized fields.
  For more context read ADR 0004 and ADR 0008 in the docs/adr folder.
  
  DelegationRole shares a couple of fields with the Role class and that's
  why it inherits it.
  I decided to use a separate Delegations class because I thought it will
  make it easier to read, verify and add additional helper functions.
  Also, I tried to make sure that I test each level of the delegations
  representation for support of storing unrecognized fields.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


