### PR TITLE
Metadata API/pylintrc: Use old style logging

### DIFF
--- a/tuf/api/pylintrc
+++ b/tuf/api/pylintrc
@@ -44,7 +44,7 @@ max-line-length=80
 single-line-if-stmt=yes
 
 [LOGGING]
-logging-format-style=new
+logging-format-style=old
 
 [MISCELLANEOUS]
 notes=TODO


### PR DESCRIPTION
This is suggested by the Google style guide: the old style logging
(%-format) allows the log strings to be lazily formatted so there's less
need to think about performance when forming debug messages.

No actual code changes are needed because the metadata API does not yet
log anything.

Fixes #1334

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

---

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)