### PR TITLE
Metadata API: change meta type in Timestamp

### DIFF
--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -100,8 +100,8 @@ class RepositorySimulator(FetcherInterface):
         snapshot = Snapshot(1, SPEC_VER, expiry, meta)
         self.md_snapshot = Metadata(snapshot, OrderedDict())
 
-        meta = {"snapshot.json": MetaFile(snapshot.version)}
-        timestamp = Timestamp(1, SPEC_VER, expiry, meta)
+        snapshot_meta = MetaFile(snapshot.version)
+        timestamp = Timestamp(1, SPEC_VER, expiry, snapshot_meta)
         self.md_timestamp = Metadata(timestamp, OrderedDict())
 
         root = Root(1, SPEC_VER, expiry, {}, {}, True)
@@ -175,7 +175,7 @@ class RepositorySimulator(FetcherInterface):
             return md.to_bytes(JSONSerializer())
 
     def update_timestamp(self):
-        self.timestamp.meta["snapshot.json"].version = self.snapshot.version
+        self.timestamp.snapshot_meta.version = self.snapshot.version
 
         self.timestamp.version += 1
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -350,11 +350,11 @@ class TestMetadata(unittest.TestCase):
         fileinfo = MetaFile(2, 520, hashes)
 
         self.assertNotEqual(
-            timestamp.signed.meta['snapshot.json'].to_dict(), fileinfo.to_dict()
+            timestamp.signed.snapshot_meta.to_dict(), fileinfo.to_dict()
         )
         timestamp.signed.update(fileinfo)
         self.assertEqual(
-            timestamp.signed.meta['snapshot.json'].to_dict(), fileinfo.to_dict()
+            timestamp.signed.snapshot_meta.to_dict(), fileinfo.to_dict()
         )
 
 
@@ -563,7 +563,7 @@ class TestMetadata(unittest.TestCase):
         timestamp_path = os.path.join(
             self.repo_dir, 'metadata', 'timestamp.json')
         timestamp = Metadata[Timestamp].from_file(timestamp_path)
-        snapshot_metafile = timestamp.signed.meta["snapshot.json"]
+        snapshot_metafile = timestamp.signed.snapshot_meta
 
         snapshot_path = os.path.join(
             self.repo_dir, 'metadata', 'snapshot.json')

--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -70,8 +70,8 @@ class TestTrustedMetadataSet(unittest.TestCase):
             cls.keystore[role] = SSlibSigner(key_dict)
 
         def hashes_length_modifier(timestamp: Timestamp) -> None:
-            timestamp.meta["snapshot.json"].hashes = None
-            timestamp.meta["snapshot.json"].length = None
+            timestamp.snapshot_meta.hashes = None
+            timestamp.snapshot_meta.length = None
 
         cls.metadata["timestamp"] = cls.modify_metadata(
             cls, "timestamp", hashes_length_modifier
@@ -245,13 +245,13 @@ class TestTrustedMetadataSet(unittest.TestCase):
 
     def test_update_timestamp_snapshot_ver_below_current(self):
         def bump_snapshot_version(timestamp: Timestamp) -> None:
-            timestamp.meta["snapshot.json"].version = 2
+            timestamp.snapshot_meta.version = 2
 
         # set current known snapshot.json version to 2
         timestamp = self.modify_metadata("timestamp", bump_snapshot_version)
         self.trusted_set.update_timestamp(timestamp)
 
-        # newtimestamp.meta["snapshot.json"].version < trusted_timestamp.meta["snapshot.json"].version
+        # newtimestamp.meta.version < trusted_timestamp.meta.version
         with self.assertRaises(exceptions.ReplayedMetadataError):
             self.trusted_set.update_timestamp(self.metadata["timestamp"])
 
@@ -271,7 +271,7 @@ class TestTrustedMetadataSet(unittest.TestCase):
 
     def test_update_snapshot_length_or_hash_mismatch(self):
         def modify_snapshot_length(timestamp: Timestamp) -> None:
-            timestamp.meta["snapshot.json"].length = 1
+            timestamp.snapshot_meta.length = 1
 
         # set known snapshot.json length to 1
         timestamp = self.modify_metadata("timestamp", modify_snapshot_length)
@@ -289,7 +289,7 @@ class TestTrustedMetadataSet(unittest.TestCase):
 
     def test_update_snapshot_version_different_timestamp_snapshot_version(self):
         def timestamp_version_modifier(timestamp: Timestamp) -> None:
-            timestamp.meta["snapshot.json"].version = 2
+            timestamp.snapshot_meta.version = 2
 
         timestamp = self.modify_metadata("timestamp", timestamp_version_modifier)
         self.trusted_set.update_timestamp(timestamp)
@@ -341,7 +341,7 @@ class TestTrustedMetadataSet(unittest.TestCase):
 
     def test_update_snapshot_successful_rollback_checks(self):
         def meta_version_bump(timestamp: Timestamp) -> None:
-            timestamp.meta["snapshot.json"].version += 1
+            timestamp.snapshot_meta.version += 1
 
         def version_bump(snapshot: Snapshot) -> None:
             snapshot.version += 1

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -233,13 +233,13 @@ class TrustedMetadataSet(abc.Mapping):
                 )
             # Prevent rolling back snapshot version
             if (
-                new_timestamp.signed.meta["snapshot.json"].version
-                < self.timestamp.signed.meta["snapshot.json"].version
+                new_timestamp.signed.snapshot_meta.version
+                < self.timestamp.signed.snapshot_meta.version
             ):
                 raise exceptions.ReplayedMetadataError(
                     "snapshot",
-                    new_timestamp.signed.meta["snapshot.json"].version,
-                    self.timestamp.signed.meta["snapshot.json"].version,
+                    new_timestamp.signed.snapshot_meta.version,
+                    self.timestamp.signed.snapshot_meta.version,
                 )
 
         # expiry not checked to allow old timestamp to be used for rollback
@@ -286,11 +286,11 @@ class TrustedMetadataSet(abc.Mapping):
         # Snapshot cannot be loaded if final timestamp is expired
         self._check_final_timestamp()
 
-        meta = self.timestamp.signed.meta["snapshot.json"]
+        snapshot_meta = self.timestamp.signed.snapshot_meta
 
         # Verify against the hashes in timestamp, if any
         try:
-            meta.verify_length_and_hashes(data)
+            snapshot_meta.verify_length_and_hashes(data)
         except exceptions.LengthOrHashMismatchError as e:
             raise exceptions.RepositoryError(
                 "Snapshot length or hashes do not match"
@@ -345,14 +345,10 @@ class TrustedMetadataSet(abc.Mapping):
         assert self.timestamp is not None  # nosec
         if self.snapshot.signed.is_expired(self.reference_time):
             raise exceptions.ExpiredMetadataError("snapshot.json is expired")
-
-        if (
-            self.snapshot.signed.version
-            != self.timestamp.signed.meta["snapshot.json"].version
-        ):
+        snapshot_meta = self.timestamp.signed.snapshot_meta
+        if self.snapshot.signed.version != snapshot_meta.version:
             raise exceptions.BadVersionNumberError(
-                f"Expected snapshot version "
-                f"{self.timestamp.signed.meta['snapshot.json'].version}, "
+                f"Expected snapshot version {snapshot_meta.version}, "
                 f"got {self.snapshot.signed.version}"
             )
 

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -352,11 +352,11 @@ class Updater:
             logger.debug("Local snapshot not valid as final: %s", e)
 
             assert self._trusted_set.timestamp is not None  # nosec
-            metainfo = self._trusted_set.timestamp.signed.meta["snapshot.json"]
-            length = metainfo.length or self.config.snapshot_max_length
+            snapshot_meta = self._trusted_set.timestamp.signed.snapshot_meta
+            length = snapshot_meta.length or self.config.snapshot_max_length
             version = None
             if self._trusted_set.root.signed.consistent_snapshot:
-                version = metainfo.version
+                version = snapshot_meta.version
 
             data = self._download_metadata("snapshot", length, version)
             self._trusted_set.update_snapshot(data)


### PR DESCRIPTION
Fixes #1443 

**Description of the changes being introduced by the pull request**:

In Timestamp, the only valid "meta" value is the dictionary representing
meta information for the snapshot file. This makes the API unnecessarily
complicated and requires validation that only information about snapshot
is available inside "meta".
Together with the python-tuf maintainers we decided that snapshot meta
information will not be represented by a "meta" dictionary but instead
by a MetaFile instance and with this it will diverge from the
specification.
This decision is coherent with ADR9 and the rationale
behind it is to provide easier, safer, and direct access to the
snapshot meta information.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**History of modifications made on the pr**:
- Proposing `snapshot_meta` as a property with a setter and getter.
- Adding annotations
- Suggestion to remove the `update` function for `Timestamp`, will be handled in https://github.com/theupdateframework/tuf/issues/1230
- Documenting that `snapshot_meta as the "API for interacting with snapshot meta information"`
and that `meta is an implementation detail that mimics the file format`.
- Decided with the python-tuf maintainers that we will change the approach to this problem
and we will change the `timestamp.meta` type to `MetaFile`.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


