### PR TITLE
Changes to updater.py to fix #1526

### DIFF
--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -292,8 +292,10 @@ class Updater:
             return f.read()
 
     def _persist_metadata(self, rolename: str, data: bytes):
-        with open(os.path.join(self._dir, f"{rolename}.json"), "wb") as f:
-            f.write(data)
+        original_filepath = os.path.join(self._dir, f"{rolename}.json")
+        temp_file = open(f'{rolename}_temp.json', 'wb+')
+        temp_file.write(data)
+        sslib_util.persist_temp_file(temp_file, original_filepath, should_close=True)
 
     def _load_root(self) -> None:
         """Load remote root metadata.

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -297,6 +297,7 @@ class Updater:
         temp_file.write(data)
         sslib_util.persist_temp_file(temp_file, original_filepath, should_close=True)
 
+
     def _load_root(self) -> None:
         """Load remote root metadata.
 

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -293,6 +293,7 @@ class Updater:
 
     def _persist_metadata(self, rolename: str, data: bytes):
         original_filepath = os.path.join(self._dir, f"{rolename}.json")
+
         temp_file = open(f'{rolename}_temp.json', 'wb+')
         temp_file.write(data)
         sslib_util.persist_temp_file(temp_file, original_filepath, should_close=True)


### PR DESCRIPTION
Signed-off-by: Suvaditya Mukherjee <suvadityamuk@gmail.com>

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

Fixes #1526 

**Description of the changes being introduced by the pull request**:
Changes the `_persist_metadata()` function to make sure it first writes to a temp file which is then moved to the correct path using sslib_util.persist_temp_file().
Fixed in accordance with instructions in #1526 

**Please verify and check that the pull request fulfills the following
requirements**:

- [Checked ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [Checked ] Tests have been added for the bug fix or new feature: Passes all tests, especially the 3 in `test_updater_ng.py`
- [Not Applicable ] Docs have been added for the bug fix or new feature


