### PR TITLE
Update pinned dependencies

### DIFF
--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -1,10 +1,11 @@
 certifi==2021.5.30        # via requests
-cffi==1.14.5              # via cryptography, pynacl
-chardet==4.0.0            # via requests
+cffi==1.14.6              # via cryptography, pynacl
+charset-normalizer==2.0.2 # via requests
 cryptography==3.4.7       # via securesystemslib
-idna==2.10                # via requests
+idna==3.2                 # via requests
 pycparser==2.20           # via cffi
 pynacl==1.4.0             # via securesystemslib
-requests==2.25.1
+requests==2.26.0
 securesystemslib[crypto,pynacl]==0.20.1
+six==1.16.0               # via pynacl, securesystemslib
 urllib3==1.26.6           # via requests


### PR DESCRIPTION
* Re-adds six: we don't use it but dependencies do
* Bumps [cffi](http://cffi.readthedocs.org) from 1.14.5 to 1.14.6.
* Bumps [requests](https://github.com/psf/requests) from 2.25.1 to 2.26.0.
  - [Release notes](https://github.com/psf/requests/releases)
  - [Changelog](https://github.com/psf/requests/blob/master/HISTORY.md)
  - [Commits](https://github.com/psf/requests/compare/v2.25.1...v2.26.0)
* Replaces chardet 4.0.0 with charset-normalizer 2.0.2: This is a
  requests dependency change
* Bumps [idna](https://github.com/kjd/idna) from 2.10 to 3.2. This is
  now possible because requests now supports idna 3.x
  - [Release notes](https://github.com/kjd/idna/releases)
  - [Changelog](https://github.com/kjd/idna/blob/master/HISTORY.rst)
  - [Commits](https://github.com/kjd/idna/compare/v2.10...v3.2)

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>
