### PR TITLE
New implementation tests: address pylint warnings

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,6 +44,8 @@ logger = logging.getLogger(__name__)
 
 
 class TestMetadata(unittest.TestCase):
+    """Tests for public API of all classes in 'tuf/api/metadata.py'."""
+
     @classmethod
     def setUpClass(cls):
         # Create a temporary directory to store the repository, metadata, and
@@ -246,8 +248,8 @@ class TestMetadata(unittest.TestCase):
         sig.signature = correct_sig
 
     def test_metadata_base(self):
-        # Use of Snapshot is arbitrary, we're just testing the base class features
-        # with real data
+        # Use of Snapshot is arbitrary, we're just testing the base class
+        # features with real data
         snapshot_path = os.path.join(self.repo_dir, "metadata", "snapshot.json")
         md = Metadata.from_file(snapshot_path)
 
@@ -473,6 +475,7 @@ class TestMetadata(unittest.TestCase):
             root.signed.remove_key("nosuchrole", keyid)
 
     def test_is_target_in_pathpattern(self):
+        # pylint: disable=protected-access
         supported_use_cases = [
             ("foo.tgz", "foo.tgz"),
             ("foo.tgz", "*"),
@@ -507,7 +510,7 @@ class TestMetadata(unittest.TestCase):
         targets_path = os.path.join(self.repo_dir, "metadata", "targets.json")
         targets = Metadata[Targets].from_file(targets_path)
 
-        # Create a fileinfo dict representing what we expect the updated data to be
+        # Create a fileinfo dict representing the expected updated data.
         filename = "file2.txt"
         hashes = {
             "sha256": "141f740f53781d1ca54b8a50af22cbf74e44c21a998fa2a8a05aaac2c002886b",

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -17,13 +17,15 @@ import unittest
 import tuf
 import tuf.exceptions
 import tuf.requests_fetcher
-import tuf.unittest_toolbox as unittest_toolbox
 from tests import utils
+from tuf import unittest_toolbox
 
 logger = logging.getLogger(__name__)
 
 
 class TestFetcher(unittest_toolbox.Modified_TestCase):
+    """Unit tests for RequestFetcher."""
+
     def setUp(self):
         """
         Create a temporary file and launch a simple server in the
@@ -35,9 +37,9 @@ class TestFetcher(unittest_toolbox.Modified_TestCase):
         # Making a temporary file.
         current_dir = os.getcwd()
         target_filepath = self.make_temp_data_file(directory=current_dir)
-        self.target_fileobj = open(target_filepath, "r")
-        self.file_contents = self.target_fileobj.read()
-        self.file_length = len(self.file_contents)
+        with open(target_filepath, "r", encoding="utf8") as target_fileobj:
+            self.file_contents = target_fileobj.read()
+            self.file_length = len(self.file_contents)
 
         # Launch a SimpleHTTPServer (serves files in the current dir).
         self.server_process_handler = utils.TestServerProcess(log=logger)
@@ -54,6 +56,7 @@ class TestFetcher(unittest_toolbox.Modified_TestCase):
 
         # Create a temporary file where the target file chunks are written
         # during fetching
+        # pylint: disable-next=consider-using-with
         self.temp_file = tempfile.TemporaryFile()
         self.fetcher = tuf.requests_fetcher.RequestsFetcher()
 
@@ -62,7 +65,6 @@ class TestFetcher(unittest_toolbox.Modified_TestCase):
         # Cleans the resources and flush the logged lines (if any).
         self.server_process_handler.clean()
 
-        self.target_fileobj.close()
         self.temp_file.close()
 
         # Remove temporary directory

--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -26,6 +26,8 @@ logger = logging.getLogger(__name__)
 
 
 class TestFetcher(unittest_toolbox.Modified_TestCase):
+    """Test RequestsFetcher class."""
+
     @classmethod
     def setUpClass(cls):
         # Launch a SimpleHTTPServer (serves files in the current dir).
@@ -48,17 +50,21 @@ class TestFetcher(unittest_toolbox.Modified_TestCase):
         current_dir = os.getcwd()
         target_filepath = self.make_temp_data_file(directory=current_dir)
 
-        self.target_fileobj = open(target_filepath, "r")
-        self.file_contents = self.target_fileobj.read()
-        self.file_length = len(self.file_contents)
+        with open(target_filepath, "r", encoding="utf8") as target_fileobj:
+            self.file_contents = target_fileobj.read()
+            self.file_length = len(self.file_contents)
+
         self.rel_target_filepath = os.path.basename(target_filepath)
-        self.url = f"http://{utils.TEST_HOST_ADDRESS}:{str(self.server_process_handler.port)}/{self.rel_target_filepath}"
+        self.url_prefix = (
+            f"http://{utils.TEST_HOST_ADDRESS}:"
+            f"{str(self.server_process_handler.port)}"
+        )
+        self.url = f"{self.url_prefix}/{self.rel_target_filepath}"
 
         # Instantiate a concrete instance of FetcherInterface
         self.fetcher = RequestsFetcher()
 
     def tearDown(self):
-        self.target_fileobj.close()
         # Remove temporary directory
         unittest_toolbox.Modified_TestCase.tearDown(self)
 
@@ -106,7 +112,7 @@ class TestFetcher(unittest_toolbox.Modified_TestCase):
     # File not found error
     def test_http_error(self):
         with self.assertRaises(exceptions.FetcherHTTPError) as cm:
-            self.url = f"http://{utils.TEST_HOST_ADDRESS}:{str(self.server_process_handler.port)}/non-existing-path"
+            self.url = f"{self.url_prefix}/non-existing-path"
             self.fetcher.fetch(self.url)
         self.assertEqual(cm.exception.status_code, 404)
 

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 class TestSerialization(unittest.TestCase):
+    """Test serialization for all classes in 'tuf/api/metadata.py'."""
 
     # Snapshot instances with meta = {} are valid, but for a full valid
     # repository it's required that meta has at least one element inside it.

--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -1,3 +1,4 @@
+"""Unit tests for 'tuf/ngclient/_internal/trusted_metadata_set.py'."""
 import logging
 import os
 import sys
@@ -26,16 +27,18 @@ from tuf.ngclient._internal.trusted_metadata_set import TrustedMetadataSet
 
 logger = logging.getLogger(__name__)
 
-
+# pylint: disable=too-many-public-methods
 class TestTrustedMetadataSet(unittest.TestCase):
+    """Tests for all public API of the TrustedMetadataSet class."""
+
     def modify_metadata(
-        self, rolename: str, modification_func: Callable[["Signed"], None]
+        self, rolename: str, modification_func: Callable[[Signed], None]
     ) -> bytes:
         """Instantiate metadata from rolename type, call modification_func and
         sign it again with self.keystore[rolename] signer.
 
         Attributes:
-            rolename: A denoting the name of the metadata which will be modified.
+            rolename: Denoting the name of the metadata which will be modified.
             modification_func: Function that will be called to modify the signed
                 portion of metadata bytes.
         """

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -17,20 +17,22 @@ from typing import List
 from securesystemslib.interface import import_rsa_privatekey_from_file
 from securesystemslib.signer import SSlibSigner
 
-import tuf.unittest_toolbox as unittest_toolbox
 from tests import utils
-from tuf import exceptions, ngclient
+from tuf import exceptions, ngclient, unittest_toolbox
 from tuf.api.metadata import Metadata, TargetFile
 
 logger = logging.getLogger(__name__)
 
 
 class TestUpdater(unittest_toolbox.Modified_TestCase):
+    """Test the Updater class from 'tuf/ngclient/updater.py'."""
+
     @classmethod
     def setUpClass(cls):
-        # Create a temporary directory to store the repository, metadata, and target
-        # files.  'temporary_directory' must be deleted in TearDownModule() so that
-        # temporary files are always removed, even when exceptions occur.
+        # Create a temporary directory to store the repository, metadata, and
+        # target files. 'temporary_directory' must be deleted in
+        # TearDownModule() so that temporary files are always removed, even when
+        # exceptions occur.
         cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
 
         # Needed because in some tests simple_server.py cannot be found.
@@ -51,8 +53,8 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         # Cleans the resources and flush the logged lines (if any).
         cls.server_process_handler.clean()
 
-        # Remove the temporary repository directory, which should contain all the
-        # metadata, targets, and key files generated for the test cases
+        # Remove the temporary repository directory, which should contain all
+        # the metadata, targets, and key files generated for the test cases
         shutil.rmtree(cls.temporary_directory)
 
     def setUp(self):
@@ -60,15 +62,15 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         unittest_toolbox.Modified_TestCase.setUp(self)
 
         # Copy the original repository files provided in the test folder so that
-        # any modifications made to repository files are restricted to the copies.
+        # any modifications are restricted to the copies.
         # The 'repository_data' directory is expected to exist in 'tuf.tests/'.
         original_repository_files = os.path.join(os.getcwd(), "repository_data")
         temporary_repository_root = self.make_temp_directory(
             directory=self.temporary_directory
         )
 
-        # The original repository, keystore, and client directories will be copied
-        # for each test case.
+        # The original repository, keystore, and client directories will be
+        # copied for each test case.
         original_repository = os.path.join(
             original_repository_files, "repository"
         )
@@ -183,6 +185,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         client_files = sorted(os.listdir(self.client_directory))
         self.assertEqual(client_files, expected_files)
 
+    # pylint: disable=protected-access
     def test_refresh_on_consistent_targets(self):
         # Generate a new root version where consistent_snapshot is set to true
         def consistent_snapshot_modifier(root):
@@ -228,7 +231,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         self.assertEqual(path, os.path.join(self.dl_dir, info3.path))
 
     def test_refresh_and_download(self):
-        # Test refresh without consistent targets - targets without hash prefixes.
+        # Test refresh without consistent targets - targets without hash prefix.
 
         # top-level targets are already in local cache (but remove others)
         os.remove(os.path.join(self.client_directory, "role1.json"))
@@ -275,7 +278,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         self._assert_files(["root", "snapshot", "targets", "timestamp"])
 
         # Get targetinfo for 'file3.txt' listed in the delegated role1
-        targetinfo3 = self.updater.get_targetinfo("file3.txt")
+        self.updater.get_targetinfo("file3.txt")
         expected_files = ["role1", "root", "snapshot", "targets", "timestamp"]
         self._assert_files(expected_files)
 
@@ -317,6 +320,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
             targetinfo.hashes = {"sha256": "abcd"}
             self.updater.download_target(targetinfo)
 
+    # pylint: disable=protected-access
     def test_updating_root(self):
         # Bump root version, resign and refresh
         self._modify_repository_root(lambda root: None, bump_version=True)

--- a/tests/test_updater_with_simulator.py
+++ b/tests/test_updater_with_simulator.py
@@ -3,7 +3,7 @@
 # Copyright 2021, New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""Test ngclient Updater using the repository simulator
+"""Test ngclient Updater using the repository simulator.
 """
 
 import os
@@ -20,10 +20,13 @@ from tuf.ngclient import Updater
 
 
 class TestUpdater(unittest.TestCase):
+    """Test ngclient Updater using the repository simulator."""
+
     # set dump_dir to trigger repository state dumps
     dump_dir: Optional[str] = None
 
     def setUp(self):
+        # pylint: disable-next=consider-using-with
         self.temp_dir = tempfile.TemporaryDirectory()
         self.metadata_dir = os.path.join(self.temp_dir.name, "metadata")
         self.targets_dir = os.path.join(self.temp_dir.name, "targets")
@@ -48,6 +51,7 @@ class TestUpdater(unittest.TestCase):
         self.temp_dir.cleanup()
 
     def _run_refresh(self) -> Updater:
+        """Creates a new updater and runs refresh."""
         if self.sim.dump_dir is not None:
             self.sim.write()
 
@@ -142,7 +146,7 @@ class TestUpdater(unittest.TestCase):
         # Add new delegated targets, update the snapshot
         spec_version = ".".join(SPECIFICATION_VERSION)
         targets = Targets(1, spec_version, self.sim.safe_expiry, {}, None)
-        for role in roles_to_filenames.keys():
+        for role in roles_to_filenames:
             self.sim.add_delegation(
                 "targets", role, targets, False, ["*"], None
             )
@@ -214,7 +218,7 @@ class TestUpdater(unittest.TestCase):
         self.sim.update_snapshot()
         self._run_refresh()
 
-        # The new targets should have a lower version than the local trusted one.
+        # The new targets must have a lower version than the local trusted one.
         self.sim.targets.version = 1
         self.sim.update_snapshot()
 

--- a/tuf/api/pylintrc
+++ b/tuf/api/pylintrc
@@ -18,7 +18,7 @@ disable=fixme,
         duplicate-code,
 
 [BASIC]
-good-names=i,j,k,v,e,f,fn,fp,_type
+good-names=i,j,k,v,e,f,fn,fp,_type,_
 # Regexes for allowed names are copied from the Google pylintrc
 # NOTE: Pylint captures regex name groups such as 'snake_case' or 'camel_case'.
 # If there are multiple groups it enfoces the prevalent naming style inside

--- a/tuf/api/pylintrc
+++ b/tuf/api/pylintrc
@@ -15,6 +15,7 @@ disable=fixme,
         too-few-public-methods,
         too-many-arguments,
         format,
+        duplicate-code,
 
 [BASIC]
 good-names=i,j,k,v,e,f,fn,fp,_type


### PR DESCRIPTION
Related to #1657:

**Description of the changes being introduced by the pull request**:

I believe we should enable linting (tox -e lint) for new test files testing the new implementation.

The first step to do that would be to apply the automatic fixes proposed
by `black` and `isort` on the new test files testing the new code.
This happened in #1658.

The next step would be to propose fixes for `pylint` and `mypy` and the last
the part will be to enable the linters themselves.

In this pr, I include fixes for the warnings by `pylint` only as those changes are **NOT**
automatically by the tool and are more than enough for a pr.


