### PR TITLE
GitHub CI workflow: tweak names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Run TUF tests and linter
+name: CI
 
 on:
   push:
@@ -8,7 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  tests:
+    name: Tests
     strategy:
       fail-fast: false
       # Run regular TUF tests on each OS/Python combination, plus special tests
@@ -88,10 +89,10 @@ jobs:
           coveralls --service=github --rcfile=tests/.coveragerc
 
   coveralls-fin:
-    # Always run when all 'build' jobs have finished even if they failed
+    # Always run when all 'tests' jobs have finished even if they failed
     # TODO: Replace always() with a 'at least one job succeeded' expression
     if: always()
-    needs: build
+    needs: tests
     runs-on: ubuntu-latest
     container: python:3-slim
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,7 @@ jobs:
             os: ubuntu-latest
             toxenv: with-sslib-master
             experimental: true
-          # TODO: Change to 3.x once pylint fully supports Python 3.9
-          - python-version: 3.8
+          - python-version: 3.x
             os: ubuntu-latest
             toxenv: lint
 


### PR DESCRIPTION
Currently the github UI dropdown for checks looks useless since every check is named "Run TUF tests and...". Tweak the workflow and job names to hopefully fit the actual step name in the UI.

Also start using python 3.x for lint since pylint now supports it.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>
