### PR TITLE
BaseFile._verify_hashes: handle sslib errors

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -707,6 +707,15 @@ class TestMetadata(unittest.TestCase):
             self.assertRaises(exceptions.LengthOrHashMismatchError,
                 snapshot_metafile.verify_length_and_hashes, data)
 
+            snapshot_metafile.hashes = {'unsupported-alg': "8f88e2ba48b412c3843e9bb26e1b6f8fc9e98aceb0fbaa97ba37b4c98717d7ab"}
+            self.assertRaises(exceptions.LengthOrHashMismatchError,
+            snapshot_metafile.verify_length_and_hashes, data)
+
+            # Test wrong algorithm format (sslib.FormatError)
+            snapshot_metafile.hashes = { 256: "8f88e2ba48b412c3843e9bb26e1b6f8fc9e98aceb0fbaa97ba37b4c98717d7ab"}
+            self.assertRaises(exceptions.LengthOrHashMismatchError,
+            snapshot_metafile.verify_length_and_hashes, data)
+
             # test optional length and hashes
             snapshot_metafile.length = None
             snapshot_metafile.hashes = None


### PR DESCRIPTION
Fixes #1452

**Description of the changes being introduced by the pull request**:
BaseFile._verify_hashes handles the following sslib errors raised during hash verification:

- securesystemslib.exceptions.UnsupportedAlgorithmError
- securesystemslib.exceptions.FormatError

and reraises them as tuf.exceptions.UnsupportedAlgorithmError.

securesystemslib.exceptions.FormatError should not be raised if the Target/MetaFile object is
created correctly through its constructor but is possible if Target/MetaFile.hashes is modified
directly so catching it just in case. 

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


