### PR TITLE
Harden mypy configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,11 @@ ignore =
 
 [mypy]
 warn_unused_configs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_unreachable = True
+strict_equality = True
+disallow_untyped_defs = True
 files = tuf/api/
 
 [mypy-securesystemslib.*]

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,8 @@ warn_unused_ignores = True
 warn_unreachable = True
 strict_equality = True
 disallow_untyped_defs = True
-files = tuf/api/
+disallow_untyped_calls = True
+files = tuf/api/, tuf/exceptions.py
 
 [mypy-securesystemslib.*]
 ignore_missing_imports = True

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1025,8 +1025,6 @@ class TargetFile(BaseFile):
 
     @property
     def custom(self) -> Any:
-        if self.unrecognized_fields is None:
-            return None
         return self.unrecognized_fields.get("custom", None)
 
     @classmethod

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -288,11 +288,11 @@ class Signed(metaclass=abc.ABCMeta):
 
     # _type and type are identical: 1st replicates file format, 2nd passes lint
     @property
-    def _type(self):
+    def _type(self) -> str:
         return self._signed_type
 
     @property
-    def type(self):
+    def type(self) -> str:
         return self._signed_type
 
     # NOTE: Signed is a stupid name, because this might not be signed yet, but
@@ -372,7 +372,7 @@ class Signed(metaclass=abc.ABCMeta):
             **self.unrecognized_fields,
         }
 
-    def is_expired(self, reference_time: datetime = None) -> bool:
+    def is_expired(self, reference_time: Optional[datetime] = None) -> bool:
         """Checks metadata expiration against a reference time.
 
         Args:
@@ -464,7 +464,7 @@ class Key:
         self,
         metadata: Metadata,
         signed_serializer: Optional[SignedSerializer] = None,
-    ):
+    ) -> None:
         """Verifies that the 'metadata.signatures' contains a signature made
         with this key, correctly signing 'metadata.signed'.
 
@@ -765,7 +765,7 @@ class MetaFile(BaseFile):
 
         return res_dict
 
-    def verify_length_and_hashes(self, data: Union[bytes, BinaryIO]):
+    def verify_length_and_hashes(self, data: Union[bytes, BinaryIO]) -> None:
         """Verifies that the length and hashes of "data" match expected values.
 
         Args:
@@ -1024,7 +1024,7 @@ class TargetFile(BaseFile):
         self.unrecognized_fields = unrecognized_fields or {}
 
     @property
-    def custom(self):
+    def custom(self) -> Any:
         if self.unrecognized_fields is None:
             return None
         return self.unrecognized_fields.get("custom", None)
@@ -1046,7 +1046,7 @@ class TargetFile(BaseFile):
             **self.unrecognized_fields,
         }
 
-    def verify_length_and_hashes(self, data: Union[bytes, BinaryIO]):
+    def verify_length_and_hashes(self, data: Union[bytes, BinaryIO]) -> None:
         """Verifies that length and hashes of "data" match expected values.
 
         Args:

--- a/tuf/exceptions.py
+++ b/tuf/exceptions.py
@@ -24,6 +24,8 @@
 
 from urllib import parse
 
+from typing import Any, Dict
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -45,16 +47,16 @@ class FormatError(Error):
 class InvalidMetadataJSONError(FormatError):
   """Indicate that a metadata file is not valid JSON."""
 
-  def __init__(self, exception):
+  def __init__(self, exception: BaseException):
     super(InvalidMetadataJSONError, self).__init__()
 
     # Store the original exception.
     self.exception = exception
 
-  def __str__(self):
+  def __str__(self) -> str:
     return repr(self)
 
-  def __repr__(self):
+  def __repr__(self) -> str:
     # Show the original exception.
     return self.__class__.__name__ + ' : wraps error: ' + repr(self.exception)
 
@@ -71,18 +73,18 @@ class LengthOrHashMismatchError(Error):
 class BadHashError(Error):
   """Indicate an error while checking the value of a hash object."""
 
-  def __init__(self, expected_hash, observed_hash):
+  def __init__(self, expected_hash: str, observed_hash: str):
     super(BadHashError, self).__init__()
 
     self.expected_hash = expected_hash
     self.observed_hash = observed_hash
 
-  def __str__(self):
+  def __str__(self) -> str:
     return (
         'Observed hash (' + repr(self.observed_hash) + ') != expected hash (' +
         repr(self.expected_hash) + ')')
 
-  def __repr__(self):
+  def __repr__(self) -> str:
     return self.__class__.__name__ + ' : ' + str(self)
 
     # # Directly instance-reproducing:
@@ -125,21 +127,20 @@ class ExpiredMetadataError(Error):
 class ReplayedMetadataError(RepositoryError):
   """Indicate that some metadata has been replayed to the client."""
 
-  def __init__(self, metadata_role, previous_version, current_version):
+  def __init__(self, metadata_role: str, previous_version: int, current_version: int):
     super(ReplayedMetadataError, self).__init__()
 
     self.metadata_role = metadata_role
     self.previous_version = previous_version
     self.current_version = current_version
 
-
-  def __str__(self):
+  def __str__(self) -> str:
     return (
         'Downloaded ' + repr(self.metadata_role) + ' is older (' +
         repr(self.previous_version) + ') than the version currently '
         'installed (' + repr(self.current_version) + ').')
 
-  def __repr__(self):
+  def __repr__(self) -> str:
     return self.__class__.__name__ + ' : ' + str(self)
 
     # # Directly instance-reproducing:
@@ -156,15 +157,15 @@ class CryptoError(Error):
 class BadSignatureError(CryptoError):
   """Indicate that some metadata file has a bad signature."""
 
-  def __init__(self, metadata_role_name):
+  def __init__(self, metadata_role_name: str):
     super(BadSignatureError, self).__init__()
 
     self.metadata_role_name = metadata_role_name
 
-  def __str__(self):
+  def __str__(self) -> str:
     return repr(self.metadata_role_name) + ' metadata has a bad signature.'
 
-  def __repr__(self):
+  def __repr__(self) -> str:
     return self.__class__.__name__ + ' : ' + str(self)
 
     # # Directly instance-reproducing:
@@ -187,18 +188,18 @@ class DownloadError(Error):
 class DownloadLengthMismatchError(DownloadError):
   """Indicate that a mismatch of lengths was seen while downloading a file."""
 
-  def __init__(self, expected_length, observed_length):
+  def __init__(self, expected_length: int, observed_length: int):
     super(DownloadLengthMismatchError, self).__init__()
 
     self.expected_length = expected_length #bytes
     self.observed_length = observed_length #bytes
 
-  def __str__(self):
+  def __str__(self) -> str:
     return (
         'Observed length (' + repr(self.observed_length) +
         ') < expected length (' + repr(self.expected_length) + ').')
 
-  def __repr__(self):
+  def __repr__(self) -> str:
     return self.__class__.__name__ + ' : ' + str(self)
 
     # # Directly instance-reproducing:
@@ -211,17 +212,17 @@ class DownloadLengthMismatchError(DownloadError):
 class SlowRetrievalError(DownloadError):
   """"Indicate that downloading a file took an unreasonably long time."""
 
-  def __init__(self, average_download_speed):
+  def __init__(self, average_download_speed: int):
     super(SlowRetrievalError, self).__init__()
 
     self.__average_download_speed = average_download_speed #bytes/second
 
-  def __str__(self):
+  def __str__(self) -> str:
     return (
         'Download was too slow. Average speed: ' +
          repr(self.__average_download_speed) + ' bytes per second.')
 
-  def __repr__(self):
+  def __repr__(self) -> str:
     return self.__class__.__name__ + ' : ' + str(self)
 
     # # Directly instance-reproducing:
@@ -252,16 +253,17 @@ class InvalidNameError(Error):
 class UnsignedMetadataError(Error):
   """Indicate metadata object with insufficient threshold of signatures."""
 
-  def __init__(self, message, signable):
+  # signable is not used but kept in method signature for backwards compat
+  def __init__(self, message: str, signable: Any = None):
     super(UnsignedMetadataError, self).__init__()
 
     self.exception_message = message
     self.signable = signable
 
-  def __str__(self):
+  def __str__(self) -> str:
     return self.exception_message
 
-  def __repr__(self):
+  def __repr__(self) -> str:
     return self.__class__.__name__ + ' : ' + str(self)
 
     # # Directly instance-reproducing:
@@ -278,13 +280,13 @@ class NoWorkingMirrorError(Error):
     provided.
   """
 
-  def __init__(self, mirror_errors):
+  def __init__(self, mirror_errors: Dict[str, BaseException]):
     super(NoWorkingMirrorError, self).__init__()
 
     # Dictionary of URL strings to Exception instances
     self.mirror_errors = mirror_errors
 
-  def __str__(self):
+  def __str__(self) -> str:
     all_errors = 'No working mirror was found:'
 
     for mirror_url, mirror_error in self.mirror_errors.items():
@@ -303,7 +305,7 @@ class NoWorkingMirrorError(Error):
 
     return all_errors
 
-  def __repr__(self):
+  def __repr__(self) -> str:
     return self.__class__.__name__ + ' : ' + str(self)
 
     # # Directly instance-reproducing:
@@ -334,6 +336,6 @@ class FetcherHTTPError(Exception):
     message (str): The HTTP error messsage
     status_code (int): The HTTP status code
   """
-  def __init__(self, message, status_code):
+  def __init__(self, message: str, status_code: int):
     super(FetcherHTTPError, self).__init__(message)
     self.status_code = status_code


### PR DESCRIPTION
We can almost enable "strict = True" already but
* we should decide if we really want to do that (what strict means may change when mypy updates)
* we're not quite there yet...

So fix a few issues and harden the mypy configuration where possible. 

The one remaining possibly interesting option (that is currently included in "strict") is: 
* `no_any_return`: seems to require securesystemslib.formats annotations (or specifying some types in tuf code that calls securesystemslib)