### PR TITLE
Metadata API: Fix Metadata.sign() return value annotation

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -188,12 +188,14 @@ class TestMetadata(unittest.TestCase):
 
         sslib_signer = SSlibSigner(self.keystore['snapshot'])
         # Append a new signature with the unrelated key and assert that ...
-        metadata_obj.sign(sslib_signer, append=True)
+        sig = metadata_obj.sign(sslib_signer, append=True)
         # ... there are now two signatures, and
         self.assertEqual(len(metadata_obj.signatures), 2)
         # ... both are valid for the corresponding keys.
         targets_key.verify_signature(metadata_obj)
         snapshot_key.verify_signature(metadata_obj)
+        # ... the returned (appended) signature is for snapshot key
+        self.assertEqual(sig.keyid, snapshot_keyid)
 
         sslib_signer = SSlibSigner(self.keystore['timestamp'])
         # Create and assign (don't append) a new signature and assert that ...

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -228,7 +228,7 @@ class Metadata:
         signer: Signer,
         append: bool = False,
         signed_serializer: Optional[SignedSerializer] = None,
-    ) -> Dict[str, Any]:
+    ) -> Signature:
         """Creates signature over 'signed' and assigns it to 'signatures'.
 
         Arguments:
@@ -247,7 +247,7 @@ class Metadata:
                 Signing errors.
 
         Returns:
-            A securesystemslib-style signature object.
+            Securesystemslib Signature object that was added into signatures.
         """
 
         if signed_serializer is None:


### PR DESCRIPTION
We've been returning Signature objects since 49aa0fc167.

Also add a test case that does something with the returned signature.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

---

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


