### PR TITLE
pylintc for new code: disable format checker

### DIFF
--- a/tuf/api/pylintrc
+++ b/tuf/api/pylintrc
@@ -14,6 +14,7 @@
 disable=fixme,
         too-few-public-methods,
         too-many-arguments,
+        format,
 
 [BASIC]
 good-names=i,j,k,v,e,f,fn,fp,_type

--- a/tuf/api/pylintrc
+++ b/tuf/api/pylintrc
@@ -35,15 +35,6 @@ no-docstring-rgx=(__.*__|main|test.*|.*test|.*Test)$
 variable-rgx=^[a-z][a-z0-9_]*$
 docstring-min-length=10
 
-[FORMAT]
-ignore-long-lines=(?x)(
-  ^\s*(\#\ )?<?https?://\S+>?$|
-  ^\s*(from\s+\S+\s+)?import\s+.+$)
-indent-string="    "
-indent-after-paren=4
-max-line-length=80
-single-line-if-stmt=yes
-
 [LOGGING]
 logging-format-style=old
 


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

By default pylint does format checks:
https://pylint.pycqa.org/en/latest/technical_reference/features.html?highlight=format#format-checker

The problem is we also use black and isort who have format checkers as
well. This makes pylint format checks obsolete.

Also, it's possible that you would want to disable a warning and you
can end up in the situation where you will have to disable it for
two tools altogether.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>


