### PR TITLE
Ngclient api polish

### DIFF
--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -202,8 +202,8 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         )
 
         # Get targetinfos, assert cache does not contain the files
-        info1 = updater.get_one_valid_targetinfo("file1.txt")
-        info3 = updater.get_one_valid_targetinfo("file3.txt")
+        info1 = updater.get_targetinfo("file1.txt")
+        info3 = updater.get_targetinfo("file3.txt")
         self.assertIsNone(updater.find_cached_target(info1))
         self.assertIsNone(updater.find_cached_target(info3))
 
@@ -238,11 +238,11 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         self._assert_files(["root", "snapshot", "targets", "timestamp"])
 
         # Get targetinfos, assert that cache does not contain files
-        info1 = self.updater.get_one_valid_targetinfo("file1.txt")
+        info1 = self.updater.get_targetinfo("file1.txt")
         self._assert_files(["root", "snapshot", "targets", "timestamp"])
 
         # Get targetinfo for 'file3.txt' listed in the delegated role1
-        info3 = self.updater.get_one_valid_targetinfo("file3.txt")
+        info3 = self.updater.get_targetinfo("file3.txt")
         expected_files = ["role1", "root", "snapshot", "targets", "timestamp"]
         self._assert_files(expected_files)
         self.assertIsNone(self.updater.find_cached_target(info1))
@@ -275,7 +275,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         self._assert_files(["root", "snapshot", "targets", "timestamp"])
 
         # Get targetinfo for 'file3.txt' listed in the delegated role1
-        targetinfo3 = self.updater.get_one_valid_targetinfo("file3.txt")
+        targetinfo3 = self.updater.get_targetinfo("file3.txt")
         expected_files = ["role1", "root", "snapshot", "targets", "timestamp"]
         self._assert_files(expected_files)
 
@@ -297,13 +297,13 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     def test_external_targets_url(self):
         self.updater.refresh()
-        info = self.updater.get_one_valid_targetinfo("file1.txt")
+        info = self.updater.get_targetinfo("file1.txt")
 
         self.updater.download_target(info, target_base_url=self.targets_url)
 
     def test_length_hash_mismatch(self):
         self.updater.refresh()
-        targetinfo = self.updater.get_one_valid_targetinfo("file1.txt")
+        targetinfo = self.updater.get_targetinfo("file1.txt")
 
         length = targetinfo.length
         with self.assertRaises(exceptions.RepositoryError):
@@ -325,7 +325,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         self.updater.refresh()
 
         # Get targetinfo for non-existing file
-        self.assertIsNone(self.updater.get_one_valid_targetinfo("file33.txt"))
+        self.assertIsNone(self.updater.get_targetinfo("file33.txt"))
 
 
 if __name__ == "__main__":

--- a/tests/test_updater_with_simulator.py
+++ b/tests/test_updater_with_simulator.py
@@ -54,6 +54,7 @@ class TestUpdater(unittest.TestCase):
         updater = Updater(
             self.metadata_dir,
             "https://example.com/metadata/",
+            self.targets_dir,
             "https://example.com/targets/",
             self.sim
         )
@@ -90,9 +91,13 @@ class TestUpdater(unittest.TestCase):
     @utils.run_sub_tests_with_dataset(targets)
     def test_targets(self, test_case_data: Tuple[str, bytes, str]):
         targetpath, content, encoded_path = test_case_data
-        # target does not exist yet
+        path = os.path.join(self.targets_dir, encoded_path)
+
         updater = self._run_refresh()
+        # target does not exist yet, configuration is what we expect
         self.assertIsNone(updater.get_one_valid_targetinfo(targetpath))
+        self.assertTrue(self.sim.root.consistent_snapshot)
+        self.assertTrue(updater.config.prefix_targets_with_hash)
 
         # Add targets to repository
         self.sim.targets.version += 1
@@ -101,30 +106,25 @@ class TestUpdater(unittest.TestCase):
 
         updater = self._run_refresh()
         # target now exists, is not in cache yet
-        file_info = updater.get_one_valid_targetinfo(targetpath)
-        self.assertIsNotNone(file_info)
-        self.assertEqual(
-            updater.updated_targets([file_info], self.targets_dir),
-            [file_info]
-        )
+        info = updater.get_one_valid_targetinfo(targetpath)
+        self.assertIsNotNone(info)
+        # Test without and with explicit local filepath
+        self.assertIsNone(updater.find_cached_target(info))
+        self.assertIsNone(updater.find_cached_target(info, path))
 
-        # Assert consistent_snapshot is True and downloaded targets have prefix.
-        self.assertTrue(self.sim.root.consistent_snapshot)
-        self.assertTrue(updater.config.prefix_targets_with_hash)
         # download target, assert it is in cache and content is correct
-        local_path = updater.download_target(file_info, self.targets_dir)
-        self.assertEqual(
-            updater.updated_targets([file_info], self.targets_dir), []
-        )
-        self.assertTrue(local_path.startswith(self.targets_dir))
-        with open(local_path, "rb") as f:
+        self.assertEqual(path, updater.download_target(info))
+        self.assertEqual(path, updater.find_cached_target(info))
+        self.assertEqual(path, updater.find_cached_target(info, path))
+
+        with open(path, "rb") as f:
             self.assertEqual(f.read(), content)
 
-        # Assert that the targetpath was URL encoded as expected.
-        encoded_absolute_path = os.path.join(self.targets_dir, encoded_path)
-        self.assertEqual(local_path, encoded_absolute_path)
-
-
+        # download using explicit filepath as well
+        os.remove(path)
+        self.assertEqual(path, updater.download_target(info, path))
+        self.assertEqual(path, updater.find_cached_target(info))
+        self.assertEqual(path, updater.find_cached_target(info, path))
 
     def test_fishy_rolenames(self):
         roles_to_filenames = {

--- a/tests/test_updater_with_simulator.py
+++ b/tests/test_updater_with_simulator.py
@@ -95,7 +95,7 @@ class TestUpdater(unittest.TestCase):
 
         updater = self._run_refresh()
         # target does not exist yet, configuration is what we expect
-        self.assertIsNone(updater.get_one_valid_targetinfo(targetpath))
+        self.assertIsNone(updater.get_targetinfo(targetpath))
         self.assertTrue(self.sim.root.consistent_snapshot)
         self.assertTrue(updater.config.prefix_targets_with_hash)
 
@@ -106,7 +106,7 @@ class TestUpdater(unittest.TestCase):
 
         updater = self._run_refresh()
         # target now exists, is not in cache yet
-        info = updater.get_one_valid_targetinfo(targetpath)
+        info = updater.get_targetinfo(targetpath)
         self.assertIsNotNone(info)
         # Test without and with explicit local filepath
         self.assertIsNone(updater.find_cached_target(info))
@@ -145,7 +145,7 @@ class TestUpdater(unittest.TestCase):
         updater = self._run_refresh()
 
         # trigger updater to fetch the delegated metadata, check filenames
-        updater.get_one_valid_targetinfo("anything")
+        updater.get_targetinfo("anything")
         local_metadata = os.listdir(self.metadata_dir)
         for fname in roles_to_filenames.values():
             self.assertTrue(fname in local_metadata)

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -24,8 +24,8 @@ High-level description of Updater functionality:
       * :func:`~tuf.ngclient.updater.Updater.get_one_valid_targetinfo()` is
         used to find information about a specific target. This will load new
         targets metadata as needed (from local cache or remote repository).
-      * :func:`~tuf.ngclient.updater.Updater.updated_targets()` can be used to
-        check if target files are already locally cached.
+      * :func:`~tuf.ngclient.updater.Updater.find_cached_target()` can be used
+        to check if a target file is already locally cached.
       * :func:`~tuf.ngclient.updater.Updater.download_target()` downloads a
         target file and ensures it is verified correct by the metadata.
 
@@ -43,27 +43,30 @@ Example::
 
     from tuf.ngclient import Updater
 
-    # Load trusted local root metadata from client metadata cache. Define the
-    # remote repository metadata URL prefix and target URL prefix.
+    # Load trusted local root metadata from client metadata cache. Define
+    # where metadata and targets will be downloaded from.
     updater = Updater(
         repository_dir="~/tufclient/metadata/",
         metadata_base_url="http://localhost:8000/tuf-repo/",
+        target_dir="~/tufclient/downloads/",
         target_base_url="http://localhost:8000/targets/",
     )
 
     # Update top-level metadata from remote
     updater.refresh()
 
-    # Securely download a target:
-    # Update target metadata, then download and verify target
-    targetinfo = updater.get_one_valid_targetinfo("file.txt")
-    updater.download_target(targetinfo, "~/tufclient/downloads/")
+    # Update metadata, then download target if needed
+    info = updater.get_one_valid_targetinfo("file.txt")
+    path = updater.find_cached_target(info)
+    if path is None:
+        path = updater.download_target(info)
+    print(f"Local file {path} contains target {info.path}")
 """
 
 import logging
 import os
 import tempfile
-from typing import List, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 from urllib import parse
 
 from securesystemslib import util as sslib_util
@@ -84,6 +87,9 @@ class Updater:
         repository_dir: Local metadata directory. Directory must be
             writable and it must contain a trusted root.json file.
         metadata_base_url: Base URL for all remote metadata downloads
+        target_dir: Local targets directory. Directory must be writable. It
+            will be used as the default target download directory by
+            ``find_cached_target()`` and ``download_target()``
         target_base_url: Optional; Default base URL for all remote target
             downloads. Can be individually set in download_target()
         fetcher: Optional; FetcherInterface implementation used to download
@@ -98,12 +104,14 @@ class Updater:
         self,
         repository_dir: str,
         metadata_base_url: str,
+        target_dir: Optional[str] = None,
         target_base_url: Optional[str] = None,
         fetcher: Optional[FetcherInterface] = None,
         config: Optional[UpdaterConfig] = None,
     ):
         self._dir = repository_dir
         self._metadata_base_url = _ensure_trailing_slash(metadata_base_url)
+        self.target_dir = target_dir
         if target_base_url is None:
             self._target_base_url = None
         else:
@@ -145,7 +153,7 @@ class Updater:
         """Returns TargetFile instance with information for 'target_path'.
 
         The return value can be used as an argument to
-        :func:`download_target()` and :func:`updated_targets()`.
+        :func:`download_target()` and :func:`find_cached_target()`.
 
         :func:`refresh()` must be called before calling
         `get_one_valid_targetinfo()`. Subsequent calls to
@@ -173,59 +181,64 @@ class Updater:
         """
         return self._preorder_depth_first_walk(target_path)
 
-    @staticmethod
-    def updated_targets(
-        targets: List[TargetFile], destination_directory: str
-    ) -> List[TargetFile]:
-        """Checks whether local cached target files are up to date
+    def find_cached_target(
+        self,
+        targetinfo: TargetFile,
+        filepath: Optional[str] = None,
+    ) -> Optional[str]:
+        """Checks whether a local file is an up to date target
 
-        After retrieving the target information for the targets that should be
-        updated, updated_targets() can be called to determine which targets
-        have changed compared to locally stored versions.
+        If the ``target_dir`` argument was given to constructor, ``filepath``
+        argument is not required here: in this case a filename will be
+        generated based on the target path like in ``download_target()``
 
-        All the targets that are not up-to-date in destination_directory are
-        returned in a list. The list items can be downloaded with
-        'download_target()'.
+        Args:
+            targetinfo: TargetFile from ``get_one_valid_targetinfo()``.
+            filepath: Local path to file. By default a filename is generated
+                and file is looked for in ``target_dir`` (see note above).
+
+        Raises:
+            ValueError: Incorrect arguments
+
+        Returns:
+            Local file path if the file is an up to date target file, or None
+            if file is not found or it is not up to date.
         """
-        # Keep track of TargetFiles and local paths. Return 'updated_targets'
-        # and use 'local_paths' to avoid duplicates.
-        updated_targets: List[TargetFile] = []
-        local_paths: List[str] = []
+        if filepath is not None:
+            pass
+        elif self.target_dir is not None:
+            # Use URL encoded target path as name, like download_target()
+            filename = parse.quote(targetinfo.path, "")
+            filepath = os.path.join(self.target_dir, filename)
+        else:
+            raise ValueError("filepath or target_dir must be set")
 
-        for target in targets:
-            # URL encode to get local filename like download_target() does
-            filename = parse.quote(target.path, "")
-            local_path = os.path.join(destination_directory, filename)
-
-            if local_path in local_paths:
-                continue
-
-            try:
-                with open(local_path, "rb") as target_file:
-                    target.verify_length_and_hashes(target_file)
-            # If the file does not exist locally or length and hashes
-            # do not match, append to updated targets.
-            except (OSError, exceptions.LengthOrHashMismatchError):
-                updated_targets.append(target)
-                local_paths.append(local_path)
-
-        return updated_targets
+        try:
+            with open(filepath, "rb") as target_file:
+                targetinfo.verify_length_and_hashes(target_file)
+            return filepath
+        except (OSError, exceptions.LengthOrHashMismatchError):
+            return None
 
     def download_target(
         self,
         targetinfo: TargetFile,
-        destination_directory: str,
+        filepath: Optional[str] = None,
         target_base_url: Optional[str] = None,
     ) -> str:
-        """Downloads the target file specified by 'targetinfo'.
+        """Downloads the target file specified by ``targetinfo``.
+
+        If the ``target_dir`` argument was given to constructor, ``filepath``
+        argument is not required here: in this case a filename will be
+        generated based on the target path.
 
         Args:
-            targetinfo: TargetFile instance received from
-                get_one_valid_targetinfo() or updated_targets().
-            destination_directory: existing local directory to download into.
-                Note that new directories may be created inside
-                destination_directory as required.
-            target_base_url: Optional; Base URL used to form the final target
+            targetinfo: TargetFile with target information from
+                get_one_valid_targetinfo().
+            filepath: Local path to download into. By default the file is
+                downloaded into ``target_dir`` (see note above) with a
+                generated filename. If file already exists, it is overwritten.
+            target_base_url: Base URL used to form the final target
                 download URL. Default is the value provided in Updater()
 
         Raises:
@@ -236,6 +249,15 @@ class Updater:
         Returns:
             Path to downloaded file
         """
+
+        if filepath is not None:
+            pass
+        elif self.target_dir is not None:
+            # Use URL encoded target path as name
+            filename = parse.quote(targetinfo.path, "")
+            filepath = os.path.join(self.target_dir, filename)
+        else:
+            raise ValueError("Either filepath or target_dir must be set")
 
         if target_base_url is None:
             if self._target_base_url is None:
@@ -266,12 +288,10 @@ class Updater:
                     f"{target_filepath} length or hashes do not match"
                 ) from e
 
-            # Use a URL encoded targetpath as the local filename
-            filename = parse.quote(targetinfo.path, "")
-            local_filepath = os.path.join(destination_directory, filename)
-            sslib_util.persist_temp_file(target_file, local_filepath)
+            sslib_util.persist_temp_file(target_file, filepath)
 
-            return local_filepath
+        logger.info("Downloaded target %s", targetinfo.path)
+        return filepath
 
     def _download_metadata(
         self, rolename: str, length: int, version: Optional[int] = None

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -21,7 +21,7 @@ High-level description of Updater functionality:
     snapshot is consistent so multiple targets can be downloaded without
     fear of repository content changing. For each target:
 
-      * :func:`~tuf.ngclient.updater.Updater.get_one_valid_targetinfo()` is
+      * :func:`~tuf.ngclient.updater.Updater.get_targetinfo()` is
         used to find information about a specific target. This will load new
         targets metadata as needed (from local cache or remote repository).
       * :func:`~tuf.ngclient.updater.Updater.find_cached_target()` can be used
@@ -56,7 +56,7 @@ Example::
     updater.refresh()
 
     # Update metadata, then download target if needed
-    info = updater.get_one_valid_targetinfo("file.txt")
+    info = updater.get_targetinfo("file.txt")
     path = updater.find_cached_target(info)
     if path is None:
         path = updater.download_target(info)
@@ -131,7 +131,7 @@ class Updater:
         all the checks required in the TUF client workflow.
 
         The metadata for delegated roles are not refreshed by this method as
-        that happens on demand during get_one_valid_targetinfo().
+        that happens on demand during get_targetinfo().
 
         The refresh() method should be called by the client before any other
         method calls.
@@ -147,19 +147,16 @@ class Updater:
         self._load_snapshot()
         self._load_targets("targets", "root")
 
-    def get_one_valid_targetinfo(
-        self, target_path: str
-    ) -> Optional[TargetFile]:
+    def get_targetinfo(self, target_path: str) -> Optional[TargetFile]:
         """Returns TargetFile instance with information for 'target_path'.
 
         The return value can be used as an argument to
         :func:`download_target()` and :func:`find_cached_target()`.
-
         :func:`refresh()` must be called before calling
-        `get_one_valid_targetinfo()`. Subsequent calls to
-        `get_one_valid_targetinfo()` will use the same consistent repository
+        `get_targetinfo()`. Subsequent calls to
+        `get_targetinfo()` will use the same consistent repository
         state: Changes that happen in the repository between calling
-        :func:`refresh()` and `get_one_valid_targetinfo()` will not be
+        :func:`refresh()` and `get_targetinfo()` will not be
         seen by the updater.
 
         As a side-effect this method downloads all the additional (delegated
@@ -193,7 +190,7 @@ class Updater:
         generated based on the target path like in ``download_target()``
 
         Args:
-            targetinfo: TargetFile from ``get_one_valid_targetinfo()``.
+            targetinfo: TargetFile from ``get_targetinfo()``.
             filepath: Local path to file. By default a filename is generated
                 and file is looked for in ``target_dir`` (see note above).
 
@@ -201,8 +198,8 @@ class Updater:
             ValueError: Incorrect arguments
 
         Returns:
-            Local file path if the file is an up to date target file, or None
-            if file is not found or it is not up to date.
+            Local file path if the file is an up to date target file.
+            None if file is not found or it is not up to date.
         """
         if filepath is not None:
             pass
@@ -233,8 +230,7 @@ class Updater:
         generated based on the target path.
 
         Args:
-            targetinfo: TargetFile with target information from
-                get_one_valid_targetinfo().
+            targetinfo: TargetFile from ``get_targetinfo()``.
             filepath: Local path to download into. By default the file is
                 downloaded into ``target_dir`` (see note above) with a
                 generated filename. If file already exists, it is overwritten.
@@ -247,7 +243,7 @@ class Updater:
             TODO: file write errors
 
         Returns:
-            Path to downloaded file
+            Local path to downloaded file
         """
 
         if filepath is not None:


### PR DESCRIPTION
NOTE: This PR including the description has been updated based on initial comments: this means the first comments look a bit strange now...

---
This is part 2 of #1580 (ngclient API tweaks): originally I thought we could just replicate old client API but the more I've used it, the more I've wanted to change it. So here's my proposal.

The PR contains a couple of semi-related changes:
* shorten `get_one_valid_targetinfo()` to `get_targetinfo()`
* Replace the unintuitive `updated_targets()` with `find_cached_target()` which operates almost exactly like `download_target()` but looks at local disk only. 
* Add a `target_dir` constructor argument that both `find_cached_target()` and `download_target()` can use: this lets Updater choose the file name. Both methods also take an optional filepath so clients can control the filename & path.

So the two ways of using the API are:

1. with direct local filepaths (when client knows the local filepath it wants to use)
```python
updater = Updater(...)
info = updater.get_targetinfo("my/target")
if not updater.find_cached_target(info, path)
    updater.download_target(info, path)
```

2. with cache directory (Updater decides filename)
```python
updater = Updater(..., target_dir="cache/dir/")
info = updater.get_targetinfo("my/target")
path = updater.find_cached_target(info)
if path is None:
    path = updater.download_target(info)
# path == "cache/dir/my%2Ftarget"
```

Based on how much better the test code now looks, I think we're approaching the correct design here...

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


