### PR TITLE
Fix Root.add_key() argument's type

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -48,10 +48,6 @@ from securesystemslib.interface import (
     import_ed25519_privatekey_from_file
 )
 
-from securesystemslib.keys import (
-    format_keyval_to_metadata
-)
-
 from securesystemslib.signer import (
     SSlibSigner
 )
@@ -234,7 +230,7 @@ class TestMetadata(unittest.TestCase):
         is_expired = md.signed.is_expired(md.signed.expires - timedelta(days=1))
         self.assertFalse(is_expired)
 
-        # Test is_expired without reference_time, 
+        # Test is_expired without reference_time,
         # manipulating md.signed.expires
         expires = md.signed.expires
         md.signed.expires = datetime.utcnow()
@@ -244,7 +240,7 @@ class TestMetadata(unittest.TestCase):
         is_expired = md.signed.is_expired()
         self.assertFalse(is_expired)
         md.signed.expires = expires
-        
+
     def test_metadata_snapshot(self):
         snapshot_path = os.path.join(
                 self.repo_dir, 'metadata', 'snapshot.json')
@@ -394,9 +390,10 @@ class TestMetadata(unittest.TestCase):
         root_key2 =  import_ed25519_publickey_from_file(
                     os.path.join(self.keystore_dir, 'root_key2.pub'))
 
+
         keyid = root_key2['keyid']
-        key_metadata = format_keyval_to_metadata(
-            root_key2['keytype'], root_key2['scheme'], root_key2['keyval'])
+        key_metadata = Key(root_key2['keytype'], root_key2['scheme'],
+            root_key2['keyval'])
 
         # Assert that root does not contain the new key
         self.assertNotIn(keyid, root.signed.roles['root'].keyids)
@@ -408,6 +405,10 @@ class TestMetadata(unittest.TestCase):
         # Assert that key is added
         self.assertIn(keyid, root.signed.roles['root'].keyids)
         self.assertIn(keyid, root.signed.keys)
+
+        # Confirm that the newly added key does not break
+        # the object serialization
+        root.to_dict()
 
         # Try adding the same key again and assert its ignored.
         pre_add_keyid = root.signed.roles['root'].keyids.copy()

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -578,9 +578,7 @@ class Root(Signed):
         return root_dict
 
     # Update key for a role.
-    def add_key(
-        self, role: str, keyid: str, key_metadata: Dict[str, Any]
-    ) -> None:
+    def add_key(self, role: str, keyid: str, key_metadata: Key) -> None:
         """Adds new key for 'role' and updates the key store."""
         self.roles[role].keyids.add(keyid)
         self.keys[keyid] = key_metadata


### PR DESCRIPTION

Fixes #1378

**Description of the changes being introduced by the pull request**:

Since the existence of a `Key` class, taking `Key` as an argument type seems like the logical change.
The test case is updated accordingly.

Since there are no "users" of this functionality yet, I can't say if further improvements are
needed for now. 

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


