### PR TITLE
Remove duplicate serialization tests from test_api

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,7 +28,6 @@ from tuf.api.metadata import (
     Timestamp,
     Targets,
     Key,
-    Role,
     MetaFile,
     TargetFile,
     Delegations,
@@ -420,49 +419,6 @@ class TestMetadata(unittest.TestCase):
         # threshold of 2 keys
         snapshot.sign(SSlibSigner(self.keystore['timestamp']), append=True)
         root.verify_delegate('snapshot', snapshot)
-
-
-    def test_key_class(self):
-        keys = {
-            "59a4df8af818e9ed7abe0764c0b47b4240952aa0d179b5b78346c470ac30278d":{
-                "keytype": "ed25519",
-                "keyval": {
-                    "public": "edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd"
-                },
-                "scheme": "ed25519"
-            },
-        }
-        for key_dict in keys.values():
-            # Test creating an instance without a required attribute.
-            for key in key_dict.keys():
-                test_key_dict = key_dict.copy()
-                del test_key_dict[key]
-                with self.assertRaises(KeyError):
-                    Key.from_dict("id", test_key_dict)
-
-
-    def test_role_class(self):
-        roles = {
-            "root": {
-                "keyids": [
-                    "4e777de0d275f9d28588dd9a1606cc748e548f9e22b6795b7cb3f63f98035fcb"
-                ],
-                "threshold": 1
-            },
-            "snapshot": {
-                "keyids": [
-                    "59a4df8af818e9ed7abe0764c0b47b4240952aa0d179b5b78346c470ac30278d"
-                ],
-                "threshold": 1
-            },
-        }
-        for role_dict in roles.values():
-            # Test creating an instance without a required attribute.
-            for role_attr in role_dict.keys():
-                test_role_dict = role_dict.copy()
-                del test_role_dict[role_attr]
-                with self.assertRaises(KeyError):
-                    Role.from_dict(test_role_dict)
 
 
     def test_metadata_root(self):


### PR DESCRIPTION
Related to #1414

**Description of the changes being introduced by the pull request**:

I was looking at how can we simplify or split `test_api.py` when I noticed
that the test cases covered by those two test functions are already
covered in the `test_metadata_serialization.py` module with the
"invalid_keys" and "invalid_roles" datasets.

- `invalid_keys`: https://github.com/theupdateframework/tuf/blob/e242a750d4d17e7649b65333ce8e073c7d7ae839/tests/test_metadata_serialization.py#L109
- `invalid_roles`:
https://github.com/theupdateframework/tuf/blob/e242a750d4d17e7649b65333ce8e073c7d7ae839/tests/test_metadata_serialization.py#L127

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


