### PR TITLE
New implementation tests: apply black and isort automatic linting fixes

### DIFF
--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -44,22 +44,22 @@ Example::
     updater.refresh()
 """
 
-from collections import OrderedDict
-from dataclasses import dataclass
-from datetime import datetime, timedelta
 import logging
 import os
 import tempfile
-import securesystemslib.hash as sslib_hash
-from securesystemslib.keys import generate_ed25519_key
-from securesystemslib.signer import SSlibSigner
+from collections import OrderedDict
+from dataclasses import dataclass
+from datetime import datetime, timedelta
 from typing import Dict, Iterator, List, Optional, Tuple
 from urllib import parse
 
-from tuf.api.metadata import TOP_LEVEL_ROLE_NAMES
-from tuf.api.serialization.json import JSONSerializer
-from tuf.exceptions import FetcherHTTPError
+import securesystemslib.hash as sslib_hash
+from securesystemslib.keys import generate_ed25519_key
+from securesystemslib.signer import SSlibSigner
+
 from tuf.api.metadata import (
+    SPECIFICATION_VERSION,
+    TOP_LEVEL_ROLE_NAMES,
     DelegatedRole,
     Delegations,
     Key,
@@ -67,12 +67,13 @@ from tuf.api.metadata import (
     MetaFile,
     Role,
     Root,
-    SPECIFICATION_VERSION,
     Snapshot,
     TargetFile,
     Targets,
     Timestamp,
 )
+from tuf.api.serialization.json import JSONSerializer
+from tuf.exceptions import FetcherHTTPError, RepositoryError
 from tuf.ngclient.fetcher import FetcherInterface
 
 logger = logging.getLogger(__name__)

--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -79,11 +79,14 @@ logger = logging.getLogger(__name__)
 
 SPEC_VER = ".".join(SPECIFICATION_VERSION)
 
+
 @dataclass
 class RepositoryTarget:
     """Contains actual target data and the related target metadata"""
+
     data: bytes
     target_file: TargetFile
+
 
 class RepositorySimulator(FetcherInterface):
     def __init__(self):
@@ -141,7 +144,7 @@ class RepositorySimulator(FetcherInterface):
         sslib_key = generate_ed25519_key()
         return Key.from_securesystemslib_key(sslib_key), SSlibSigner(sslib_key)
 
-    def add_signer(self, role:str, signer: SSlibSigner):
+    def add_signer(self, role: str, signer: SSlibSigner):
         if role not in self.signers:
             self.signers[role] = {}
         self.signers[role][signer.key_dict["keyid"]] = signer
@@ -197,7 +200,7 @@ class RepositorySimulator(FetcherInterface):
         elif path.startswith("/targets/"):
             # figure out target path and hash prefix
             target_path = path[len("/targets/") :]
-            dir_parts, sep , prefixed_filename = target_path.rpartition("/")
+            dir_parts, sep, prefixed_filename = target_path.rpartition("/")
             prefix, _, filename = prefixed_filename.partition(".")
             target_path = f"{dir_parts}{sep}{filename}"
 
@@ -219,7 +222,9 @@ class RepositorySimulator(FetcherInterface):
         logger.debug("fetched target %s", target_path)
         return repo_target.data
 
-    def _fetch_metadata(self, role: str, version: Optional[int] = None) -> bytes:
+    def _fetch_metadata(
+        self, role: str, version: Optional[int] = None
+    ) -> bytes:
         """Return signed metadata for 'role', using 'version' if it is given.
 
         If version is None, non-versioned metadata is being requested
@@ -264,7 +269,7 @@ class RepositorySimulator(FetcherInterface):
         data = self._fetch_metadata(role)
         digest_object = sslib_hash.digest(sslib_hash.DEFAULT_HASH_ALGORITHM)
         digest_object.update(data)
-        hashes = {sslib_hash.DEFAULT_HASH_ALGORITHM:  digest_object.hexdigest()}
+        hashes = {sslib_hash.DEFAULT_HASH_ALGORITHM: digest_object.hexdigest()}
         return hashes, len(data)
 
     def update_timestamp(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -91,21 +91,17 @@ class TestMetadata(unittest.TestCase):
             # Load JSON-formatted metdata of each supported type from file
             # and from out-of-band read JSON string
             path = os.path.join(self.repo_dir, "metadata", metadata + ".json")
-            metadata_obj = Metadata.from_file(path)
+            md_obj = Metadata.from_file(path)
             with open(path, "rb") as f:
-                metadata_obj2 = Metadata.from_bytes(f.read())
+                md_obj2 = Metadata.from_bytes(f.read())
 
             # Assert that both methods instantiate the right inner class for
             # each metadata type and ...
-            self.assertTrue(isinstance(metadata_obj.signed, inner_metadata_cls))
-            self.assertTrue(
-                isinstance(metadata_obj2.signed, inner_metadata_cls)
-            )
+            self.assertTrue(isinstance(md_obj.signed, inner_metadata_cls))
+            self.assertTrue(isinstance(md_obj2.signed, inner_metadata_cls))
 
             # ... and return the same object (compared by dict representation)
-            self.assertDictEqual(
-                metadata_obj.to_dict(), metadata_obj2.to_dict()
-            )
+            self.assertDictEqual(md_obj.to_dict(), md_obj2.to_dict())
 
         # Assert that it chokes correctly on an unknown metadata type
         bad_metadata_path = "bad-metadata.json"
@@ -123,24 +119,21 @@ class TestMetadata(unittest.TestCase):
 
     def test_compact_json(self):
         path = os.path.join(self.repo_dir, "metadata", "targets.json")
-        metadata_obj = Metadata.from_file(path)
+        md_obj = Metadata.from_file(path)
         self.assertTrue(
-            len(JSONSerializer(compact=True).serialize(metadata_obj))
-            < len(JSONSerializer().serialize(metadata_obj))
+            len(JSONSerializer(compact=True).serialize(md_obj))
+            < len(JSONSerializer().serialize(md_obj))
         )
 
     def test_read_write_read_compare(self):
         for metadata in ["root", "snapshot", "timestamp", "targets"]:
             path = os.path.join(self.repo_dir, "metadata", metadata + ".json")
-            metadata_obj = Metadata.from_file(path)
+            md_obj = Metadata.from_file(path)
 
             path_2 = path + ".tmp"
-            metadata_obj.to_file(path_2)
-            metadata_obj_2 = Metadata.from_file(path_2)
-
-            self.assertDictEqual(
-                metadata_obj.to_dict(), metadata_obj_2.to_dict()
-            )
+            md_obj.to_file(path_2)
+            md_obj_2 = Metadata.from_file(path_2)
+            self.assertDictEqual(md_obj.to_dict(), md_obj_2.to_dict())
 
             os.remove(path_2)
 
@@ -149,17 +142,15 @@ class TestMetadata(unittest.TestCase):
             path = os.path.join(self.repo_dir, "metadata", metadata + ".json")
             with open(path, "rb") as f:
                 metadata_bytes = f.read()
-            metadata_obj = Metadata.from_bytes(metadata_bytes)
+            md_obj = Metadata.from_bytes(metadata_bytes)
             # Comparate that from_bytes/to_bytes doesn't change the content
             # for two cases for the serializer: noncompact and compact.
 
             # Case 1: test noncompact by overriding the default serializer.
-            self.assertEqual(
-                metadata_obj.to_bytes(JSONSerializer()), metadata_bytes
-            )
+            self.assertEqual(md_obj.to_bytes(JSONSerializer()), metadata_bytes)
 
             # Case 2: test compact by using the default serializer.
-            obj_bytes = metadata_obj.to_bytes()
+            obj_bytes = md_obj.to_bytes()
             metadata_obj_2 = Metadata.from_bytes(obj_bytes)
             self.assertEqual(metadata_obj_2.to_bytes(), obj_bytes)
 
@@ -177,66 +168,66 @@ class TestMetadata(unittest.TestCase):
 
         # Load sample metadata (targets) and assert ...
         path = os.path.join(self.repo_dir, "metadata", "targets.json")
-        metadata_obj = Metadata.from_file(path)
+        md_obj = Metadata.from_file(path)
 
         # ... it has a single existing signature,
-        self.assertEqual(len(metadata_obj.signatures), 1)
+        self.assertEqual(len(md_obj.signatures), 1)
         # ... which is valid for the correct key.
-        targets_key.verify_signature(metadata_obj)
+        targets_key.verify_signature(md_obj)
         with self.assertRaises(exceptions.UnsignedMetadataError):
-            snapshot_key.verify_signature(metadata_obj)
+            snapshot_key.verify_signature(md_obj)
 
         # Test verifying with explicitly set serializer
-        targets_key.verify_signature(metadata_obj, CanonicalJSONSerializer())
+        targets_key.verify_signature(md_obj, CanonicalJSONSerializer())
         with self.assertRaises(exceptions.UnsignedMetadataError):
-            targets_key.verify_signature(metadata_obj, JSONSerializer())
+            targets_key.verify_signature(md_obj, JSONSerializer())
 
         sslib_signer = SSlibSigner(self.keystore["snapshot"])
         # Append a new signature with the unrelated key and assert that ...
-        sig = metadata_obj.sign(sslib_signer, append=True)
+        sig = md_obj.sign(sslib_signer, append=True)
         # ... there are now two signatures, and
-        self.assertEqual(len(metadata_obj.signatures), 2)
+        self.assertEqual(len(md_obj.signatures), 2)
         # ... both are valid for the corresponding keys.
-        targets_key.verify_signature(metadata_obj)
-        snapshot_key.verify_signature(metadata_obj)
+        targets_key.verify_signature(md_obj)
+        snapshot_key.verify_signature(md_obj)
         # ... the returned (appended) signature is for snapshot key
         self.assertEqual(sig.keyid, snapshot_keyid)
 
         sslib_signer = SSlibSigner(self.keystore["timestamp"])
         # Create and assign (don't append) a new signature and assert that ...
-        metadata_obj.sign(sslib_signer, append=False)
+        md_obj.sign(sslib_signer, append=False)
         # ... there now is only one signature,
-        self.assertEqual(len(metadata_obj.signatures), 1)
+        self.assertEqual(len(md_obj.signatures), 1)
         # ... valid for that key.
-        timestamp_key.verify_signature(metadata_obj)
+        timestamp_key.verify_signature(md_obj)
         with self.assertRaises(exceptions.UnsignedMetadataError):
-            targets_key.verify_signature(metadata_obj)
+            targets_key.verify_signature(md_obj)
 
         # Test failure on unknown scheme (securesystemslib UnsupportedAlgorithmError)
         scheme = timestamp_key.scheme
         timestamp_key.scheme = "foo"
         with self.assertRaises(exceptions.UnsignedMetadataError):
-            timestamp_key.verify_signature(metadata_obj)
+            timestamp_key.verify_signature(md_obj)
         timestamp_key.scheme = scheme
 
         # Test failure on broken public key data (securesystemslib CryptoError)
         public = timestamp_key.keyval["public"]
         timestamp_key.keyval["public"] = "ffff"
         with self.assertRaises(exceptions.UnsignedMetadataError):
-            timestamp_key.verify_signature(metadata_obj)
+            timestamp_key.verify_signature(md_obj)
         timestamp_key.keyval["public"] = public
 
         # Test failure with invalid signature (securesystemslib FormatError)
-        sig = metadata_obj.signatures[timestamp_keyid]
+        sig = md_obj.signatures[timestamp_keyid]
         correct_sig = sig.signature
         sig.signature = "foo"
         with self.assertRaises(exceptions.UnsignedMetadataError):
-            timestamp_key.verify_signature(metadata_obj)
+            timestamp_key.verify_signature(md_obj)
 
         # Test failure with valid but incorrect signature
         sig.signature = "ff" * 64
         with self.assertRaises(exceptions.UnsignedMetadataError):
-            timestamp_key.verify_signature(metadata_obj)
+            timestamp_key.verify_signature(md_obj)
         sig.signature = correct_sig
 
     def test_metadata_base(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,44 +7,38 @@
 """
 
 import json
-import sys
 import logging
 import os
 import shutil
+import sys
 import tempfile
 import unittest
-
 from datetime import datetime, timedelta
+
 from dateutil.relativedelta import relativedelta
+from securesystemslib import hash as sslib_hash
+from securesystemslib.interface import (
+    import_ed25519_privatekey_from_file,
+    import_ed25519_publickey_from_file,
+)
+from securesystemslib.keys import generate_ed25519_key
+from securesystemslib.signer import Signature, SSlibSigner
 
 from tests import utils
-
 from tuf import exceptions
 from tuf.api.metadata import (
+    DelegatedRole,
+    Key,
     Metadata,
+    MetaFile,
     Root,
     Snapshot,
-    Timestamp,
-    Targets,
-    Key,
-    MetaFile,
     TargetFile,
-    DelegatedRole,
+    Targets,
+    Timestamp,
 )
-
 from tuf.api.serialization import DeserializationError
-
-from tuf.api.serialization.json import JSONSerializer, CanonicalJSONSerializer
-
-from securesystemslib.interface import (
-    import_ed25519_publickey_from_file,
-    import_ed25519_privatekey_from_file,
-)
-
-from securesystemslib import hash as sslib_hash
-from securesystemslib.signer import SSlibSigner, Signature
-
-from securesystemslib.keys import generate_ed25519_key
+from tuf.api.serialization.json import CanonicalJSONSerializer, JSONSerializer
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,35 +32,24 @@ from tuf.api.metadata import (
     DelegatedRole,
 )
 
-from tuf.api.serialization import (
-    DeserializationError
-)
+from tuf.api.serialization import DeserializationError
 
-from tuf.api.serialization.json import (
-    JSONSerializer,
-    CanonicalJSONSerializer
-)
+from tuf.api.serialization.json import JSONSerializer, CanonicalJSONSerializer
 
 from securesystemslib.interface import (
     import_ed25519_publickey_from_file,
-    import_ed25519_privatekey_from_file
+    import_ed25519_privatekey_from_file,
 )
 
 from securesystemslib import hash as sslib_hash
-from securesystemslib.signer import (
-    SSlibSigner,
-    Signature
-)
+from securesystemslib.signer import SSlibSigner, Signature
 
-from securesystemslib.keys import (
-    generate_ed25519_key
-)
+from securesystemslib.keys import generate_ed25519_key
 
 logger = logging.getLogger(__name__)
 
 
 class TestMetadata(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         # Create a temporary directory to store the repository, metadata, and
@@ -70,24 +59,26 @@ class TestMetadata(unittest.TestCase):
         cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
 
         test_repo_data = os.path.join(
-                os.path.dirname(os.path.realpath(__file__)), 'repository_data')
+            os.path.dirname(os.path.realpath(__file__)), "repository_data"
+        )
 
-        cls.repo_dir = os.path.join(cls.temporary_directory, 'repository')
+        cls.repo_dir = os.path.join(cls.temporary_directory, "repository")
         shutil.copytree(
-                os.path.join(test_repo_data, 'repository'), cls.repo_dir)
+            os.path.join(test_repo_data, "repository"), cls.repo_dir
+        )
 
-        cls.keystore_dir = os.path.join(cls.temporary_directory, 'keystore')
+        cls.keystore_dir = os.path.join(cls.temporary_directory, "keystore")
         shutil.copytree(
-                os.path.join(test_repo_data, 'keystore'), cls.keystore_dir)
+            os.path.join(test_repo_data, "keystore"), cls.keystore_dir
+        )
 
         # Load keys into memory
         cls.keystore = {}
-        for role in ['delegation', 'snapshot', 'targets', 'timestamp']:
+        for role in ["delegation", "snapshot", "targets", "timestamp"]:
             cls.keystore[role] = import_ed25519_privatekey_from_file(
-                os.path.join(cls.keystore_dir, role + '_key'),
-                password="password"
+                os.path.join(cls.keystore_dir, role + "_key"),
+                password="password",
             )
-
 
     @classmethod
     def tearDownClass(cls):
@@ -95,37 +86,38 @@ class TestMetadata(unittest.TestCase):
         # the metadata, targets, and key files generated for the test cases.
         shutil.rmtree(cls.temporary_directory)
 
-
     def test_generic_read(self):
         for metadata, inner_metadata_cls in [
-                ('root', Root),
-                ('snapshot', Snapshot),
-                ('timestamp', Timestamp),
-                ('targets', Targets)]:
+            ("root", Root),
+            ("snapshot", Snapshot),
+            ("timestamp", Timestamp),
+            ("targets", Targets),
+        ]:
 
             # Load JSON-formatted metdata of each supported type from file
             # and from out-of-band read JSON string
-            path = os.path.join(self.repo_dir, 'metadata', metadata + '.json')
+            path = os.path.join(self.repo_dir, "metadata", metadata + ".json")
             metadata_obj = Metadata.from_file(path)
-            with open(path, 'rb') as f:
+            with open(path, "rb") as f:
                 metadata_obj2 = Metadata.from_bytes(f.read())
 
             # Assert that both methods instantiate the right inner class for
             # each metadata type and ...
+            self.assertTrue(isinstance(metadata_obj.signed, inner_metadata_cls))
             self.assertTrue(
-                    isinstance(metadata_obj.signed, inner_metadata_cls))
-            self.assertTrue(
-                    isinstance(metadata_obj2.signed, inner_metadata_cls))
+                isinstance(metadata_obj2.signed, inner_metadata_cls)
+            )
 
             # ... and return the same object (compared by dict representation)
             self.assertDictEqual(
-                    metadata_obj.to_dict(), metadata_obj2.to_dict())
+                metadata_obj.to_dict(), metadata_obj2.to_dict()
+            )
 
         # Assert that it chokes correctly on an unknown metadata type
-        bad_metadata_path = 'bad-metadata.json'
-        bad_metadata = {'signed': {'_type': 'bad-metadata'}}
-        bad_string = json.dumps(bad_metadata).encode('utf-8')
-        with open(bad_metadata_path, 'wb') as f:
+        bad_metadata_path = "bad-metadata.json"
+        bad_metadata = {"signed": {"_type": "bad-metadata"}}
+        bad_string = json.dumps(bad_metadata).encode("utf-8")
+        with open(bad_metadata_path, "wb") as f:
             f.write(bad_string)
 
         with self.assertRaises(DeserializationError):
@@ -135,35 +127,33 @@ class TestMetadata(unittest.TestCase):
 
         os.remove(bad_metadata_path)
 
-
     def test_compact_json(self):
-        path = os.path.join(self.repo_dir, 'metadata', 'targets.json')
+        path = os.path.join(self.repo_dir, "metadata", "targets.json")
         metadata_obj = Metadata.from_file(path)
         self.assertTrue(
-                len(JSONSerializer(compact=True).serialize(metadata_obj)) <
-                len(JSONSerializer().serialize(metadata_obj)))
-
+            len(JSONSerializer(compact=True).serialize(metadata_obj))
+            < len(JSONSerializer().serialize(metadata_obj))
+        )
 
     def test_read_write_read_compare(self):
-        for metadata in ['root', 'snapshot', 'timestamp', 'targets']:
-            path = os.path.join(self.repo_dir, 'metadata', metadata + '.json')
+        for metadata in ["root", "snapshot", "timestamp", "targets"]:
+            path = os.path.join(self.repo_dir, "metadata", metadata + ".json")
             metadata_obj = Metadata.from_file(path)
 
-            path_2 = path + '.tmp'
+            path_2 = path + ".tmp"
             metadata_obj.to_file(path_2)
             metadata_obj_2 = Metadata.from_file(path_2)
 
             self.assertDictEqual(
-                    metadata_obj.to_dict(),
-                    metadata_obj_2.to_dict())
+                metadata_obj.to_dict(), metadata_obj_2.to_dict()
+            )
 
             os.remove(path_2)
 
-
     def test_to_from_bytes(self):
         for metadata in ["root", "snapshot", "timestamp", "targets"]:
-            path = os.path.join(self.repo_dir, 'metadata', metadata + '.json')
-            with open(path, 'rb') as f:
+            path = os.path.join(self.repo_dir, "metadata", metadata + ".json")
+            with open(path, "rb") as f:
                 metadata_bytes = f.read()
             metadata_obj = Metadata.from_bytes(metadata_bytes)
             # Comparate that from_bytes/to_bytes doesn't change the content
@@ -177,13 +167,10 @@ class TestMetadata(unittest.TestCase):
             # Case 2: test compact by using the default serializer.
             obj_bytes = metadata_obj.to_bytes()
             metadata_obj_2 = Metadata.from_bytes(obj_bytes)
-            self.assertEqual(
-                metadata_obj_2.to_bytes(), obj_bytes
-            )
-
+            self.assertEqual(metadata_obj_2.to_bytes(), obj_bytes)
 
     def test_sign_verify(self):
-        root_path = os.path.join(self.repo_dir, 'metadata', 'root.json')
+        root_path = os.path.join(self.repo_dir, "metadata", "root.json")
         root = Metadata[Root].from_file(root_path).signed
 
         # Locate the public keys we need from root
@@ -195,7 +182,7 @@ class TestMetadata(unittest.TestCase):
         timestamp_key = root.keys[timestamp_keyid]
 
         # Load sample metadata (targets) and assert ...
-        path = os.path.join(self.repo_dir, 'metadata', 'targets.json')
+        path = os.path.join(self.repo_dir, "metadata", "targets.json")
         metadata_obj = Metadata.from_file(path)
 
         # ... it has a single existing signature,
@@ -210,7 +197,7 @@ class TestMetadata(unittest.TestCase):
         with self.assertRaises(exceptions.UnsignedMetadataError):
             targets_key.verify_signature(metadata_obj, JSONSerializer())
 
-        sslib_signer = SSlibSigner(self.keystore['snapshot'])
+        sslib_signer = SSlibSigner(self.keystore["snapshot"])
         # Append a new signature with the unrelated key and assert that ...
         sig = metadata_obj.sign(sslib_signer, append=True)
         # ... there are now two signatures, and
@@ -221,7 +208,7 @@ class TestMetadata(unittest.TestCase):
         # ... the returned (appended) signature is for snapshot key
         self.assertEqual(sig.keyid, snapshot_keyid)
 
-        sslib_signer = SSlibSigner(self.keystore['timestamp'])
+        sslib_signer = SSlibSigner(self.keystore["timestamp"])
         # Create and assign (don't append) a new signature and assert that ...
         metadata_obj.sign(sslib_signer, append=False)
         # ... there now is only one signature,
@@ -253,7 +240,7 @@ class TestMetadata(unittest.TestCase):
             timestamp_key.verify_signature(metadata_obj)
 
         # Test failure with valid but incorrect signature
-        sig.signature = "ff"*64
+        sig.signature = "ff" * 64
         with self.assertRaises(exceptions.UnsignedMetadataError):
             timestamp_key.verify_signature(metadata_obj)
         sig.signature = correct_sig
@@ -261,8 +248,7 @@ class TestMetadata(unittest.TestCase):
     def test_metadata_base(self):
         # Use of Snapshot is arbitrary, we're just testing the base class features
         # with real data
-        snapshot_path = os.path.join(
-                self.repo_dir, 'metadata', 'snapshot.json')
+        snapshot_path = os.path.join(self.repo_dir, "metadata", "snapshot.json")
         md = Metadata.from_file(snapshot_path)
 
         self.assertEqual(md.signed.version, 1)
@@ -295,33 +281,35 @@ class TestMetadata(unittest.TestCase):
 
         # Test deserializing metadata with non-unique signatures:
         data = md.to_dict()
-        data["signatures"].append({"keyid": data["signatures"][0]["keyid"], "sig": "foo"})
+        data["signatures"].append(
+            {"keyid": data["signatures"][0]["keyid"], "sig": "foo"}
+        )
         with self.assertRaises(ValueError):
             Metadata.from_dict(data)
 
-
     def test_metadata_snapshot(self):
-        snapshot_path = os.path.join(
-                self.repo_dir, 'metadata', 'snapshot.json')
+        snapshot_path = os.path.join(self.repo_dir, "metadata", "snapshot.json")
         snapshot = Metadata[Snapshot].from_file(snapshot_path)
 
         # Create a MetaFile instance representing what we expect
         # the updated data to be.
-        hashes = {'sha256': 'c2986576f5fdfd43944e2b19e775453b96748ec4fe2638a6d2f32f1310967095'}
+        hashes = {
+            "sha256": "c2986576f5fdfd43944e2b19e775453b96748ec4fe2638a6d2f32f1310967095"
+        }
         fileinfo = MetaFile(2, 123, hashes)
 
         self.assertNotEqual(
-            snapshot.signed.meta['role1.json'].to_dict(), fileinfo.to_dict()
+            snapshot.signed.meta["role1.json"].to_dict(), fileinfo.to_dict()
         )
-        snapshot.signed.update('role1', fileinfo)
+        snapshot.signed.update("role1", fileinfo)
         self.assertEqual(
-            snapshot.signed.meta['role1.json'].to_dict(), fileinfo.to_dict()
+            snapshot.signed.meta["role1.json"].to_dict(), fileinfo.to_dict()
         )
-
 
     def test_metadata_timestamp(self):
         timestamp_path = os.path.join(
-                self.repo_dir, 'metadata', 'timestamp.json')
+            self.repo_dir, "metadata", "timestamp.json"
+        )
         timestamp = Metadata[Timestamp].from_file(timestamp_path)
 
         self.assertEqual(timestamp.signed.version, 1)
@@ -345,7 +333,9 @@ class TestMetadata(unittest.TestCase):
 
         # Create a MetaFile instance representing what we expect
         # the updated data to be.
-        hashes = {'sha256': '0ae9664468150a9aa1e7f11feecb32341658eb84292851367fea2da88e8a58dc'}
+        hashes = {
+            "sha256": "0ae9664468150a9aa1e7f11feecb32341658eb84292851367fea2da88e8a58dc"
+        }
         fileinfo = MetaFile(2, 520, hashes)
 
         self.assertNotEqual(
@@ -356,102 +346,99 @@ class TestMetadata(unittest.TestCase):
             timestamp.signed.snapshot_meta.to_dict(), fileinfo.to_dict()
         )
 
-
     def test_metadata_verify_delegate(self):
-        root_path = os.path.join(self.repo_dir, 'metadata', 'root.json')
+        root_path = os.path.join(self.repo_dir, "metadata", "root.json")
         root = Metadata[Root].from_file(root_path)
-        snapshot_path = os.path.join(
-                self.repo_dir, 'metadata', 'snapshot.json')
+        snapshot_path = os.path.join(self.repo_dir, "metadata", "snapshot.json")
         snapshot = Metadata[Snapshot].from_file(snapshot_path)
-        targets_path = os.path.join(
-                self.repo_dir, 'metadata', 'targets.json')
+        targets_path = os.path.join(self.repo_dir, "metadata", "targets.json")
         targets = Metadata[Targets].from_file(targets_path)
-        role1_path = os.path.join(
-                self.repo_dir, 'metadata', 'role1.json')
+        role1_path = os.path.join(self.repo_dir, "metadata", "role1.json")
         role1 = Metadata[Targets].from_file(role1_path)
-        role2_path = os.path.join(
-                self.repo_dir, 'metadata', 'role2.json')
+        role2_path = os.path.join(self.repo_dir, "metadata", "role2.json")
         role2 = Metadata[Targets].from_file(role2_path)
 
         # test the expected delegation tree
-        root.verify_delegate('root', root)
-        root.verify_delegate('snapshot', snapshot)
-        root.verify_delegate('targets', targets)
-        targets.verify_delegate('role1', role1)
-        role1.verify_delegate('role2', role2)
+        root.verify_delegate("root", root)
+        root.verify_delegate("snapshot", snapshot)
+        root.verify_delegate("targets", targets)
+        targets.verify_delegate("role1", role1)
+        role1.verify_delegate("role2", role2)
 
         # only root and targets can verify delegates
         with self.assertRaises(TypeError):
-            snapshot.verify_delegate('snapshot', snapshot)
+            snapshot.verify_delegate("snapshot", snapshot)
         # verify fails for roles that are not delegated by delegator
         with self.assertRaises(ValueError):
-            root.verify_delegate('role1', role1)
+            root.verify_delegate("role1", role1)
         with self.assertRaises(ValueError):
-            targets.verify_delegate('targets', targets)
+            targets.verify_delegate("targets", targets)
         # verify fails when delegator has no delegations
         with self.assertRaises(ValueError):
-            role2.verify_delegate('role1', role1)
+            role2.verify_delegate("role1", role1)
 
         # verify fails when delegate content is modified
         expires = snapshot.signed.expires
         snapshot.signed.bump_expiration()
         with self.assertRaises(exceptions.UnsignedMetadataError):
-            root.verify_delegate('snapshot', snapshot)
+            root.verify_delegate("snapshot", snapshot)
         snapshot.signed.expires = expires
 
         # verify fails if roles keys do not sign the metadata
         with self.assertRaises(exceptions.UnsignedMetadataError):
-            root.verify_delegate('timestamp', snapshot)
+            root.verify_delegate("timestamp", snapshot)
 
         # Add a key to snapshot role, make sure the new sig fails to verify
         ts_keyid = next(iter(root.signed.roles["timestamp"].keyids))
         root.signed.add_key("snapshot", root.signed.keys[ts_keyid])
-        snapshot.signatures[ts_keyid] = Signature(ts_keyid, "ff"*64)
+        snapshot.signatures[ts_keyid] = Signature(ts_keyid, "ff" * 64)
 
         # verify succeeds if threshold is reached even if some signatures
         # fail to verify
-        root.verify_delegate('snapshot', snapshot)
+        root.verify_delegate("snapshot", snapshot)
 
         # verify fails if threshold of signatures is not reached
-        root.signed.roles['snapshot'].threshold = 2
+        root.signed.roles["snapshot"].threshold = 2
         with self.assertRaises(exceptions.UnsignedMetadataError):
-            root.verify_delegate('snapshot', snapshot)
+            root.verify_delegate("snapshot", snapshot)
 
         # verify succeeds when we correct the new signature and reach the
         # threshold of 2 keys
-        snapshot.sign(SSlibSigner(self.keystore['timestamp']), append=True)
-        root.verify_delegate('snapshot', snapshot)
-
+        snapshot.sign(SSlibSigner(self.keystore["timestamp"]), append=True)
+        root.verify_delegate("snapshot", snapshot)
 
     def test_key_class(self):
         # Test if from_securesystemslib_key removes the private key from keyval
         # of a securesystemslib key dictionary.
         sslib_key = generate_ed25519_key()
         key = Key.from_securesystemslib_key(sslib_key)
-        self.assertFalse('private' in key.keyval.keys())
-
+        self.assertFalse("private" in key.keyval.keys())
 
     def test_root_add_key_and_remove_key(self):
-        root_path = os.path.join(
-                self.repo_dir, 'metadata', 'root.json')
+        root_path = os.path.join(self.repo_dir, "metadata", "root.json")
         root = Metadata[Root].from_file(root_path)
 
         # Create a new key
-        root_key2 =  import_ed25519_publickey_from_file(
-                    os.path.join(self.keystore_dir, 'root_key2.pub'))
-        keyid = root_key2['keyid']
-        key_metadata = Key(keyid, root_key2['keytype'], root_key2['scheme'],
-            root_key2['keyval'])
+        root_key2 = import_ed25519_publickey_from_file(
+            os.path.join(self.keystore_dir, "root_key2.pub")
+        )
+        keyid = root_key2["keyid"]
+        key_metadata = Key(
+            keyid,
+            root_key2["keytype"],
+            root_key2["scheme"],
+            root_key2["keyval"],
+        )
 
         # Assert that root does not contain the new key
-        self.assertNotIn(keyid, root.signed.roles['root'].keyids)
+        self.assertNotIn(keyid, root.signed.roles["root"].keyids)
         self.assertNotIn(keyid, root.signed.keys)
 
         # Add new root key
-        root.signed.add_key('root', key_metadata)
+        root.signed.add_key("root", key_metadata)
 
         # Assert that key is added
-        self.assertIn(keyid, root.signed.roles['root'].keyids)
+        self.assertIn(keyid, root.signed.roles["root"].keyids)
         self.assertIn(keyid, root.signed.keys)
 
         # Confirm that the newly added key does not break
@@ -459,31 +446,31 @@ class TestMetadata(unittest.TestCase):
         root.to_dict()
 
         # Try adding the same key again and assert its ignored.
-        pre_add_keyid = root.signed.roles['root'].keyids.copy()
-        root.signed.add_key('root', key_metadata)
-        self.assertEqual(pre_add_keyid, root.signed.roles['root'].keyids)
+        pre_add_keyid = root.signed.roles["root"].keyids.copy()
+        root.signed.add_key("root", key_metadata)
+        self.assertEqual(pre_add_keyid, root.signed.roles["root"].keyids)
 
         # Add the same key to targets role as well
-        root.signed.add_key('targets', key_metadata)
+        root.signed.add_key("targets", key_metadata)
 
         # Add the same key to a nonexistent role.
         with self.assertRaises(ValueError):
             root.signed.add_key("nosuchrole", key_metadata)
 
         # Remove the key from root role (targets role still uses it)
-        root.signed.remove_key('root', keyid)
-        self.assertNotIn(keyid, root.signed.roles['root'].keyids)
+        root.signed.remove_key("root", keyid)
+        self.assertNotIn(keyid, root.signed.roles["root"].keyids)
         self.assertIn(keyid, root.signed.keys)
 
         # Remove the key from targets as well
-        root.signed.remove_key('targets', keyid)
-        self.assertNotIn(keyid, root.signed.roles['targets'].keyids)
+        root.signed.remove_key("targets", keyid)
+        self.assertNotIn(keyid, root.signed.roles["targets"].keyids)
         self.assertNotIn(keyid, root.signed.keys)
 
         with self.assertRaises(ValueError):
-            root.signed.remove_key('root', 'nosuchkey')
+            root.signed.remove_key("root", "nosuchkey")
         with self.assertRaises(ValueError):
-            root.signed.remove_key('nosuchrole', keyid)
+            root.signed.remove_key("nosuchrole", keyid)
 
     def test_is_target_in_pathpattern(self):
         supported_use_cases = [
@@ -505,28 +492,26 @@ class TestMetadata(unittest.TestCase):
 
         invalid_use_cases = [
             ("targets/foo.tgz", "*.tgz"),
-            ("/foo.tgz", "*.tgz",),
+            ("/foo.tgz", "*.tgz"),
             ("targets/foo.tgz", "*"),
             ("foo-version-alpha.tgz", "foo-version-?.tgz"),
             ("foo//bar", "*/bar"),
-            ("foo/bar", "f?/bar")
+            ("foo/bar", "f?/bar"),
         ]
         for targetpath, pathpattern in invalid_use_cases:
             self.assertFalse(
                 DelegatedRole._is_target_in_pathpattern(targetpath, pathpattern)
             )
 
-
     def test_metadata_targets(self):
-        targets_path = os.path.join(
-                self.repo_dir, 'metadata', 'targets.json')
+        targets_path = os.path.join(self.repo_dir, "metadata", "targets.json")
         targets = Metadata[Targets].from_file(targets_path)
 
         # Create a fileinfo dict representing what we expect the updated data to be
-        filename = 'file2.txt'
+        filename = "file2.txt"
         hashes = {
             "sha256": "141f740f53781d1ca54b8a50af22cbf74e44c21a998fa2a8a05aaac2c002886b",
-            "sha512": "ef5beafa16041bcdd2937140afebd485296cd54f7348ecd5a4d035c09759608de467a7ac0eb58753d0242df873c305e8bffad2454aa48f44480f15efae1cacd0"
+            "sha512": "ef5beafa16041bcdd2937140afebd485296cd54f7348ecd5a4d035c09759608de467a7ac0eb58753d0242df873c305e8bffad2454aa48f44480f15efae1cacd0",
         }
 
         fileinfo = TargetFile(length=28, hashes=hashes, path=filename)
@@ -543,18 +528,19 @@ class TestMetadata(unittest.TestCase):
         )
 
     def test_targets_key_api(self):
-        targets_path = os.path.join(
-                self.repo_dir, 'metadata', 'targets.json')
+        targets_path = os.path.join(self.repo_dir, "metadata", "targets.json")
         targets: Targets = Metadata[Targets].from_file(targets_path).signed
 
         # Add a new delegated role "role2" in targets
-        delegated_role = DelegatedRole.from_dict({
+        delegated_role = DelegatedRole.from_dict(
+            {
                 "keyids": [],
                 "name": "role2",
                 "paths": ["fn3", "fn4"],
                 "terminating": False,
-                "threshold": 1
-        })
+                "threshold": 1,
+            }
+        )
         targets.delegations.roles["role2"] = delegated_role
 
         key_dict = {
@@ -562,7 +548,7 @@ class TestMetadata(unittest.TestCase):
             "keyval": {
                 "public": "edcd0a32a07dce33f7c7873aaffbff36d20ea30787574ead335eefd337e4dacd"
             },
-            "scheme": "ed25519"
+            "scheme": "ed25519",
         }
         key = Key.from_dict("id2", key_dict)
 
@@ -618,19 +604,18 @@ class TestMetadata(unittest.TestCase):
             targets.remove_key("role1", key.keyid)
         self.assertTrue(targets.delegations is None)
 
-
-    def  test_length_and_hash_validation(self):
+    def test_length_and_hash_validation(self):
 
         # Test metadata files' hash and length verification.
         # Use timestamp to get a MetaFile object and snapshot
         # for untrusted metadata file to verify.
         timestamp_path = os.path.join(
-            self.repo_dir, 'metadata', 'timestamp.json')
+            self.repo_dir, "metadata", "timestamp.json"
+        )
         timestamp = Metadata[Timestamp].from_file(timestamp_path)
         snapshot_metafile = timestamp.signed.snapshot_meta
 
-        snapshot_path = os.path.join(
-            self.repo_dir, 'metadata', 'snapshot.json')
+        snapshot_path = os.path.join(self.repo_dir, "metadata", "snapshot.json")
 
         with open(snapshot_path, "rb") as file:
             # test with  data as a file object
@@ -643,36 +628,49 @@ class TestMetadata(unittest.TestCase):
             # test exceptions
             expected_length = snapshot_metafile.length
             snapshot_metafile.length = 2345
-            self.assertRaises(exceptions.LengthOrHashMismatchError,
-                snapshot_metafile.verify_length_and_hashes, data)
+            self.assertRaises(
+                exceptions.LengthOrHashMismatchError,
+                snapshot_metafile.verify_length_and_hashes,
+                data,
+            )
 
             snapshot_metafile.length = expected_length
-            snapshot_metafile.hashes = {'sha256': 'incorrecthash'}
-            self.assertRaises(exceptions.LengthOrHashMismatchError,
-                snapshot_metafile.verify_length_and_hashes, data)
+            snapshot_metafile.hashes = {"sha256": "incorrecthash"}
+            self.assertRaises(
+                exceptions.LengthOrHashMismatchError,
+                snapshot_metafile.verify_length_and_hashes,
+                data,
+            )
 
-            snapshot_metafile.hashes = {'unsupported-alg': "8f88e2ba48b412c3843e9bb26e1b6f8fc9e98aceb0fbaa97ba37b4c98717d7ab"}
-            self.assertRaises(exceptions.LengthOrHashMismatchError,
-            snapshot_metafile.verify_length_and_hashes, data)
+            snapshot_metafile.hashes = {
+                "unsupported-alg": "8f88e2ba48b412c3843e9bb26e1b6f8fc9e98aceb0fbaa97ba37b4c98717d7ab"
+            }
+            self.assertRaises(
+                exceptions.LengthOrHashMismatchError,
+                snapshot_metafile.verify_length_and_hashes,
+                data,
+            )
 
             # Test wrong algorithm format (sslib.FormatError)
-            snapshot_metafile.hashes = { 256: "8f88e2ba48b412c3843e9bb26e1b6f8fc9e98aceb0fbaa97ba37b4c98717d7ab"}
-            self.assertRaises(exceptions.LengthOrHashMismatchError,
-            snapshot_metafile.verify_length_and_hashes, data)
+            snapshot_metafile.hashes = {
+                256: "8f88e2ba48b412c3843e9bb26e1b6f8fc9e98aceb0fbaa97ba37b4c98717d7ab"
+            }
+            self.assertRaises(
+                exceptions.LengthOrHashMismatchError,
+                snapshot_metafile.verify_length_and_hashes,
+                data,
+            )
 
             # test optional length and hashes
             snapshot_metafile.length = None
             snapshot_metafile.hashes = None
             snapshot_metafile.verify_length_and_hashes(data)
 
-
         # Test target files' hash and length verification
-        targets_path = os.path.join(
-            self.repo_dir, 'metadata', 'targets.json')
+        targets_path = os.path.join(self.repo_dir, "metadata", "targets.json")
         targets = Metadata[Targets].from_file(targets_path)
-        file1_targetfile = targets.signed.targets['file1.txt']
-        filepath = os.path.join(
-            self.repo_dir, 'targets', 'file1.txt')
+        file1_targetfile = targets.signed.targets["file1.txt"]
+        filepath = os.path.join(self.repo_dir, "targets", "file1.txt")
 
         with open(filepath, "rb") as file1:
             file1_targetfile.verify_length_and_hashes(file1)
@@ -680,50 +678,58 @@ class TestMetadata(unittest.TestCase):
             # test exceptions
             expected_length = file1_targetfile.length
             file1_targetfile.length = 2345
-            self.assertRaises(exceptions.LengthOrHashMismatchError,
-                file1_targetfile.verify_length_and_hashes, file1)
+            self.assertRaises(
+                exceptions.LengthOrHashMismatchError,
+                file1_targetfile.verify_length_and_hashes,
+                file1,
+            )
 
             file1_targetfile.length = expected_length
-            file1_targetfile.hashes = {'sha256': 'incorrecthash'}
-            self.assertRaises(exceptions.LengthOrHashMismatchError,
-                file1_targetfile.verify_length_and_hashes, file1)     
+            file1_targetfile.hashes = {"sha256": "incorrecthash"}
+            self.assertRaises(
+                exceptions.LengthOrHashMismatchError,
+                file1_targetfile.verify_length_and_hashes,
+                file1,
+            )
 
     def test_targetfile_from_file(self):
         # Test with an existing file and valid hash algorithm
-        file_path = os.path.join(self.repo_dir, 'targets', 'file1.txt')
+        file_path = os.path.join(self.repo_dir, "targets", "file1.txt")
         targetfile_from_file = TargetFile.from_file(
-            file_path, file_path, ['sha256']
+            file_path, file_path, ["sha256"]
         )
 
         with open(file_path, "rb") as file:
             targetfile_from_file.verify_length_and_hashes(file)
 
         # Test with a non-existing file
-        file_path = os.path.join(self.repo_dir, 'targets', 'file123.txt')
+        file_path = os.path.join(self.repo_dir, "targets", "file123.txt")
         self.assertRaises(
-            FileNotFoundError, 
-            TargetFile.from_file, 
-            file_path, 
+            FileNotFoundError,
+            TargetFile.from_file,
             file_path,
-            [sslib_hash.DEFAULT_HASH_ALGORITHM]
+            file_path,
+            [sslib_hash.DEFAULT_HASH_ALGORITHM],
         )
 
         # Test with an unsupported algorithm
-        file_path = os.path.join(self.repo_dir, 'targets', 'file1.txt')
+        file_path = os.path.join(self.repo_dir, "targets", "file1.txt")
         self.assertRaises(
             exceptions.UnsupportedAlgorithmError,
-            TargetFile.from_file, 
-            file_path, 
+            TargetFile.from_file,
             file_path,
-            ['123']
+            file_path,
+            ["123"],
         )
 
     def test_targetfile_from_data(self):
         data = b"Inline test content"
-        target_file_path = os.path.join(self.repo_dir, 'targets', 'file1.txt')
-        
+        target_file_path = os.path.join(self.repo_dir, "targets", "file1.txt")
+
         # Test with a valid hash algorithm
-        targetfile_from_data = TargetFile.from_data(target_file_path, data, ['sha256'])
+        targetfile_from_data = TargetFile.from_data(
+            target_file_path, data, ["sha256"]
+        )
         targetfile_from_data.verify_length_and_hashes(data)
 
         # Test with no algorithms specified
@@ -753,7 +759,8 @@ class TestMetadata(unittest.TestCase):
             self.assertFalse(role.is_delegated_path("a/non-matching path"))
             self.assertTrue(role.is_delegated_path("a/path"))
 
+
 # Run unit test.
-if __name__ == '__main__':
+if __name__ == "__main__":
     utils.configure_test_logging(sys.argv)
     unittest.main()

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -6,19 +6,18 @@
 """Unit test for RequestsFetcher.
 """
 
-import logging
-import os
 import io
-import sys
-import unittest
-import tempfile
+import logging
 import math
+import os
+import sys
+import tempfile
+import unittest
 
 import tuf
 import tuf.exceptions
 import tuf.requests_fetcher
 import tuf.unittest_toolbox as unittest_toolbox
-
 from tests import utils
 
 logger = logging.getLogger(__name__)

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -25,107 +25,109 @@ logger = logging.getLogger(__name__)
 
 
 class TestFetcher(unittest_toolbox.Modified_TestCase):
-  def setUp(self):
-    """
-    Create a temporary file and launch a simple server in the
-    current working directory.
-    """
+    def setUp(self):
+        """
+        Create a temporary file and launch a simple server in the
+        current working directory.
+        """
 
-    unittest_toolbox.Modified_TestCase.setUp(self)
+        unittest_toolbox.Modified_TestCase.setUp(self)
 
-    # Making a temporary file.
-    current_dir = os.getcwd()
-    target_filepath = self.make_temp_data_file(directory=current_dir)
-    self.target_fileobj = open(target_filepath, 'r')
-    self.file_contents = self.target_fileobj.read()
-    self.file_length = len(self.file_contents)
+        # Making a temporary file.
+        current_dir = os.getcwd()
+        target_filepath = self.make_temp_data_file(directory=current_dir)
+        self.target_fileobj = open(target_filepath, "r")
+        self.file_contents = self.target_fileobj.read()
+        self.file_length = len(self.file_contents)
 
-    # Launch a SimpleHTTPServer (serves files in the current dir).
-    self.server_process_handler = utils.TestServerProcess(log=logger)
+        # Launch a SimpleHTTPServer (serves files in the current dir).
+        self.server_process_handler = utils.TestServerProcess(log=logger)
 
-    rel_target_filepath = os.path.basename(target_filepath)
-    self.url = 'http://' + utils.TEST_HOST_ADDRESS + ':' \
-        + str(self.server_process_handler.port) + '/' + rel_target_filepath
+        rel_target_filepath = os.path.basename(target_filepath)
+        self.url = (
+            "http://"
+            + utils.TEST_HOST_ADDRESS
+            + ":"
+            + str(self.server_process_handler.port)
+            + "/"
+            + rel_target_filepath
+        )
 
-    # Create a temporary file where the target file chunks are written
-    # during fetching
-    self.temp_file = tempfile.TemporaryFile()
-    self.fetcher = tuf.requests_fetcher.RequestsFetcher()
+        # Create a temporary file where the target file chunks are written
+        # during fetching
+        self.temp_file = tempfile.TemporaryFile()
+        self.fetcher = tuf.requests_fetcher.RequestsFetcher()
 
+    # Stop server process and perform clean up.
+    def tearDown(self):
+        # Cleans the resources and flush the logged lines (if any).
+        self.server_process_handler.clean()
 
-  # Stop server process and perform clean up.
-  def tearDown(self):
-    # Cleans the resources and flush the logged lines (if any).
-    self.server_process_handler.clean()
+        self.target_fileobj.close()
+        self.temp_file.close()
 
-    self.target_fileobj.close()
-    self.temp_file.close()
+        # Remove temporary directory
+        unittest_toolbox.Modified_TestCase.tearDown(self)
 
-    # Remove temporary directory
-    unittest_toolbox.Modified_TestCase.tearDown(self)
+    # Test: Normal case.
+    def test_fetch(self):
+        for chunk in self.fetcher.fetch(self.url, self.file_length):
+            self.temp_file.write(chunk)
 
+        self.temp_file.seek(0)
+        temp_file_data = self.temp_file.read().decode("utf-8")
+        self.assertEqual(self.file_contents, temp_file_data)
 
-  # Test: Normal case.
-  def test_fetch(self):
-    for chunk in self.fetcher.fetch(self.url, self.file_length):
-        self.temp_file.write(chunk)
+    # Test if fetcher downloads file up to a required length
+    def test_fetch_restricted_length(self):
+        for chunk in self.fetcher.fetch(self.url, self.file_length - 4):
+            self.temp_file.write(chunk)
 
-    self.temp_file.seek(0)
-    temp_file_data = self.temp_file.read().decode('utf-8')
-    self.assertEqual(self.file_contents, temp_file_data)
+        self.temp_file.seek(0, io.SEEK_END)
+        self.assertEqual(self.temp_file.tell(), self.file_length - 4)
 
-  # Test if fetcher downloads file up to a required length
-  def test_fetch_restricted_length(self):
-    for chunk in self.fetcher.fetch(self.url, self.file_length-4):
-        self.temp_file.write(chunk)
+    # Test that fetcher does not download more than actual file length
+    def test_fetch_upper_length(self):
+        for chunk in self.fetcher.fetch(self.url, self.file_length + 4):
+            self.temp_file.write(chunk)
 
-    self.temp_file.seek(0, io.SEEK_END)
-    self.assertEqual(self.temp_file.tell(), self.file_length-4)
+        self.temp_file.seek(0, io.SEEK_END)
+        self.assertEqual(self.temp_file.tell(), self.file_length)
 
+    # Test incorrect URL parsing
+    def test_url_parsing(self):
+        with self.assertRaises(tuf.exceptions.URLParsingError):
+            self.fetcher.fetch(self.random_string(), self.file_length)
 
-  # Test that fetcher does not download more than actual file length
-  def test_fetch_upper_length(self):
-    for chunk in self.fetcher.fetch(self.url, self.file_length+4):
-        self.temp_file.write(chunk)
+    # Test: Normal case with url data downloaded in more than one chunk
+    def test_fetch_in_chunks(self):
+        # Set smaller chunk size to ensure that the file will be downloaded
+        # in more than one chunk
+        default_chunk_size = tuf.settings.CHUNK_SIZE
+        tuf.settings.CHUNK_SIZE = 4
 
-    self.temp_file.seek(0, io.SEEK_END)
-    self.assertEqual(self.temp_file.tell(), self.file_length)
+        # expected_chunks_count: 3
+        expected_chunks_count = math.ceil(
+            self.file_length / tuf.settings.CHUNK_SIZE
+        )
+        self.assertEqual(expected_chunks_count, 3)
 
+        chunks_count = 0
+        for chunk in self.fetcher.fetch(self.url, self.file_length):
+            self.temp_file.write(chunk)
+            chunks_count += 1
 
-  # Test incorrect URL parsing
-  def test_url_parsing(self):
-    with self.assertRaises(tuf.exceptions.URLParsingError):
-      self.fetcher.fetch(self.random_string(), self.file_length)
+        self.temp_file.seek(0)
+        temp_file_data = self.temp_file.read().decode("utf-8")
+        self.assertEqual(self.file_contents, temp_file_data)
+        # Check that we calculate chunks as expected
+        self.assertEqual(chunks_count, expected_chunks_count)
 
-
-  # Test: Normal case with url data downloaded in more than one chunk
-  def test_fetch_in_chunks(self):
-    # Set smaller chunk size to ensure that the file will be downloaded
-    # in more than one chunk
-    default_chunk_size = tuf.settings.CHUNK_SIZE
-    tuf.settings.CHUNK_SIZE = 4
-
-    # expected_chunks_count: 3
-    expected_chunks_count = math.ceil(self.file_length/tuf.settings.CHUNK_SIZE)
-    self.assertEqual(expected_chunks_count, 3)
-
-    chunks_count = 0
-    for chunk in self.fetcher.fetch(self.url, self.file_length):
-      self.temp_file.write(chunk)
-      chunks_count+=1
-
-    self.temp_file.seek(0)
-    temp_file_data = self.temp_file.read().decode('utf-8')
-    self.assertEqual(self.file_contents, temp_file_data)
-    # Check that we calculate chunks as expected
-    self.assertEqual(chunks_count, expected_chunks_count)
-
-    # Restore default settings
-    tuf.settings.CHUNK_SIZE = default_chunk_size
-
+        # Restore default settings
+        tuf.settings.CHUNK_SIZE = default_chunk_size
 
 
 # Run unit test.
-if __name__ == '__main__':
-  utils.configure_test_logging(sys.argv)
-  unittest.main()
+if __name__ == "__main__":
+    utils.configure_test_logging(sys.argv)
+    unittest.main()

--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -25,7 +25,6 @@ logger = logging.getLogger(__name__)
 
 
 class TestFetcher(unittest_toolbox.Modified_TestCase):
-
     @classmethod
     def setUpClass(cls):
         # Launch a SimpleHTTPServer (serves files in the current dir).
@@ -111,10 +110,14 @@ class TestFetcher(unittest_toolbox.Modified_TestCase):
         self.assertEqual(cm.exception.status_code, 404)
 
     # Response read timeout error
-    @patch.object(requests.Session, 'get')
+    @patch.object(requests.Session, "get")
     def test_response_read_timeout(self, mock_session_get):
         mock_response = Mock()
-        attr = {'raw.read.side_effect': urllib3.exceptions.ReadTimeoutError(None, None, "Read timed out.")}
+        attr = {
+            "raw.read.side_effect": urllib3.exceptions.ReadTimeoutError(
+                None, None, "Read timed out."
+            )
+        }
         mock_response.configure_mock(**attr)
         mock_session_get.return_value = mock_response
 
@@ -123,7 +126,9 @@ class TestFetcher(unittest_toolbox.Modified_TestCase):
         mock_response.raw.read.assert_called_once()
 
     # Read/connect session timeout error
-    @patch.object(requests.Session, 'get', side_effect=urllib3.exceptions.TimeoutError)
+    @patch.object(
+        requests.Session, "get", side_effect=urllib3.exceptions.TimeoutError
+    )
     def test_session_get_timeout(self, mock_session_get):
         with self.assertRaises(exceptions.SlowRetrievalError):
             self.fetcher.fetch(self.url)

--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -8,18 +8,19 @@
 
 import io
 import logging
+import math
 import os
 import sys
-import unittest
 import tempfile
-import math
-import urllib3.exceptions
+import unittest
+from unittest.mock import Mock, patch
+
 import requests
+import urllib3.exceptions
 
 from tests import utils
 from tuf import exceptions, unittest_toolbox
 from tuf.ngclient._internal.requests_fetcher import RequestsFetcher
-from unittest.mock import Mock, patch
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -6,27 +6,25 @@ serialization and deserialization.
 
 """
 
-import json
-import sys
-import logging
-import unittest
 import copy
-
+import json
+import logging
+import sys
+import unittest
 from typing import Dict
 
 from tests import utils
-
 from tuf.api.metadata import (
+    DelegatedRole,
+    Delegations,
+    Key,
+    MetaFile,
+    Role,
     Root,
     Snapshot,
-    Timestamp,
-    Targets,
-    Key,
-    Role,
-    MetaFile,
     TargetFile,
-    Delegations,
-    DelegatedRole,
+    Targets,
+    Timestamp,
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -41,28 +41,17 @@ class TestSerialization(unittest.TestCase):
         "no spec_version": '{"_type": "signed", "version": 1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
         "no version": '{"_type": "signed", "spec_version": "1.0.0", "expires": "2030-01-01T00:00:00Z", "meta": {}}',
         "no expires": '{"_type": "signed", "spec_version": "1.0.0", "version": 1, "meta": {}}',
-        "empty str _type":
-            '{"_type": "", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
-        "empty str spec_version":
-            '{"_type": "signed", "spec_version": "", "version": 1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
-        "_type wrong type":
-            '{"_type": "foo", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
-        "version wrong type":
-            '{"_type": "signed", "spec_version": "1.0.0", "version": "a", "expires": "2030-01-01T00:00:00Z", "meta": {}}',
-        "invalid spec_version str":
-            '{"_type": "signed", "spec_version": "abc", "version": 1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
-        "two digit spec_version":
-            '{"_type": "signed", "spec_version": "1.2.a", "version": 1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
-        "no digit spec_version":
-            '{"_type": "signed", "spec_version": "a.b.c", "version": 1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
-        "different major spec_version":
-            '{"_type": "signed", "spec_version": "0.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
-        "version 0":
-            '{"_type": "signed", "spec_version": "1.0.0", "version": 0, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
-        "version below 0":
-            '{"_type": "signed", "spec_version": "1.0.0", "version": -1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
-        "wrong datetime string":
-            '{"_type": "signed", "spec_version": "1.0.0", "version": 1, "expires": "abc", "meta": {}}',
+        "empty str _type": '{"_type": "", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
+        "empty str spec_version": '{"_type": "signed", "spec_version": "", "version": 1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
+        "_type wrong type": '{"_type": "foo", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
+        "version wrong type": '{"_type": "signed", "spec_version": "1.0.0", "version": "a", "expires": "2030-01-01T00:00:00Z", "meta": {}}',
+        "invalid spec_version str": '{"_type": "signed", "spec_version": "abc", "version": 1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
+        "two digit spec_version": '{"_type": "signed", "spec_version": "1.2.a", "version": 1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
+        "no digit spec_version": '{"_type": "signed", "spec_version": "a.b.c", "version": 1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
+        "different major spec_version": '{"_type": "signed", "spec_version": "0.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
+        "version 0": '{"_type": "signed", "spec_version": "1.0.0", "version": 0, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
+        "version below 0": '{"_type": "signed", "spec_version": "1.0.0", "version": -1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
+        "wrong datetime string": '{"_type": "signed", "spec_version": "1.0.0", "version": 1, "expires": "abc", "meta": {}}',
     }
 
     @utils.run_sub_tests_with_dataset(invalid_signed)
@@ -70,7 +59,6 @@ class TestSerialization(unittest.TestCase):
         case_dict = json.loads(test_case_data)
         with self.assertRaises((KeyError, ValueError, TypeError)):
             Snapshot.from_dict(copy.deepcopy(case_dict))
-
 
     valid_keys: utils.DataSet = {
         "all": '{"keytype": "rsa", "scheme": "rsassa-pss-sha256", \
@@ -86,7 +74,6 @@ class TestSerialization(unittest.TestCase):
         case_dict = json.loads(test_case_data)
         key = Key.from_dict("id", copy.copy(case_dict))
         self.assertDictEqual(case_dict, key.to_dict())
-
 
     invalid_keys: utils.DataSet = {
         "no keyid": '{"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "abc"}}',
@@ -120,7 +107,6 @@ class TestSerialization(unittest.TestCase):
         with self.assertRaises((KeyError, TypeError, ValueError)):
             Role.from_dict(copy.deepcopy(case_dict))
 
-
     valid_roles: utils.DataSet = {
         "all": '{"keyids": ["keyid"], "threshold": 3}',
         "many keyids": '{"keyids": ["a", "b", "c", "d", "e"], "threshold": 1}',
@@ -133,7 +119,6 @@ class TestSerialization(unittest.TestCase):
         case_dict = json.loads(test_case_data)
         role = Role.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, role.to_dict())
-
 
     valid_roots: utils.DataSet = {
         "all": '{"_type": "root", "spec_version": "1.0.0", "version": 1, \
@@ -182,7 +167,6 @@ class TestSerialization(unittest.TestCase):
         case_dict = json.loads(test_case_data)
         root = Root.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, root.to_dict())
-
 
     invalid_roots: utils.DataSet = {
         "invalid role name": '{"_type": "root", "spec_version": "1.0.0", "version": 1, \
@@ -236,11 +220,12 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_metafiles)
-    def test_invalid_metafile_serialization(self, test_case_data: Dict[str, str]):
+    def test_invalid_metafile_serialization(
+        self, test_case_data: Dict[str, str]
+    ):
         case_dict = json.loads(test_case_data)
         with self.assertRaises((TypeError, ValueError, AttributeError)):
             MetaFile.from_dict(copy.deepcopy(case_dict))
-
 
     valid_metafiles: utils.DataSet = {
         "all": '{"hashes": {"sha256" : "abc"}, "length": 12, "version": 1}',
@@ -261,11 +246,12 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_timestamps)
-    def test_invalid_timestamp_serialization(self, test_case_data: Dict[str, str]):
+    def test_invalid_timestamp_serialization(
+        self, test_case_data: Dict[str, str]
+    ):
         case_dict = json.loads(test_case_data)
         with self.assertRaises((ValueError, KeyError)):
             Timestamp.from_dict(copy.deepcopy(case_dict))
-
 
     valid_timestamps: utils.DataSet = {
         "all": '{ "_type": "timestamp", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
@@ -279,7 +265,6 @@ class TestSerialization(unittest.TestCase):
         case_dict = json.loads(test_case_data)
         timestamp = Timestamp.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, timestamp.to_dict())
-
 
     valid_snapshots: utils.DataSet = {
         "all": '{ "_type": "snapshot", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
@@ -300,23 +285,18 @@ class TestSerialization(unittest.TestCase):
         snapshot = Snapshot.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, snapshot.to_dict())
 
-
     valid_delegated_roles: utils.DataSet = {
         # DelegatedRole inherits Role and some use cases can be found in the valid_roles.
-        "no hash prefix attribute":
-            '{"keyids": ["keyid"], "name": "a", "paths": ["fn1", "fn2"], \
+        "no hash prefix attribute": '{"keyids": ["keyid"], "name": "a", "paths": ["fn1", "fn2"], \
             "terminating": false, "threshold": 1}',
-        "no path attribute":
-            '{"keyids": ["keyid"], "name": "a", "terminating": false, \
+        "no path attribute": '{"keyids": ["keyid"], "name": "a", "terminating": false, \
             "path_hash_prefixes": ["h1", "h2"], "threshold": 99}',
         "empty paths": '{"keyids": ["keyid"], "name": "a", "paths": [], \
             "terminating": false, "threshold": 1}',
         "empty path_hash_prefixes": '{"keyids": ["keyid"], "name": "a", "terminating": false, \
             "path_hash_prefixes": [], "threshold": 99}',
-        "unrecognized field":
-            '{"keyids": ["keyid"], "name": "a", "terminating": true, "paths": ["fn1"], "threshold": 3, "foo": "bar"}',
-        "many keyids":
-            '{"keyids": ["keyid1", "keyid2"], "name": "a", "paths": ["fn1", "fn2"], \
+        "unrecognized field": '{"keyids": ["keyid"], "name": "a", "terminating": true, "paths": ["fn1"], "threshold": 3, "foo": "bar"}',
+        "many keyids": '{"keyids": ["keyid1", "keyid2"], "name": "a", "paths": ["fn1", "fn2"], \
             "terminating": false, "threshold": 1}',
     }
 
@@ -326,13 +306,10 @@ class TestSerialization(unittest.TestCase):
         deserialized_role = DelegatedRole.from_dict(copy.copy(case_dict))
         self.assertDictEqual(case_dict, deserialized_role.to_dict())
 
-
     invalid_delegated_roles: utils.DataSet = {
         # DelegatedRole inherits Role and some use cases can be found in the invalid_roles.
-        "missing hash prefixes and paths":
-            '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false}',
-        "both hash prefixes and paths":
-            '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false, \
+        "missing hash prefixes and paths": '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false}',
+        "both hash prefixes and paths": '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false, \
             "paths": ["fn1", "fn2"], "path_hash_prefixes": ["h1", "h2"]}',
     }
 
@@ -342,9 +319,8 @@ class TestSerialization(unittest.TestCase):
         with self.assertRaises(ValueError):
             DelegatedRole.from_dict(copy.copy(case_dict))
 
-
     invalid_delegations: utils.DataSet = {
-        "empty delegations": '{}',
+        "empty delegations": "{}",
         "bad keys": '{"keys": "foo", \
             "roles": [{"keyids": ["keyid"], "name": "a", "paths": ["fn1", "fn2"], "terminating": false, "threshold": 3}]}',
         "bad roles": '{"keys": {"keyid" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
@@ -363,18 +339,15 @@ class TestSerialization(unittest.TestCase):
         with self.assertRaises((ValueError, KeyError, AttributeError)):
             Delegations.from_dict(copy.deepcopy(case_dict))
 
-
     valid_delegations: utils.DataSet = {
-        "all":
-            '{"keys": { \
+        "all": '{"keys": { \
                 "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}, \
                 "keyid2" : {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "bar"}}}, \
             "roles": [ \
                 {"keyids": ["keyid"], "name": "a", "terminating": true, "paths": ["fn1"], "threshold": 3}, \
                 {"keyids": ["keyid2"], "name": "b", "terminating": true, "paths": ["fn2"], "threshold": 4} ] \
             }',
-        "unrecognized field":
-            '{"keys": {"keyid" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
+        "unrecognized field": '{"keys": {"keyid" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
             "roles": [ {"keyids": ["keyid"], "name": "a", "paths": ["fn1", "fn2"], "terminating": true, "threshold": 3} ], \
             "foo": "bar"}',
         "empty keys and roles": '{"keys": {}, \
@@ -388,7 +361,6 @@ class TestSerialization(unittest.TestCase):
         delegation = Delegations.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, delegation.to_dict())
 
-
     invalid_targetfiles: utils.DataSet = {
         "no hashes": '{"length": 1}',
         "no length": '{"hashes": {"sha256": "abc"}}'
@@ -397,11 +369,12 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_targetfiles)
-    def test_invalid_targetfile_serialization(self, test_case_data: Dict[str, str]):
+    def test_invalid_targetfile_serialization(
+        self, test_case_data: Dict[str, str]
+    ):
         case_dict = json.loads(test_case_data)
         with self.assertRaises(KeyError):
             TargetFile.from_dict(copy.deepcopy(case_dict), "file1.txt")
-
 
     valid_targetfiles: utils.DataSet = {
         "all": '{"length": 12, "hashes": {"sha256" : "abc"}, \
@@ -416,7 +389,6 @@ class TestSerialization(unittest.TestCase):
         case_dict = json.loads(test_case_data)
         target_file = TargetFile.from_dict(copy.copy(case_dict), "file1.txt")
         self.assertDictEqual(case_dict, target_file.to_dict())
-
 
     valid_targets: utils.DataSet = {
         "all attributes": '{"_type": "targets", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
@@ -452,6 +424,6 @@ class TestSerialization(unittest.TestCase):
 
 
 # Run unit test.
-if __name__ == '__main__':
+if __name__ == "__main__":
     utils.configure_test_logging(sys.argv)
     unittest.main()

--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -1,29 +1,28 @@
 import logging
-from typing import Optional, Callable
 import os
 import sys
 import unittest
 from datetime import datetime
+from typing import Callable, Optional
 
-from tuf import exceptions
-from tuf.api.metadata import (
-    Metadata,
-    Signed,
-    Root,
-    Timestamp,
-    Snapshot,
-    MetaFile,
-    Targets,
-)
-from tuf.ngclient._internal.trusted_metadata_set import TrustedMetadataSet
-
-from securesystemslib.signer import SSlibSigner
 from securesystemslib.interface import (
     import_ed25519_privatekey_from_file,
     import_rsa_privatekey_from_file,
 )
+from securesystemslib.signer import SSlibSigner
 
 from tests import utils
+from tuf import exceptions
+from tuf.api.metadata import (
+    Metadata,
+    MetaFile,
+    Root,
+    Signed,
+    Snapshot,
+    Targets,
+    Timestamp,
+)
+from tuf.ngclient._internal.trusted_metadata_set import TrustedMetadataSet
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_updater_key_rotations.py
+++ b/tests/test_updater_key_rotations.py
@@ -33,6 +33,7 @@ class RootVersion:
 
 class TestUpdaterKeyRotations(unittest.TestCase):
     """Test ngclient root rotation handling"""
+
     # set dump_dir to trigger repository state dumps
     dump_dir: Optional[str] = None
 

--- a/tests/test_updater_key_rotations.py
+++ b/tests/test_updater_key_rotations.py
@@ -5,22 +5,21 @@
 
 """Test ngclient Updater key rotation handling"""
 
-from dataclasses import dataclass
-from typing import List, Optional, Type
 import os
 import sys
 import tempfile
 import unittest
+from dataclasses import dataclass
+from typing import List, Optional, Type
 
 from securesystemslib.signer import SSlibSigner
-
-from tuf.api.metadata import Key
-from tuf.exceptions import UnsignedMetadataError
-from tuf.ngclient import Updater
 
 from tests import utils
 from tests.repository_simulator import RepositorySimulator
 from tests.utils import run_sub_tests_with_dataset
+from tuf.api.metadata import Key
+from tuf.exceptions import UnsignedMetadataError
+from tuf.ngclient import Updater
 
 
 @dataclass

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -118,7 +118,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
             repository_dir=self.client_directory,
             metadata_base_url=self.metadata_url,
             target_dir=self.dl_dir,
-            target_base_url=self.targets_url
+            target_base_url=self.targets_url,
         )
 
     def tearDown(self):
@@ -191,15 +191,16 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
             consistent_snapshot_modifier, bump_version=True
         )
         updater = ngclient.Updater(
-            self.client_directory, self.metadata_url, self.dl_dir, self.targets_url
+            self.client_directory,
+            self.metadata_url,
+            self.dl_dir,
+            self.targets_url,
         )
 
         # All metadata is in local directory already
         updater.refresh()
         # Make sure that consistent snapshot is enabled
-        self.assertTrue(
-            updater._trusted_set.root.signed.consistent_snapshot
-        )
+        self.assertTrue(updater._trusted_set.root.signed.consistent_snapshot)
 
         # Get targetinfos, assert cache does not contain the files
         info1 = updater.get_targetinfo("file1.txt")
@@ -252,9 +253,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         self.updater.download_target(info1)
         path = self.updater.find_cached_target(info1)
         self.assertEqual(path, os.path.join(self.dl_dir, info1.path))
-        self.assertIsNone(
-            self.updater.find_cached_target(info3)
-        )
+        self.assertIsNone(self.updater.find_cached_target(info3))
 
         self.updater.download_target(info3)
         path = self.updater.find_cached_target(info1)
@@ -281,7 +280,9 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
     def test_both_target_urls_not_set(self):
         # target_base_url = None and Updater._target_base_url = None
-        updater = ngclient.Updater(self.client_directory, self.metadata_url, self.dl_dir)
+        updater = ngclient.Updater(
+            self.client_directory, self.metadata_url, self.dl_dir
+        )
         info = TargetFile(1, {"sha256": ""}, "targetpath")
         with self.assertRaises(ValueError):
             updater.download_target(info)

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -6,20 +6,21 @@
 """Test Updater class
 """
 
+import logging
 import os
 import shutil
-import tempfile
-import logging
 import sys
-from typing import List
+import tempfile
 import unittest
-import tuf.unittest_toolbox as unittest_toolbox
+from typing import List
 
-from tests import utils
-from tuf.api.metadata import Metadata, TargetFile
-from tuf import exceptions, ngclient
-from securesystemslib.signer import SSlibSigner
 from securesystemslib.interface import import_rsa_privatekey_from_file
+from securesystemslib.signer import SSlibSigner
+
+import tuf.unittest_toolbox as unittest_toolbox
+from tests import utils
+from tuf import exceptions, ngclient
+from tuf.api.metadata import Metadata, TargetFile
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_updater_with_simulator.py
+++ b/tests/test_updater_with_simulator.py
@@ -9,16 +9,14 @@
 import os
 import sys
 import tempfile
-from tuf.api.metadata import SPECIFICATION_VERSION, Targets
-from typing import Optional, Tuple
-from tuf.exceptions import UnsignedMetadataError, BadVersionNumberError
 import unittest
-
-from tuf.ngclient import Updater
+from typing import Optional, Tuple
 
 from tests import utils
 from tests.repository_simulator import RepositorySimulator
-from securesystemslib import hash as sslib_hash
+from tuf.api.metadata import SPECIFICATION_VERSION, Targets
+from tuf.exceptions import BadVersionNumberError, UnsignedMetadataError
+from tuf.ngclient import Updater
 
 
 class TestUpdater(unittest.TestCase):

--- a/tests/test_updater_with_simulator.py
+++ b/tests/test_updater_with_simulator.py
@@ -23,7 +23,7 @@ from securesystemslib import hash as sslib_hash
 
 class TestUpdater(unittest.TestCase):
     # set dump_dir to trigger repository state dumps
-    dump_dir:Optional[str] = None
+    dump_dir: Optional[str] = None
 
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
@@ -35,12 +35,14 @@ class TestUpdater(unittest.TestCase):
         # Setup the repository, bootstrap client root.json
         self.sim = RepositorySimulator()
         with open(os.path.join(self.metadata_dir, "root.json"), "bw") as f:
-            root = self.sim.download_bytes("https://example.com/metadata/1.root.json", 100000)
+            root = self.sim.download_bytes(
+                "https://example.com/metadata/1.root.json", 100000
+            )
             f.write(root)
 
         if self.dump_dir is not None:
             # create test specific dump directory
-            name = self.id().split('.')[-1]
+            name = self.id().split(".")[-1]
             self.sim.dump_dir = os.path.join(self.dump_dir, name)
             os.mkdir(self.sim.dump_dir)
 
@@ -56,7 +58,7 @@ class TestUpdater(unittest.TestCase):
             "https://example.com/metadata/",
             self.targets_dir,
             "https://example.com/targets/",
-            self.sim
+            self.sim,
         )
         updater.refresh()
         return updater
@@ -85,7 +87,11 @@ class TestUpdater(unittest.TestCase):
     targets: utils.DataSet = {
         "standard case": ("targetpath", b"content", "targetpath"),
         "non-asci case": ("åäö", b"more content", "%C3%A5%C3%A4%C3%B6"),
-        "subdirectory case": ("a/b/c/targetpath", b"dir target content", "a%2Fb%2Fc%2Ftargetpath"),
+        "subdirectory case": (
+            "a/b/c/targetpath",
+            b"dir target content",
+            "a%2Fb%2Fc%2Ftargetpath",
+        ),
     }
 
     @utils.run_sub_tests_with_dataset(targets)
@@ -132,14 +138,16 @@ class TestUpdater(unittest.TestCase):
             "": ".json",
             ".": "..json",
             "/": "%2F.json",
-            "ö": "%C3%B6.json"
+            "ö": "%C3%B6.json",
         }
 
         # Add new delegated targets, update the snapshot
         spec_version = ".".join(SPECIFICATION_VERSION)
         targets = Targets(1, spec_version, self.sim.safe_expiry, {}, None)
         for role in roles_to_filenames.keys():
-            self.sim.add_delegation("targets", role, targets, False, ["*"], None)
+            self.sim.add_delegation(
+                "targets", role, targets, False, ["*"], None
+            )
         self.sim.update_snapshot()
 
         updater = self._run_refresh()


### PR DESCRIPTION
Fixes #1656

**Description of the changes being introduced by the pull request**:

Currently, we don't do any listing for our tests.
I believe we should enable linting (tox -e lint) for new test files.

The first step to do that would be to apply the automatic fixes proposed
by `black` and isort on the new test files testing the new code.
The next step would be to propose fixes for `pylint` and `mypy` and the last
the part will be to enable the linters themselves. 

Additionally, I saw one opportunity to simplify a little test_api.py and that's
what the last commit is all about.

Related to issue #1582.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>


