### PR TITLE
test ngclient with simulated repo

### DIFF
--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+
+# Copyright 2021, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+""""Test utility to simulate a repository
+
+RepositorySimulator provides methods to modify repository metadata so that it's
+easy to "publish" new repository versions with modified metadata, while serving
+the versions to client test code.
+
+RepositorySimulator implements FetcherInterface so Updaters in tests can use it
+as a way to "download" new metadata from remote: in practice no downloading,
+network connections or even file access happens as RepositorySimulator serves
+everything from memory.
+"""
+
+import logging
+from collections import OrderedDict
+from datetime import datetime, timedelta
+from securesystemslib.keys import generate_ed25519_key
+from securesystemslib.signer import SSlibSigner
+from tuf.exceptions import FetcherHTTPError
+from typing import Dict, Iterator, List, Optional, Tuple
+from urllib import parse
+
+from tuf.api.metadata import(
+    Key,
+    Metadata,
+    MetaFile,
+    Role,
+    Root,
+    SPECIFICATION_VERSION,
+    Snapshot,
+    Targets,
+    Timestamp
+)
+from tuf.ngclient.fetcher import FetcherInterface
+
+logger = logging.getLogger(__name__)
+
+SPEC_VER = ".".join(SPECIFICATION_VERSION)
+
+class RepositorySimulator(FetcherInterface):
+    def __init__(self):
+        # all root versions are stored
+        self.md_roots: Dict[int, Metadata[Root]] = {}
+        self.md_timestamp: Metadata[Timestamp] = None
+        self.md_snapshot: Metadata[Snapshot] = None
+        self.md_targets: Metadata[Targets] = None
+        # all targets in one dict
+        self.md_delegates: Dict[str, Metadata[Targets]] = {}
+
+        self.signers: Dict[str, List[SSlibSigner]] = {}
+
+        self._initialize()
+
+    @property
+    def root(self) -> Root:
+        raise NotImplementedError
+
+    @property
+    def timestamp(self) -> Timestamp:
+        return self.md_timestamp.signed
+
+    @property
+    def snapshot(self) -> Snapshot:
+        return self.md_snapshot.signed
+
+    @property
+    def targets(self) -> Targets:
+        return self.md_targets.signed
+
+    def delegates(self) -> Iterator[Tuple[str, Targets]]:
+        for role, md in self.md_delegates.items():
+            yield role, md.signed
+
+    def _create_key(self, role:str) -> Key:
+        sslib_key = generate_ed25519_key()
+        if role not in self.signers:
+            self.signers[role] = []
+        self.signers[role].append(SSlibSigner(sslib_key))
+
+        key = Key.from_securesystemslib_key(sslib_key)
+        return key
+
+    def _initialize(self):
+        """Setup a minimal valid repository"""
+        expiry = datetime.utcnow().replace(microsecond=0) + timedelta(days=30)
+
+        targets = Targets(1, SPEC_VER, expiry, {}, None)
+        self.md_targets = Metadata(targets, OrderedDict())
+
+        meta = {"targets.json": MetaFile(targets.version)}
+        snapshot = Snapshot(1, SPEC_VER, expiry, meta)
+        self.md_snapshot = Metadata(snapshot, OrderedDict())
+
+        meta = {"snapshot.json": MetaFile(snapshot.version)}
+        timestamp = Timestamp(1, SPEC_VER, expiry, meta)
+        self.md_timestamp = Metadata(timestamp, OrderedDict())
+
+        keys = {}
+        roles = {}
+        for role in ["root", "timestamp", "snapshot", "targets"]:
+            key = self._create_key(role)
+            keys[key.keyid] = key
+            roles[role] = Role([key.keyid], 1)
+        root = Root(1, SPEC_VER, expiry, keys, roles, True)
+        self.md_roots[1] = Metadata(root, OrderedDict())
+
+    def fetch(self, url: str) -> Iterator[bytes]:
+        spliturl = parse.urlparse(url)
+        if spliturl.path.startswith("/metadata/"):
+            parts = spliturl.path[len("/metadata/"):].split(".")
+            if len(parts) == 3:
+                version = int(parts[0])
+                role = parts[1]
+            else:
+                version = None
+                role = parts[0]
+            yield self._fetch_metadata (role, version)
+        else:
+            raise FetcherHTTPError(f"Unknown path '{spliturl.path}'", 404)
+
+    def _fetch_metadata(self, role: str, version: Optional[int] = None) -> bytes:
+        if role == "root":
+            md = self.md_roots.get(version)
+        elif role == "timestamp":
+            md = self.md_timestamp
+        elif role == "snapshot":
+            md = self.md_snapshot
+        elif role == "targets":
+            md = self.md_targets
+        else:
+            md = self.md_delegates.get(role)
+
+        if md is None:
+            raise FetcherHTTPError(f"Unknown role {role}", 404)
+
+        md.signatures.clear()
+        for signer in self.signers[role]:
+            md.sign(signer)
+
+        logger.debug("fetched metadata %s version %d", role, md.signed.version)
+        return md.to_bytes()
+
+    def update_timestamp(self):
+        self.timestamp.meta["snapshot.json"].version = self.snapshot.version
+
+        self.timestamp.version += 1
+
+    def update_snapshot(self):
+        self.snapshot.meta["targets.json"].version = self.targets.version
+        for role, delegate in self.delegates():
+            self.snapshot.meta[f"{role}.json"].version = delegate.version
+
+        self.snapshot.version += 1
+        self.update_timestamp()
+
+    def write(self, directory:str):
+        """Write current repository metadata to a directory"""
+        raise NotImplementedError
+

--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -260,11 +260,12 @@ class TestTrustedMetadataSet(unittest.TestCase):
         def timestamp_expired_modifier(timestamp: Timestamp) -> None:
             timestamp.expires = datetime(1970, 1, 1)
 
-        # intermediate timestamp is allowed to be expired
+        # expired intermediate timestamp is loaded but raises
         timestamp = self.modify_metadata("timestamp", timestamp_expired_modifier)
-        self.trusted_set.update_timestamp(timestamp)
+        with self.assertRaises(exceptions.ExpiredMetadataError):
+            self.trusted_set.update_timestamp(timestamp)
 
-        # update snapshot to trigger final timestamp expiry check
+        # snapshot update does start but fails because timestamp is expired
         with self.assertRaises(exceptions.ExpiredMetadataError):
             self.trusted_set.update_snapshot(self.metadata["snapshot"])
 
@@ -293,10 +294,11 @@ class TestTrustedMetadataSet(unittest.TestCase):
         timestamp = self.modify_metadata("timestamp", timestamp_version_modifier)
         self.trusted_set.update_timestamp(timestamp)
 
-        #intermediate snapshot is allowed to not match meta version
-        self.trusted_set.update_snapshot(self.metadata["snapshot"])
+        # if intermediate snapshot version is incorrect, load it but also raise
+        with self.assertRaises(exceptions.BadVersionNumberError):
+            self.trusted_set.update_snapshot(self.metadata["snapshot"])
 
-        # final snapshot must match meta version
+        # targets update starts but fails if snapshot version does not match
         with self.assertRaises(exceptions.BadVersionNumberError):
             self.trusted_set.update_targets(self.metadata["targets"])
 
@@ -328,11 +330,12 @@ class TestTrustedMetadataSet(unittest.TestCase):
         def snapshot_expired_modifier(snapshot: Snapshot) -> None:
             snapshot.expires = datetime(1970, 1, 1)
 
-        # intermediate snapshot is allowed to be expired
+        # expired intermediate snapshot is loaded but will raise
         snapshot = self.modify_metadata("snapshot", snapshot_expired_modifier)
-        self.trusted_set.update_snapshot(snapshot)
+        with self.assertRaises(exceptions.ExpiredMetadataError):
+            self.trusted_set.update_snapshot(snapshot)
 
-        # update targets to trigger final snapshot expiry check
+        # targets update does start but fails because snapshot is expired
         with self.assertRaises(exceptions.ExpiredMetadataError):
             self.trusted_set.update_targets(self.metadata["targets"])
 
@@ -348,8 +351,10 @@ class TestTrustedMetadataSet(unittest.TestCase):
         new_timestamp = self.modify_metadata("timestamp", meta_version_bump)
         self.trusted_set.update_timestamp(new_timestamp)
 
-        # load a "local" snapshot, then update to newer one:
-        self.trusted_set.update_snapshot(self.metadata["snapshot"])
+        # load a "local" snapshot with mismatching version (loading happens but
+        # BadVersionNumberError is raised), then update to newer one:
+        with self.assertRaises(exceptions.BadVersionNumberError):
+            self.trusted_set.update_snapshot(self.metadata["snapshot"])
         new_snapshot = self.modify_metadata("snapshot", version_bump)
         self.trusted_set.update_snapshot(new_snapshot)
 

--- a/tests/test_updater_with_simulator.py
+++ b/tests/test_updater_with_simulator.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+# Copyright 2021, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""Test ngclient Updater using the repository simulator
+"""
+
+import logging
+import os
+import sys
+import tempfile
+import unittest
+
+from tuf.ngclient import Updater
+
+from tests import utils
+from tests.repository_simulator import RepositorySimulator
+
+class TestUpdater(unittest.TestCase):
+    def setUp(self):
+        self.client_dir = tempfile.TemporaryDirectory()
+
+        # Setup the repository, bootstrap client root.json
+        self.sim = RepositorySimulator()
+        with open(os.path.join(self.client_dir.name, "root.json"), "bw") as f:
+            root = self.sim.download_bytes("https://example.com/metadata/1.root.json", 100000)
+            f.write(root)
+
+    def _new_updater(self):
+        return Updater(
+            self.client_dir.name,
+            "https://example.com/metadata/",
+            "https://example.com/targets/",
+            self.sim
+        )
+
+    def test_refresh(self):
+        # Update top level metadata
+        updater = self._new_updater()
+        updater.refresh()
+
+        # TODO compare file contents?
+
+        # New timestamp version
+        self.sim.update_timestamp()
+
+        updater = self._new_updater()
+        updater.refresh()
+
+        # TODO compare file contents?
+
+        # New targets version
+        self.sim.targets.version += 1
+        self.sim.update_snapshot()
+
+        updater = self._new_updater()
+        updater.refresh()
+
+        # TODO compare file contents?
+
+
+    def tearDown(self):
+        self.client_dir.cleanup()
+
+if __name__ == "__main__":
+  utils.configure_test_logging(sys.argv)
+  unittest.main()

--- a/tests/test_updater_with_simulator.py
+++ b/tests/test_updater_with_simulator.py
@@ -10,6 +10,7 @@ import logging
 import os
 import sys
 import tempfile
+from tuf.exceptions import UnsignedMetadataError
 import unittest
 
 from tuf.ngclient import Updater
@@ -37,16 +38,18 @@ class TestUpdater(unittest.TestCase):
 
     def test_refresh(self):
         # Update top level metadata
-        updater = self._new_updater()
-        updater.refresh()
+        self._new_updater().refresh()
+
+        # New root (root needs to be explicitly published)
+        self.sim.root.version += 1
+        self.sim.publish_root()
 
         # TODO compare file contents?
 
         # New timestamp version
         self.sim.update_timestamp()
 
-        updater = self._new_updater()
-        updater.refresh()
+        self._new_updater().refresh()
 
         # TODO compare file contents?
 
@@ -54,10 +57,47 @@ class TestUpdater(unittest.TestCase):
         self.sim.targets.version += 1
         self.sim.update_snapshot()
 
-        updater = self._new_updater()
-        updater.refresh()
+        self._new_updater().refresh()
 
         # TODO compare file contents?
+
+    # this is just an example of testing different key/signature situations
+    def test_targets_signatures(self):
+        # Update top level metadata
+        self._new_updater().refresh()
+
+        # New targets: signed by a new key that is not in roles keys
+        old_signer = self.sim.signers["targets"].pop()
+        key, signer = self.sim.create_key()
+        self.sim.signers["targets"] = [signer]
+        self.sim.targets.version += 1
+        self.sim.update_snapshot()
+
+        with self.assertRaises(UnsignedMetadataError):
+            self._new_updater().refresh()
+
+        # New root: Add the new key as targets role key
+        # (root changes require explicit publishing)
+        self.sim.root.add_key("targets", key)
+        self.sim.root.version += 1
+        self.sim.publish_root()
+
+        self._new_updater().refresh()
+
+        # New root: Raise targets threshold to 2
+        self.sim.root.roles["targets"].threshold = 2
+        self.sim.root.version += 1
+        self.sim.publish_root()
+
+        with self.assertRaises(UnsignedMetadataError):
+            self._new_updater().refresh()
+
+        # New targets: sign with both new and old key
+        self.sim.signers["targets"] = [signer, old_signer]
+        self.sim.targets.version += 1
+        self.sim.update_snapshot()
+
+        self._new_updater().refresh()
 
 
     def tearDown(self):

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -180,7 +180,7 @@ class TrustedMetadataSet(abc.Mapping):
         new_root.verify_delegate("root", new_root)
 
         self._trusted_set["root"] = new_root
-        logger.debug("Updated root")
+        logger.info("Updated root v%d", new_root.signed.version)
 
     def update_timestamp(self, data: bytes) -> None:
         """Verifies and loads 'data' as new timestamp metadata.
@@ -246,7 +246,7 @@ class TrustedMetadataSet(abc.Mapping):
         # protection of new timestamp: expiry is checked in update_snapshot()
 
         self._trusted_set["timestamp"] = new_timestamp
-        logger.debug("Updated timestamp")
+        logger.info("Updated timestamp v%d", new_timestamp.signed.version)
 
         # timestamp is loaded: raise if it is not valid _final_ timestamp
         self._check_final_timestamp()
@@ -333,7 +333,7 @@ class TrustedMetadataSet(abc.Mapping):
         # protection of new snapshot: it is checked when targets is updated
 
         self._trusted_set["snapshot"] = new_snapshot
-        logger.debug("Updated snapshot")
+        logger.info("Updated snapshot v%d", new_snapshot.signed.version)
 
         # snapshot is loaded, but we raise if it's not valid _final_ snapshot
         self._check_final_snapshot()
@@ -421,17 +421,17 @@ class TrustedMetadataSet(abc.Mapping):
 
         delegator.verify_delegate(role_name, new_delegate)
 
-        if new_delegate.signed.version != meta.version:
+        version = new_delegate.signed.version
+        if version != meta.version:
             raise exceptions.BadVersionNumberError(
-                f"Expected {role_name} version "
-                f"{meta.version}, got {new_delegate.signed.version}."
+                f"Expected {role_name} v{meta.version}, got v{version}."
             )
 
         if new_delegate.signed.is_expired(self.reference_time):
             raise exceptions.ExpiredMetadataError(f"New {role_name} is expired")
 
         self._trusted_set[role_name] = new_delegate
-        logger.debug("Updated %s delegated by %s", role_name, delegator_name)
+        logger.info("Updated %s v%d", role_name, version)
 
     def _load_trusted_root(self, data: bytes) -> None:
         """Verifies and loads 'data' as trusted root metadata.
@@ -452,4 +452,4 @@ class TrustedMetadataSet(abc.Mapping):
         new_root.verify_delegate("root", new_root)
 
         self._trusted_set["root"] = new_root
-        logger.debug("Loaded trusted root")
+        logger.info("Loaded trusted root v%d", new_root.signed.version)

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -13,11 +13,18 @@ Loaded metadata can be accessed via index access with rolename as key
 (trusted_set["root"]) or, in the case of top-level metadata, using the helper
 properties (trusted_set.root).
 
-The rules for top-level metadata are
- * Metadata is updatable only if metadata it depends on is loaded
- * Metadata is not updatable if any metadata depending on it has been loaded
- * Metadata must be updated in order:
-   root -> timestamp -> snapshot -> targets -> (delegated targets)
+The rules that TrustedMetadataSet follows for top-level metadata are
+ * Metadata must be loaded in order:
+   root -> timestamp -> snapshot -> targets -> (delegated targets).
+ * Metadata can be loaded even if it is expired (or in the snapshot case if the
+   meta info does not match): this is called "intermediate metadata".
+ * Intermediate metadata can _only_ be used to load newer versions of the
+   same metadata: As an example an expired root can be used to load a new root.
+ * Metadata is loadable only if metadata before it in loading order is loaded
+   (and is not intermediate): As an example timestamp can be loaded if a
+   final (non-expired) root has been loaded.
+ * Metadata is not loadable if any metadata after it in loading order has been
+   loaded: As an example new roots cannot be loaded if timestamp is loaded.
 
 Exceptions are raised if metadata fails to load in any way.
 

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -322,7 +322,7 @@ class Updater:
             self._trusted_set.update_timestamp(data)
         except (OSError, exceptions.RepositoryError) as e:
             # Local timestamp does not exist or is invalid
-            logger.debug("Failed to load local timestamp %s", e)
+            logger.debug("Local timestamp not valid as final: %s", e)
 
         # Load from remote (whether local load succeeded or not)
         data = self._download_metadata(
@@ -339,7 +339,7 @@ class Updater:
             logger.debug("Local snapshot is valid: not downloading new one")
         except (OSError, exceptions.RepositoryError) as e:
             # Local snapshot does not exist or is invalid: update from remote
-            logger.debug("Failed to load local snapshot %s", e)
+            logger.debug("Local snapshot not valid as final: %s", e)
 
             assert self._trusted_set.timestamp is not None  # nosec
             metainfo = self._trusted_set.timestamp.signed.meta["snapshot.json"]


### PR DESCRIPTION
I'm not sure if this is quite ready but I do think I need other people to comment on this.

* Add a RepositorySimulator as a test utility
* Add some tests that demonstrate how to use RepositorySimulator
* Add "--dump" option to the tests to show how to debug (or just how to create repository test data if that's needed)
* Include the fix from #1565: let's review that one there even if we merge all together

So I've not tried to implement any real test coverage yet: I'm making a PR now since there's a lot of activity around client tests and maybe this will help others if it turns out reasonable. At the very least the folks creating tests should have opinions :) I do think that if this looks like a good solution we should move most updater tests to this testing style and have extensive coverage here -- and only leave existing tests as smoke test for the whole stack with a network connection etc. 

The note worthy aspects of this are
* `test_updater_with_simulator.py`  is tiny for what it does: 125 lines includes one test with 5 different repository versions and another with 4 different repository versions. I think our current tests _never_ have that many versions anywhere
* it should also be quite fast (although I've not benchmarked this) as network connections are not created and the only file access is by ngclient itself
* `python3 test_updater_with_simulator.py -vvv` will be fairly informative: you can see all the metadata versions that get loaded
* `python3 test_updater_with_simulator.py --dump` is quite good for debugging: it stores a repository version every time the client refreshes. These versions can be easily diffed: `diff /tmp/tmp614pepb4/test_keys_and_signatures/2 /tmp/tmp614pepb4/test_keys_and_signatures/3`
* Writing the tests is not as simple as I'd hope (with e.g. `publish_root()` complication) but maybe still understandable
* I'm still not quite sure _what exactly_ we should check when a refresh succeeds... but this is not unique to my approach here