### PR TITLE
Prepare v0.18.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.18.1
+
+### Changed
+* Update setup.cfg to not build universal wheels (#1566)
+
 ## v0.18.0
 
 0.18 is a big release with 3 main themes:

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ with open('README.md') as file_object:
 
 setup(
   name = 'tuf',
-  version = '0.18.0', # If updating version, also update it in tuf/__init__.py
+  version = '0.18.1', # If updating version, also update it in tuf/__init__.py
   description = 'A secure updater framework for Python',
   long_description = long_description,
   long_description_content_type='text/markdown',

--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -2,7 +2,7 @@
 # setup.py has it hard-coded separately.
 # Currently, when the version is changed, it must be set in both locations.
 # TODO: Single-source the version number.
-__version__ = "0.18.0"
+__version__ = "0.18.1"
 
 # This reference implementation produces metadata intended to conform to
 # version 1.0.0 of the TUF specification, and is expected to consume metadata


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

The v0.18.0 release was made with the changes from #1566, resulting in
a release with sources which don't match the git tag. Rectify this with
a brown bag point release.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


