### PR TITLE
Nominate Teodora to maintainers

### DIFF
--- a/docs/MAINTAINERS.txt
+++ b/docs/MAINTAINERS.txt
@@ -43,5 +43,9 @@ Maintainers:
 
   Jussi Kukkonen
     Email: jkukkonen@vmware.com
-    Github username: @jku
+    GitHub username: @jku
     PGP fingerprint: 1343 C98F AB84 859F E5EC  9E37 0527 D8A3 7F52 1A2F
+
+  Teodora Sechkova
+    Email: tsechkova@vmware.com
+    GitHub username: @sechkova


### PR DESCRIPTION
I'd like to propose we make Teodora a maintainer of python-tuf. She has been very active contributing quality implementation to the modern refactor (Metadata API and ngclient) and, more recently, doing a great job with reviewing others' contributions. 

@sechkova please confirm you are willing.

@jku @trishankatdatadog @mnm678 @JustinCappos please cast your vote here.