### PR TITLE
Metadata API: make Root roles a Mapping

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -722,7 +722,7 @@ class Root(Signed):
         spec_version: str,
         expires: datetime,
         keys: Dict[str, Key],
-        roles: Dict[str, Role],
+        roles: Mapping[str, Role],
         consistent_snapshot: Optional[bool] = None,
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ):


### PR DESCRIPTION
Fixes #1356 

**Description of the changes being introduced by the pull request**:

This pr includes a couple of smaller changes:
- make root roles `Mapping`  to indicate that users should not add or remove
values from the dictionary during the lifetime of the Root object

**_EDIT: Those two were included in the initial version of the pr._**
**Then together with @jku we agreed we don't want to do that.
See my comment https://github.com/theupdateframework/python-tuf/pull/1668#issuecomment-971755506**
- validate that TARGETPATHs are not empty strings
- validate that METAPATHs are not empty strings or any of the top-level metadata roles

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


