### PR TITLE
Metadata API: Fix keyval "public" requirement

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -424,8 +424,9 @@ class Key:
         keyval: Dict[str, str],
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ) -> None:
-        val = keyval["public"]
-        if not all(isinstance(at, str) for at in [keyid, keytype, scheme, val]):
+        if not all(
+            isinstance(at, str) for at in [keyid, keytype, scheme]
+        ) or not isinstance(keyval, Dict):
             raise ValueError("Unexpected Key attributes types!")
         self.keyid = keyid
         self.keytype = keytype


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Currently, we require that the keyval attribute in the Key class
is a dictionary and has "public" as a key, otherwise, we throw
KeyError or ValueError.

This requirement is too strict given that in the spec for KEYVAL it's
only said that KEYVAL is:
"A dictionary containing the public portion of the key."
See: https://theupdateframework.github.io/specification/latest/index.html#keyva

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


