### PR TITLE
github: explicitly set workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Tests


### PR DESCRIPTION
* current workflow only needs to read git content
* if the workflow in the future does need write access (or even other read access than the git repo), it's good to
  see permissions explicitly changing

For context: "pull_request" runs never have any write access anyway, so this
significantly changes only the "push" runs that happen when branches are
merged to develop.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

Fixes #1662
