### PR TITLE
Introduce the idea of trusted/untrusted snapshot

### DIFF
--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -124,7 +124,8 @@ class RepositorySimulator(FetcherInterface):
     def targets(self) -> Targets:
         return self.md_targets.signed
 
-    def delegates(self) -> Iterator[Tuple[str, Targets]]:
+    def all_targets(self) -> Iterator[Tuple[str, Targets]]:
+        yield "targets", self.md_targets.signed
         for role, md in self.md_delegates.items():
             yield role, md.signed
 
@@ -266,8 +267,7 @@ class RepositorySimulator(FetcherInterface):
         self.timestamp.version += 1
 
     def update_snapshot(self):
-        self.snapshot.meta["targets.json"].version = self.targets.version
-        for role, delegate in self.delegates():
+        for role, delegate in self.all_targets():
             self.snapshot.meta[f"{role}.json"].version = delegate.version
 
             if self.compute_metafile_hashes_length:

--- a/tests/test_updater_with_simulator.py
+++ b/tests/test_updater_with_simulator.py
@@ -169,6 +169,14 @@ class TestUpdater(unittest.TestCase):
         # when the local snapshot is loaded even when there is a hash mismatch
         # with timestamp.snapshot_meta.
 
+        # By raising this flag on timestamp update the simulator would:
+        # 1) compute the hash of the new modified version of snapshot
+        # 2) assign the hash to timestamp.snapshot_meta
+        # The purpose is to create a hash mismatch between timestamp.meta and
+        # the local snapshot, but to have hash match between timestamp.meta and
+        # the next snapshot version.
+        self.sim.compute_metafile_hashes_length = True
+
         # Initialize all metadata and assign targets version higher than 1.
         self.sim.targets.version = 2
         self.sim.update_snapshot()
@@ -177,16 +185,6 @@ class TestUpdater(unittest.TestCase):
         # The new targets should have a lower version than the local trusted one.
         self.sim.targets.version = 1
         self.sim.update_snapshot()
-
-        # Calculate the hash of the new modified version of snapshot.
-        # The purpose is to create a hash mismatch between timestamp.meta and
-        # the local snapshot, but to have hash match between timestamp.meta and
-        # the next snapshot version.
-        digest_object = sslib_hash.digest("sha256")
-        digest_object.update(self.sim._fetch_metadata("snapshot"))
-        new_snapshot_hash = digest_object.hexdigest()
-        self.sim.timestamp.snapshot_meta.hashes = {"sha256": new_snapshot_hash}
-        self.sim.update_timestamp()
 
         # During the snapshot update, the local snapshot will be loaded even if
         # there is a hash mismatch with timestamp.snapshot_meta, because it will

--- a/tests/test_updater_with_simulator.py
+++ b/tests/test_updater_with_simulator.py
@@ -6,18 +6,18 @@
 """Test ngclient Updater using the repository simulator
 """
 
-import logging
 import os
 import sys
 import tempfile
 from typing import Optional, Tuple
-from tuf.exceptions import UnsignedMetadataError
+from tuf.exceptions import UnsignedMetadataError, BadVersionNumberError
 import unittest
 
 from tuf.ngclient import Updater
 
 from tests import utils
 from tests.repository_simulator import RepositorySimulator
+from securesystemslib import hash as sslib_hash
 
 
 class TestUpdater(unittest.TestCase):
@@ -163,6 +163,39 @@ class TestUpdater(unittest.TestCase):
         self.sim.update_snapshot()
 
         self._run_refresh()
+
+    def test_snapshot_rollback_with_local_snapshot_hash_mismatch(self):
+        # Test triggering snapshot rollback check on a newly downloaded snapshot
+        # when the local snapshot is loaded even when there is a hash mismatch
+        # with timestamp.snapshot_meta.
+
+        # Initialize all metadata and assign targets version higher than 1.
+        self.sim.targets.version = 2
+        self.sim.update_snapshot()
+        self._run_refresh()
+
+        # The new targets should have a lower version than the local trusted one.
+        self.sim.targets.version = 1
+        self.sim.update_snapshot()
+
+        # Calculate the hash of the new modified version of snapshot.
+        # The purpose is to create a hash mismatch between timestamp.meta and
+        # the local snapshot, but to have hash match between timestamp.meta and
+        # the next snapshot version.
+        digest_object = sslib_hash.digest("sha256")
+        digest_object.update(self.sim._fetch_metadata("snapshot"))
+        new_snapshot_hash = digest_object.hexdigest()
+        self.sim.timestamp.snapshot_meta.hashes = {"sha256": new_snapshot_hash}
+        self.sim.update_timestamp()
+
+        # During the snapshot update, the local snapshot will be loaded even if
+        # there is a hash mismatch with timestamp.snapshot_meta, because it will
+        # be considered as trusted.
+        # Should fail as a new version of snapshot will be fetched which lowers
+        # the snapshot.meta["targets.json"] version by 1 and throws an error.
+        with self.assertRaises(BadVersionNumberError):
+            self._run_refresh()
+
 
 if __name__ == "__main__":
     if "--dump" in sys.argv:

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -346,7 +346,7 @@ class Updater:
         """Load local (and if needed remote) snapshot metadata"""
         try:
             data = self._load_local_metadata("snapshot")
-            self._trusted_set.update_snapshot(data)
+            self._trusted_set.update_snapshot(data, trusted=True)
             logger.debug("Local snapshot is valid: not downloading new one")
         except (OSError, exceptions.RepositoryError) as e:
             # Local snapshot does not exist or is invalid: update from remote


### PR DESCRIPTION
Fixes #1523 

**Description of the changes being introduced by the pull request**:

If you do the following steps with a repository that contains hashes in meta dicts:
1. call Updater.refresh() and load, verify and cache all metadata files
2. modify timestamp snapshot meta information:
(One or more of hashes or length for snapshot changes here)
3. call Updater.refresh() again
4. root and timestamp will be updated to their latest versions
5. local snapshot will be loaded, but hashes/length will be different
then the ones in timestamp.snapshot_meta and that will prevent loading
6. remote snapshot is loaded and verification starts

then when executing step 6 the rollback checks will not be done because
the old snapshot was not loaded on step 5.

In order to resolve this issue, we are introducing the idea of trusted and
untrusted snapshot.
Trusted snapshot is the locally available cached version. This version has
been verified at least once meaning hashes and length were already checked
against timestamp.snapshot_meta hashes and length.
That's why we can allow loading a trusted snapshot version even if there is a
mismatch between the current timestamp.snapshot_meta hashes/length and
hashes/length inside the trusted snapshot.
Untrusted snapshot is the one downloaded from the web. It hasn't been verified
before and that's why we mandate that timestamp.snapshot_meta hashes and length
should match the hashes and legth calculated on this untrusted version of
snapshot.

As the TrustedMetadataSet doesn't have information on which snapshot is trusted or
not, so possibly the best solution is to add a new argument "trusted"
to update_snapshot.
Even though this is ugly as the rest of the update functions doesn't
have such an argument, it seems the best solution as it seems to work
in all cases:
- when loading a local snapshot, we know the data has at some point been
trusted (signatures have been checked): it doesn't need to match hashes
now
- if there is no local snapshot and we're updating from remote, the
remote data must match meta hashes in timestamp
- if there is a local snapshot and we're updating from remote, the remote
data must match meta hashes in timestamp

Lastly, I want to point out that  hash checks for metadata files are not
essential to TUF security guarantees: they are just an additional layer of
security that allows us to avoid even parsing json that could be malicious -
we already know the malicious metadata would be stopped at metadata
verification after the parsing.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


