### PR TITLE
tox: Fix with-sslib-master install

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,10 +29,8 @@ install_command = python3 -m pip install {opts} {packages}
 # Develop test env to run tests against securesystemslib's master branch
 # Must to be invoked explicitly with, e.g. `tox -e with-sslib-master`
 [testenv:with-sslib-master]
-deps =
-    git+https://github.com/secure-systems-lab/securesystemslib.git@master#egg=securesystemslib[crypto,pynacl]
-    -r{toxinidir}/requirements-test.txt
-    --editable {toxinidir}
+commands_pre =
+    python3 -m pip install git+https://github.com/secure-systems-lab/securesystemslib.git@master#egg=securesystemslib[crypto,pynacl]
 
 commands =
     python3 -m coverage run aggregate_tests.py


### PR DESCRIPTION
pip nowadays recognizes that we are asking for two different versions of
securesystemslib in the "with-sslib-master" env, and errors out.

Instead install normal dependencies first, then install the new
securesystemslib separately (this ends up upgrading securesystemslib).

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>


--- 
This is the fix for current CI install errors:
```
The conflict is caused by:
    The user requested securesystemslib 0.21.0 (from git+https://github.com/secure-systems-lab/securesystemslib.git@master#egg=securesystemslib[crypto,pynacl]) [crypto, pynacl]
    The user requested securesystemslib[crypto and pynacl]==0.20.1
```
The fix _seems_ to work both when sslib git version has updated and also when it's the same as the pypi one... but we've tweaked this several times over the last year so :shrug: