### PR TITLE
Build: Initial mypy integration

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -11,4 +11,5 @@ coverage
 black
 isort
 pylint
+mypy
 bandit

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,10 @@ ignore =
   requirements-dev.txt
   .travis.yml
   .coveragerc
+
+[mypy]
+warn_unused_configs = True
+files = tuf/api/
+
+[mypy-securesystemslib.*]
+ignore_missing_imports = True

--- a/tox.ini
+++ b/tox.ini
@@ -39,15 +39,18 @@ commands =
     python -m coverage report -m
 
 [testenv:lint]
+changedir = {toxinidir}
 commands =
     # Use different configs for new (tuf/api/*) and legacy code
     # TODO: configure black and isort args in pyproject.toml (see #1161)
-    black --check --diff --line-length 80 {toxinidir}/tuf/api
-    isort --check --diff --line-length 80 --profile black -p tuf {toxinidir}/tuf/api
-    pylint {toxinidir}/tuf/api --rcfile={toxinidir}/tuf/api/pylintrc
+    black --check --diff --line-length 80 tuf/api
+    isort --check --diff --line-length 80 --profile black -p tuf tuf/api
+    pylint tuf/api --rcfile=tuf/api/pylintrc
 
     # NOTE: Contrary to what the pylint docs suggest, ignoring full paths does
     # work, unfortunately each subdirectory has to be ignored explicitly.
-    pylint {toxinidir}/tuf --ignore={toxinidir}/tuf/api,{toxinidir}/tuf/api/serialization
+    pylint tuf --ignore=tuf/api,tuf/api/serialization
 
-    bandit -r {toxinidir}/tuf
+    mypy
+
+    bandit -r tuf

--- a/tox.ini
+++ b/tox.ini
@@ -45,11 +45,11 @@ commands =
     # TODO: configure black and isort args in pyproject.toml (see #1161)
     black --check --diff --line-length 80 tuf/api
     isort --check --diff --line-length 80 --profile black -p tuf tuf/api
-    pylint tuf/api --rcfile=tuf/api/pylintrc
+    pylint -j 0 tuf/api --rcfile=tuf/api/pylintrc
 
     # NOTE: Contrary to what the pylint docs suggest, ignoring full paths does
     # work, unfortunately each subdirectory has to be ignored explicitly.
-    pylint tuf --ignore=tuf/api,tuf/api/serialization
+    pylint -j 0 tuf --ignore=tuf/api,tuf/api/serialization
 
     mypy
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -18,7 +18,7 @@ available in the class model.
 import abc
 import tempfile
 from datetime import datetime, timedelta
-from typing import Any, ClassVar, Dict, List, Mapping, Optional, Type
+from typing import Any, ClassVar, Dict, List, Mapping, Optional, Tuple, Type
 
 from securesystemslib.keys import verify_signature
 from securesystemslib.signer import Signature, Signer
@@ -364,7 +364,9 @@ class Signed(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @classmethod
-    def _common_fields_from_dict(cls, signed_dict: Dict[str, Any]) -> List[Any]:
+    def _common_fields_from_dict(
+        cls, signed_dict: Dict[str, Any]
+    ) -> Tuple[int, str, datetime]:
         """Returns common fields of 'Signed' instances from the passed dict
         representation, and returns an ordered list to be passed as leading
         positional arguments to a subclass constructor.
@@ -383,7 +385,7 @@ class Signed(metaclass=abc.ABCMeta):
         # what the constructor expects and what we store. The inverse operation
         # is implemented in '_common_fields_to_dict'.
         expires = formats.expiry_string_to_datetime(expires_str)
-        return [version, spec_version, expires]
+        return version, spec_version, expires
 
     def _common_fields_to_dict(self) -> Dict[str, Any]:
         """Returns dict representation of common fields of 'Signed' instances.

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -815,7 +815,7 @@ class DelegatedRole(Role):
         self.path_hash_prefixes = path_hash_prefixes
 
     @classmethod
-    def from_dict(cls, role_dict: Mapping[str, Any]) -> "Role":
+    def from_dict(cls, role_dict: Dict[str, Any]) -> "DelegatedRole":
         """Creates DelegatedRole object from its dict representation."""
         name = role_dict.pop("name")
         keyids = role_dict.pop("keyids")

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -18,7 +18,7 @@ available in the class model.
 import abc
 import tempfile
 from datetime import datetime, timedelta
-from typing import Any, ClassVar, Dict, List, Mapping, Optional
+from typing import Any, ClassVar, Dict, List, Mapping, Optional, Type
 
 from securesystemslib.keys import verify_signature
 from securesystemslib.signer import Signature, Signer
@@ -79,7 +79,7 @@ class Metadata:
         _type = metadata["signed"]["_type"]
 
         if _type == "targets":
-            inner_cls = Targets
+            inner_cls: Type[Signed] = Targets
         elif _type == "snapshot":
             inner_cls = Snapshot
         elif _type == "timestamp":

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -17,7 +17,7 @@ available in the class model.
 """
 import tempfile
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, ClassVar, Dict, List, Mapping, Optional
 
 from securesystemslib.keys import verify_signature
 from securesystemslib.signer import Signature, Signer
@@ -321,7 +321,7 @@ class Signed:
     """
 
     # Signed implementations are expected to override this
-    _signed_type = None
+    _signed_type: ClassVar[str] = "signed"
 
     # _type and type are identical: 1st replicates file format, 2nd passes lint
     @property

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -660,7 +660,10 @@ class MetaFile:
 
     def to_dict(self) -> Dict[str, Any]:
         """Returns the dictionary representation of self."""
-        res_dict = {"version": self.version, **self.unrecognized_fields}
+        res_dict: Dict[str, Any] = {
+            "version": self.version,
+            **self.unrecognized_fields,
+        }
 
         if self.length is not None:
             res_dict["length"] = self.length

--- a/tuf/api/serialization/__init__.py
+++ b/tuf/api/serialization/__init__.py
@@ -15,6 +15,11 @@ base classes defined in this __init__.py module.
 
 """
 import abc
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # pylint: disable=cyclic-import
+    from tuf.api.metadata import Metadata, Signed
 
 
 # TODO: Should these be in tuf.exceptions or inherit from tuf.exceptions.Error?


### PR DESCRIPTION
Goal is to start using mypy to statically check our source code:
* Add mypy configuration: start by just checking `tuf/api`, and ignoring securesystemslib imports
* Use mypy in tox "lint" environment.  
* Refactor tox lint env a little
* Use all cores for pylint to make it faster (pylint is the slowest part of the lint by far)
* Fix all kinds of typing issues in tuf/api/ (either actual issues or just things that prevent mypy from doing its job)

How mypy is used after this PR:
* CI will run it as part of lint
* developers can run `tox -e lint` or just `mypy`


Fixes #1335