### PR TITLE
Avoid using falsy tests for None

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -497,6 +497,21 @@ class TestMetadata(unittest.TestCase):
         delegations = Delegations.from_dict(copy.deepcopy(delegations_dict))
         self.assertEqual(delegations_dict, delegations.to_dict())
 
+        # empty keys and roles
+        delegations_dict = {"keys":{}, "roles":[]}
+        delegations = Delegations.from_dict(delegations_dict.copy())
+        self.assertEqual(delegations_dict, delegations.to_dict())
+
+        # Test some basic missing or broken input
+        invalid_delegations_dicts = [
+            {},
+            {"keys":None, "roles":None},
+            {"keys":{"foo":0}, "roles":[]},
+            {"keys":{}, "roles":["foo"]},
+        ]
+        for d in invalid_delegations_dicts:
+            with self.assertRaises((KeyError, AttributeError)):
+                Delegations.from_dict(d)
 
     def test_metadata_targets(self):
         targets_path = os.path.join(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -451,21 +451,23 @@ class TestMetadata(unittest.TestCase):
             with self.assertRaises(ValueError):
                 DelegatedRole.from_dict(role.copy())
 
-            # Test creating DelegatedRole only with "path_hash_prefixes"
+            # Test creating DelegatedRole only with "path_hash_prefixes" (an empty one)
             del role["paths"]
-            DelegatedRole.from_dict(role.copy())
-            role["paths"] = "foo"
+            role["path_hash_prefixes"] = []
+            role_obj = DelegatedRole.from_dict(role.copy())
+            self.assertEqual(role_obj.to_dict(), role)
 
-            # Test creating DelegatedRole only with "paths"
+            # Test creating DelegatedRole only with "paths" (now an empty one)
             del role["path_hash_prefixes"]
-            DelegatedRole.from_dict(role.copy())
-            role["path_hash_prefixes"] = "foo"
+            role["paths"] = []
+            role_obj = DelegatedRole.from_dict(role.copy())
+            self.assertEqual(role_obj.to_dict(), role)
 
             # Test creating DelegatedRole without "paths" and
             # "path_hash_prefixes" set
             del role["paths"]
-            del role["path_hash_prefixes"]
-            DelegatedRole.from_dict(role)
+            role_obj = DelegatedRole.from_dict(role.copy())
+            self.assertEqual(role_obj.to_dict(), role)
 
 
     def test_delegation_class(self):

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -909,9 +909,12 @@ class Targets(Signed):
         """Creates Targets object from its dict representation."""
         common_args = cls._common_fields_from_dict(targets_dict)
         targets = targets_dict.pop("targets")
-        delegations = targets_dict.pop("delegations", None)
-        if delegations:
-            delegations = Delegations.from_dict(delegations)
+        try:
+            delegations_dict = targets_dict.pop("delegations")
+        except KeyError:
+            delegations = None
+        else:
+            delegations = Delegations.from_dict(delegations_dict)
         # All fields left in the targets_dict are unrecognized.
         return cls(*common_args, targets, delegations, targets_dict)
 
@@ -919,7 +922,7 @@ class Targets(Signed):
         """Returns the dict representation of self."""
         targets_dict = self._common_fields_to_dict()
         targets_dict["targets"] = self.targets
-        if self.delegations:
+        if self.delegations is not None:
             targets_dict["delegations"] = self.delegations.to_dict()
         return targets_dict
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -768,7 +768,7 @@ class DelegatedRole(Role):
         super().__init__(keyids, threshold, unrecognized_fields)
         self.name = name
         self.terminating = terminating
-        if paths and path_hash_prefixes:
+        if paths is not None and path_hash_prefixes is not None:
             raise ValueError(
                 "Only one of the attributes 'paths' and"
                 "'path_hash_prefixes' can be set!"
@@ -804,9 +804,9 @@ class DelegatedRole(Role):
             "terminating": self.terminating,
             **base_role_dict,
         }
-        if self.paths:
+        if self.paths is not None:
             res_dict["paths"] = self.paths
-        elif self.path_hash_prefixes:
+        elif self.path_hash_prefixes is not None:
             res_dict["path_hash_prefixes"] = self.path_hash_prefixes
         return res_dict
 


### PR DESCRIPTION
Fix a bug in DelegatedRole serialization and change all "falsy" object comparisons to something else.

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature


