### PR TITLE
new API: test containers for zero or more elements

### DIFF
--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -142,6 +142,7 @@ class TestSerialization(unittest.TestCase):
     valid_roles: DataSet = {
         "all": '{"keyids": ["keyid"], "threshold": 3}',
         "many keyids": '{"keyids": ["a", "b", "c", "d", "e"], "threshold": 1}',
+        "empty keyids": '{"keyids": [], "threshold": 1}',
         "unrecognized field": '{"keyids": ["keyid"], "threshold": 3, "foo": "bar"}',
     }
 
@@ -166,6 +167,11 @@ class TestSerialization(unittest.TestCase):
             "expires": "2030-01-01T00:00:00Z", \
             "keys": {"keyid" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"} }}, \
             "roles": { "targets": {"keyids": ["keyid"], "threshold": 3} } \
+            }',
+        "empty keys and roles": '{"_type": "root", "spec_version": "1.0.0", "version": 1, \
+            "expires": "2030-01-01T00:00:00Z", "consistent_snapshot": false, \
+            "keys": {}, \
+            "roles": {} \
             }',
         "unrecognized field": '{"_type": "root", "spec_version": "1.0.0", "version": 1, \
             "expires": "2030-01-01T00:00:00Z", "consistent_snapshot": false, \
@@ -257,12 +263,17 @@ class TestSerialization(unittest.TestCase):
 
 
     valid_delegated_roles: DataSet = {
+        # DelegatedRole inherits Role and some use cases can be found in the valid_roles.
         "no hash prefix attribute":
             '{"keyids": ["keyid"], "name": "a", "paths": ["fn1", "fn2"], \
             "terminating": false, "threshold": 1}',
         "no path attribute":
             '{"keyids": ["keyid"], "name": "a", "terminating": false, \
             "path_hash_prefixes": ["h1", "h2"], "threshold": 99}',
+        "empty paths": '{"keyids": ["keyid"], "name": "a", "paths": [], \
+            "terminating": false, "threshold": 1}',
+        "empty path_hash_prefixes": '{"keyids": ["keyid"], "name": "a", "terminating": false, \
+            "path_hash_prefixes": [], "threshold": 99}',
         "unrecognized field":
             '{"keyids": ["keyid"], "name": "a", "terminating": true, "paths": ["fn1"], "threshold": 3, "foo": "bar"}',
         "many keyids":
@@ -278,6 +289,7 @@ class TestSerialization(unittest.TestCase):
 
 
     invalid_delegated_roles: DataSet = {
+        # DelegatedRole inherits Role and some use cases can be found in the invalid_roles.
         "missing hash prefixes and paths":
             '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false}',
         "both hash prefixes and paths":


### PR DESCRIPTION
Fixes #1485 

**Description of the changes being introduced by the pull request**:

Test metadata (de)serialization with input data containing containers with zero or more elements.
    
Here is the status for the different use cases:

Root:
- many keys: added
- many roles: added

Root role keyids:
- many keids: already added in https://github.com/theupdateframework/tuf/pull/1481

MetaFile hashes:
- many hashes: already tested
- zero hashes: added. Testing as invalid test case.

Timestamp meta:
- zero elements: already tested
- many elements: added

Snapshot meta:
- zero items: added
- many items: added

Delegation:
- many keys: added
- many keyids: added

Delegation role:
- many paths: already tested
- many path_hash_path_prefixes: already tested

Delegation roles:
- zero roles: added
- multiple roles: added

Targets targets:
- zero items: already tested
- multiple items: added

Additional tests are added for containers with 0 or more elements for some specific cases.
Those tests are needed to cover use cases when syntactically as
standalone objects the metadata classes and their helper classes defined
in tuf/api/metadata.py are valid even if they cannot be verified.

An example where an object is valid, but cannot be verified is
if we have a Role instance with an empty list of "keyids".
This instance is valid and can be created, but cannot be verified
because there is a requirement that the threshold should be above
1, meaning that there should be at least 1 element inside the "keyids"
list to complete successful threshold verification.

The situation is the same for the rest of the tests I am adding to this
commit:
- Root object without keys
- Root object without roles
- DelegationRole object with empty "keyids"
- DelegationRole object with an empty list of "paths"
- DelegationRole object with an empty list of "path_hash_prefixes"
all of these objects can be instantiated, but cannot complete successfully
threshold verification.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


