### PR TITLE
Enforce role name uniqueness and add Targets key helpers

### DIFF
--- a/tests/slow_retrieval_server.py
+++ b/tests/slow_retrieval_server.py
@@ -22,7 +22,6 @@
 """
 
 import os
-import sys
 import time
 import http.server
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,7 +29,6 @@ from tuf.api.metadata import (
     Key,
     MetaFile,
     TargetFile,
-    Delegations,
     DelegatedRole,
 )
 
@@ -536,6 +535,82 @@ class TestMetadata(unittest.TestCase):
         self.assertEqual(
             targets.signed.targets[filename].to_dict(), fileinfo.to_dict()
         )
+
+    def test_targets_key_api(self):
+        targets_path = os.path.join(
+                self.repo_dir, 'metadata', 'targets.json')
+        targets: Targets = Metadata[Targets].from_file(targets_path).signed
+
+        # Add a new delegated role "role2" in targets
+        delegated_role = DelegatedRole.from_dict({
+                "keyids": [],
+                "name": "role2",
+                "paths": ["fn3", "fn4"],
+                "terminating": False,
+                "threshold": 1
+        })
+        targets.delegations.roles["role2"] = delegated_role
+
+        key_dict = {
+            "keytype": "ed25519",
+            "keyval": {
+                "public": "edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd"
+            },
+            "scheme": "ed25519"
+        }
+        key = Key.from_dict("id2", key_dict)
+
+        # Assert that delegated role "role1" does not contain the new key
+        self.assertNotIn(key.keyid, targets.delegations.roles["role1"].keyids)
+        targets.add_key("role1", key)
+
+        # Assert that the new key is added to the delegated role "role1"
+        self.assertIn(key.keyid, targets.delegations.roles["role1"].keyids)
+
+        # Confirm that the newly added key does not break the obj serialization
+        targets.to_dict()
+
+        # Try adding the same key again and assert its ignored.
+        past_keyid = targets.delegations.roles["role1"].keyids.copy()
+        targets.add_key("role1", key)
+        self.assertEqual(past_keyid, targets.delegations.roles["role1"].keyids)
+
+        # Try adding a key to a delegated role that doesn't exists
+        with self.assertRaises(ValueError):
+            targets.add_key("nosuchrole", key)
+
+        # Add the same key to "role2" as well
+        targets.add_key("role2", key)
+
+        # Remove the key from "role1" role ("role2" still uses it)
+        targets.remove_key("role1", key.keyid)
+
+        # Assert that delegated role "role1" doesn't contain the key.
+        self.assertNotIn(key.keyid, targets.delegations.roles["role1"].keyids)
+        self.assertIn(key.keyid, targets.delegations.roles["role2"].keyids)
+
+        # Remove the key from "role2" as well
+        targets.remove_key("role2", key.keyid)
+        self.assertNotIn(key.keyid, targets.delegations.roles["role2"].keyids)
+
+        # Try remove key not used by "role1"
+        with self.assertRaises(ValueError):
+            targets.remove_key("role1", key.keyid)
+
+        # Try removing a key from delegated role that doesn't exists
+        with self.assertRaises(ValueError):
+            targets.remove_key("nosuchrole", key.keyid)
+
+        # Remove delegations as a whole
+        targets.delegations = None
+        # Test that calling add_key and remove_key throws an error
+        # and that delegations is still None after each of the api calls
+        with self.assertRaises(ValueError):
+            targets.add_key("role1", key)
+        self.assertTrue(targets.delegations is None)
+        with self.assertRaises(ValueError):
+            targets.remove_key("role1", key.keyid)
+        self.assertTrue(targets.delegations is None)
 
 
     def  test_length_and_hash_validation(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -466,6 +466,10 @@ class TestMetadata(unittest.TestCase):
         # Add the same key to targets role as well
         root.signed.add_key('targets', key_metadata)
 
+        # Add the same key to a nonexistent role.
+        with self.assertRaises(ValueError):
+            root.signed.add_key("nosuchrole", key_metadata)
+
         # Remove the key from root role (targets role still uses it)
         root.signed.remove_key('root', keyid)
         self.assertNotIn(keyid, root.signed.roles['root'].keyids)
@@ -476,8 +480,10 @@ class TestMetadata(unittest.TestCase):
         self.assertNotIn(keyid, root.signed.roles['targets'].keyids)
         self.assertNotIn(keyid, root.signed.keys)
 
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ValueError):
             root.signed.remove_key('root', 'nosuchkey')
+        with self.assertRaises(ValueError):
+            root.signed.remove_key('nosuchrole', keyid)
 
     def test_is_target_in_pathpattern(self):
         supported_use_cases = [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -512,23 +512,6 @@ class TestMetadata(unittest.TestCase):
             )
 
 
-    def test_delegation_class(self):
-        # empty keys and roles
-        delegations_dict = {"keys":{}, "roles":[]}
-        delegations = Delegations.from_dict(delegations_dict.copy())
-        self.assertEqual(delegations_dict, delegations.to_dict())
-
-        # Test some basic missing or broken input
-        invalid_delegations_dicts = [
-            {},
-            {"keys":None, "roles":None},
-            {"keys":{"foo":0}, "roles":[]},
-            {"keys":{}, "roles":["foo"]},
-        ]
-        for d in invalid_delegations_dicts:
-            with self.assertRaises((KeyError, AttributeError)):
-                Delegations.from_dict(d)
-
     def test_metadata_targets(self):
         targets_path = os.path.join(
                 self.repo_dir, 'metadata', 'targets.json')

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -46,11 +46,7 @@ import logging
 import unittest
 import sys
 from urllib import request
-
-if sys.version_info >= (3, 3):
-  import unittest.mock as mock
-else:
-  import mock
+import unittest.mock as mock
 
 import tuf.formats
 import tuf.log

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -12,13 +12,11 @@ import logging
 import unittest
 import copy
 
-from typing import Dict, Callable, Optional, Mapping, Any
-from datetime import datetime
+from typing import Dict, Callable
 
 from tests import utils
 
 from tuf.api.metadata import (
-    Signed,
     Root,
     Snapshot,
     Timestamp,

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -305,6 +305,11 @@ class TestSerialization(unittest.TestCase):
 
 
     invalid_delegations: DataSet = {
+        "empty delegations": '{}',
+        "bad keys": '{"keys": "foo", \
+            "roles": [{"keyids": ["keyid"], "name": "a", "paths": ["fn1", "fn2"], "terminating": false, "threshold": 3}]}',
+        "bad roles": '{"keys": {"keyid" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
+            "roles": ["foo"]}',
         "duplicate role names": '{"keys": {"keyid" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
             "roles": [ \
                 {"keyids": ["keyid"], "name": "a", "paths": ["fn1", "fn2"], "terminating": false, "threshold": 3}, \
@@ -316,7 +321,7 @@ class TestSerialization(unittest.TestCase):
     @run_sub_tests_with_dataset(invalid_delegations)
     def test_invalid_delegation_serialization(self, test_case_data: str):
         case_dict = json.loads(test_case_data)
-        with self.assertRaises(ValueError):
+        with self.assertRaises((ValueError, KeyError, AttributeError)):
             Delegations.from_dict(copy.deepcopy(case_dict))
 
 

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -304,6 +304,22 @@ class TestSerialization(unittest.TestCase):
             DelegatedRole.from_dict(copy.copy(case_dict))
 
 
+    invalid_delegations: DataSet = {
+        "duplicate role names": '{"keys": {"keyid" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
+            "roles": [ \
+                {"keyids": ["keyid"], "name": "a", "paths": ["fn1", "fn2"], "terminating": false, "threshold": 3}, \
+                {"keyids": ["keyid2"], "name": "a", "paths": ["fn3"], "terminating": false, "threshold": 2}    \
+                ] \
+            }',
+    }
+
+    @run_sub_tests_with_dataset(invalid_delegations)
+    def test_invalid_delegation_serialization(self, test_case_data: str):
+        case_dict = json.loads(test_case_data)
+        with self.assertRaises(ValueError):
+            Delegations.from_dict(copy.deepcopy(case_dict))
+
+
     valid_delegations: DataSet = {
         "all":
             '{"keys": { \

--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Union, Callable
+from typing import Optional, Callable
 import os
 import sys
 import unittest

--- a/tests/test_tutorial.py
+++ b/tests/test_tutorial.py
@@ -28,12 +28,7 @@ import os # part of TUTORIAL.md, but also needed separately
 import shutil
 import tempfile
 import sys
-
-if sys.version_info >= (3, 3):
-  import unittest.mock as mock
-
-else:
-  import mock
+import unittest.mock as mock
 
 from tuf.repository_tool import *   # part of TUTORIAL.md
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -51,11 +51,7 @@ import errno
 import sys
 import unittest
 import json
-
-if sys.version_info >= (3, 3):
-  import unittest.mock as mock
-else:
-  import mock
+import unittest.mock as mock
 
 import tuf
 import tuf.exceptions

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -760,7 +760,13 @@ class Root(Signed):
 
     # Update key for a role.
     def add_key(self, role: str, key: Key) -> None:
-        """Adds new signing key for delegated role 'role'."""
+        """Adds new signing key for delegated role 'role'.
+
+        Raises:
+            ValueError: If 'role' doesn't exist.
+        """
+        if role not in self.roles:
+            raise ValueError(f"Role {role} doesn't exist")
         self.roles[role].keyids.add(key.keyid)
         self.keys[key.keyid] = key
 
@@ -768,8 +774,13 @@ class Root(Signed):
         """Removes key from 'role' and updates the key store.
 
         Raises:
-            KeyError: If 'role' does not include the key
+            ValueError: If 'role' doesn't exist or if 'role' doesn't include
+                the key.
         """
+        if role not in self.roles:
+            raise ValueError(f"Role {role} doesn't exist")
+        if keyid not in self.roles[role].keyids:
+            raise ValueError(f"Key with id {keyid} is not used by {role}")
         self.roles[role].keyids.remove(keyid)
         for keyinfo in self.roles.values():
             if keyid in keyinfo.keyids:

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -430,7 +430,7 @@ class Updater:
                 child_roles_to_visit = []
                 # NOTE: This may be a slow operation if there are many
                 # delegated roles.
-                for child_role in role_metadata.delegations.roles:
+                for child_role in role_metadata.delegations.roles.values():
                     if child_role.is_delegated_path(target_filepath):
                         logger.debug("Adding child role %s", child_role.name)
 


### PR DESCRIPTION
Fixes #1426, #1469

**Description of the changes being introduced by the pull request**:

This pr contains three types of changes:

**Enforce Delegation role name uniqueness**

The spec does not say anything about role name uniqueness in a
delegations object, but I believe we cannot safely allow multiple roles
with the same role name in the roles array of a delegations object.
If we did then the roles could have different keyids, and then we would
end up in a situation where metadata may be both a valid delegation
and an invalid delegation at the same time, depending on how the role
gets chosen and that does not seem like the intention of the design.
There is an issue open in the specification with number 167 about
that issue.

Regardless of the Metadata API, I think we should enforce role name
uniqueness.
I chose to change the data structure containing roles to
OrderedDict, where keys are role names and values, are DelegatedRole
instances, because role names are the unique identifier of a role and
their order is important to the way they are traversed afterward.

**Add missing key helpers in Delegations**

Root class has the functionality to add and remove keys for delegated
metadata (add_key()/remove_key()) but the other delegator Targets does
not.
It should provide the same/similar functionality.

**Some cleaning**

1. Moves a couple of Delegations serialization tests inside `test_metadata_serialization.py`
2. Removed some unused imports.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


