### PR TITLE
Fixed #1526 using tempfile creation and atomic move

### DIFF
--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -73,13 +73,13 @@ from tuf.ngclient._internal import requests_fetcher, trusted_metadata_set
 from tuf.ngclient.config import UpdaterConfig
 from tuf.ngclient.fetcher import FetcherInterface
 
-logger = logging.getLogger(_name_)
+logger = logging.getLogger(__name__)
 
 
 class Updater:
     """Implementation of the TUF client workflow."""
 
-    def _init_(
+    def __init__(
         self,
         repository_dir: str,
         metadata_base_url: str,

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -79,7 +79,7 @@ logger = logging.getLogger(__name__)
 class Updater:
     """Implementation of the TUF client workflow."""
 
-    def _init_(
+    def __init__(
         self,
         repository_dir: str,
         metadata_base_url: str,

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -73,7 +73,7 @@ from tuf.ngclient._internal import requests_fetcher, trusted_metadata_set
 from tuf.ngclient.config import UpdaterConfig
 from tuf.ngclient.fetcher import FetcherInterface
 
-logger = logging.getLogger(_name_)
+logger = logging.getLogger(__name__)
 
 
 class Updater:


### PR DESCRIPTION
Signed-off-by: Suvaditya Mukherjee <suvadityamuk@gmail.com>

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

Fixes #1526

**Description of the changes being introduced by the pull request**:
Uses `tempfile.NamedTemporaryFile` to first write to a temp file which is then moved on top of the original file. Passes all tests on local system.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ Checked ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ Checked ] Tests have been added for the bug fix or new feature
- [ Not Applicable ] Docs have been added for the bug fix or new feature


