### PR TITLE
ngclient: Fix intermediate metadata loading with rollback checks

### DIFF
--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -13,11 +13,18 @@ Loaded metadata can be accessed via index access with rolename as key
 (trusted_set["root"]) or, in the case of top-level metadata, using the helper
 properties (trusted_set.root).
 
-The rules for top-level metadata are
- * Metadata is updatable only if metadata it depends on is loaded
- * Metadata is not updatable if any metadata depending on it has been loaded
- * Metadata must be updated in order:
-   root -> timestamp -> snapshot -> targets -> (delegated targets)
+The rules that TrustedMetadataSet follows for top-level metadata are
+ * Metadata must be loaded in order:
+   root -> timestamp -> snapshot -> targets -> (delegated targets).
+ * Metadata can be loaded even if it is expired (or in the snapshot case if the
+   meta info does not match): this is called "intermediate metadata".
+ * Intermediate metadata can _only_ be used to load newer versions of the
+   same metadata: As an example an expired root can be used to load a new root.
+ * Metadata is loadable only if metadata before it in loading order is loaded
+   (and is not intermediate): As an example timestamp can be loaded if a
+   final (non-expired) root has been loaded.
+ * Metadata is not loadable if any metadata after it in loading order has been
+   loaded: As an example new roots cannot be loaded if timestamp is loaded.
 
 Exceptions are raised if metadata fails to load in any way.
 

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -322,7 +322,7 @@ class Updater:
             self._trusted_set.update_timestamp(data)
         except (OSError, exceptions.RepositoryError) as e:
             # Local timestamp does not exist or is invalid
-            logger.debug("Failed to load local timestamp %s", e)
+            logger.debug("Local timestamp not valid as final: %s", e)
 
         # Load from remote (whether local load succeeded or not)
         data = self._download_metadata(
@@ -339,7 +339,7 @@ class Updater:
             logger.debug("Local snapshot is valid: not downloading new one")
         except (OSError, exceptions.RepositoryError) as e:
             # Local snapshot does not exist or is invalid: update from remote
-            logger.debug("Failed to load local snapshot %s", e)
+            logger.debug("Local snapshot not valid as final: %s", e)
 
             assert self._trusted_set.timestamp is not None  # nosec
             metainfo = self._trusted_set.timestamp.signed.meta["snapshot.json"]


### PR DESCRIPTION
The rollback checks themselves work, but they create a situation
where Updater does not realize that it needs to download e.g. a new
snapshot because the local snapshot is valid as _intermediate_ snapshot
(that can be used for rollback protection but nothing else), but is not
valid as final snapshot.

The PR changes very little but documentation is improved in several places:
* defines `_check_final_timestamp()` for consistency with `_check_final_snapshot()`
* `update_timestamp()` and `update_snapshot()` will still load "intermediate" metadata as before, but will now raise in the end of function if the metadata is not valid final metadata
* this is what Updater is expecting so there are no changes in Updater

The reason this bug was introduced (by me) was lacking tests. The tests are still missing: I found the issue while working on the tests in #1444. It might make sense to merge this commit when the tests are merged but I wanted to have separate review for this as it's clearly an implementation bug.
