### PR TITLE
 Add Key.from_securesystemslib_key

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -54,6 +54,10 @@ from securesystemslib.signer import (
     Signature
 )
 
+from securesystemslib.keys import (
+    generate_ed25519_key
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -419,6 +423,14 @@ class TestMetadata(unittest.TestCase):
         # threshold of 2 keys
         snapshot.sign(SSlibSigner(self.keystore['timestamp']), append=True)
         root.verify_delegate('snapshot', snapshot)
+
+
+    def test_key_class(self):
+        # Test if from_securesystemslib_key removes the private key from keyval
+        # of a securesystemslib key dictionary.
+        sslib_key = generate_ed25519_key()
+        key = Key.from_securesystemslib_key(sslib_key)
+        self.assertFalse('private' in key.keyval.keys())
 
 
     def test_metadata_root(self):

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -562,6 +562,24 @@ class Key:
             "keyval": self.keyval,
         }
 
+    @classmethod
+    def from_securesystemslib_key(cls, key_dict: Dict[str, Any]) -> "Key":
+        """
+        Creates a Key object from a securesystemlib key dict representation
+        removing the private key from keyval.
+        """
+        key_meta = sslib_keys.format_keyval_to_metadata(
+            key_dict["keytype"],
+            key_dict["scheme"],
+            key_dict["keyval"],
+        )
+        return cls(
+            key_dict["keyid"],
+            key_meta["keytype"],
+            key_meta["scheme"],
+            key_meta["keyval"],
+        )
+
     def verify_signature(
         self,
         metadata: Metadata,


### PR DESCRIPTION
The securesystemslib key dictionary representation includes
the private key in keyval. TUF key doesn't handle it in any way,
but considering that we allow unrecognized symbols in the format,
we should exclude the private key.
A call to securesystemslib.keys.format_keyval_to_metadata
with the default private=False would do exactly that.

Signed-off-by: Velichka Atanasova <avelichka@vmware.com>

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

Fixes #1458

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


