### PR TITLE
Fix handling consistent targets same as legacy updater

### DIFF
--- a/tests/test_updater_with_simulator.py
+++ b/tests/test_updater_with_simulator.py
@@ -107,6 +107,9 @@ class TestUpdater(unittest.TestCase):
             [file_info]
         )
 
+        # Assert consistent_snapshot is True and downloaded targets have prefix.
+        self.assertTrue(self.sim.root.consistent_snapshot)
+        self.assertTrue(updater.config.prefix_targets_with_hash)
         # download target, assert it is in cache and content is correct
         local_path = updater.download_target(file_info, self.targets_dir)
         self.assertEqual(

--- a/tests/test_updater_with_simulator.py
+++ b/tests/test_updater_with_simulator.py
@@ -82,7 +82,8 @@ class TestUpdater(unittest.TestCase):
     def test_targets(self):
         targets = {
             "targetpath": b"content",
-            "åäö": b"more content"
+            "åäö": b"more content",
+            "dir/targetpath": b"dir target content"
         }
 
         # Add targets to repository
@@ -110,8 +111,13 @@ class TestUpdater(unittest.TestCase):
             with open(local_path, "rb") as f:
                 self.assertEqual(f.read(), content)
 
-        # TODO: run the same download tests for target paths like "dir/file2")
-        # This currently fails because issue #1576
+            if "/" in targetpath:
+                # assert local_path != targetpath because of the URL encoding
+                # make target_path absolute as local_path
+                target_path = os.path.join(self.targets_dir, targetpath)
+                self.assertNotEqual(target_path, local_path)
+
+
 
     def test_keys_and_signatures(self):
         """Example of the two trickiest test areas: keys and root updates"""

--- a/tests/test_updater_with_simulator.py
+++ b/tests/test_updater_with_simulator.py
@@ -10,7 +10,7 @@ import logging
 import os
 import sys
 import tempfile
-from typing import Optional
+from typing import Optional, Tuple
 from tuf.exceptions import UnsignedMetadataError
 import unittest
 
@@ -18,6 +18,7 @@ from tuf.ngclient import Updater
 
 from tests import utils
 from tests.repository_simulator import RepositorySimulator
+
 
 class TestUpdater(unittest.TestCase):
     # set dump_dir to trigger repository state dumps
@@ -79,43 +80,45 @@ class TestUpdater(unittest.TestCase):
 
         self._run_refresh()
 
-    def test_targets(self):
-        targets = {
-            "targetpath": b"content",
-            "åäö": b"more content",
-            "dir/targetpath": b"dir target content"
-        }
+    targets: utils.DataSet = {
+        "standard case": ("targetpath", b"content", "targetpath"),
+        "non-asci case": ("åäö", b"more content", "%C3%A5%C3%A4%C3%B6"),
+        "subdirectory case": ("a/b/c/targetpath", b"dir target content", "a%2Fb%2Fc%2Ftargetpath"),
+    }
+
+    @utils.run_sub_tests_with_dataset(targets)
+    def test_targets(self, test_case_data: Tuple[str, bytes, str]):
+        targetpath, content, encoded_path = test_case_data
+        # target does not exist yet
+        updater = self._run_refresh()
+        self.assertIsNone(updater.get_one_valid_targetinfo(targetpath))
 
         # Add targets to repository
         self.sim.targets.version += 1
-        for targetpath, content in targets.items():
-            self.sim.add_target("targets", content, targetpath)
+        self.sim.add_target("targets", content, targetpath)
         self.sim.update_snapshot()
 
         updater = self._run_refresh()
-        for targetpath, content in targets.items():
-            # target now exists, is not in cache yet
-            file_info = updater.get_one_valid_targetinfo(targetpath)
-            self.assertIsNotNone(file_info)
-            self.assertEqual(
-                updater.updated_targets([file_info], self.targets_dir),
-                [file_info]
-            )
+        # target now exists, is not in cache yet
+        file_info = updater.get_one_valid_targetinfo(targetpath)
+        self.assertIsNotNone(file_info)
+        self.assertEqual(
+            updater.updated_targets([file_info], self.targets_dir),
+            [file_info]
+        )
 
-            # download target, assert it is in cache and content is correct
-            local_path = updater.download_target(file_info, self.targets_dir)
-            self.assertEqual(
-                updater.updated_targets([file_info], self.targets_dir), []
-            )
-            self.assertTrue(local_path.startswith(self.targets_dir))
-            with open(local_path, "rb") as f:
-                self.assertEqual(f.read(), content)
+        # download target, assert it is in cache and content is correct
+        local_path = updater.download_target(file_info, self.targets_dir)
+        self.assertEqual(
+            updater.updated_targets([file_info], self.targets_dir), []
+        )
+        self.assertTrue(local_path.startswith(self.targets_dir))
+        with open(local_path, "rb") as f:
+            self.assertEqual(f.read(), content)
 
-            if "/" in targetpath:
-                # assert local_path != targetpath because of the URL encoding
-                # make target_path absolute as local_path
-                target_path = os.path.join(self.targets_dir, targetpath)
-                self.assertNotEqual(target_path, local_path)
+        # Assert that the targetpath was URL encoded as expected.
+        encoded_absolute_path = os.path.join(self.targets_dir, encoded_path)
+        self.assertEqual(local_path, encoded_absolute_path)
 
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,8 +20,10 @@
   Provide common utilities for TUF tests
 """
 
-import argparse
 from contextlib import contextmanager
+from typing import Dict, Any, Callable
+import unittest
+import argparse
 import errno
 import logging
 import socket
@@ -38,6 +40,22 @@ logger = logging.getLogger(__name__)
 
 # Used when forming URLs on the client side
 TEST_HOST_ADDRESS = '127.0.0.1'
+
+
+# DataSet is only here so type hints can be used.
+DataSet = Dict[str, Any]
+
+# Test runner decorator: Runs the test as a set of N SubTests,
+# (where N is number of items in dataset), feeding the actual test
+# function one test case at a time
+def run_sub_tests_with_dataset(dataset: DataSet):
+    def real_decorator(function: Callable[[unittest.TestCase, Any], None]):
+        def wrapper(test_cls: unittest.TestCase):
+            for case, data in dataset.items():
+                with test_cls.subTest(case=case):
+                    function(test_cls, data)
+        return wrapper
+    return real_decorator
 
 
 class TestServerProcessError(Exception):

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -229,6 +229,7 @@ class Updater:
                 download URL. Default is the value provided in Updater()
 
         Raises:
+            ValueError: Invalid arguments
             TODO: download-related errors
             TODO: file write errors
 
@@ -251,8 +252,9 @@ class Updater:
         consistent_snapshot = self._trusted_set.root.signed.consistent_snapshot
         if consistent_snapshot and self.config.prefix_targets_with_hash:
             hashes = list(targetinfo.hashes.values())
-            target_filepath = f"{hashes[0]}.{target_filepath}"
-        full_url = parse.urljoin(target_base_url, target_filepath)
+            dirname, sep, basename = target_filepath.rpartition("/")
+            target_filepath = f"{dirname}{sep}{hashes[0]}.{basename}"
+        full_url = f"{target_base_url}{target_filepath}"
 
         with self._fetcher.download_file(
             full_url, targetinfo.length


### PR DESCRIPTION
**Note:** This pr is dependent on pr #1592.

Fixes #1576

**Description of the changes being introduced by the pull request**:

The definition of consistent targets in the spec is ambiguous:
"consistent target files should be written to non-volatile storage
as digest.filename.ext"
Additionally, the specification describes consistent targets when the
client builds the download URL as follows:
"The filename is of the form HASH.FILENAME.EXT".
The issue is about how we interpreted those quotes.
The legacy updater has decided this means a target path `a/b` will translate to a download url path `a/{HASH}.b`.
The ngclient however translates the target path `a/b` to a download URL path `{HASH}.a/b`.

We decided we want to follow the same approach taken from the legacy
updater and thus change how we construct the consistent targets.
Additionally, we want to make sure we test for cases when the TARGETPATH
is an empty string or points to a directory.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


