### PR TITLE
Address Pylint new unspecified-encoding warning

### DIFF
--- a/tuf/developer_tool.py
+++ b/tuf/developer_tool.py
@@ -749,7 +749,7 @@ def _save_project_configuration(metadata_directory, targets_directory,
     project_config['public_keys'][key] = key_metadata
 
   # Save the actual file.
-  with open(project_filename, 'wt') as fp:
+  with open(project_filename, 'wt', encoding='utf8') as fp:
     json.dump(project_config, fp)
 
 

--- a/tuf/unittest_toolbox.py
+++ b/tuf/unittest_toolbox.py
@@ -116,7 +116,7 @@ class Modified_TestCase(unittest.TestCase):
   def make_temp_data_file(self, suffix='', directory=None, data = 'junk data'):
     """Returns an absolute path of a temp file containing data."""
     temp_file_path = self.make_temp_file(suffix=suffix, directory=directory)
-    temp_file = open(temp_file_path, 'wt')
+    temp_file = open(temp_file_path, 'wt', encoding='utf8')
     temp_file.write(data)
     temp_file.close()
     return temp_file_path


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

A new warning appeared from `pylint` when calling "tox -e lint" on the
"develop" branch with id "unspecified-encoding".
I read about the warning and it makes sense, so maybe we shouldn't ignore it?
I chose `UTF8` as a parameter because it made sense to me at least.

Read more about the warning here:
https://github.com/PyCQA/pylint/issues/3826

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


