### PR TITLE
More trusted set tests

### DIFF
--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -277,6 +277,16 @@ class TestTrustedMetadataSet(unittest.TestCase):
         with self.assertRaises(exceptions.ExpiredMetadataError):
             self.trusted_set.update_timestamp(timestamp)
 
+    def test_update_snapshot_length_or_hash_mismatch(self):
+        def modify_snapshot_length(timestamp: Timestamp) -> None:
+            timestamp.meta["snapshot.json"].length = 1
+
+        # set known snapshot.json length to 1
+        timestamp = self.modify_metadata("timestamp", modify_snapshot_length)
+        self._root_updated_and_update_timestamp(timestamp)
+
+        with self.assertRaises(exceptions.RepositoryError):
+            self.trusted_set.update_snapshot(self.metadata["snapshot"])
 
     def test_update_snapshot_cannot_verify_snapshot_with_threshold(self):
         self._root_updated_and_update_timestamp(self.metadata["timestamp"])

--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -131,6 +131,13 @@ class TestTrustedMetadataSet(unittest.TestCase):
         # the 4 top level metadata objects + 2 additional delegated targets
         self.assertTrue(len(self.trusted_set), 6)
 
+        count = 0
+        for md in self.trusted_set:
+            self.assertIsInstance(md, Metadata)
+            count += 1
+
+        self.assertTrue(count, 6)
+
     def test_out_of_order_ops(self):
         # Update timestamp before root is finished
         with self.assertRaises(RuntimeError):

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -116,7 +116,7 @@ class TrustedMetadataSet(abc.Mapping):
 
     def __iter__(self) -> Iterator[Metadata]:
         """Returns iterator over all Metadata objects in TrustedMetadataSet"""
-        return iter(self._trusted_set)
+        return iter(self._trusted_set.values())
 
     # Helper properties for top level metadata
     @property


### PR DESCRIPTION
* fixes a bug in TrustedMetadataSet
* adds three tests to improve TrustedMetadataSet coverage
* Fixes one broken test to also improve TrustedMetadataSet coverage

This gets us to 99% coverage (the only missing thing is successful rollback test -- IOW successfully updating a new snapshot when a snapshot is loaded already -- this requires #1498 I think)

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature


