### PR TITLE
ngclient rollback improvements

### DIFF
--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -268,9 +268,13 @@ class TestTrustedMetadataSet(unittest.TestCase):
         def timestamp_expired_modifier(timestamp: Timestamp) -> None:
             timestamp.expires = datetime(1970, 1, 1)
 
+        # intermediate timestamp is allowed to be expired
         timestamp = self.modify_metadata("timestamp", timestamp_expired_modifier)
+        self.trusted_set.update_timestamp(timestamp)
+
+        # update snapshot to trigger final timestamp expiry check
         with self.assertRaises(exceptions.ExpiredMetadataError):
-            self.trusted_set.update_timestamp(timestamp)
+            self.trusted_set.update_snapshot(self.metadata["snapshot"])
 
     def test_update_snapshot_length_or_hash_mismatch(self):
         def modify_snapshot_length(timestamp: Timestamp) -> None:
@@ -328,13 +332,16 @@ class TestTrustedMetadataSet(unittest.TestCase):
 
     def test_update_snapshot_expired_new_snapshot(self):
         self._root_updated_and_update_timestamp(self.metadata["timestamp"])
-        # new_snapshot has expired
         def snapshot_expired_modifier(snapshot: Snapshot) -> None:
             snapshot.expires = datetime(1970, 1, 1)
 
+        # intermediate snapshot is allowed to be expired
         snapshot = self.modify_metadata("snapshot", snapshot_expired_modifier)
+        self.trusted_set.update_snapshot(snapshot)
+
+        # update targets to trigger final snapshot expiry check
         with self.assertRaises(exceptions.ExpiredMetadataError):
-            self.trusted_set.update_snapshot(snapshot)
+            self.trusted_set.update_targets(self.metadata["targets"])
 
     def test_update_targets_no_meta_in_snapshot(self):
         def no_meta_modifier(snapshot: Snapshot) -> None:

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -320,9 +320,6 @@ class Updater:
                 # 404/403 means current root is newest available
                 break
 
-        # Verify final root
-        self._trusted_set.root_update_finished()
-
     def _load_timestamp(self) -> None:
         """Load local and remote timestamp metadata"""
         try:


### PR DESCRIPTION
Fixes #1498

**Improve rollback protection in ngclient**

Spec does not explicitly say so but the intent is that "local" timestamp and snapshot metadata can be trusted for rollback checks of new versions of the same metadata even if the local metadata is expired. This is similar to root (but in that case the intent is explicitly explained in the spec).

Likewise intent is that "local" snapshot can be trusted for rollback checks of new versions of the snapshot even if local snapshot does not match the meta version in current timestamp.

Implement the above by moving the expiry and meta version checks to the "next" metadata update: check timestamp expiry just before snapshot is updated, and check snapshot expiry and meta version just before targets is updated. This means that when e.g. a second timestamp (that was downloaded from remote) is loaded, the current (first) timestamp is used for rollback checks even if it is expired -- but when snapshot is loaded the expiry of the current, final timestamp is checked.

Some additional details -- note especially the two divergences from the spec letter (but IMO not intent):
 * the expiry/meta checks are now done every time the "next" metadata updates: e.g. snapshot expiry and meta version are checked every time a targets metadata is updated -- it would be fine to do it only once (when initial "targets" is first updated) but this is simple to implement and the cost is likely minimal
 * metadata does get written to disk before we know if it fulfills the "complete" requirements for expiry and meta version: this is not what the spec says but seems correct to me as the data is "trusted" (signed by threshold of correct keys) and spec documents similar process for root. Even if the final metadata really is expired and the update fails, if the remote later starts serving non-expired metadata, the client will succeed in a later update (and will correctly use the earlier expired metadata for rollback checks!)
 * As Martin points out in comments, the "next" metadata may in some cases be downloaded before the final checks are done (so a snapshot file may be downloaded, but not parsed, before final timestamp expiry is checked): this does not have security implications but is not the order spec demands
 * This does not solve the issue with snapshot hashes/length in timestamp meta: it seems to require TrustedMetadataSet API change so I left it in separate issue: #1523

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature


