### PR TITLE
Metadata API: Add Key attributes types validation

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -376,7 +376,7 @@ class TestMetadata(unittest.TestCase):
                     Key.from_dict("id", test_key_dict)
             # Test creating a Key instance with wrong keyval format.
             key_dict["keyval"] = {}
-            with self.assertRaises(ValueError):
+            with self.assertRaises(KeyError):
                 Key.from_dict("id", key_dict)
 
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -376,6 +376,8 @@ class Signed(metaclass=abc.ABCMeta):
 
 class Key:
     """A container class representing the public portion of a Key.
+    Please note that "Key" instances are not semanticly validated during
+    initialization. We consider this as responsibility of securesystemslib.
 
     Attributes:
         keyid: An identifier string that must uniquely identify a key within
@@ -398,15 +400,9 @@ class Key:
         keyval: Dict[str, str],
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ) -> None:
-        public_val = keyval.get("public")
-        if not public_val or not isinstance(public_val, str):
-            raise ValueError("keyval doesn't follow the specification format!")
-        if not isinstance(scheme, str):
-            raise ValueError("scheme should be a string!")
-        if not isinstance(keytype, str):
-            raise ValueError("keytype should be a string!")
-        if not isinstance(keyid, str):
-            raise ValueError("keyid should be a string!")
+        val = keyval["public"]
+        if not all(isinstance(at, str) for at in [keyid, keytype, scheme, val]):
+            raise ValueError("Unexpected Key attributes types!")
         self.keyid = keyid
         self.keytype = keytype
         self.scheme = scheme

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -398,8 +398,15 @@ class Key:
         keyval: Dict[str, str],
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ) -> None:
-        if not keyval.get("public"):
+        public_val = keyval.get("public")
+        if not public_val or not isinstance(public_val, str):
             raise ValueError("keyval doesn't follow the specification format!")
+        if not isinstance(scheme, str):
+            raise ValueError("scheme should be a string!")
+        if not isinstance(keytype, str):
+            raise ValueError("keytype should be a string!")
+        if not isinstance(keyid, str):
+            raise ValueError("keyid should be a string!")
         self.keyid = keyid
         self.keytype = keytype
         self.scheme = scheme


### PR DESCRIPTION
Fixes #1438

**Description of the changes being introduced by the pull request**:

In our discussion with @jku , we come to the conclusion that we want
to verify that all Key attributes contain values in the expected types,
but at the same time, we don't want to focus on validating the semantics
behind them.
The reason is that having a Key instance with invalid attributes is
possible and supported by the spec.
That's why we have a "threshold" for the roles meaning we can have up to
a certain number of invalid Keys until we satisfy
the required threshold.

Also, for deeper semantic validation it's better to be done in
securesystemslib which does the actual work with keys.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


