### PR TITLE
Metadata API: implement sig verification in Key, store id in key

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -373,18 +373,18 @@ class TestMetadata(unittest.TestCase):
             # Testing that the workflow of deserializing and serializing
             # a key dictionary doesn't change the content.
             test_key_dict = key_dict.copy()
-            key_obj = Key.from_dict(test_key_dict)
+            key_obj = Key.from_dict("id", test_key_dict)
             self.assertEqual(key_dict, key_obj.to_dict())
             # Test creating an instance without a required attribute.
             for key in key_dict.keys():
                 test_key_dict = key_dict.copy()
                 del test_key_dict[key]
                 with self.assertRaises(KeyError):
-                    Key.from_dict(test_key_dict)
+                    Key.from_dict("id", test_key_dict)
             # Test creating a Key instance with wrong keyval format.
             key_dict["keyval"] = {}
             with self.assertRaises(ValueError):
-                Key.from_dict(key_dict)
+                Key.from_dict("id", key_dict)
 
 
     def test_role_class(self):
@@ -413,7 +413,7 @@ class TestMetadata(unittest.TestCase):
                 test_role_dict = role_dict.copy()
                 del test_role_dict[role_attr]
                 with self.assertRaises(KeyError):
-                    Key.from_dict(test_role_dict)
+                    Key.from_dict("id", test_role_dict)
             # Test creating a Role instance with keyid dublicates.
             # for keyid in role_dict["keyids"]:
             role_dict["keyids"].append(role_dict["keyids"][0])
@@ -433,7 +433,7 @@ class TestMetadata(unittest.TestCase):
 
 
         keyid = root_key2['keyid']
-        key_metadata = Key(root_key2['keytype'], root_key2['scheme'],
+        key_metadata = Key(keyid, root_key2['keytype'], root_key2['scheme'],
             root_key2['keyval'])
 
         # Assert that root does not contain the new key
@@ -441,7 +441,7 @@ class TestMetadata(unittest.TestCase):
         self.assertNotIn(keyid, root.signed.keys)
 
         # Add new root key
-        root.signed.add_key('root', keyid, key_metadata)
+        root.signed.add_key('root', key_metadata)
 
         # Assert that key is added
         self.assertIn(keyid, root.signed.roles['root'].keyids)
@@ -453,7 +453,7 @@ class TestMetadata(unittest.TestCase):
 
         # Try adding the same key again and assert its ignored.
         pre_add_keyid = root.signed.roles['root'].keyids.copy()
-        root.signed.add_key('root', keyid, key_metadata)
+        root.signed.add_key('root', key_metadata)
         self.assertEqual(pre_add_keyid, root.signed.roles['root'].keyids)
 
         # Remove the key

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -81,13 +81,10 @@ class TestMetadata(unittest.TestCase):
         # Load keys into memory
         cls.keystore = {}
         for role in ['delegation', 'snapshot', 'targets', 'timestamp']:
-            cls.keystore[role] = {
-                'private': import_ed25519_privatekey_from_file(
-                        os.path.join(cls.keystore_dir, role + '_key'),
-                        password="password"),
-                'public': import_ed25519_publickey_from_file(
-                        os.path.join(cls.keystore_dir, role + '_key.pub'))
-            }
+            cls.keystore[role] = import_ed25519_privatekey_from_file(
+                os.path.join(cls.keystore_dir, role + '_key'),
+                password="password"
+            )
 
 
     @classmethod
@@ -162,6 +159,17 @@ class TestMetadata(unittest.TestCase):
 
 
     def test_sign_verify(self):
+        root_path = os.path.join(self.repo_dir, 'metadata', 'root.json')
+        root:Root = Metadata.from_file(root_path).signed
+
+        # Locate the public keys we need from root
+        targets_keyid = next(iter(root.roles["targets"].keyids))
+        targets_key = root.keys[targets_keyid]
+        snapshot_keyid = next(iter(root.roles["snapshot"].keyids))
+        snapshot_key = root.keys[snapshot_keyid]
+        timestamp_keyid = next(iter(root.roles["timestamp"].keyids))
+        timestamp_key = root.keys[timestamp_keyid]
+
         # Load sample metadata (targets) and assert ...
         path = os.path.join(self.repo_dir, 'metadata', 'targets.json')
         metadata_obj = Metadata.from_file(path)
@@ -169,43 +177,28 @@ class TestMetadata(unittest.TestCase):
         # ... it has a single existing signature,
         self.assertTrue(len(metadata_obj.signatures) == 1)
         # ... which is valid for the correct key.
-        self.assertTrue(metadata_obj.verify(
-                self.keystore['targets']['public']))
+        targets_key.verify_signature(metadata_obj)
+        with self.assertRaises(tuf.exceptions.UnsignedMetadataError):
+            snapshot_key.verify_signature(metadata_obj)
 
-        sslib_signer = SSlibSigner(self.keystore['snapshot']['private'])
+        sslib_signer = SSlibSigner(self.keystore['snapshot'])
         # Append a new signature with the unrelated key and assert that ...
         metadata_obj.sign(sslib_signer, append=True)
         # ... there are now two signatures, and
         self.assertTrue(len(metadata_obj.signatures) == 2)
         # ... both are valid for the corresponding keys.
-        self.assertTrue(metadata_obj.verify(
-                self.keystore['targets']['public']))
-        self.assertTrue(metadata_obj.verify(
-                self.keystore['snapshot']['public']))
+        targets_key.verify_signature(metadata_obj)
+        snapshot_key.verify_signature(metadata_obj)
 
-        sslib_signer.key_dict = self.keystore['timestamp']['private']
+        sslib_signer = SSlibSigner(self.keystore['timestamp'])
         # Create and assign (don't append) a new signature and assert that ...
         metadata_obj.sign(sslib_signer, append=False)
         # ... there now is only one signature,
         self.assertTrue(len(metadata_obj.signatures) == 1)
         # ... valid for that key.
-        self.assertTrue(metadata_obj.verify(
-                self.keystore['timestamp']['public']))
-
-        # Assert exception if there are more than one signatures for a key
-        metadata_obj.sign(sslib_signer, append=True)
-        with self.assertRaises(tuf.exceptions.Error) as ctx:
-            metadata_obj.verify(self.keystore['timestamp']['public'])
-        self.assertTrue(
-                '2 signatures for key' in str(ctx.exception),
-                str(ctx.exception))
-
-        # Assert exception if there is no signature for a key
-        with self.assertRaises(tuf.exceptions.Error) as ctx:
-            metadata_obj.verify(self.keystore['targets']['public'])
-        self.assertTrue(
-                'no signature for' in str(ctx.exception),
-                str(ctx.exception))
+        timestamp_key.verify_signature(metadata_obj)
+        with self.assertRaises(tuf.exceptions.UnsignedMetadataError):
+            targets_key.verify_signature(metadata_obj)
 
 
     def test_metadata_base(self):


### PR DESCRIPTION
Fixes #1417 

Adding id to Key class simplifies life for API users as usually a key needs its identifier: this is visible in how Root.add_key() becomes simpler and in how `verify_signature()` is now possible to implement in key without an additional id argument.

Moving verification to Key arguably also makes the API cleaner because including both "verify myself" and "verify a delegate with threshold" can look awkward in Metadata, and because the somewhat ugly Securesystemslib integration is now Key class implementation detail (see e.g. call to `format_metadata_to_key()`).

Returning bool on verify failure was found to confuse API users (both me and Teodora misused it the first time) and was arguably not a pythonic way to handle it: Now an exception is raised.

There are two issues in this code that are still unresolved:
* #1351: exceptions story is now better but low-level exceptions still bleed through API
* #1422: Metadata should enforce that signatures are unique per key id

I intend to fix these in the next weeks

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


