### PR TITLE
Fix pylint warnings

### DIFF
--- a/tuf/keydb.py
+++ b/tuf/keydb.py
@@ -429,10 +429,8 @@ def clear_keydb(repository_name='default', clear_all=False):
   sslib_formats.NAME_SCHEMA.check_match(repository_name)
   sslib_formats.BOOLEAN_SCHEMA.check_match(clear_all)
 
-  global _keydb_dict
-
   if clear_all:
-    _keydb_dict = {}
+    _keydb_dict.clear()
     _keydb_dict['default'] = {}
 
   if repository_name not in _keydb_dict:

--- a/tuf/log.py
+++ b/tuf/log.py
@@ -276,9 +276,6 @@ def set_console_log_level(log_level=_DEFAULT_CONSOLE_LOG_LEVEL):
   # Raise 'securesystems.exceptions.FormatError' if there is a mismatch.
   sslib_formats.LOGLEVEL_SCHEMA.check_match(log_level)
 
-  # Assign to the global console_handler object.
-  global console_handler
-
   if console_handler is not None:
     console_handler.setLevel(log_level)
 

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -108,9 +108,6 @@ def create_roledb_from_root_metadata(root_metadata, repository_name='default'):
   # Is 'repository_name' formatted correctly?
   sslib_formats.NAME_SCHEMA.check_match(repository_name)
 
-  global _roledb_dict
-  global _dirty_roles
-
   # Clear the role database.
   if repository_name in _roledb_dict:
     _roledb_dict[repository_name].clear()
@@ -176,9 +173,6 @@ def create_roledb(repository_name):
   # 'securesystemslib.exceptions.FormatError'.
   sslib_formats.NAME_SCHEMA.check_match(repository_name)
 
-  global _roledb_dict
-  global _dirty_roles
-
   if repository_name in _roledb_dict or repository_name in _dirty_roles:
     raise sslib_exceptions.InvalidNameError('Repository name'
       ' already exists: ' + repr(repository_name))
@@ -218,9 +212,6 @@ def remove_roledb(repository_name):
   # Is 'repository_name' properly formatted?  If not, raise
   # 'securesystemslib.exceptions.FormatError'.
   sslib_formats.NAME_SCHEMA.check_match(repository_name)
-
-  global _roledb_dict
-  global _dirty_roles
 
   if repository_name not in _roledb_dict or repository_name not in _dirty_roles:
     logger.warning('Repository name does not exist:'
@@ -293,8 +284,6 @@ def add_role(rolename, roleinfo, repository_name='default'):
 
   # Is 'repository_name' correctly formatted?
   sslib_formats.NAME_SCHEMA.check_match(repository_name)
-
-  global _roledb_dict
 
   # Raises securesystemslib.exceptions.InvalidNameError.
   _validate_rolename(rolename)
@@ -380,9 +369,6 @@ def update_roleinfo(rolename, roleinfo, mark_role_as_dirty=True, repository_name
   # Raises securesystemslib.exceptions.InvalidNameError.
   _validate_rolename(rolename)
 
-  global _roledb_dict
-  global _dirty_roles
-
   if repository_name not in _roledb_dict or repository_name not in _dirty_roles:
     raise sslib_exceptions.InvalidNameError('Repository name does not' ' exist: ' +
       repository_name)
@@ -432,9 +418,6 @@ def get_dirty_roles(repository_name='default'):
   # 'securesystemslib.exceptions.FormatError' if not.
   sslib_formats.NAME_SCHEMA.check_match(repository_name)
 
-  global _roledb_dict
-  global _dirty_roles
-
   if repository_name not in _roledb_dict or repository_name not in _dirty_roles:
     raise sslib_exceptions.InvalidNameError('Repository name does'
       '  not' ' exist: ' + repository_name)
@@ -475,9 +458,6 @@ def mark_dirty(roles, repository_name='default'):
   sslib_formats.NAMES_SCHEMA.check_match(roles)
   sslib_formats.NAME_SCHEMA.check_match(repository_name)
 
-  global _roledb_dict
-  global _dirty_roles
-
   if repository_name not in _roledb_dict or repository_name not in _dirty_roles:
     raise sslib_exceptions.InvalidNameError('Repository name does'
       ' not' ' exist: ' + repository_name)
@@ -517,9 +497,6 @@ def unmark_dirty(roles, repository_name='default'):
   # securesystemslib.exceptions.FormatError.
   sslib_formats.NAMES_SCHEMA.check_match(roles)
   sslib_formats.NAME_SCHEMA.check_match(repository_name)
-
-  global _roledb_dict
-  global _dirty_roles
 
   if repository_name not in _roledb_dict or repository_name not in _dirty_roles:
     raise sslib_exceptions.InvalidNameError('Repository name does'
@@ -623,9 +600,6 @@ def remove_role(rolename, repository_name='default'):
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
 
-  global _roledb_dict
-  global _dirty_roles
-
   # 'rolename' was verified to exist in _check_rolename().
   # Remove 'rolename' now.
   del _roledb_dict[repository_name][rolename]
@@ -661,9 +635,6 @@ def get_rolenames(repository_name='default'):
   # Does 'repository_name' have the correct format?  Raise
   # 'securesystemslib.exceptions.FormatError' if it is improperly formatted.
   sslib_formats.NAME_SCHEMA.check_match(repository_name)
-
-  global _roledb_dict
-  global _dirty_roles
 
   if repository_name not in _roledb_dict or repository_name not in _dirty_roles:
     raise sslib_exceptions.InvalidNameError('Repository name does'
@@ -725,9 +696,6 @@ def get_roleinfo(rolename, repository_name='default'):
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
 
-  global _roledb_dict
-  global _dirty_roles
-
   return copy.deepcopy(_roledb_dict[repository_name][rolename])
 
 
@@ -778,9 +746,6 @@ def get_role_keyids(rolename, repository_name='default'):
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
 
-  global _roledb_dict
-  global _dirty_roles
-
   roleinfo = _roledb_dict[repository_name][rolename]
 
   return roleinfo['keyids']
@@ -830,9 +795,6 @@ def get_role_threshold(rolename, repository_name='default'):
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
 
-  global _roledb_dict
-  global _dirty_roles
-
   roleinfo = _roledb_dict[repository_name][rolename]
 
   return roleinfo['threshold']
@@ -880,9 +842,6 @@ def get_role_paths(rolename, repository_name='default'):
   # tuf.exceptions.UnknownRoleError, or
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
-
-  global _roledb_dict
-  global _dirty_roles
 
   roleinfo = _roledb_dict[repository_name][rolename]
 
@@ -941,9 +900,6 @@ def get_delegated_rolenames(rolename, repository_name='default'):
   # securesystemslib.exceptions.InvalidNameError.
   _check_rolename(rolename, repository_name)
 
-  global _roledb_dict
-  global _dirty_roles
-
   # get_roleinfo() raises a 'securesystemslib.exceptions.InvalidNameError' if
   # 'repository_name' does not exist in the role database.
   roleinfo = get_roleinfo(rolename, repository_name)
@@ -990,8 +946,8 @@ def clear_roledb(repository_name='default', clear_all=False):
   sslib_formats.NAME_SCHEMA.check_match(repository_name)
   sslib_formats.BOOLEAN_SCHEMA.check_match(clear_all)
 
-  global _roledb_dict
-  global _dirty_roles
+  global _roledb_dict # pylint: disable=global-variable-not-assigned
+  global _dirty_roles # pylint: disable=global-variable-not-assigned
 
   if repository_name not in _roledb_dict or repository_name not in _dirty_roles:
     raise sslib_exceptions.InvalidNameError('Repository name does not'
@@ -1029,9 +985,6 @@ def _check_rolename(rolename, repository_name='default'):
 
   # Raises securesystemslib.exceptions.InvalidNameError.
   _validate_rolename(rolename)
-
-  global _roledb_dict
-  global _dirty_roles
 
   if repository_name not in _roledb_dict or repository_name not in _dirty_roles:
     raise sslib_exceptions.InvalidNameError('Repository name does not'

--- a/tuf/roledb.py
+++ b/tuf/roledb.py
@@ -946,17 +946,14 @@ def clear_roledb(repository_name='default', clear_all=False):
   sslib_formats.NAME_SCHEMA.check_match(repository_name)
   sslib_formats.BOOLEAN_SCHEMA.check_match(clear_all)
 
-  global _roledb_dict # pylint: disable=global-variable-not-assigned
-  global _dirty_roles # pylint: disable=global-variable-not-assigned
-
   if repository_name not in _roledb_dict or repository_name not in _dirty_roles:
     raise sslib_exceptions.InvalidNameError('Repository name does not'
       ' exist: ' + repository_name)
 
   if clear_all:
-    _roledb_dict = {}
+    _roledb_dict.clear()
     _roledb_dict['default'] = {}
-    _dirty_roles = {}
+    _dirty_roles.clear()
     _dirty_roles['default'] = set()
     return
 


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

**Description of the changes being introduced by the pull request**:

New pylint warnings appeared (for the first time here: https://github.com/theupdateframework/python-tuf/pull/1446/checks?check_run_id=3630842220) with code:
`W0602: Using global for X but no assignment is done (global-variable-not-assigned)`
where X is a global variable.
In the lines pointed by the warnings, "global" was used inside a
function scope in order to enable assignment of the global variable to
a new value in the function.
The reason for these warnings was that pylint noticed we are using
"global" for the variable X inside a function scope without actually
assigning it to a new value.
Overall that was true for the reported cases and I removed the use of
"global", but there were only two cases where pylint reported a
false-positive. Then we were using "global", but pylint didn't
understand there were assignments.
In those cases, I disabled the warnings.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


