### PR TITLE
Update links to account for repository rename

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -5,7 +5,7 @@ version: 2
 cli:
   server: https://app.fossa.com
   fetcher: custom
-  project: github.com/theupdateframework/tuf
+  project: github.com/theupdateframework/python-tuf
 analyze:
   modules:
   - name: tuf

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="https://cdn.rawgit.com/theupdateframework/artwork/3a649fa6/tuf-logo.svg" height="100" valign="middle" alt="TUF"/> A Framework for Securing Software Update Systems
 
-![Build](https://github.com/theupdateframework/tuf/workflows/Run%20TUF%20tests%20and%20linter/badge.svg)
+![Build](https://github.com/theupdateframework/python-tuf/workflows/Run%20TUF%20tests%20and%20linter/badge.svg)
 [![Coveralls](https://coveralls.io/repos/theupdateframework/tuf/badge.svg?branch=develop)](https://coveralls.io/r/theupdateframework/tuf?branch=develop)
 [![CII](https://bestpractices.coreinfrastructure.org/projects/1351/badge)](https://bestpractices.coreinfrastructure.org/projects/1351)
 [![PyPI](https://img.shields.io/pypi/v/tuf)](https://pypi.org/project/tuf/)
@@ -127,9 +127,9 @@ York University](https://engineering.nyu.edu/).  We appreciate the efforts of
 Konstantin Andrianov, Geremy Condra, Vladimir Diaz, Yuyu Zheng, Sebastien Awwad,
 Santiago Torres-Arias, Trishank Kuppusamy, Zane Fisher, Pankhuri Goyal, Tian Tian,
 Konstantin Andrianov, and Justin Samuel who are among those who helped significantly
-with TUF's reference implementation.  [Contributors](https://github.com/theupdateframework/tuf/blob/develop/docs/AUTHORS.txt)
+with TUF's reference implementation.  [Contributors](https://github.com/theupdateframework/python-tuf/blob/develop/docs/AUTHORS.txt)
 and
-[maintainers](https://github.com/theupdateframework/tuf/blob/develop/docs/MAINTAINERS.txt)
+[maintainers](https://github.com/theupdateframework/python-tuf/blob/develop/docs/MAINTAINERS.txt)
 are governed by the [CNCF Community Code of
 Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -174,7 +174,7 @@ supporting Python 2.7.
 
 ## v0.11.1
 
-* Prevent persistent freeze attack (pr [#737](https://github.com/theupdateframework/tuf/pull/737)).
+* Prevent persistent freeze attack (pr [#737](https://github.com/theupdateframework/python-tuf/pull/737)).
 
 * Add --no-release option to CLI.
 

--- a/docs/CONTRIBUTORS.rst
+++ b/docs/CONTRIBUTORS.rst
@@ -93,7 +93,7 @@ To work on the TUF project, it's best to perform a development install.
 
 ::
 
-    $ git clone https://github.com/theupdateframework/tuf
+    $ git clone https://github.com/theupdateframework/python-tuf
 
 3. Then perform a full, editable/development install.  This will include all
    optional cryptographic support, the testing/linting dependencies, etc.

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -2,13 +2,13 @@
 This document covers the project's governance and committer process.  The
 project consists of the TUF
 [specification](https://github.com/theupdateframework/specification) and
-[reference implementation](https://github.com/theupdateframework/tuf).
+[reference implementation](https://github.com/theupdateframework/python-tuf).
 
 ## Maintainership and Consensus Builder
 The project is maintained by the people indicated in
 [MAINTAINERS](MAINTAINERS.txt).  A maintainer is expected to (1) submit and
 review GitHub pull requests and (2) open issues or [submit vulnerability
-reports](https://github.com/theupdateframework/tuf#security-issues-and-bugs).
+reports](https://github.com/theupdateframework/python-tuf#security-issues-and-bugs).
 A maintainer has the authority to approve or reject pull requests submitted by
 contributors.    
 
@@ -27,7 +27,7 @@ guidelines](https://github.com/secure-systems-lab/code-style-guidelines), and
 must unit test any new software feature or change.  Submitted pull requests
 undergo review and automated testing, including, but not limited to:
 
-* Unit and build testing via [GitHub Actions](https://github.com/theupdateframework/tuf/actions) and
+* Unit and build testing via [GitHub Actions](https://github.com/theupdateframework/python-tuf/actions) and
 [Tox](https://tox.readthedocs.io/en/latest/).
 * Static code analysis via [Pylint](https://www.pylint.org/) and
 [Bandit](https://wiki.openstack.org/wiki/Security/Projects/Bandit).

--- a/docs/INSTALLATION.rst
+++ b/docs/INSTALLATION.rst
@@ -4,20 +4,20 @@ Installation
 *pip* is the recommended installer for installing and managing Python packages.
 The project can be installed either locally or from the Python Package Index.
 All `TUF releases
-<https://github.com/theupdateframework/tuf/releases>`_ are cryptographically
+<https://github.com/theupdateframework/python-tuf/releases>`_ are cryptographically
 signed, with GPG signatures available on both GitHub and `PyPI
 <https://pypi.python.org/pypi/tuf/>`_.  PGP key information for our maintainers
 is available on our `website
 <https://theupdateframework.github.io/people.html>`_, on major keyservers,
 and on the `maintainers page
-<https://github.com/theupdateframework/tuf/blob/develop/docs/MAINTAINERS.txt>`_.
+<https://github.com/theupdateframework/python-tuf/blob/develop/docs/MAINTAINERS.txt>`_.
 
 
 Release Verification
 --------------------
 
 Assuming you trust `the maintainer's PGP key
-<https://github.com/theupdateframework/tuf/blob/develop/docs/MAINTAINERS.txt>`_,
+<https://github.com/theupdateframework/python-tuf/blob/develop/docs/MAINTAINERS.txt>`_,
 the detached ASC signature can be downloaded and verified.  For example::
 
    $ gpg --verify securesystemslib-0.10.8.tar.gz.asc

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -144,6 +144,6 @@ workflow.
 
 Please provide feedback or questions for this or other tutorials, or
 TUF in general, by checking out
-[our contact info](https://github.com/theupdateframework/tuf#contact), or
-creating [issues](https://github.com/theupdateframework/tuf/issues) in this
+[our contact info](https://github.com/theupdateframework/python-tuf#contact), or
+creating [issues](https://github.com/theupdateframework/python-tuf/issues) in this
 repository!

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,19 +6,19 @@ This is the roadmap for the project.
 A new release of the project is expected every 3 months.  The release cycle,
 upcoming tasks, and any stated goals are subject to change.
 
-Releases are available both on [GitHub](https://github.com/theupdateframework/tuf/releases)
+Releases are available both on [GitHub](https://github.com/theupdateframework/python-tuf/releases)
 and on [PyPI](https://pypi.org/project/tuf/#history).  The GitHub listing
 includes release notes.
 
 
 ## Latest release
 Please consult the repository's
-[releases page on GitHub](https://github.com/theupdateframework/tuf/releases)
+[releases page on GitHub](https://github.com/theupdateframework/python-tuf/releases)
 for information about the latest releases.
 
 As of the last editing of this document, the latest release was:
 Pre-release v0.11.2.dev3, January 10, 2019.
-* [Release notes and Download](https://github.com/theupdateframework/tuf/releases/tag/v0.11.1)
+* [Release notes and Download](https://github.com/theupdateframework/python-tuf/releases/tag/v0.11.1)
 * [PyPI release](https://pypi.org/project/tuf/)
 * Packaged by Sebastien Awwad <sebastien.awwad@gmail.com, @awwad>
 * PGP fingerprint: C2FB 9C91 0758 B682 7BC4  3233 BC0C 6DED D5E5 CC03
@@ -42,7 +42,7 @@ production-quality HTTP libraries (requests currently).
   - [x] silver badge
   - [ ] gold badge (currently at 74%)
 
-- [ ] [Support graph of delegations](https://github.com/theupdateframework/tuf/issues/660)
+- [ ] [Support graph of delegations](https://github.com/theupdateframework/python-tuf/issues/660)
 (requires refactor of API and client code).
 
 - [ ] [TAP 3: Multi-role delegations](https://github.com/theupdateframework/taps/blob/master/tap3.md).

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -21,7 +21,7 @@ snapshot metadata, and thus new updates could never be downloaded.
 * **Endless data attacks**. An attacker responds to a file download request with an endless stream of data, causing harm to clients (e.g. a disk partition filling up or memory exhaustion). 
 
 * **~~Slow retrieval attacks~~**. An attacker responds to clients with a very slow stream of data that essentially results in the client never continuing the update process.\
-**_NOTE: Due to limitations in a 3rd-party HTTP library, the TUF reference implementation currently provides only limited protection against slow retrieval attacks (see [tuf#932](https://github.com/theupdateframework/tuf/issues/932)). We plan to fix this in a future release._**
+**_NOTE: Due to limitations in a 3rd-party HTTP library, the TUF reference implementation currently provides only limited protection against slow retrieval attacks (see [tuf#932](https://github.com/theupdateframework/python-tuf/issues/932)). We plan to fix this in a future release._**
 
 * **Extraneous dependencies attacks**. An attacker indicates to clients that in order to install the software they wanted, they also need to install unrelated software. This unrelated software can be from a trusted source but may have known vulnerabilities that are exploitable by the attacker. 
 

--- a/docs/adr/0000-use-markdown-architectural-decision-records.md
+++ b/docs/adr/0000-use-markdown-architectural-decision-records.md
@@ -3,7 +3,7 @@
 * Status: accepted
 * Date: 2020-10-20
 
-Technical Story: https://github.com/theupdateframework/tuf/issues/1141
+Technical Story: https://github.com/theupdateframework/python-tuf/issues/1141
 
 ## Context and Problem Statement
 

--- a/docs/adr/0001-python-version-3-6-plus.md
+++ b/docs/adr/0001-python-version-3-6-plus.md
@@ -3,7 +3,7 @@
 * Status: accepted
 * Date: 2020-10-20
 
-Technical Story: https://github.com/theupdateframework/tuf/issues/1125
+Technical Story: https://github.com/theupdateframework/python-tuf/issues/1125
 
 ## Context and Problem Statement
 
@@ -44,5 +44,5 @@ untenable as more libraries are dropping support for EOL Python releases.
 
 ## Links
 
-* [Discussion of how/where to develop the refactored codebase](https://github.com/theupdateframework/tuf/issues/1126)
-* [Discussion of deprecation policy for the pre-1.0, Python 2.7 supporting, code](https://github.com/theupdateframework/tuf/issues/1127)
+* [Discussion of how/where to develop the refactored codebase](https://github.com/theupdateframework/python-tuf/issues/1126)
+* [Discussion of deprecation policy for the pre-1.0, Python 2.7 supporting, code](https://github.com/theupdateframework/python-tuf/issues/1127)

--- a/docs/adr/0002-pre-1-0-deprecation-strategy.md
+++ b/docs/adr/0002-pre-1-0-deprecation-strategy.md
@@ -2,7 +2,7 @@
 
 * Date: 2020-11-05
 
-Technical Story: https://github.com/theupdateframework/tuf/issues/1127
+Technical Story: https://github.com/theupdateframework/python-tuf/issues/1127
 
 ## Context and Problem Statement
 

--- a/docs/adr/0003-where-to-develop-TUF-1-0-0.md
+++ b/docs/adr/0003-where-to-develop-TUF-1-0-0.md
@@ -3,7 +3,7 @@
 * Status: accepted
 * Date: 2020-11-23
 
-Technical Story: https://github.com/theupdateframework/tuf/issues/1126
+Technical Story: https://github.com/theupdateframework/python-tuf/issues/1126
 
 ## Context and Problem Statement
 
@@ -61,5 +61,5 @@ old code unlike option 3.
 
 ## Links
 
-* [Discussion of Python version support in TUF 1.0.0](https://github.com/theupdateframework/tuf/issues/1125)
-* [Discussion of deprecation policy for the pre-1.0, Python 2.7 supporting, code](https://github.com/theupdateframework/tuf/issues/1127)
+* [Discussion of Python version support in TUF 1.0.0](https://github.com/theupdateframework/python-tuf/issues/1125)
+* [Discussion of deprecation policy for the pre-1.0, Python 2.7 supporting, code](https://github.com/theupdateframework/python-tuf/issues/1127)

--- a/docs/adr/0004-extent-of-OOP-in-metadata-model.md
+++ b/docs/adr/0004-extent-of-OOP-in-metadata-model.md
@@ -3,7 +3,7 @@
 * Status: accepted
 * Date: 2020-11-30
 
-Technical Story: https://github.com/theupdateframework/tuf/issues/1133
+Technical Story: https://github.com/theupdateframework/python-tuf/issues/1133
 
 ## Context and Problem Statement
 Custom classes for the TUF signed metadata wrapper (Metadata) and metadata
@@ -41,8 +41,8 @@ checks.
 
 ## Links
 
-* [class model](https://github.com/theupdateframework/tuf/pull/1112)
-* [class model (root)](https://github.com/theupdateframework/tuf/pull/1193)
-* [WIP: class model (complex attributes)](https://github.com/theupdateframework/tuf/pull/1223)
-* [new TUF validation guidelines](https://github.com/theupdateframework/tuf/issues/1130)
+* [class model](https://github.com/theupdateframework/python-tuf/pull/1112)
+* [class model (root)](https://github.com/theupdateframework/python-tuf/pull/1193)
+* [WIP: class model (complex attributes)](https://github.com/theupdateframework/python-tuf/pull/1223)
+* [new TUF validation guidelines](https://github.com/theupdateframework/python-tuf/issues/1130)
 * [securesystemslib schema checker issues](https://github.com/secure-systems-lab/securesystemslib/issues/183)

--- a/docs/adr/0005-use-google-python-style-guide.md
+++ b/docs/adr/0005-use-google-python-style-guide.md
@@ -1,6 +1,6 @@
 # Use Google Python style guide with minimal refinements
 
-Technical Story: https://github.com/theupdateframework/tuf/issues/1128
+Technical Story: https://github.com/theupdateframework/python-tuf/issues/1128
 
 ## Context and Problem Statement
 

--- a/docs/adr/0006-where-to-implemenent-model-serialization.md
+++ b/docs/adr/0006-where-to-implemenent-model-serialization.md
@@ -1,6 +1,6 @@
 # Separate metadata serialization from metadata class model but keep helpers
 
-Technical Story: https://github.com/theupdateframework/tuf/pull/1279
+Technical Story: https://github.com/theupdateframework/python-tuf/pull/1279
 
 ## Context and Problem Statement
 In the course of implementing a class-based role metadata model we have also
@@ -107,10 +107,10 @@ as `Metadata.to_dict()`, etc.
 
 ## Links
 * [ADR4: Add classes for complex metadata attributes (decision driver)](/Users/lukp/tuf/tuf/docs/adr/0004-extent-of-OOP-in-metadata-model.md)
-* [PR: Add simple TUF role metadata model (implements option 1)](https://github.com/theupdateframework/tuf/pull/1112)
-  - [details about separation of serialization and instantiation](https://github.com/theupdateframework/tuf/commit/f63dce6dddb9cfbf8986141340c6fac00a36d46e)
-  - [code comment about issues with inheritance](https://github.com/theupdateframework/tuf/blob/9401059101b08a18abc5e3be4d60e18670693f62/tuf/api/metadata.py#L297-L306)
-* [PR: New metadata API: add MetadataInfo and TargetFile classes (recent ADR discussion impetus)](https://github.com/theupdateframework/tuf/pull/1223)
-  - [more discussion about issues with inheritance](https://github.com/theupdateframework/tuf/pull/1223#issuecomment-737188686)
+* [PR: Add simple TUF role metadata model (implements option 1)](https://github.com/theupdateframework/python-tuf/pull/1112)
+  - [details about separation of serialization and instantiation](https://github.com/theupdateframework/python-tuf/commit/f63dce6dddb9cfbf8986141340c6fac00a36d46e)
+  - [code comment about issues with inheritance](https://github.com/theupdateframework/python-tuf/blob/9401059101b08a18abc5e3be4d60e18670693f62/tuf/api/metadata.py#L297-L306)
+* [PR: New metadata API: add MetadataInfo and TargetFile classes (recent ADR discussion impetus)](https://github.com/theupdateframework/python-tuf/pull/1223)
+  - [more discussion about issues with inheritance](https://github.com/theupdateframework/python-tuf/pull/1223#issuecomment-737188686)
 * [SSLIB/Issue: Add metadata container classes (comparison of options 1 and 2)](https://github.com/secure-systems-lab/securesystemslib/issues/272)
 * [tuf-on-a-plane parser (implements option 3)](https://github.com/trishankatdatadog/tuf-on-a-plane/blob/master/src/tuf_on_a_plane/parsers/)

--- a/docs/adr/0008-accept-unrecognised-fields.md
+++ b/docs/adr/0008-accept-unrecognised-fields.md
@@ -3,7 +3,7 @@
 - Status: accepted
 - Date: 2021-04-08
 
-Technical Story: https://github.com/theupdateframework/tuf/issues/1266
+Technical Story: https://github.com/theupdateframework/python-tuf/issues/1266
 
 ## Context and Problem Statement
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@ TUF Developer Documentation
 
 This documentation provides essential information for those developing software
 with the `Python reference implementation of The Update Framework (TUF)
-<https://github.com/theupdateframework/tuf>`_.
+<https://github.com/theupdateframework/python-tuf>`_.
 
 The reference implementation provides easy-to-use components for Python
 developers but also aims to be a readable guide and demonstration for those

--- a/setup.py
+++ b/setup.py
@@ -106,8 +106,8 @@ setup(
     'Topic :: Software Development'
   ],
   project_urls={
-    'Source': 'https://github.com/theupdateframework/tuf',
-    'Issues': 'https://github.com/theupdateframework/tuf/issues'
+    'Source': 'https://github.com/theupdateframework/python-tuf',
+    'Issues': 'https://github.com/theupdateframework/python-tuf/issues'
   },
   python_requires="~=3.6",
   install_requires = [

--- a/tests/repository_data/README.md
+++ b/tests/repository_data/README.md
@@ -9,7 +9,7 @@ $ tox
 ```
 
 Or by invoking `aggregate_tests.py` from the
-[tests](https://github.com/theupdateframework/tuf/tree/develop/tests)
+[tests](https://github.com/theupdateframework/python-tuf/tree/develop/tests)
 directory.
 
 ```
@@ -34,15 +34,15 @@ $ python3 -m unittest test_updater.TestMultiRepoUpdater.test_get_one_valid_targe
 ## Setup
 The unit and integration tests operate on static metadata available in the
 [repository_data
-directory](https://github.com/theupdateframework/tuf/tree/develop/tests/repository_data/).
+directory](https://github.com/theupdateframework/python-tuf/tree/develop/tests/repository_data/).
 Before running the tests, static metadata is first copied to temporary
 directories and modified, as needed, by the tests.
 
 The test modules typically spawn HTTP(S) servers that serve metadata and target
 files for the unit tests.  The [map
-file](https://github.com/theupdateframework/tuf/tree/develop/tests/repository_data)
+file](https://github.com/theupdateframework/python-tuf/tree/develop/tests/repository_data)
 specifies the location of the test repositories and other properties.  For
 specific targets and metadata provided by the tests repositories, please
 inspect their [respective
-metadata](https://github.com/theupdateframework/tuf/tree/develop/tests/repository_data/repository).
+metadata](https://github.com/theupdateframework/python-tuf/tree/develop/tests/repository_data/repository).
 

--- a/tests/test_indefinite_freeze_attack.py
+++ b/tests/test_indefinite_freeze_attack.py
@@ -20,7 +20,7 @@
 
   March 9, 2016.
     Additional test added relating to issue:
-    https://github.com/theupdateframework/tuf/issues/322
+    https://github.com/theupdateframework/python-tuf/issues/322
     If a metadata file is not updated (no indication of a new version
     available), the expiration of the pre-existing, locally trusted metadata
     must still be detected. This additional test complains if such does not
@@ -238,7 +238,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
 
     # Test 1 Begin:
     #
-    # Addresses this issue: https://github.com/theupdateframework/tuf/issues/322
+    # Addresses this issue: https://github.com/theupdateframework/python-tuf/issues/322
     #
     # If time has passed and our snapshot or targets role is expired, and
     # the mirror whose timestamp we fetched doesn't indicate the existence of a
@@ -377,7 +377,7 @@ class TestIndefiniteFreezeAttack(unittest_toolbox.Modified_TestCase):
     # After the attack, attempt to re-issue a valid Snapshot to verify that
     # the client is still able to update. A bug previously caused snapshot
     # expiration or replay to result in an indefinite freeze; see
-    # github.com/theupdateframework/tuf/issues/736
+    # github.com/theupdateframework/python-tuf/issues/736
     repository = repo_tool.load_repository(self.repository_directory)
 
     ts_key_file = os.path.join(self.keystore_directory, 'timestamp_key')

--- a/tuf/ATTACKS.md
+++ b/tuf/ATTACKS.md
@@ -19,7 +19,7 @@ in TUF metadata.
 
 The following demonstration requires and operates on the repository created in
 the [repository management
-tutorial](https://github.com/theupdateframework/tuf/blob/develop/tuf/README.md).
+tutorial](https://github.com/theupdateframework/python-tuf/blob/develop/tuf/README.md).
 
 ### Arbitrary Package Attack ###
 In an arbitrary package attack, an  attacker installs anything they want on the
@@ -319,5 +319,5 @@ SlowRetrievalError exception to the client application.
 ## Conclusion ##
 These are just some of the attacks that TUF provides protection against.  For
 more attacks and updater weaknesses, please see the
-[Security](https://github.com/theupdateframework/tuf/blob/develop/docs/SECURITY.md)
+[Security](https://github.com/theupdateframework/python-tuf/blob/develop/docs/SECURITY.md)
 page.

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -2613,7 +2613,7 @@ class Targets(Metadata):
       # PEP 458: https://www.python.org/dev/peps/pep-0458/
       # The source of the slowness is the interactions with the roledb, which
       # causes several deep copies of roleinfo dictionaries:
-      # https://github.com/theupdateframework/tuf/issues/1005
+      # https://github.com/theupdateframework/python-tuf/issues/1005
       # Once the underlying issues in #1005 are resolved, i.e. some combination
       # of the intermediate and long-term fixes, we may simplify here by
       # switching back to just calling self.delegate(), but until that time we


### PR DESCRIPTION
Fixes #1555 

**Description of the changes being introduced by the pull request**:

Prepare for a rename of the repository from tuf->python-tuf by updating links to the repository.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


