### PR TITLE
Remove disable=broad-except

### DIFF
--- a/tuf/api/serialization/json.py
+++ b/tuf/api/serialization/json.py
@@ -36,7 +36,7 @@ class JSONDeserializer(MetadataDeserializer):
             json_dict = json.loads(raw_data.decode("utf-8"))
             metadata_obj = Metadata.from_dict(json_dict)
 
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             raise DeserializationError from e
 
         return metadata_obj
@@ -66,7 +66,7 @@ class JSONSerializer(MetadataSerializer):
                 sort_keys=True,
             ).encode("utf-8")
 
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             raise SerializationError from e
 
         return json_bytes
@@ -83,7 +83,7 @@ class CanonicalJSONSerializer(SignedSerializer):
             signed_dict = signed_obj.to_dict()
             canonical_bytes = encode_canonical(signed_dict).encode("utf-8")
 
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             raise SerializationError from e
 
         return canonical_bytes


### PR DESCRIPTION
Fixes #1332 

**Description of the changes being introduced by the pull request**:

The pylint warning W0703:broad-except was raised only when six was used and python 2 was still supported. 
The warning is no longer raised, the exceptions are handled/raised correctly and the disabling can be removed.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


