### PR TITLE
Reuse computation of hashes and length

### DIFF
--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -50,13 +50,13 @@ from datetime import datetime, timedelta
 import logging
 import os
 import tempfile
-import securesystemslib.hash as sslib_hash
 from securesystemslib.keys import generate_ed25519_key
 from securesystemslib.signer import SSlibSigner
 from typing import Dict, Iterator, List, Optional, Tuple
 from urllib import parse
 
 from tuf.api.serialization.json import JSONSerializer
+from tuf.api.metadata import _compute_hashes
 from tuf.exceptions import FetcherHTTPError
 from tuf.api.metadata import (
     Key,
@@ -251,10 +251,7 @@ class RepositorySimulator(FetcherInterface):
         self, role: str
     ) -> Tuple[Dict[str, str], int]:
         data = self._fetch_metadata(role)
-        digest_object = sslib_hash.digest(sslib_hash.DEFAULT_HASH_ALGORITHM)
-        digest_object.update(data)
-        hashes = {sslib_hash.DEFAULT_HASH_ALGORITHM:  digest_object.hexdigest()}
-        return hashes, len(data)
+        return _compute_hashes(data), len(data)
 
     def update_timestamp(self):
         self.timestamp.snapshot_meta.version = self.snapshot.version

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -705,7 +705,6 @@ class TestMetadata(unittest.TestCase):
             TargetFile.from_file, 
             file_path, 
             file_path,
-            [sslib_hash.DEFAULT_HASH_ALGORITHM]
         )
 
         # Test with an unsupported algorithm


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:
I experimented moving the computation of hashes and length into two separate functions,
so it can be reused instead of copying the same code at a couple of
different places.

Do you think that's better or should we leave it the way it was?

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


