### PR TITLE
Ngclient: persist metadata safely

### DIFF
--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -62,6 +62,7 @@ Example::
 
 import logging
 import os
+import tempfile
 from typing import List, Optional, Set, Tuple
 from urllib import parse
 
@@ -287,8 +288,17 @@ class Updater:
             return f.read()
 
     def _persist_metadata(self, rolename: str, data: bytes) -> None:
-        with open(os.path.join(self._dir, f"{rolename}.json"), "wb") as f:
-            f.write(data)
+        """Acts as an atomic write operation to make sure
+        that if the process of writing is halted, at least the
+        original data is left intact.
+        """
+
+        original_filename = os.path.join(self._dir, f"{rolename}.json")
+        with tempfile.NamedTemporaryFile(
+            dir=self._dir, delete=False
+        ) as temp_file:
+            temp_file.write(data)
+        os.replace(temp_file.name, original_filename)
 
     def _load_root(self) -> None:
         """Load remote root metadata.


### PR DESCRIPTION
Fixes #1526

Persist new metadata in an atomic manner. This contains:
* @Suvadityamuk's commit from #1549, I've modified the commit by fixing the method signature as required to successfully rebase the change on current develop
* my commit that adds some tests

Copying a more thorough explanation of why this is done as it is from https://github.com/theupdateframework/python-tuf/issues/1526#issuecomment-903674931:
* use NamedTemporaryFile to generate a safe temp file name (to avoid overwriting an existing file)
* use the dir argument to make sure the temp file is in same filesystem as the final file (otherwise replace can't be atomic)
* use delete=False argument so NamedTemporaryFile doesn't try to delete the temp file (because we want to move it and can't move if it's been deleted)

This change has one side-effect: if the write fails mid-way or the replace fails, the temp file is not cleaned: #1575 .

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


