### PR TITLE
ngclient: Avoid loading targets metadata twice

### DIFF
--- a/tests/test_updater_with_simulator.py
+++ b/tests/test_updater_with_simulator.py
@@ -6,11 +6,13 @@
 """Test ngclient Updater using the repository simulator.
 """
 
+import builtins
 import os
 import sys
 import tempfile
 import unittest
 from typing import Optional, Tuple
+from unittest.mock import MagicMock, Mock, patch
 
 from tests import utils
 from tests.repository_simulator import RepositorySimulator
@@ -229,6 +231,32 @@ class TestUpdater(unittest.TestCase):
         # the snapshot.meta["targets.json"] version by 1 and throws an error.
         with self.assertRaises(BadVersionNumberError):
             self._run_refresh()
+
+    @patch.object(builtins, "open", wraps=builtins.open)
+    def test_not_loading_targets_twice(self, wrapped_open: MagicMock):
+        # Do not load targets roles more than once when traversing
+        # the delegations tree
+
+        # Add new delegated targets, update the snapshot
+        spec_version = ".".join(SPECIFICATION_VERSION)
+        targets = Targets(1, spec_version, self.sim.safe_expiry, {}, None)
+        self.sim.add_delegation("targets", "role1", targets, False, ["*"], None)
+        self.sim.update_snapshot()
+
+        # Run refresh, top-level roles are loaded
+        updater = self._run_refresh()
+        # Clean up calls to open during refresh()
+        wrapped_open.reset_mock()
+
+        # First time looking for "somepath", only 'role1' must be loaded
+        updater.get_targetinfo("somepath")
+        wrapped_open.assert_called_once_with(
+            os.path.join(self.metadata_dir, "role1.json"), "rb"
+        )
+        wrapped_open.reset_mock()
+        # Second call to get_targetinfo, all metadata is already loaded
+        updater.get_targetinfo("somepath")
+        wrapped_open.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -370,6 +370,11 @@ class Updater:
 
     def _load_targets(self, role: str, parent_role: str) -> Metadata[Targets]:
         """Load local (and if needed remote) metadata for 'role'."""
+
+        # Avoid loading 'role' more than once during "get_targetinfo"
+        if role in self._trusted_set:
+            return self._trusted_set[role]
+
         try:
             data = self._load_local_metadata(role)
             delegated_targets = self._trusted_set.update_delegated_targets(


### PR DESCRIPTION
Fixes #1578 

**Description of the changes being introduced by the pull request**:
When traversing the delegations tree looking for targets, avoid re-loading already verified targets metadata.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


