### PR TITLE
ADR 8: change "Decision outcome"

### DIFF
--- a/docs/adr/0008-accept-unrecognised-fields.md
+++ b/docs/adr/0008-accept-unrecognised-fields.md
@@ -33,15 +33,18 @@ intermediate operations:
 
 then, the checksum (the content) of the file must not be changed.
 - Flexibility to add new fields in the spec without adding breaking changes.
+- Don't store unrecognized fields when it is not allowed by the specification.
 
 ## Considered Options
 - Ignore and drop unrecognized fields.
 - Ignore, but store unrecognized fields as an additional attribute.
+- Ignore, but store unrecognized fields as an additional attribute
+except for a couple of places where it's not allowed by the specification.
 
 ## Decision Outcome
 
-Chosen option: "Ignore, but store unrecognized fields as an additional
-attribute."
+Chosen option: "Ignore, but store unrecognized fields as an additional attribute
+except for a couple of places where it's not allowed by the specification."
 The motivation for this decision is that the TUF specification already implies
 that we should accept unrecognized fields for backward compatibility and easier
 future extensibility.
@@ -49,3 +52,7 @@ future extensibility.
 Additionally, it seems unacceptable to change a metadata file content just by
 reading and writing it back.
 
+There are exceptions however for places in the metadata format when it is not
+allowed by specification: keys, roles, meta, hashes, and targets are
+actual dictionaries (vs JSON objects that most structures in the format are)
+where `unrecognized field` is not a meaningful concept.


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

After a discussion with Jussi, we realized that there are a couple of
places where we don't want to allow unrecognized fields because the
they are sensitive dictionaries and the specification requires an items
of certain types inside them.
The places where we don't want to allow unrecognized fields are
"keys", "roles", "meta", "hashes" or "targets".

This is pr is updating ADR8 with the decision we already take in #1466.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>


