### PR TITLE
Stop using formats.py in metadata.py

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -25,7 +25,7 @@ from securesystemslib.signer import Signature, Signer
 from securesystemslib.storage import FilesystemBackend, StorageBackendInterface
 from securesystemslib.util import persist_temp_file
 
-from tuf import exceptions, formats
+from tuf import exceptions
 from tuf.api.serialization import (
     MetadataDeserializer,
     MetadataSerializer,
@@ -384,7 +384,7 @@ class Signed(metaclass=abc.ABCMeta):
         # Convert 'expires' TUF metadata string to a datetime object, which is
         # what the constructor expects and what we store. The inverse operation
         # is implemented in '_common_fields_to_dict'.
-        expires = formats.expiry_string_to_datetime(expires_str)
+        expires = datetime.strptime(expires_str, "%Y-%m-%dT%H:%M:%SZ")
         return version, spec_version, expires
 
     def _common_fields_to_dict(self) -> Dict[str, Any]:


### PR DESCRIPTION
Currently, we have one use of tuf/formats.py in tuf/api/metadata.py.
If we do the conversion of the expires string in metadata.py,
we can keep the two implementations separate.

Fixes #1384

**Description of the changes being introduced by the pull request**:

The use of tuf/formats.py is removed from tuf/api/metadata.py and 
the **expires** string conversion to datetime is done directly in metadata.py

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


