### PR TITLE
tests: Add some missing coverage

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -623,6 +623,28 @@ class TestMetadata(unittest.TestCase):
             self.assertRaises(exceptions.LengthOrHashMismatchError,
                 file1_targetfile.verify_length_and_hashes, file1)
 
+    def test_is_delegated_role(self):
+        # test path matches
+        # see more extensive tests in test_is_target_in_pathpattern()
+        for paths in [
+            ["a/path"],
+            ["otherpath", "a/path"],
+            ["*/?ath"],
+        ]:
+            role = DelegatedRole("", [], 1, False, paths, None)
+            self.assertFalse(role.is_delegated_path("a/non-matching path"))
+            self.assertTrue(role.is_delegated_path("a/path"))
+
+        # test path hash prefix matches: sha256 sum of "a/path" is 927b0ecf9...
+        for hash_prefixes in [
+            ["927b0ecf9"],
+            ["other prefix", "927b0ecf9"],
+            ["927b0"],
+            ["92"],
+        ]:
+            role = DelegatedRole("", [], 1, False, None, hash_prefixes)
+            self.assertFalse(role.is_delegated_path("a/non-matching path"))
+            self.assertTrue(role.is_delegated_path("a/path"))
 
 # Run unit test.
 if __name__ == '__main__':


### PR DESCRIPTION
Add full test coverage for `Root.remove_key()`  and `DelegatedRole.is_delegated_path()`

After this metadata.py coverage only has a few missing validation branches (that should probably be handled by test_metadata_serialization.py)

The review comment I would give myself on this is: 

> Could we avoid the use of  `for testcase in list_of_test_cases` that is used many times in test_api.py? It makes deciphering failing test results hard since you only get `AssertionError: True is not false` without any context (no idea which case failed). 

... we could. 
* Serialization tests use the sub-test-decorator approach that would work here as well. It does add a bit of complexity -- but on the other hand allows separating test data and test code quite nicely and shows test results with very good context.
* alternatively we could manually add better messages in our `self.assert_*()` calls

Still, I've opted to just do what the other tests do for now.