### PR TITLE
Metadata API: validate root role names

### DIFF
--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -152,10 +152,12 @@ class RepositorySimulator(FetcherInterface):
         timestamp = Timestamp(1, SPEC_VER, self.safe_expiry, snapshot_meta)
         self.md_timestamp = Metadata(timestamp, OrderedDict())
 
-        root = Root(1, SPEC_VER, self.safe_expiry, {}, {}, True)
-        for role in ["root", "timestamp", "snapshot", "targets"]:
+        top_level_md = ["root", "timestamp", "snapshot", "targets"]
+        roles = {role_name: Role([], 1) for role_name in top_level_md}
+        root = Root(1, SPEC_VER, self.safe_expiry, {}, roles, True)
+
+        for role in top_level_md:
             key, signer = self.create_key()
-            root.roles[role] = Role([], 1)
             root.add_key(role, key)
             # store the private key
             if role not in self.signers:

--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -56,6 +56,7 @@ from securesystemslib.signer import SSlibSigner
 from typing import Dict, Iterator, List, Optional, Tuple
 from urllib import parse
 
+from tuf.api.metadata import TOP_LEVEL_ROLE_NAMES
 from tuf.api.serialization.json import JSONSerializer
 from tuf.exceptions import FetcherHTTPError
 from tuf.api.metadata import (
@@ -152,11 +153,10 @@ class RepositorySimulator(FetcherInterface):
         timestamp = Timestamp(1, SPEC_VER, self.safe_expiry, snapshot_meta)
         self.md_timestamp = Metadata(timestamp, OrderedDict())
 
-        top_level_md = ["root", "timestamp", "snapshot", "targets"]
-        roles = {role_name: Role([], 1) for role_name in top_level_md}
+        roles = {role_name: Role([], 1) for role_name in TOP_LEVEL_ROLE_NAMES}
         root = Root(1, SPEC_VER, self.safe_expiry, {}, roles, True)
 
-        for role in top_level_md:
+        for role in TOP_LEVEL_ROLE_NAMES:
             key, signer = self.create_key()
             root.add_key(role, key)
             # store the private key

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -68,6 +68,7 @@ logger = logging.getLogger(__name__)
 # We aim to support SPECIFICATION_VERSION and require the input metadata
 # files to have the same major version (the first number) as ours.
 SPECIFICATION_VERSION = ["1", "0", "19"]
+TOP_LEVEL_ROLE_NAMES = {"root", "timestamp", "snapshot", "targets"}
 
 # T is a Generic type constraint for Metadata.signed
 T = TypeVar("T", "Root", "Timestamp", "Snapshot", "Targets")

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -729,8 +729,7 @@ class Root(Signed):
         super().__init__(version, spec_version, expires, unrecognized_fields)
         self.consistent_snapshot = consistent_snapshot
         self.keys = keys
-        mandatory_roles = ["root", "timestamp", "snapshot", "targets"]
-        if not (len(roles) == 4 and all(r in roles for r in mandatory_roles)):
+        if set(roles) != TOP_LEVEL_ROLE_NAMES:
             raise ValueError("Role names must be the top-level metadata roles")
 
         self.roles = roles

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -729,6 +729,10 @@ class Root(Signed):
         super().__init__(version, spec_version, expires, unrecognized_fields)
         self.consistent_snapshot = consistent_snapshot
         self.keys = keys
+        mandatory_roles = ["root", "timestamp", "snapshot", "targets"]
+        if not (len(roles) == 4 and all(r in roles for r in mandatory_roles)):
+            raise ValueError("Role names must be the top-level metadata roles")
+
         self.roles = roles
 
     @classmethod


### PR DESCRIPTION
Fixes #1516

**Description of the changes being introduced by the pull request**:

Validate that root role names are 4 and that they are exactly
"root", "snapshot", "targets" and "timestamp" as described in
the spec:
https://theupdateframework.github.io/specification/latest/#root-role

Additionally, fix the valid_roots dataset, so each of the cases contains
the top metadata role names inside the roles dictionary.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


