### PR TITLE
Metadata API: Simplify unrecognized fields testing

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -465,52 +465,6 @@ class TestMetadata(unittest.TestCase):
         )
 
 
-    def setup_dict_with_unrecognized_field(self, file_path, field, value):
-        json_dict = {}
-        with open(file_path) as f:
-            json_dict = json.loads(f.read())
-        # We are changing the json dict without changing the signature.
-        # This could be a problem if we want to do verification on this dict.
-        json_dict["signed"][field] = value
-        return json_dict
-
-    def test_support_for_unrecognized_fields(self):
-        for metadata in ["root", "timestamp", "snapshot", "targets"]:
-            path = os.path.join(self.repo_dir, "metadata", metadata + ".json")
-            dict1 = self.setup_dict_with_unrecognized_field(path, "f", "b")
-            # Test that the metadata classes store unrecognized fields when
-            # initializing and passes them when casting the instance to a dict.
-
-            # Add unrecognized fields to all metadata sub (helper) classes.
-            if metadata == "root":
-                for keyid in dict1["signed"]["keys"].keys():
-                    dict1["signed"]["keys"][keyid]["d"] = "c"
-                for role_str in dict1["signed"]["roles"].keys():
-                    dict1["signed"]["roles"][role_str]["e"] = "g"
-            elif metadata == "targets" and dict1["signed"].get("delegations"):
-                for keyid in dict1["signed"]["delegations"]["keys"].keys():
-                    dict1["signed"]["delegations"]["keys"][keyid]["d"] = "c"
-                new_roles = []
-                for role in dict1["signed"]["delegations"]["roles"]:
-                    role["e"] = "g"
-                    new_roles.append(role)
-                dict1["signed"]["delegations"]["roles"] = new_roles
-                dict1["signed"]["delegations"]["foo"] = "bar"
-
-            temp_copy = copy.deepcopy(dict1)
-            metadata_obj = Metadata.from_dict(temp_copy)
-
-            self.assertEqual(dict1["signed"], metadata_obj.signed.to_dict())
-
-            # Test that two instances of the same class could have different
-            # unrecognized fields.
-            dict2 = self.setup_dict_with_unrecognized_field(path, "f2", "b2")
-            temp_copy2 = copy.deepcopy(dict2)
-            metadata_obj2 = Metadata.from_dict(temp_copy2)
-            self.assertNotEqual(
-                metadata_obj.signed.to_dict(), metadata_obj2.signed.to_dict()
-            )
-
     def  test_length_and_hash_validation(self):
 
         # Test metadata files' hash and length verification.

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -53,6 +53,10 @@ class TestSerialization(unittest.TestCase):
     valid_keys: DataSet = {
         "all": '{"keytype": "rsa", "scheme": "rsassa-pss-sha256", \
             "keyval": {"public": "foo"}}',
+        "unrecognized field": '{"keytype": "rsa", "scheme": "rsassa-pss-sha256", \
+            "keyval": {"public": "foo"}, "foo": "bar"}',
+        "unrecognized field in keyval": '{"keytype": "rsa", "scheme": "rsassa-pss-sha256", \
+            "keyval": {"public": "foo", "foo": "bar"}}',
     }
 
     @run_sub_tests_with_dataset(valid_keys)
@@ -63,7 +67,8 @@ class TestSerialization(unittest.TestCase):
 
 
     valid_roles: DataSet = {
-        "all": '{"keyids": ["keyid"], "threshold": 3}'
+        "all": '{"keyids": ["keyid"], "threshold": 3}',
+        "unrecognized field": '{"keyids": ["keyid"], "threshold": 3, "foo": "bar"}',
     }
 
     @run_sub_tests_with_dataset(valid_roles)
@@ -84,6 +89,11 @@ class TestSerialization(unittest.TestCase):
             "keys": {"keyid" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"} }}, \
             "roles": { "targets": {"keyids": ["keyid"], "threshold": 3} } \
             }',
+        "unrecognized field": '{"_type": "root", "spec_version": "1.0.0", "version": 1, \
+            "expires": "2030-01-01T00:00:00Z", "consistent_snapshot": false, \
+            "keys": {"keyid" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
+            "roles": { "targets": {"keyids": ["keyid"], "threshold": 3}}, \
+            "foo": "bar"}',
     }
 
     @run_sub_tests_with_dataset(valid_roots)
@@ -95,7 +105,9 @@ class TestSerialization(unittest.TestCase):
     valid_metafiles: DataSet = {
         "all": '{"hashes": {"sha256" : "abc"}, "length": 12, "version": 1}',
         "no length": '{"hashes": {"sha256" : "abc"}, "version": 1 }',
-        "no hashes": '{"length": 12, "version": 1}'
+        "no hashes": '{"length": 12, "version": 1}',
+        "unrecognized field": '{"hashes": {"sha256" : "abc"}, "length": 12, "version": 1, \
+            "foo": "bar"}',
     }
 
     @run_sub_tests_with_dataset(valid_metafiles)
@@ -107,7 +119,9 @@ class TestSerialization(unittest.TestCase):
 
     valid_timestamps: DataSet = {
         "all": '{ "_type": "timestamp", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
-            "meta": {"snapshot.json": {"hashes": {"sha256" : "abc"}, "version": 1}}}'
+            "meta": {"snapshot.json": {"hashes": {"sha256" : "abc"}, "version": 1}}}',
+        "unrecognized field": '{ "_type": "timestamp", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
+            "meta": {"snapshot.json": {"hashes": {"sha256" : "abc"}, "version": 1}}, "foo": "bar"}',
     }
 
     @run_sub_tests_with_dataset(valid_timestamps)
@@ -119,7 +133,9 @@ class TestSerialization(unittest.TestCase):
 
     valid_snapshots: DataSet = {
         "all": '{ "_type": "snapshot", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
-            "meta": { "file.txt": { "hashes": {"sha256" : "abc"}, "version": 1 }}}'
+            "meta": { "file.txt": { "hashes": {"sha256" : "abc"}, "version": 1 }}}',
+        "unrecognized field": '{ "_type": "snapshot", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
+            "meta": { "file.txt": { "hashes": {"sha256" : "abc"}, "version": 1 }}, "foo": "bar"}',
     }
 
     @run_sub_tests_with_dataset(valid_snapshots)
@@ -138,6 +154,8 @@ class TestSerialization(unittest.TestCase):
             "path_hash_prefixes": ["h1", "h2"], "threshold": 99}',
         "no hash or path prefix":
             '{"keyids": ["keyid"], "name": "a", "terminating": true, "threshold": 3}',
+        "unrecognized field":
+            '{"keyids": ["keyid"], "name": "a", "terminating": true, "threshold": 3, "foo": "bar"}',
     }
 
     @run_sub_tests_with_dataset(valid_delegated_roles)
@@ -149,7 +167,11 @@ class TestSerialization(unittest.TestCase):
 
     valid_delegations: DataSet = {
         "all": '{"keys": {"keyid" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
-            "roles": [ {"keyids": ["keyid"], "name": "a", "terminating": true, "threshold": 3} ]}'
+            "roles": [ {"keyids": ["keyid"], "name": "a", "terminating": true, "threshold": 3} ]}',
+        "unrecognized field":
+            '{"keys": {"keyid" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
+            "roles": [ {"keyids": ["keyid"], "name": "a", "terminating": true, "threshold": 3} ], \
+            "foo": "bar"}',
     }
 
     @run_sub_tests_with_dataset(valid_delegations)
@@ -162,7 +184,9 @@ class TestSerialization(unittest.TestCase):
     valid_targetfiles: DataSet = {
         "all": '{"length": 12, "hashes": {"sha256" : "abc"}, \
             "custom" : {"foo": "bar"} }',
-        "no custom": '{"length": 12, "hashes": {"sha256" : "abc"}}'
+        "no custom": '{"length": 12, "hashes": {"sha256" : "abc"}}',
+        "unrecognized field": '{"length": 12, "hashes": {"sha256" : "abc"}, \
+            "custom" : {"foo": "bar"}, "foo": "bar"}',
     }
 
     @run_sub_tests_with_dataset(valid_targetfiles)
@@ -187,7 +211,9 @@ class TestSerialization(unittest.TestCase):
             }',
         "no delegations": '{"_type": "targets", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
             "targets":  { "file.txt": {"length": 12, "hashes": {"sha256" : "abc"} } } \
-            }'
+            }',
+        "unrecognized_field": '{"_type": "targets", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
+            "targets":  {}, "foo": "bar"}',
     }
 
     @run_sub_tests_with_dataset(valid_targets)


### PR DESCRIPTION
Fixes #1464 

**Description of the changes being introduced by the pull request**:

We have merged ADR 8 allowing for unrecognized fields everywhere.
After a discussion with Jussi, we realized that there are a couple of
places where we don't want to allow `unrecognized fields` because they
are sensitive or there are limited acceptable values for them.
The places where we don't want to allow unrecognized fields are
`keys`, `roles`, `meta`, `hashes` or `targets`.
If we allow unrecognized fields in them we won't follow the spec or
even open the door for possible security vulnerability.

Second, the test we added for `unrecognized fields`
added tests for that which are too specific and not scalable.
Now, I use table testing which we have used initially in #1416
to test unrecognized fields support in a cleaner and much more readable
way.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


