### PR TITLE
CI: Do not require coveralls-fin to succeed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
     container: python:3-slim
     steps:
       - name: Finalize publishing on coveralls.io
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
We already do not require individual build uploads to succeed: let's
also not require the final step to succeed.
    
The immediate context for this is that coveralls has been down for
three days now.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>
