### PR TITLE
Don't build universal wheels

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -10,7 +10,7 @@
   (ensure commands invoking `python` below are using Python 3)
   * Remove existing dist build dirs
   * Create source dist `python3 setup.py sdist`
-  * Create wheel (with 2 and 3 support) `python3 setup.py bdist_wheel --universal`
+  * Create wheel `python3 setup.py bdist_wheel`
   * Sign the dists `gpg --detach-sign -a dist/tuf-vA.B.C.tar.gz`
   * Upload to test PyPI `twine upload --repository testpypi dist/*`
   * Verify the uploaded package https://testpypi.python.org/pypi/tuf/
@@ -25,9 +25,9 @@
   (ensure commands invoking `python` below are using Python 3)
   * Remove existing dist build dirs
   * Create source dist `python3 setup.py sdist`
-  * Create wheel (with 2 and 3 support) `python3 setup.py bdist_wheel --universal`
+  * Create wheel `python3 setup.py bdist_wheel`
   * Sign source dist `gpg --detach-sign -a dist/tuf-vA.B.C.tar.gz`
-  * Sign wheel `gpg --detach-sign -a dist/tuf-vA.B.C-py2.py3-none-any.whl`
+  * Sign wheel `gpg --detach-sign -a dist/tuf-vA.B.C-py3-none-any.whl`
   * Upload to test PyPI `twine upload --repository testpypi dist/*`
   * Verify the uploaded package https://testpypi.python.org/pypi/tuf/
   * Upload to PyPI `twine upload dist/*`

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[wheel]
-universal = 1
-
 [check-manifest]
 ignore =
   requirements-dev.txt


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

We no longer support Python 2, so do not need to build universal wheels. Remove that option from our release process and setup.cfg.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


