### PR TITLE
Metadata API: preserve Role.keyids order

### DIFF
--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -141,6 +141,7 @@ class TestSerialization(unittest.TestCase):
 
     valid_roles: DataSet = {
         "all": '{"keyids": ["keyid"], "threshold": 3}',
+        "many keyids": '{"keyids": ["a", "b", "c", "d", "e"], "threshold": 1}',
         "unrecognized field": '{"keyids": ["keyid"], "threshold": 3, "foo": "bar"}',
     }
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -554,7 +554,7 @@ class Role:
     def to_dict(self) -> Dict[str, Any]:
         """Returns the dictionary representation of self."""
         return {
-            "keyids": list(self.keyids),
+            "keyids": sorted(self.keyids),
             "threshold": self.threshold,
             **self.unrecognized_fields,
         }


### PR DESCRIPTION
Fixes #1478 

We made Role.keyids a set because the keyids are supposed
to be unique and this still makes sense.

However, the data should also preserve order
(when deserialized and serialized) and currently, it does not.
This is fairly serious since writing signed data potentially modifies
the data (making the signature invalid).

The simplest solution (as proposed by Jussi) is to make keyids
a property and there to enforce keyids uniqueness and preserve the
order by using a list instead of a set.


**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


