### PR TITLE
Improve signed typing

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -183,7 +183,7 @@ class TestMetadata(unittest.TestCase):
 
     def test_sign_verify(self):
         root_path = os.path.join(self.repo_dir, 'metadata', 'root.json')
-        root:Root = Metadata.from_file(root_path).signed
+        root = Metadata[Root].from_file(root_path).signed
 
         # Locate the public keys we need from root
         targets_keyid = next(iter(root.roles["targets"].keyids))
@@ -302,7 +302,7 @@ class TestMetadata(unittest.TestCase):
     def test_metadata_snapshot(self):
         snapshot_path = os.path.join(
                 self.repo_dir, 'metadata', 'snapshot.json')
-        snapshot = Metadata.from_file(snapshot_path)
+        snapshot = Metadata[Snapshot].from_file(snapshot_path)
 
         # Create a MetaFile instance representing what we expect
         # the updated data to be.
@@ -321,7 +321,7 @@ class TestMetadata(unittest.TestCase):
     def test_metadata_timestamp(self):
         timestamp_path = os.path.join(
                 self.repo_dir, 'metadata', 'timestamp.json')
-        timestamp = Metadata.from_file(timestamp_path)
+        timestamp = Metadata[Timestamp].from_file(timestamp_path)
 
         self.assertEqual(timestamp.signed.version, 1)
         timestamp.signed.bump_version()
@@ -358,19 +358,19 @@ class TestMetadata(unittest.TestCase):
 
     def test_metadata_verify_delegate(self):
         root_path = os.path.join(self.repo_dir, 'metadata', 'root.json')
-        root = Metadata.from_file(root_path)
+        root = Metadata[Root].from_file(root_path)
         snapshot_path = os.path.join(
                 self.repo_dir, 'metadata', 'snapshot.json')
-        snapshot = Metadata.from_file(snapshot_path)
+        snapshot = Metadata[Snapshot].from_file(snapshot_path)
         targets_path = os.path.join(
                 self.repo_dir, 'metadata', 'targets.json')
-        targets = Metadata.from_file(targets_path)
+        targets = Metadata[Targets].from_file(targets_path)
         role1_path = os.path.join(
                 self.repo_dir, 'metadata', 'role1.json')
-        role1 = Metadata.from_file(role1_path)
+        role1 = Metadata[Targets].from_file(role1_path)
         role2_path = os.path.join(
                 self.repo_dir, 'metadata', 'role2.json')
-        role2 = Metadata.from_file(role2_path)
+        role2 = Metadata[Targets].from_file(role2_path)
 
         # test the expected delegation tree
         root.verify_delegate('root', root)
@@ -468,7 +468,7 @@ class TestMetadata(unittest.TestCase):
     def test_metadata_root(self):
         root_path = os.path.join(
                 self.repo_dir, 'metadata', 'root.json')
-        root = Metadata.from_file(root_path)
+        root = Metadata[Root].from_file(root_path)
 
         # Add a second key to root role
         root_key2 =  import_ed25519_publickey_from_file(
@@ -530,7 +530,7 @@ class TestMetadata(unittest.TestCase):
     def test_metadata_targets(self):
         targets_path = os.path.join(
                 self.repo_dir, 'metadata', 'targets.json')
-        targets = Metadata.from_file(targets_path)
+        targets = Metadata[Targets].from_file(targets_path)
 
         # Create a fileinfo dict representing what we expect the updated data to be
         filename = 'file2.txt'
@@ -560,7 +560,7 @@ class TestMetadata(unittest.TestCase):
         # for untrusted metadata file to verify.
         timestamp_path = os.path.join(
             self.repo_dir, 'metadata', 'timestamp.json')
-        timestamp = Metadata.from_file(timestamp_path)
+        timestamp = Metadata[Timestamp].from_file(timestamp_path)
         snapshot_metafile = timestamp.signed.meta["snapshot.json"]
 
         snapshot_path = os.path.join(
@@ -603,7 +603,7 @@ class TestMetadata(unittest.TestCase):
         # Test target files' hash and length verification
         targets_path = os.path.join(
             self.repo_dir, 'metadata', 'targets.json')
-        targets = Metadata.from_file(targets_path)
+        targets = Metadata[Targets].from_file(targets_path)
         file1_targetfile = targets.signed.targets['file1.txt']
         filepath = os.path.join(
             self.repo_dir, 'targets', 'file1.txt')


### PR DESCRIPTION
_EDIT: the current proposal only contains generic annotations, not the runtime enforcing that is also described below. I'm leaving the original text here for posterity, but see the commit message to see current state._

---

This is a PR but I invite discussion about whether it is a good idea: I implemented it first because I did not know what it would end up looking like so discussion before implementation seemed futile.

Please see[ comment below](https://github.com/theupdateframework/tuf/pull/1457#issuecomment-866588434) for detailed reasoning and a comparison with alternatives.

copying description from one of the commits:

    The purpose is two-fold:
    1. When we deserialize metadata, we usually know what signed type we
       expect: make it easy to enforce that
    2. When we use Metadata, it is helpful if the specific signed type (and
       all of the classes attribute types are correctly annotated
    
    Making Metadata Generic over T, where
    
        T = TypeVar("T", "Root", "Timestamp", "Snapshot", "Targets")
    
    allows both of these cases to work. Using Generics is completely
    optional so all existing code still works. For case 1, the following
    calls will now raise a Deserialization error if the expected type is
    incorrect:
    
        md = Metadata.from_bytes(data, signed_type=Snapshot)
        md = Metadata.from_file(filename, signed_type=Snapshot)
    
    For case 2, the return value md of those calls is now of type
    "Metadata[Snapshot]", and md.signed is now of type "Snapshot" allowing
    IDE annotations and static type checking.
    
    Adding a type argument is an unconventional way to do this: the reason
    for it is that the specific type (e.g. Snapshot) is not otherwise
    available at runtime. A call like this works fine and md is annotated:
    
        md = Metadata[Snapshot].from_bytes(data)
    
    but it's not possible to validate that "data" contains a "Snapshot",
    because the value "Snapshot" is not defined at runtime at all, it is
    purely an annotation. So an actual argument is needed.
    
Fixes #1433

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [] Docs have been added for the bug fix or new feature


