### PR TITLE
Metadata API: snapshot_meta property in Timestamp

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -343,11 +343,11 @@ class TestMetadata(unittest.TestCase):
         fileinfo = MetaFile(2, 520, hashes)
 
         self.assertNotEqual(
-            timestamp.signed.meta['snapshot.json'].to_dict(), fileinfo.to_dict()
+            timestamp.signed.snapshot_meta.to_dict(), fileinfo.to_dict()
         )
         timestamp.signed.update(fileinfo)
         self.assertEqual(
-            timestamp.signed.meta['snapshot.json'].to_dict(), fileinfo.to_dict()
+            timestamp.signed.snapshot_meta.to_dict(), fileinfo.to_dict()
         )
 
         # Test from_dict and to_dict without hashes and length.

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -697,6 +697,14 @@ class Timestamp(Signed):
 
     _signed_type = "timestamp"
 
+    @property
+    def snapshot_meta(self):
+        return self.meta["snapshot.json"]
+
+    @snapshot_meta.setter
+    def snapshot_meta(self, value):
+        self.meta["snapshot.json"] = value
+
     def __init__(
         self,
         version: int,
@@ -720,15 +728,13 @@ class Timestamp(Signed):
     def to_dict(self) -> Dict[str, Any]:
         """Returns the dict representation of self."""
         res_dict = self._common_fields_to_dict()
-        res_dict["meta"] = {
-            "snapshot.json": self.meta["snapshot.json"].to_dict()
-        }
+        res_dict["meta"] = {"snapshot.json": self.snapshot_meta.to_dict()}
         return res_dict
 
     # Modification.
     def update(self, snapshot_meta: MetaFile) -> None:
         """Assigns passed info about snapshot metadata to meta dict."""
-        self.meta["snapshot.json"] = snapshot_meta
+        self.snapshot_meta = snapshot_meta
 
 
 class Snapshot(Signed):


### PR DESCRIPTION
Fixes #1443 

**Description of the changes being introduced by the pull request**:

In Timestamp, the only valid "meta" value is the dictionary representing
meta information for the snapshot file.
That's why we want to provide an access to it without changing the
timestamp representation through the Timestamp class.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


