### PR TITLE
Metadata API: Provide type as well as _type

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -315,20 +315,24 @@ class Signed:
     are common for all TUF metadata types (roles).
 
     Attributes:
-        _type: The metadata type string.
+        _type: The metadata type string. Also available without underscore.
         version: The metadata version number.
         spec_version: The TUF specification version number (semver) the
             metadata format adheres to.
         expires: The metadata expiration datetime object.
         unrecognized_fields: Dictionary of all unrecognized fields.
-
     """
 
     # Signed implementations are expected to override this
     _signed_type = None
 
+    # _type and type are identical: 1st replicates file format, 2nd passes lint
     @property
     def _type(self):
+        return self._signed_type
+
+    @property
+    def type(self):
         return self._signed_type
 
     # NOTE: Signed is a stupid name, because this might not be signed yet, but


### PR DESCRIPTION
Using Metadata APIs '_type' attribute (from outside metadata.py) currently
results in linter errors.

Add a duplicate 'type': this way the API users can avoid linter errors
but '_type' is still available in case the strict file format
compatibility is needed.

Fixes #1375

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

---

I think the only alternative to this that I would consider acceptable is just replacing `_type` with `type`.


- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


