### PR TITLE
Test metadata files: bump expiration date and resign

### DIFF
--- a/tests/repository_data/fishy_rolenames/1.a.json
+++ b/tests/repository_data/fishy_rolenames/1.a.json
@@ -1,13 +1,13 @@
 {
  "signatures": [
   {
-   "keyid": "056a036ef6f15c1dbff1f3d61dfadfc9e92699f6b66a2e21513698b576cc498d",
-   "sig": "6550a087bd0f01648f57e02a275f20c8e38974271d73739c446f53a028c4118e070b1d37224bc022ab6e0500c8051494f276365868ed6039ec49c7ecd8b9f602"
+   "keyid": "f9b50dd62b5540788b5c5cde0842124b64fa467261bc349dd77de49568eed0ef",
+   "sig": "a36aa69e0c35d8b5b9578bc656ce5d8a76ea05a2c814f59cc710a11f5e3fe6c7bcbef2bfba4812e3b2936f99e89f10862f6320c901e213f1343e79525474920a"
   }
  ],
  "signed": {
   "_type": "targets",
-  "expires": "2021-10-22T11:21:56Z",
+  "expires": "2050-10-22T11:21:56Z",
   "spec_version": "1.0.19",
   "targets": {},
   "version": 1

--- a/tests/repository_data/fishy_rolenames/metadata/1...json
+++ b/tests/repository_data/fishy_rolenames/metadata/1...json
@@ -1,13 +1,13 @@
 {
  "signatures": [
   {
-   "keyid": "c4f5b1013293e01cedb1680fc3aa670278fd46277c62d0bfa24ffff5f0ad0602",
-   "sig": "c0266de0724c2ab9c14e679b258033fe3aff8ce3c99419479456170975bb43de9e8539caed437cccc8e6c6068252a921f7badc5384149dab18261a7f157ae406"
+   "keyid": "80a5bda93ec130c2fda8ce0c619d7b122b24cc2e0743afedf98a8e368d32019c",
+   "sig": "8fff438c2347dd7c4fb94c43ec347bcd6b0e79521bd11d95121cb8cc25723efa38565a959a6123da0a2375a2093e53f13a5412df9e51397e06b313837d0d590c"
   }
  ],
  "signed": {
   "_type": "targets",
-  "expires": "2021-10-22T11:21:56Z",
+  "expires": "2050-10-22T11:21:56Z",
   "spec_version": "1.0.19",
   "targets": {},
   "version": 1

--- a/tests/repository_data/fishy_rolenames/metadata/1.root.json
+++ b/tests/repository_data/fishy_rolenames/metadata/1.root.json
@@ -1,40 +1,40 @@
 {
  "signatures": [
   {
-   "keyid": "b24fc41c37a5e3c7b504516351633494e462137338182d8f701dc889acbd2eb6",
-   "sig": "1d3b9cebfdab388db500d01cb2cd499f016320029df17bf2f1196d8f83f12d041832dc165f23667e537d8a8aa66c716d19835bd2bcd55d4c18bbbd0c6eaf4b06"
+   "keyid": "72b70899257dc30b596af3a9fe141a924af821aff28ed58d1aea0db9f70a70f7",
+   "sig": "53ae844137dd04abf9d3ed10380ba46fa2726f328963ffe006aa955804afa3b0d100bc59610c1584234a9598ab4b9af762b533174b8b8d8aaf2be8e413c1b304"
   }
  ],
  "signed": {
   "_type": "root",
   "consistent_snapshot": true,
-  "expires": "2021-10-22T11:21:56Z",
+  "expires": "2050-10-22T11:21:56Z",
   "keys": {
-   "965e45aad2af966bafe3719a99152fa34576a07b61742e6501c0b235fd3b8f9c": {
+   "59a4df8af818e9ed7abe0764c0b47b4240952aa0d179b5b78346c470ac30278d": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "d98dace51d795525971342b9f7317cea0d743710dca932543fedb92bb083c2c0"
+     "public": "edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd"
     },
     "scheme": "ed25519"
    },
-   "b24fc41c37a5e3c7b504516351633494e462137338182d8f701dc889acbd2eb6": {
+   "65171251a9aff5a8b3143a813481cb07f6e0de4eb197c767837fe4491b739093": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "46d386175220afd55ad9b09b6b18fa96cd69e25bc29c97ed7024a522e7e7938c"
+     "public": "89f28bd4ede5ec3786ab923fd154f39588d20881903e69c7b08fb504c6750815"
     },
     "scheme": "ed25519"
    },
-   "c808865e701882b89c075941ca158034d8c47bde97f1dcdb2afd854334a3ffef": {
+   "72b70899257dc30b596af3a9fe141a924af821aff28ed58d1aea0db9f70a70f7": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "a7beb72fb686a645f5ffd52e246a55d2914411853c70a5b47d837ed7b4c40734"
+     "public": "3ba219e69666298bce5d1d653a166346aef807c02e32a846aaefcb5190fddeb4"
     },
     "scheme": "ed25519"
    },
-   "e1f4f87b77838c39ec348fc6e74a10e28272fb6bf3f45bff09cd694148150095": {
+   "8a1c4a3ac2d515dec982ba9910c5fd79b91ae57f625b9cff25d06bf0a61c1758": {
     "keytype": "ed25519",
     "keyval": {
-     "public": "efdf10805063c1b7356f40ede43d2c5c6d2d11d79e350887ce96fe5d1e44901a"
+     "public": "82ccf6ac47298ff43bfa0cd639868894e305a99c723ff0515ae2e9856eb5bbf4"
     },
     "scheme": "ed25519"
    }
@@ -42,25 +42,25 @@
   "roles": {
    "root": {
     "keyids": [
-     "b24fc41c37a5e3c7b504516351633494e462137338182d8f701dc889acbd2eb6"
+     "72b70899257dc30b596af3a9fe141a924af821aff28ed58d1aea0db9f70a70f7"
     ],
     "threshold": 1
    },
    "snapshot": {
     "keyids": [
-     "e1f4f87b77838c39ec348fc6e74a10e28272fb6bf3f45bff09cd694148150095"
+     "59a4df8af818e9ed7abe0764c0b47b4240952aa0d179b5b78346c470ac30278d"
     ],
     "threshold": 1
    },
    "targets": {
     "keyids": [
-     "c808865e701882b89c075941ca158034d8c47bde97f1dcdb2afd854334a3ffef"
+     "65171251a9aff5a8b3143a813481cb07f6e0de4eb197c767837fe4491b739093"
     ],
     "threshold": 1
    },
    "timestamp": {
     "keyids": [
-     "965e45aad2af966bafe3719a99152fa34576a07b61742e6501c0b235fd3b8f9c"
+     "8a1c4a3ac2d515dec982ba9910c5fd79b91ae57f625b9cff25d06bf0a61c1758"
     ],
     "threshold": 1
    }

--- a/tests/repository_data/fishy_rolenames/metadata/1.targets.json
+++ b/tests/repository_data/fishy_rolenames/metadata/1.targets.json
@@ -1,32 +1,32 @@
 {
  "signatures": [
   {
-   "keyid": "c808865e701882b89c075941ca158034d8c47bde97f1dcdb2afd854334a3ffef",
-   "sig": "ffa055ab5108f9d22f309fecd0160b02971d7a454c8d48db4f99cdaf114b329a401b756a11e42630bff6667ad897fb05f501e3299d25fe786d12651cb0db6c06"
+   "keyid": "65171251a9aff5a8b3143a813481cb07f6e0de4eb197c767837fe4491b739093",
+   "sig": "b390c5d9d5355b963e94dfa30ce04520c462fd869fad968d01f0a3b185db5895807b14435e725ff376adc793fd21ef8f01890ac722c94e9c05ab3797c4887101"
   }
  ],
  "signed": {
   "_type": "targets",
   "delegations": {
    "keys": {
-    "056a036ef6f15c1dbff1f3d61dfadfc9e92699f6b66a2e21513698b576cc498d": {
+    "426edf0d9fa383688c5b40b7b7d15a7cd11a991f12cc20da87f1b48dd6c036a1": {
      "keytype": "ed25519",
      "keyval": {
-      "public": "45d4d9ee28ef61506695130fe600d637e5f2de0de72473c280b02b89467d7aab"
+      "public": "d38eef769f6dee77b6d898dce548c0ea0f90add0072dc28a20769b6421552ec3"
      },
      "scheme": "ed25519"
     },
-    "c4f5b1013293e01cedb1680fc3aa670278fd46277c62d0bfa24ffff5f0ad0602": {
+    "80a5bda93ec130c2fda8ce0c619d7b122b24cc2e0743afedf98a8e368d32019c": {
      "keytype": "ed25519",
      "keyval": {
-      "public": "abe021d7594f04467627c2be390c665b311dceb83cceb685edc9b90a6e229d08"
+      "public": "bb256c0b6d5226a5a9ae8377c0bf68e958fb668d063971f48638b9bae5251f3b"
      },
      "scheme": "ed25519"
     },
-    "e38fb1b3a2dea12551541bbb205f09609d9386e147207182c8b900bc0a25e2b8": {
+    "f9b50dd62b5540788b5c5cde0842124b64fa467261bc349dd77de49568eed0ef": {
      "keytype": "ed25519",
      "keyval": {
-      "public": "52b790190bccf730fad4b769e7073c1551938101483ff8612534eb9105426dce"
+      "public": "da1b8586dc0cdd5fe0d8d428bde62dc63e06138f58cfc39770c424a4636f59f4"
      },
      "scheme": "ed25519"
     }
@@ -34,7 +34,7 @@
    "roles": [
     {
      "keyids": [
-      "056a036ef6f15c1dbff1f3d61dfadfc9e92699f6b66a2e21513698b576cc498d"
+      "f9b50dd62b5540788b5c5cde0842124b64fa467261bc349dd77de49568eed0ef"
      ],
      "name": "../a",
      "paths": [
@@ -45,7 +45,7 @@
     },
     {
      "keyids": [
-      "c4f5b1013293e01cedb1680fc3aa670278fd46277c62d0bfa24ffff5f0ad0602"
+      "80a5bda93ec130c2fda8ce0c619d7b122b24cc2e0743afedf98a8e368d32019c"
      ],
      "name": ".",
      "paths": [
@@ -56,7 +56,7 @@
     },
     {
      "keyids": [
-      "e38fb1b3a2dea12551541bbb205f09609d9386e147207182c8b900bc0a25e2b8"
+      "426edf0d9fa383688c5b40b7b7d15a7cd11a991f12cc20da87f1b48dd6c036a1"
      ],
      "name": "\u00f6",
      "paths": [
@@ -67,7 +67,7 @@
     }
    ]
   },
-  "expires": "2021-10-22T11:21:56Z",
+  "expires": "2050-10-22T11:21:56Z",
   "spec_version": "1.0.19",
   "targets": {},
   "version": 1

--- a/tests/repository_data/fishy_rolenames/metadata/1.ö.json
+++ b/tests/repository_data/fishy_rolenames/metadata/1.ö.json
@@ -1,13 +1,13 @@
 {
  "signatures": [
   {
-   "keyid": "e38fb1b3a2dea12551541bbb205f09609d9386e147207182c8b900bc0a25e2b8",
-   "sig": "854fdccea623c33bf968c7ef5abea6e5e5f7c390a691ae0ae5ad87a7580fc00910b566d5dbdbfcaa948f2d8fe4348eecd5a12710d05f576aecf83fbec32c580b"
+   "keyid": "426edf0d9fa383688c5b40b7b7d15a7cd11a991f12cc20da87f1b48dd6c036a1",
+   "sig": "faada7f8c9a238955d5b27dbd88032a6c9068742cb114a66f97c730235a8033dd1ff0647f4bbc2b49210c33655a3d7755e754e245799683b3f4e00a59f3da006"
   }
  ],
  "signed": {
   "_type": "targets",
-  "expires": "2021-10-22T11:21:56Z",
+  "expires": "2050-10-22T11:21:56Z",
   "spec_version": "1.0.19",
   "targets": {},
   "version": 1

--- a/tests/repository_data/fishy_rolenames/metadata/2.snapshot.json
+++ b/tests/repository_data/fishy_rolenames/metadata/2.snapshot.json
@@ -1,13 +1,13 @@
 {
  "signatures": [
   {
-   "keyid": "e1f4f87b77838c39ec348fc6e74a10e28272fb6bf3f45bff09cd694148150095",
-   "sig": "f00f4b0040dc6879e7ad69867ba611d52bd5e9993cbfd27e6d8073449356c716b4277093c67ae70eba90ab0367a070e69be750284e70e1135615832efda54008"
+   "keyid": "59a4df8af818e9ed7abe0764c0b47b4240952aa0d179b5b78346c470ac30278d",
+   "sig": "5b00100e9cf1c083f8347371ab840cf60124780305124ed7a53fe31bf43473c90b1d2c802ed2f11f5057ba21e6b7a05118b1907f737d2e29c9692aa3345f9801"
   }
  ],
  "signed": {
   "_type": "snapshot",
-  "expires": "2021-10-22T11:21:56Z",
+  "expires": "2050-10-22T11:21:56Z",
   "meta": {
    "../a.json": {
     "version": 1

--- a/tests/repository_data/fishy_rolenames/metadata/timestamp.json
+++ b/tests/repository_data/fishy_rolenames/metadata/timestamp.json
@@ -1,13 +1,13 @@
 {
  "signatures": [
   {
-   "keyid": "965e45aad2af966bafe3719a99152fa34576a07b61742e6501c0b235fd3b8f9c",
-   "sig": "5a0040f56454f2f338acb8a81b4c2e170e0bc61219a7cd823f635dfc9faeefcf30dfe9c792f148a25949cc9594f8ac1bfffe436b737eff140d236eba57fe9e08"
+   "keyid": "8a1c4a3ac2d515dec982ba9910c5fd79b91ae57f625b9cff25d06bf0a61c1758",
+   "sig": "f7003e848366c7e55f474df2c0c68471c44c68a87c0d3c1aa56f64778c91e9c8f22c3adc4dd9ec0535b6b4dc04783f7fa4ca992bed2445c7395a58acff152f0d"
   }
  ],
  "signed": {
   "_type": "timestamp",
-  "expires": "2021-10-22T11:21:56Z",
+  "expires": "2050-10-22T11:21:56Z",
   "meta": {
    "snapshot.json": {
     "version": 2


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Our newly added metadata files in the
tests/repository_data/fishy_rolenames/metadata directory have an expiry
date until "2021-10-22T11:21:56Z" and today while running the tests on
develop branch I recived this error:
`ExpiredMetadataError("Metadata X expired on Fri Oct 22 11:21:56 2021")`
when running the tests in tests/test_updater.py file and more precisly
the TestUpdaterRolenames.test_unusual_rolenames() test.

That's why I decided to bump the expiration date to a random time in
the future (October 22-nd 2050) and I had to resign all of the metadata
files.

Signed-off-by: Martin Vrachev **<mvrachev@vmware.com>**

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


