### PR TITLE
Enable mypy for ngclient

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,3 +13,4 @@ isort
 pylint
 mypy
 bandit
+types-requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,10 @@ warn_unreachable = True
 strict_equality = True
 disallow_untyped_defs = True
 disallow_untyped_calls = True
-files = tuf/api/, tuf/exceptions.py
+files =
+  tuf/api/,
+  tuf/ngclient,
+  tuf/exceptions.py
 
 [mypy-securesystemslib.*]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,6 @@ files =
 
 [mypy-securesystemslib.*]
 ignore_missing_imports = True
+
+[mypy-urllib3.*]
+ignore_missing_imports = True

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -24,8 +24,8 @@ import tempfile
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from typing import (
+    IO,
     Any,
-    BinaryIO,
     ClassVar,
     Dict,
     Generic,
@@ -753,7 +753,7 @@ class BaseFile:
 
     @staticmethod
     def _verify_hashes(
-        data: Union[bytes, BinaryIO], expected_hashes: Dict[str, str]
+        data: Union[bytes, IO[bytes]], expected_hashes: Dict[str, str]
     ) -> None:
         """Verifies that the hash of 'data' matches 'expected_hashes'"""
         is_bytes = isinstance(data, bytes)
@@ -782,7 +782,7 @@ class BaseFile:
 
     @staticmethod
     def _verify_length(
-        data: Union[bytes, BinaryIO], expected_length: int
+        data: Union[bytes, IO[bytes]], expected_length: int
     ) -> None:
         """Verifies that the length of 'data' matches 'expected_length'"""
         if isinstance(data, bytes):
@@ -867,7 +867,7 @@ class MetaFile(BaseFile):
 
         return res_dict
 
-    def verify_length_and_hashes(self, data: Union[bytes, BinaryIO]) -> None:
+    def verify_length_and_hashes(self, data: Union[bytes, IO[bytes]]) -> None:
         """Verifies that the length and hashes of "data" match expected values.
 
         Args:
@@ -1182,7 +1182,7 @@ class TargetFile(BaseFile):
             **self.unrecognized_fields,
         }
 
-    def verify_length_and_hashes(self, data: Union[bytes, BinaryIO]) -> None:
+    def verify_length_and_hashes(self, data: Union[bytes, IO[bytes]]) -> None:
         """Verifies that length and hashes of "data" match expected values.
 
         Args:

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -98,7 +98,7 @@ class Metadata(Generic[T]):
         self.signatures = signatures
 
     @classmethod
-    def from_dict(cls, metadata: Dict[str, Any]) -> "Metadata":
+    def from_dict(cls, metadata: Dict[str, Any]) -> "Metadata[T]":
         """Creates Metadata object from its dict representation.
 
         Arguments:

--- a/tuf/exceptions.py
+++ b/tuf/exceptions.py
@@ -24,7 +24,7 @@
 
 from urllib import parse
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import logging
 logger = logging.getLogger(__name__)
@@ -206,15 +206,18 @@ class DownloadLengthMismatchError(DownloadError):
 class SlowRetrievalError(DownloadError):
   """"Indicate that downloading a file took an unreasonably long time."""
 
-  def __init__(self, average_download_speed: int):
+  def __init__(self, average_download_speed: Optional[int] = None):
     super(SlowRetrievalError, self).__init__()
 
     self.__average_download_speed = average_download_speed #bytes/second
 
   def __str__(self) -> str:
-    return (
-        'Download was too slow. Average speed: ' +
+    msg = 'Download was too slow.'
+    if self.__average_download_speed is not None:
+      msg = ('Download was too slow. Average speed: ' +
          repr(self.__average_download_speed) + ' bytes per second.')
+
+    return msg
 
   def __repr__(self) -> str:
     return self.__class__.__name__ + ' : ' + str(self)

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -141,7 +141,7 @@ class RequestsFetcher(FetcherInterface):
             )
 
         except urllib3.exceptions.ReadTimeoutError as e:
-            raise exceptions.SlowRetrievalError(str(e))
+            raise exceptions.SlowRetrievalError from e
 
         finally:
             response.close()

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -7,7 +7,7 @@
 
 import logging
 import time
-from typing import Iterator, Optional
+from typing import Dict, Iterator, Optional
 from urllib import parse
 
 # Imports
@@ -31,7 +31,7 @@ class RequestsFetcher(FetcherInterface):
             session per scheme+hostname combination.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         # http://docs.python-requests.org/en/master/user/advanced/#session-objects:
         #
         # "The Session object allows you to persist certain parameters across
@@ -46,7 +46,7 @@ class RequestsFetcher(FetcherInterface):
         # improve efficiency, but avoiding sharing state between different
         # hosts-scheme combinations to minimize subtle security issues.
         # Some cookies may not be HTTP-safe.
-        self._sessions = {}
+        self._sessions: Dict[str, requests.Session] = {}
 
         # Default settings
         self.socket_timeout: int = 4  # seconds
@@ -146,7 +146,7 @@ class RequestsFetcher(FetcherInterface):
         finally:
             response.close()
 
-    def _get_session(self, url):
+    def _get_session(self, url: str) -> requests.Session:
         """Returns a different customized requests.Session per schema+hostname
         combination.
         """

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -92,7 +92,7 @@ class TrustedMetadataSet(abc.Mapping):
             RepositoryError: Metadata failed to load or verify. The actual
                 error type and content will contain more details.
         """
-        self._trusted_set = {}  # type: Dict[str: Metadata]
+        self._trusted_set: Dict[str, Metadata] = {}
         self.reference_time = datetime.utcnow()
 
         # Load and validate the local root metadata. Valid initial trusted root
@@ -134,7 +134,7 @@ class TrustedMetadataSet(abc.Mapping):
         return self._trusted_set.get("targets")
 
     # Methods for updating metadata
-    def update_root(self, data: bytes):
+    def update_root(self, data: bytes) -> None:
         """Verifies and loads 'data' as new root metadata.
 
         Note that an expired intermediate root is considered valid: expiry is
@@ -175,7 +175,7 @@ class TrustedMetadataSet(abc.Mapping):
         self._trusted_set["root"] = new_root
         logger.debug("Updated root")
 
-    def update_timestamp(self, data: bytes):
+    def update_timestamp(self, data: bytes) -> None:
         """Verifies and loads 'data' as new timestamp metadata.
 
         Note that an expired intermediate timestamp is considered valid so it
@@ -237,7 +237,7 @@ class TrustedMetadataSet(abc.Mapping):
         self._trusted_set["timestamp"] = new_timestamp
         logger.debug("Updated timestamp")
 
-    def update_snapshot(self, data: bytes):
+    def update_snapshot(self, data: bytes) -> None:
         """Verifies and loads 'data' as new snapshot metadata.
 
         Note that intermediate snapshot is considered valid even if it is
@@ -314,7 +314,9 @@ class TrustedMetadataSet(abc.Mapping):
         self._trusted_set["snapshot"] = new_snapshot
         logger.debug("Updated snapshot")
 
-    def _check_final_snapshot(self):
+    def _check_final_snapshot(self) -> None:
+        """Check snapshot expiry and version before targets is updated"""
+
         if self.snapshot.signed.is_expired(self.reference_time):
             raise exceptions.ExpiredMetadataError("snapshot.json is expired")
 
@@ -328,7 +330,7 @@ class TrustedMetadataSet(abc.Mapping):
                 f"got {self.snapshot.signed.version}"
             )
 
-    def update_targets(self, data: bytes):
+    def update_targets(self, data: bytes) -> None:
         """Verifies and loads 'data' as new top-level targets metadata.
 
         Args:
@@ -342,7 +344,7 @@ class TrustedMetadataSet(abc.Mapping):
 
     def update_delegated_targets(
         self, data: bytes, role_name: str, delegator_name: str
-    ):
+    ) -> None:
         """Verifies and loads 'data' as new metadata for target 'role_name'.
 
         Args:

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -114,9 +114,9 @@ class TrustedMetadataSet(abc.Mapping):
 
     # Helper properties for top level metadata
     @property
-    def root(self) -> Optional[Metadata]:
-        """Current root Metadata or None"""
-        return self._trusted_set.get("root")
+    def root(self) -> Metadata:
+        """Current root Metadata"""
+        return self._trusted_set["root"]
 
     @property
     def timestamp(self) -> Optional[Metadata]:
@@ -161,7 +161,7 @@ class TrustedMetadataSet(abc.Mapping):
                 f"Expected 'root', got '{new_root.signed.type}'"
             )
 
-        if self.root is not None:
+        if self._trusted_set.get("root") is not None:
             # We are not loading initial trusted root: verify the new one
             self.root.verify_delegate("root", new_root)
 

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -317,6 +317,8 @@ class TrustedMetadataSet(abc.Mapping):
     def _check_final_snapshot(self) -> None:
         """Check snapshot expiry and version before targets is updated"""
 
+        assert self.snapshot is not None  # nosec
+        assert self.timestamp is not None  # nosec
         if self.snapshot.signed.is_expired(self.reference_time):
             raise exceptions.ExpiredMetadataError("snapshot.json is expired")
 

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -66,7 +66,7 @@ from datetime import datetime
 from typing import Dict, Iterator, Optional
 
 from tuf import exceptions
-from tuf.api.metadata import Metadata
+from tuf.api.metadata import Metadata, Root, Snapshot, Targets, Timestamp
 from tuf.api.serialization import DeserializationError
 
 logger = logging.getLogger(__name__)
@@ -114,22 +114,22 @@ class TrustedMetadataSet(abc.Mapping):
 
     # Helper properties for top level metadata
     @property
-    def root(self) -> Metadata:
+    def root(self) -> Metadata[Root]:
         """Current root Metadata"""
         return self._trusted_set["root"]
 
     @property
-    def timestamp(self) -> Optional[Metadata]:
+    def timestamp(self) -> Optional[Metadata[Timestamp]]:
         """Current timestamp Metadata or None"""
         return self._trusted_set.get("timestamp")
 
     @property
-    def snapshot(self) -> Optional[Metadata]:
+    def snapshot(self) -> Optional[Metadata[Snapshot]]:
         """Current snapshot Metadata or None"""
         return self._trusted_set.get("snapshot")
 
     @property
-    def targets(self) -> Optional[Metadata]:
+    def targets(self) -> Optional[Metadata[Targets]]:
         """Current targets Metadata or None"""
         return self._trusted_set.get("targets")
 
@@ -152,7 +152,7 @@ class TrustedMetadataSet(abc.Mapping):
         logger.debug("Updating root")
 
         try:
-            new_root = Metadata.from_bytes(data)
+            new_root = Metadata[Root].from_bytes(data)
         except DeserializationError as e:
             raise exceptions.RepositoryError("Failed to load root") from e
 
@@ -199,7 +199,7 @@ class TrustedMetadataSet(abc.Mapping):
         # timestamp/snapshot can not yet be loaded at this point
 
         try:
-            new_timestamp = Metadata.from_bytes(data)
+            new_timestamp = Metadata[Timestamp].from_bytes(data)
         except DeserializationError as e:
             raise exceptions.RepositoryError("Failed to load timestamp") from e
 
@@ -276,7 +276,7 @@ class TrustedMetadataSet(abc.Mapping):
             ) from e
 
         try:
-            new_snapshot = Metadata.from_bytes(data)
+            new_snapshot = Metadata[Snapshot].from_bytes(data)
         except DeserializationError as e:
             raise exceptions.RepositoryError("Failed to load snapshot") from e
 
@@ -387,7 +387,7 @@ class TrustedMetadataSet(abc.Mapping):
             ) from e
 
         try:
-            new_delegate = Metadata.from_bytes(data)
+            new_delegate = Metadata[Targets].from_bytes(data)
         except DeserializationError as e:
             raise exceptions.RepositoryError("Failed to load snapshot") from e
 

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -112,12 +112,7 @@ class Updater:
         # Read trusted local root metadata
         data = self._load_local_metadata("root")
         self._trusted_set = trusted_metadata_set.TrustedMetadataSet(data)
-
-        if fetcher is None:
-            self._fetcher = requests_fetcher.RequestsFetcher()
-        else:
-            self._fetcher = fetcher
-
+        self._fetcher = fetcher or requests_fetcher.RequestsFetcher()
         self.config = config or UpdaterConfig()
 
     def refresh(self) -> None:
@@ -225,7 +220,7 @@ class Updater:
         targetinfo: TargetFile,
         destination_directory: str,
         target_base_url: Optional[str] = None,
-    ):
+    ) -> None:
         """Downloads the target file specified by 'targetinfo'.
 
         Args:
@@ -241,12 +236,14 @@ class Updater:
             TODO: download-related errors
             TODO: file write errors
         """
-        if target_base_url is None and self._target_base_url is None:
-            raise ValueError(
-                "target_base_url must be set in either download_target() or "
-                "constructor"
-            )
+
         if target_base_url is None:
+            if self._target_base_url is None:
+                raise ValueError(
+                    "target_base_url must be set in either "
+                    "download_target() or constructor"
+                )
+
             target_base_url = self._target_base_url
         else:
             target_base_url = _ensure_trailing_slash(target_base_url)
@@ -289,7 +286,7 @@ class Updater:
         with open(os.path.join(self._dir, f"{rolename}.json"), "rb") as f:
             return f.read()
 
-    def _persist_metadata(self, rolename: str, data: bytes):
+    def _persist_metadata(self, rolename: str, data: bytes) -> None:
         with open(os.path.join(self._dir, f"{rolename}.json"), "wb") as f:
             f.write(data)
 
@@ -450,6 +447,6 @@ class Updater:
         return None
 
 
-def _ensure_trailing_slash(url: str):
+def _ensure_trailing_slash(url: str) -> str:
     """Return url guaranteed to end in a slash"""
     return url if url.endswith("/") else f"{url}/"

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -341,6 +341,7 @@ class Updater:
             # Local snapshot does not exist or is invalid: update from remote
             logger.debug("Failed to load local snapshot %s", e)
 
+            assert self._trusted_set.timestamp is not None  # nosec
             metainfo = self._trusted_set.timestamp.signed.meta["snapshot.json"]
             length = metainfo.length or self.config.snapshot_max_length
             version = None
@@ -361,6 +362,7 @@ class Updater:
             # Local 'role' does not exist or is invalid: update from remote
             logger.debug("Failed to load local %s: %s", role, e)
 
+            assert self._trusted_set.snapshot is not None  # nosec
             metainfo = self._trusted_set.snapshot.signed.meta[f"{role}.json"]
             length = metainfo.length or self.config.targets_max_length
             version = None


### PR DESCRIPTION
Fixes #1409 
**Description of the changes being introduced by the pull request**:

Enable static type checking for ngclient.
- add all missing type annotations
- fix errors (partially for updater.py and trusted_metadata_set.py
- add urllib3 to ignored includes
- download suggested stub packages when running mypy

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


