### PR TITLE
Implement glob-like pattern matching

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -19,7 +19,6 @@ import abc
 import fnmatch
 import io
 import logging
-import os
 import tempfile
 from collections import OrderedDict
 from datetime import datetime, timedelta
@@ -1077,7 +1076,14 @@ class DelegatedRole(Role):
 
     def is_delegated_path(self, target_filepath: str) -> bool:
         """Determines whether the given 'target_filepath' is in one of
-        the paths that DelegatedRole is trusted to provide"""
+        the paths that DelegatedRole is trusted to provide.
+
+        The target_filepath and the DelegatedRole paths are expected to be in
+        their canonical forms, so e.g. "a/b" instead of "a//b" . Only "/" is
+        supported as target path separator. Leading separators are not handled
+        as special cases (see `TUF specification on targetpath
+        <https://theupdateframework.github.io/specification/latest/#targetpath>`_).
+        """
 
         if self.path_hash_prefixes is not None:
             # Calculate the hash of the filepath
@@ -1093,13 +1099,8 @@ class DelegatedRole(Role):
         elif self.paths is not None:
             for pathpattern in self.paths:
                 # A delegated role path may be an explicit path or glob
-                # pattern (Unix shell-style wildcards). Explicit filepaths
-                # are also considered matches. Make sure to strip any leading
-                # path separators so that a match is made.
-                # Example: "foo.tgz" should match with "/*.tgz".
-                if self._is_target_in_pathpattern(
-                    target_filepath.lstrip(os.sep), pathpattern.lstrip(os.sep)
-                ):
+                # pattern (Unix shell-style wildcards).
+                if self._is_target_in_pathpattern(target_filepath, pathpattern):
                     return True
 
         return False


### PR DESCRIPTION
Fixes #1505, #1506

**Description of the changes being introduced by the pull request**:

**Implement glob-like pattern matching - 1505**

According to the recently updated version of the specification the shell
style wildcard matching is glob-like (see https://github.com/theupdateframework/specification/pull/174),
and therefore a path separator in a path should not be matched by a
wildcard in the PATHPATTERN.

That's not what happens with `fnmatch.fnmatch()` which doesn't
see "/" separator as a special symbol.
For example: fnmatch.fnmatch("targets/foo.tgz", "*.tgz") will return
True which is not what glob-like implementation will do.

We should make sure that target_path and the `pathpattern` contain the
same number of directories and because each part of the `pathpattern`
could include a glob pattern we should check that `fnmatch.fnmatch()` is true
on each target and `pathpattern` directory fragment separated by "/".

**Avoid lstrip(os.sep) on target paths - 1506**

For targetpath: we don't want to support corner cases such as
file paths starting with separator.
Why this case should be treated especially than any other case where
you have multiple "/" for example "foo//bar/tar.gz"?

For pathpattern: it's recommended that the separator in the pathpattern
should be "/":
see https://theupdateframework.github.io/specification/latest/#targetpath
I believe it could lead to issues for a client implementation if it
supports arbitrary separators - every implementation needs to choose one
and stick with it.
Then, if we decide that "/" is our separator using lstrip on "os.sep" is
wrong, because the os separator from the server could be different that
the one used in the client.

Because of the above arguments, it makes sense to just remove
lstrip on os separators.

Additionally, document in the public API that we only support "/" as a
separator and don't handle corner cases such as leading separators
in either pathpattern or target_filepath.


Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


