### PR TITLE
ngclient: handle timeout on session.get() 

### DIFF
--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -19,7 +19,7 @@ import requests
 from tests import utils
 from tuf import exceptions, unittest_toolbox
 from tuf.ngclient._internal.requests_fetcher import RequestsFetcher
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 logger = logging.getLogger(__name__)
 
@@ -110,19 +110,17 @@ class TestFetcher(unittest_toolbox.Modified_TestCase):
             self.fetcher.fetch(self.url)
         self.assertEqual(cm.exception.status_code, 404)
 
-    # Read timeout error
-    def test_read_timeout(self):
-        # Reduce the read socket timeout to speed up the test
-        # while keeping the connect timeout
-        default_socket_timeout = self.fetcher.socket_timeout
-        self.fetcher.socket_timeout = (default_socket_timeout, 0.1)
-        # Launch a new "slow retrieval" server sending one byte each 40s
-        slow_server_process_handler = utils.TestServerProcess(log=logger, server='slow_retrieval_server.py')
-        self.url = f"http://{utils.TEST_HOST_ADDRESS}:{str(slow_server_process_handler.port)}/{self.rel_target_filepath}"
+    # Response read timeout error
+    @patch.object(requests.Session, 'get')
+    def test_response_read_timeout(self, mock_session_get):
+        mock_response = Mock()
+        attr = {'raw.read.side_effect': urllib3.exceptions.ReadTimeoutError(None, None, "Read timed out.")}
+        mock_response.configure_mock(**attr)
+        mock_session_get.return_value = mock_response
+
         with self.assertRaises(exceptions.SlowRetrievalError):
             next(self.fetcher.fetch(self.url))
-
-        slow_server_process_handler.clean()
+        mock_response.raw.read.assert_called_once()
 
     # Read/connect session timeout error
     @patch.object(requests.Session, 'get', side_effect=urllib3.exceptions.TimeoutError)

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -77,7 +77,13 @@ class RequestsFetcher(FetcherInterface):
         # requests as:
         #  - connect timeout (max delay before first byte is received)
         #  - read (gap) timeout (max delay between bytes received)
-        response = session.get(url, stream=True, timeout=self.socket_timeout)
+        try:
+            response = session.get(
+                url, stream=True, timeout=self.socket_timeout
+            )
+        except urllib3.exceptions.TimeoutError as e:
+            raise exceptions.SlowRetrievalError from e
+
         # Check response status.
         try:
             response.raise_for_status()


### PR DESCRIPTION
Fixes #1570

**Description of the changes being introduced by the pull request**:

`RequestsFetcher` should handle connect/read timeout errors on `session.get()` as it does when reading data.
- Now excepting `TimeoutError` (which is the base error for `ConnectTimeoutError` and `ReadTimeoutError`) and re-raising as `SlowRetreivalError`
- Adding a test which uses `unittest.mock` to patch `session.get` instead of simulating the error with a server.
- Instead of starting a dedicated `slow_retrieval_server` to test for read timeout in RequestsFetcher, use `unittest.mock` to mock the `response.raw.read` call.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


