### PR TITLE
new API: make sure targets in Targets can be empty

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -585,6 +585,13 @@ class TestMetadata(unittest.TestCase):
             targets.signed.targets[filename].to_dict(), fileinfo.to_dict()
         )
 
+        # Test from_dict/to_dict Targets with empty targets.
+        targets_dict = copy.deepcopy(targets.to_dict())
+        targets_dict["signed"]["targets"] = {}
+        tmp_dict = copy.deepcopy(targets_dict["signed"])
+        targets_obj = Targets.from_dict(tmp_dict)
+        self.assertEqual(targets_dict["signed"], targets_obj.to_dict())
+
         # Test from_dict/to_dict Targets without delegations
         targets_dict = targets.to_dict()
         del targets_dict["signed"]["delegations"]


### PR DESCRIPTION
This change is relevant to the new metadata class Targets.

In the specification, when describing the Targets metadata file format
and more precisely "TARGETPATH" (or targets containing the actual
target files) it's said:

```
It is allowed to have a TARGETS object with no TARGETPATH elements.
This can be used to indicate that no target files are available.
```

If there are no "TARGETPATH" keys for the dictionary "targets", this
would mean that "Targets.targets" is {}.
Make sure we test for that.

See: https://theupdateframework.github.io/specification/latest/#targetpath

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


