### PR TITLE
Handle exceptions in verify

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -181,6 +181,11 @@ class TestMetadata(unittest.TestCase):
         with self.assertRaises(exceptions.UnsignedMetadataError):
             snapshot_key.verify_signature(metadata_obj)
 
+        # Test verifying with explicitly set serializer
+        targets_key.verify_signature(metadata_obj, CanonicalJSONSerializer())
+        with self.assertRaises(exceptions.UnsignedMetadataError):
+            targets_key.verify_signature(metadata_obj, JSONSerializer())
+
         sslib_signer = SSlibSigner(self.keystore['snapshot'])
         # Append a new signature with the unrelated key and assert that ...
         metadata_obj.sign(sslib_signer, append=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -205,6 +205,25 @@ class TestMetadata(unittest.TestCase):
         with self.assertRaises(exceptions.UnsignedMetadataError):
             targets_key.verify_signature(metadata_obj)
 
+        # Test failure on broken public key data (securesystemslib CryptoError)
+        public = timestamp_key.keyval["public"]
+        timestamp_key.keyval["public"] = "ffff"
+        with self.assertRaises(exceptions.UnsignedMetadataError):
+            timestamp_key.verify_signature(metadata_obj)
+        timestamp_key.keyval["public"] = public
+
+        # Test failure with invalid signature (securesystemslib FormatError)
+        sig = metadata_obj.signatures[timestamp_keyid]
+        correct_sig = sig.signature
+        sig.signature = "foo"
+        with self.assertRaises(exceptions.UnsignedMetadataError):
+            timestamp_key.verify_signature(metadata_obj)
+
+        # Test failure with valid but incorrect signature
+        sig.signature = "52af76354db3403242e1437b1fbf1c7edc4e66b81dfd63b3026ff681d57e88e11a697cca78061a376a9dd8d7fde5777b14d4e6d8e75f976101cbc61321642f06"
+        with self.assertRaises(exceptions.UnsignedMetadataError):
+            timestamp_key.verify_signature(metadata_obj)
+        sig.signature = correct_sig
 
     def test_metadata_base(self):
         # Use of Snapshot is arbitrary, we're just testing the base class features

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -205,6 +205,13 @@ class TestMetadata(unittest.TestCase):
         with self.assertRaises(exceptions.UnsignedMetadataError):
             targets_key.verify_signature(metadata_obj)
 
+        # Test failure on unknown scheme (securesystemslib UnsupportedAlgorithmError)
+        scheme = timestamp_key.scheme
+        timestamp_key.scheme = "foo"
+        with self.assertRaises(exceptions.UnsignedMetadataError):
+            timestamp_key.verify_signature(metadata_obj)
+        timestamp_key.scheme = scheme
+
         # Test failure on broken public key data (securesystemslib CryptoError)
         public = timestamp_key.keyval["public"]
         timestamp_key.keyval["public"] = "ffff"
@@ -220,7 +227,7 @@ class TestMetadata(unittest.TestCase):
             timestamp_key.verify_signature(metadata_obj)
 
         # Test failure with valid but incorrect signature
-        sig.signature = "52af76354db3403242e1437b1fbf1c7edc4e66b81dfd63b3026ff681d57e88e11a697cca78061a376a9dd8d7fde5777b14d4e6d8e75f976101cbc61321642f06"
+        sig.signature = "ff"*64
         with self.assertRaises(exceptions.UnsignedMetadataError):
             timestamp_key.verify_signature(metadata_obj)
         sig.signature = correct_sig


### PR DESCRIPTION
#1417 has been merged so this is good to go.

We want to handle exceptions in verify_signature(): Callers are not going to be interested in the various details of why verification failed (or rather, good error messages are important but no-one is going to write code to handle the different cases). 

This call is typically used on the client: the metadata comes from remote repository, and we're trying to verify it. We might try to handle a specific error situation by saying something specific like "we can't verify this sig because we're missing dependency X"... but this could also just be a mistake in the remote end. I feel like `UnsignedMetadataError` with descriptive message and exception history is probably the best we can do.

Still, discussing each error case here probably makes sense... I'll write a list.

Fixes #1351 