### PR TITLE
Add python3.10 and fix test failures on python3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       # Run regular TUF tests on each OS/Python combination, plus special tests
       # (sslib master) and linters on Linux/Python3.x only.
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         toxenv: [py]
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       # Run regular TUF tests on each OS/Python combination, plus special tests
       # (sslib master) and linters on Linux/Python3.x only.
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
         os: [ubuntu-latest, macos-latest, windows-latest]
         toxenv: [py]
         include:

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: Implementation :: CPython',
     'Topic :: Security',
     'Topic :: Software Development'

--- a/tests/simple_https_server.py
+++ b/tests/simple_https_server.py
@@ -22,8 +22,8 @@
   to verify that https downloads are permitted.
 
 <Reference>
-  ssl.wrap_socket:
-    https://docs.python.org/2/library/ssl.html#functions-constants-and-exceptions
+  ssl.SSLContext.wrap_socket:
+    https://docs.python.org/3/library/ssl.html#ssl.SSLContext.wrap_socket
 
   SimpleHTTPServer:
     http://docs.python.org/library/simplehttpserver.html#module-SimpleHTTPServer
@@ -44,8 +44,9 @@ if len(sys.argv) > 1 and os.path.exists(sys.argv[1]):
 httpd = http.server.HTTPServer(('localhost', 0),
    http.server.SimpleHTTPRequestHandler)
 
-httpd.socket = ssl.wrap_socket(
-    httpd.socket, keyfile=keyfile, certfile=certfile, server_side=True)
+context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+context.load_cert_chain(certfile, keyfile)
+httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
 
 port_message = 'bind succeeded, server port is: ' \
     + str(httpd.server_address[1])

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = lint,py{36,37,38,39}
+envlist = lint,py{36,37,38,39,310}
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
Fixes #1614

**Description of the changes being introduced by the pull request**:

Python 3.10 is released on October 4-th 2021 and it seems
logical to add support for it as it doesn't require any major effort
from the project.

For reference read:
https://www.python.org/downloads/release/python-3100/

I tried adding support for Python3.10 in https://github.com/theupdateframework/python-tuf/pull/1610.
Then, we had CI errors due to test failures: https://github.com/theupdateframework/python-tuf/pull/1610/checks?check_run_id=3861875325
The problem comes from the fact that we start a subprocess
executing simple_https_server.py, but then we fail to communicate the
message we expect from the server process to the main process actually
running the test. We expect our custom message to be the first line
printed from the server process, but instead, a deprecation warning is
printed first about the usage of ssl.wrap_socket(). Our custom message
is printed second.
As of Python 3.7 this function has been deprecated:
https://docs.python.org/3/library/ssl.html#ssl.wrap_socket and for
whatever the reason we didn't get a warning when using it before.

My fix does what is suggested in the warning and replaces the usage of
ssl.wrap_socket() by instantiating a ssl.SSLContext object and then
calling SSLContext.wrap_socket().
This removes the warning.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


