### PR TITLE
Metadata API: Store signatures as dict

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -175,7 +175,7 @@ class TestMetadata(unittest.TestCase):
         metadata_obj = Metadata.from_file(path)
 
         # ... it has a single existing signature,
-        self.assertTrue(len(metadata_obj.signatures) == 1)
+        self.assertEqual(len(metadata_obj.signatures), 1)
         # ... which is valid for the correct key.
         targets_key.verify_signature(metadata_obj)
         with self.assertRaises(tuf.exceptions.UnsignedMetadataError):
@@ -185,7 +185,7 @@ class TestMetadata(unittest.TestCase):
         # Append a new signature with the unrelated key and assert that ...
         metadata_obj.sign(sslib_signer, append=True)
         # ... there are now two signatures, and
-        self.assertTrue(len(metadata_obj.signatures) == 2)
+        self.assertEqual(len(metadata_obj.signatures), 2)
         # ... both are valid for the corresponding keys.
         targets_key.verify_signature(metadata_obj)
         snapshot_key.verify_signature(metadata_obj)
@@ -194,7 +194,7 @@ class TestMetadata(unittest.TestCase):
         # Create and assign (don't append) a new signature and assert that ...
         metadata_obj.sign(sslib_signer, append=False)
         # ... there now is only one signature,
-        self.assertTrue(len(metadata_obj.signatures) == 1)
+        self.assertEqual(len(metadata_obj.signatures), 1)
         # ... valid for that key.
         timestamp_key.verify_signature(metadata_obj)
         with self.assertRaises(tuf.exceptions.UnsignedMetadataError):
@@ -235,6 +235,12 @@ class TestMetadata(unittest.TestCase):
         is_expired = md.signed.is_expired()
         self.assertFalse(is_expired)
         md.signed.expires = expires
+
+        # Test deserializing metadata with non-unique signatures:
+        data = md.to_dict()
+        data["signatures"].append({"keyid": data["signatures"][0]["keyid"], "sig": "foo"})
+        with self.assertRaises(ValueError):
+            Metadata.from_dict(data)
 
 
     def test_metafile_class(self):

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -17,6 +17,7 @@ available in the class model.
 """
 import abc
 import tempfile
+from collections import OrderedDict
 from datetime import datetime, timedelta
 from typing import Any, ClassVar, Dict, List, Mapping, Optional, Tuple, Type
 
@@ -48,11 +49,13 @@ class Metadata:
         signed: A subclass of Signed, which has the actual metadata payload,
             i.e. one of Targets, Snapshot, Timestamp or Root.
 
-        signatures: A dict of keyids to Securesystemslib Signature objects,
-            each signing the canonical serialized representation of 'signed'.
+        signatures: An ordered dictionary of keyids to Signature objects, each
+            signing the canonical serialized representation of 'signed'.
     """
 
-    def __init__(self, signed: "Signed", signatures: Dict[str, Signature]):
+    def __init__(
+        self, signed: "Signed", signatures: "OrderedDict[str, Signature]"
+    ):
         self.signed = signed
         self.signatures = signatures
 
@@ -89,7 +92,7 @@ class Metadata:
             raise ValueError(f'unrecognized metadata type "{_type}"')
 
         # Make sure signatures are unique
-        signatures: Dict[str, Signature] = {}
+        signatures: "OrderedDict[str, Signature]" = OrderedDict()
         for sig_dict in metadata.pop("signatures"):
             sig = Signature.from_dict(sig_dict)
             if sig.keyid in signatures:
@@ -249,7 +252,7 @@ class Metadata:
         if append:
             self.signatures[signature.keyid] = signature
         else:
-            self.signatures = {signature.keyid: signature}
+            self.signatures = OrderedDict({signature.keyid: signature})
 
         return signature
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -249,10 +249,10 @@ class Metadata:
 
         signature = signer.sign(signed_serializer.serialize(self.signed))
 
-        if append:
-            self.signatures[signature.keyid] = signature
-        else:
-            self.signatures = OrderedDict({signature.keyid: signature})
+        if not append:
+            self.signatures.clear()
+
+        self.signatures[signature.keyid] = signature
 
         return signature
 


### PR DESCRIPTION
store signatures in a Dict of keyid to Signature. This ensures
signature uniqueness. Raise in from_dict() if input contains multiple
different signatures for a keyid.

This changes Metadata object API, and makes it slightly different from
the file format: this is justified by making the API safer to use and
easier to validate.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

Fixes #1422

---

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


