### PR TITLE
build(deps): bump securesystemslib

### DIFF
--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -6,5 +6,5 @@ idna==2.10                # via requests
 pycparser==2.20           # via cffi
 pynacl==1.4.0             # via securesystemslib
 requests==2.25.1
-securesystemslib[crypto,pynacl]==0.20.0
+securesystemslib[crypto,pynacl]==0.20.1
 urllib3==1.26.4           # via requests


### PR DESCRIPTION
Bumps [securesystemslib[crypto,pynacl]](https://github.com/secure-systems-lab/securesystemslib) from 0.20.0 to 0.20.1
- [Release notes](https://github.com/secure-systems-lab/securesystemslib/releases)
- [Changelog](https://github.com/secure-systems-lab/securesystemslib/blob/master/CHANGELOG.md)
- [Commits](https://github.com/secure-systems-lab/securesystemslib/compare/v0.20.0...v0.20.1)

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>