### PR TITLE
Metadata API: Implement threshold verification

### DIFF
--- a/tests/repository_data/repository/metadata/role2.json
+++ b/tests/repository_data/repository/metadata/role2.json
@@ -2,15 +2,11 @@
  "signatures": [
   {
    "keyid": "c8022fa1e9b9cb239a6b362bbdffa9649e61ad2cb699d2e4bc4fdf7930a0e64a",
-   "sig": "6c32f8cc2c642803a7b3b022ede0cf727e82964c1aa934571ef366bd5050ed02cfe3fdfe5477c08d0cbcc2dd17bb786d37ab1ce2b27e01ad79faf087594e0300"
+   "sig": "75b196a224fd200e46e738b1216b3316c5384f61083872f8d14b8b0a378b2344e64b1a6f1a89a711206a66a0b199d65ac0e30fe15ddbc4de89fa8ff645f99403"
   }
  ],
  "signed": {
   "_type": "targets",
-  "delegations": {
-   "keys": {},
-   "roles": []
-  },
   "expires": "2030-01-01T00:00:00Z",
   "spec_version": "1.0.0",
   "targets": {},

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,7 +51,8 @@ from securesystemslib.interface import (
 )
 
 from securesystemslib.signer import (
-    SSlibSigner
+    SSlibSigner,
+    Signature
 )
 
 logger = logging.getLogger(__name__)
@@ -357,7 +358,7 @@ class TestMetadata(unittest.TestCase):
         role1.verify_delegate('role2', role2)
 
         # only root and targets can verify delegates
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             snapshot.verify_delegate('snapshot', snapshot)
         # verify fails for roles that are not delegated by delegator
         with self.assertRaises(ValueError):
@@ -376,12 +377,25 @@ class TestMetadata(unittest.TestCase):
         with self.assertRaises(exceptions.UnsignedMetadataError):
             root.verify_delegate('timestamp', snapshot)
 
+        # Add a key to snapshot role, make sure the new sig fails to verify
+        ts_keyid = next(iter(root.signed.roles["timestamp"].keyids))
+        root.signed.add_key("snapshot", root.signed.keys[ts_keyid])
+        snapshot.signatures[ts_keyid] = Signature(ts_keyid, "ff"*64)
+
+        # verify succeeds if threshold is reached even if some signatures
+        # fail to verify
+        root.verify_delegate('snapshot', snapshot)
+
         # verify fails if threshold of signatures is not reached
         root.signed.roles['snapshot'].threshold = 2
         with self.assertRaises(exceptions.UnsignedMetadataError):
             root.verify_delegate('snapshot', snapshot)
 
-        # TODO test successful verify with higher thresholds
+        # verify succeeds when we correct the new signature and reach the
+        # threshold of 2 keys
+        snapshot.sign(SSlibSigner(self.keystore['timestamp']), append=True)
+        root.verify_delegate('snapshot', snapshot)
+
 
     def test_key_class(self):
         keys = {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -365,6 +365,9 @@ class TestMetadata(unittest.TestCase):
             root.verify_delegate('role1', role1)
         with self.assertRaises(ValueError):
             targets.verify_delegate('targets', targets)
+        # verify fails when delegator has no delegations
+        with self.assertRaises(ValueError):
+            role2.verify_delegate('role1', role1)
 
         # verify fails when delegate content is modified
         expires = snapshot.signed.expires

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -298,7 +298,7 @@ class Metadata:
                 roles = self.signed.delegations.roles
                 role = next((r for r in roles if r.name == role_name), None)
         else:
-            raise ValueError("Call is valid only on delegator metadata")
+            raise TypeError("Call is valid only on delegator metadata")
 
         if role is None:
             raise ValueError(f"No delegation found for {role_name}")

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -17,6 +17,7 @@ available in the class model.
 """
 import abc
 import io
+import logging
 import tempfile
 from collections import OrderedDict
 from datetime import datetime, timedelta
@@ -48,6 +49,8 @@ from tuf.api.serialization import (
 )
 
 # pylint: disable=too-many-lines
+
+logger = logging.getLogger(__name__)
 
 # We aim to support SPECIFICATION_VERSION and require the input metadata
 # files to have the same major version (the first number) as ours.
@@ -309,10 +312,9 @@ class Metadata:
             key = keys[keyid]
             try:
                 key.verify_signature(delegate, signed_serializer)
-                # keyids are unique. Try to make sure the public keys are too
-                signing_keys.add(key.keyval["public"])
+                signing_keys.add(key.keyid)
             except exceptions.UnsignedMetadataError:
-                pass
+                logger.info("Key %s failed to verify %s", keyid, role_name)
 
         if len(signing_keys) < role.threshold:
             raise exceptions.UnsignedMetadataError(


### PR DESCRIPTION
#1417 is merged so this is good to go

The delegating Metadata (root or targets) verifies that the delegated metadata is signed by required threshold of keys for the delegated role.

This implementation raises UnsignedMetadataError if threshold is not met. Other possible exceptions are programming errors.

Fixes #1306 

