### PR TITLE
New metadata API: spec_version attribute validation

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -293,7 +293,6 @@ class Signed(metaclass=abc.ABCMeta):
         self.spec_version = spec_version
         self.expires = expires
 
-        # TODO: Should we separate data validation from constructor?
         if version <= 0:
             raise ValueError(f"version must be > 0, got {version}")
         self.version = version

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -37,6 +37,10 @@ from tuf.api.serialization import (
 # and currently, we are above 1000 lines by a small margin.
 # pylint: disable=C0302
 
+# We aim to support SPECIFICATION_VERSION and require the input metadata
+# files to have the same major version (the first number) as ours.
+SPECIFICATION_VERSION = ["1", "0", "19"]
+
 
 class Metadata:
     """A container for signed TUF metadata.
@@ -290,6 +294,16 @@ class Signed(metaclass=abc.ABCMeta):
         expires: datetime,
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ) -> None:
+        spec_list = spec_version.split(".")
+        if (
+            len(spec_list) != 3
+            or not all(el.isdigit() for el in spec_list)
+            or spec_list[0] != SPECIFICATION_VERSION[0]
+        ):
+            raise ValueError(
+                f"Unsupported spec_version, got {spec_list}, "
+                f"supported {'.'.join(SPECIFICATION_VERSION)}"
+            )
         self.spec_version = spec_version
         self.expires = expires
 


### PR DESCRIPTION
Fixes #1419

**Description of the changes being introduced by the pull request**:
Even though version strings like `2.0.0-rc.2` or `1.0.0-beta` are
valid strings in semantic versioning format, in TUF we never needed
to add letters for our specification number.

That's why I validate that: spec_version is a `.` separated string
and when split it has a length of 3 and that each of the
three elements is a number.

Also, I remove one comment about the `version` validation place, because it
seems irrelevant anymore.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


