### PR TITLE
Metadata minor fixes

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -419,6 +419,8 @@ class TestMetadata(unittest.TestCase):
         self.assertNotIn(keyid, root.signed.roles['root'].keyids)
         self.assertNotIn(keyid, root.signed.keys)
 
+        with self.assertRaises(KeyError):
+            root.signed.remove_key('root', 'nosuchkey')
 
 
     def test_metadata_targets(self):

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -589,16 +589,18 @@ class Root(Signed):
         self.roles[role].keyids.add(keyid)
         self.keys[keyid] = key_metadata
 
-    # Remove key for a role.
     def remove_key(self, role: str, keyid: str) -> None:
-        """Removes key for 'role' and updates the key store."""
-        if keyid in self.roles[role].keyids:
-            self.roles[role].keyids.remove(keyid)
-            for keyinfo in self.roles.values():
-                if keyid in keyinfo.keyids:
-                    return
+        """Removes key from 'role' and updates the key store.
 
-            del self.keys[keyid]
+        Raises:
+            KeyError: If 'role' does not include the key
+        """
+        self.roles[role].keyids.remove(keyid)
+        for keyinfo in self.roles.values():
+            if keyid in keyinfo.keyids:
+                return
+
+        del self.keys[keyid]
 
 
 class Timestamp(Signed):


### PR DESCRIPTION
Some minor improvements to metadata.py:
 * type hint fixes
 * Root.remove_key(): avoid unneeded lookups, also raise if key is not found

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)

