### PR TITLE
Metadata API: Add simple threshold validation

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -506,6 +506,8 @@ class Role:
                 f"keyids should be a list of unique strings,"
                 f" instead got {keyids}"
             )
+        if threshold < 1:
+            raise ValueError("threshold should be at least 1!")
         self.keyids = keyids_set
         self.threshold = threshold
         self.unrecognized_fields: Mapping[str, Any] = unrecognized_fields or {}


### PR DESCRIPTION
Fixes #1439

**Description of the changes being introduced by the pull request**:

Probably there could be future API calls that modify "threshold"
to a new value, but the problem is we don't have a clear idea
if they would exist and what exactly they will do.
That's why it makes sense to validate against the potential problems
we can imagine - in this case, is passing a threshold below 1.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


