### PR TITLE
Create constants for top-level rolenames

### DIFF
--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -58,10 +58,10 @@ class TestTrustedMetadataSet(unittest.TestCase):
         )
         cls.metadata = {}
         for md in [
-            "root",
-            "timestamp",
-            "snapshot",
-            "targets",
+            Root.type,
+            Timestamp.type,
+            Snapshot.type,
+            Targets.type,
             "role1",
             "role2",
         ]:
@@ -71,10 +71,10 @@ class TestTrustedMetadataSet(unittest.TestCase):
         keystore_dir = os.path.join(os.getcwd(), "repository_data", "keystore")
         cls.keystore = {}
         root_key_dict = import_rsa_privatekey_from_file(
-            os.path.join(keystore_dir, "root" + "_key"), password="password"
+            os.path.join(keystore_dir, Root.type + "_key"), password="password"
         )
-        cls.keystore["root"] = SSlibSigner(root_key_dict)
-        for role in ["delegation", "snapshot", "targets", "timestamp"]:
+        cls.keystore[Root.type] = SSlibSigner(root_key_dict)
+        for role in ["delegation", Snapshot.type, Targets.type, Timestamp.type]:
             key_dict = import_ed25519_privatekey_from_file(
                 os.path.join(keystore_dir, role + "_key"), password="password"
             )
@@ -84,12 +84,12 @@ class TestTrustedMetadataSet(unittest.TestCase):
             timestamp.snapshot_meta.hashes = None
             timestamp.snapshot_meta.length = None
 
-        cls.metadata["timestamp"] = cls.modify_metadata(
-            "timestamp", hashes_length_modifier
+        cls.metadata[Timestamp.type] = cls.modify_metadata(
+            Timestamp.type, hashes_length_modifier
         )
 
     def setUp(self) -> None:
-        self.trusted_set = TrustedMetadataSet(self.metadata["root"])
+        self.trusted_set = TrustedMetadataSet(self.metadata[Root.type])
 
     def _update_all_besides_targets(
         self,
@@ -101,24 +101,24 @@ class TestTrustedMetadataSet(unittest.TestCase):
         Args:
             timestamp_bytes:
                 Bytes used when calling trusted_set.update_timestamp().
-                Default self.metadata["timestamp"].
+                Default self.metadata[Timestamp.type].
             snapshot_bytes:
                 Bytes used when calling trusted_set.update_snapshot().
-                Default self.metadata["snapshot"].
+                Default self.metadata[Snapshot.type].
 
         """
 
-        timestamp_bytes = timestamp_bytes or self.metadata["timestamp"]
+        timestamp_bytes = timestamp_bytes or self.metadata[Timestamp.type]
         self.trusted_set.update_timestamp(timestamp_bytes)
-        snapshot_bytes = snapshot_bytes or self.metadata["snapshot"]
+        snapshot_bytes = snapshot_bytes or self.metadata[Snapshot.type]
         self.trusted_set.update_snapshot(snapshot_bytes)
 
     def test_update(self) -> None:
-        self.trusted_set.update_timestamp(self.metadata["timestamp"])
-        self.trusted_set.update_snapshot(self.metadata["snapshot"])
-        self.trusted_set.update_targets(self.metadata["targets"])
+        self.trusted_set.update_timestamp(self.metadata[Timestamp.type])
+        self.trusted_set.update_snapshot(self.metadata[Snapshot.type])
+        self.trusted_set.update_targets(self.metadata[Targets.type])
         self.trusted_set.update_delegated_targets(
-            self.metadata["role1"], "role1", "targets"
+            self.metadata["role1"], "role1", Targets.type
         )
         self.trusted_set.update_delegated_targets(
             self.metadata["role2"], "role2", "role1"
@@ -154,38 +154,38 @@ class TestTrustedMetadataSet(unittest.TestCase):
     def test_out_of_order_ops(self) -> None:
         # Update snapshot before timestamp
         with self.assertRaises(RuntimeError):
-            self.trusted_set.update_snapshot(self.metadata["snapshot"])
+            self.trusted_set.update_snapshot(self.metadata[Snapshot.type])
 
-        self.trusted_set.update_timestamp(self.metadata["timestamp"])
+        self.trusted_set.update_timestamp(self.metadata[Timestamp.type])
 
         # Update root after timestamp
         with self.assertRaises(RuntimeError):
-            self.trusted_set.update_root(self.metadata["root"])
+            self.trusted_set.update_root(self.metadata[Root.type])
 
         # Update targets before snapshot
         with self.assertRaises(RuntimeError):
-            self.trusted_set.update_targets(self.metadata["targets"])
+            self.trusted_set.update_targets(self.metadata[Targets.type])
 
-        self.trusted_set.update_snapshot(self.metadata["snapshot"])
+        self.trusted_set.update_snapshot(self.metadata[Snapshot.type])
 
         # update timestamp after snapshot
         with self.assertRaises(RuntimeError):
-            self.trusted_set.update_timestamp(self.metadata["timestamp"])
+            self.trusted_set.update_timestamp(self.metadata[Timestamp.type])
 
         # Update delegated targets before targets
         with self.assertRaises(RuntimeError):
             self.trusted_set.update_delegated_targets(
-                self.metadata["role1"], "role1", "targets"
+                self.metadata["role1"], "role1", Targets.type
             )
 
-        self.trusted_set.update_targets(self.metadata["targets"])
+        self.trusted_set.update_targets(self.metadata[Targets.type])
 
         # Update snapshot after sucessful targets update
         with self.assertRaises(RuntimeError):
-            self.trusted_set.update_snapshot(self.metadata["snapshot"])
+            self.trusted_set.update_snapshot(self.metadata[Snapshot.type])
 
         self.trusted_set.update_delegated_targets(
-            self.metadata["role1"], "role1", "targets"
+            self.metadata["role1"], "role1", Targets.type
         )
 
     def test_root_with_invalid_json(self) -> None:
@@ -196,20 +196,20 @@ class TestTrustedMetadataSet(unittest.TestCase):
                 test_func(b"")
 
             # root is invalid
-            root = Metadata.from_bytes(self.metadata["root"])
+            root = Metadata.from_bytes(self.metadata[Root.type])
             root.signed.version += 1
             with self.assertRaises(exceptions.UnsignedMetadataError):
                 test_func(root.to_bytes())
 
             # metadata is of wrong type
             with self.assertRaises(exceptions.RepositoryError):
-                test_func(self.metadata["snapshot"])
+                test_func(self.metadata[Snapshot.type])
 
     def test_top_level_md_with_invalid_json(self) -> None:
         top_level_md: List[Tuple[bytes, Callable[[bytes], Metadata]]] = [
-            (self.metadata["timestamp"], self.trusted_set.update_timestamp),
-            (self.metadata["snapshot"], self.trusted_set.update_snapshot),
-            (self.metadata["targets"], self.trusted_set.update_targets),
+            (self.metadata[Timestamp.type], self.trusted_set.update_timestamp),
+            (self.metadata[Snapshot.type], self.trusted_set.update_snapshot),
+            (self.metadata[Targets.type], self.trusted_set.update_targets),
         ]
         for metadata, update_func in top_level_md:
             md = Metadata.from_bytes(metadata)
@@ -224,7 +224,7 @@ class TestTrustedMetadataSet(unittest.TestCase):
 
             # metadata is of wrong type
             with self.assertRaises(exceptions.RepositoryError):
-                update_func(self.metadata["root"])
+                update_func(self.metadata[Root.type])
 
             update_func(metadata)
 
@@ -233,53 +233,53 @@ class TestTrustedMetadataSet(unittest.TestCase):
         def root_new_version_modifier(root: Root) -> None:
             root.version += 1
 
-        root = self.modify_metadata("root", root_new_version_modifier)
+        root = self.modify_metadata(Root.type, root_new_version_modifier)
         self.trusted_set.update_root(root)
 
     def test_update_root_new_root_fail_threshold_verification(self) -> None:
         # new_root data with threshold which cannot be verified.
-        root = Metadata.from_bytes(self.metadata["root"])
+        root = Metadata.from_bytes(self.metadata[Root.type])
         # remove root role keyids representing root signatures
-        root.signed.roles["root"].keyids = set()
+        root.signed.roles[Root.type].keyids = set()
         with self.assertRaises(exceptions.UnsignedMetadataError):
             self.trusted_set.update_root(root.to_bytes())
 
     def test_update_root_new_root_ver_same_as_trusted_root_ver(self) -> None:
         with self.assertRaises(exceptions.ReplayedMetadataError):
-            self.trusted_set.update_root(self.metadata["root"])
+            self.trusted_set.update_root(self.metadata[Root.type])
 
     def test_root_expired_final_root(self) -> None:
         def root_expired_modifier(root: Root) -> None:
             root.expires = datetime(1970, 1, 1)
 
         # intermediate root can be expired
-        root = self.modify_metadata("root", root_expired_modifier)
+        root = self.modify_metadata(Root.type, root_expired_modifier)
         tmp_trusted_set = TrustedMetadataSet(root)
         # update timestamp to trigger final root expiry check
         with self.assertRaises(exceptions.ExpiredMetadataError):
-            tmp_trusted_set.update_timestamp(self.metadata["timestamp"])
+            tmp_trusted_set.update_timestamp(self.metadata[Timestamp.type])
 
     def test_update_timestamp_new_timestamp_ver_below_trusted_ver(self) -> None:
         # new_timestamp.version < trusted_timestamp.version
         def version_modifier(timestamp: Timestamp) -> None:
             timestamp.version = 3
 
-        timestamp = self.modify_metadata("timestamp", version_modifier)
+        timestamp = self.modify_metadata(Timestamp.type, version_modifier)
         self.trusted_set.update_timestamp(timestamp)
         with self.assertRaises(exceptions.ReplayedMetadataError):
-            self.trusted_set.update_timestamp(self.metadata["timestamp"])
+            self.trusted_set.update_timestamp(self.metadata[Timestamp.type])
 
     def test_update_timestamp_snapshot_ver_below_current(self) -> None:
         def bump_snapshot_version(timestamp: Timestamp) -> None:
             timestamp.snapshot_meta.version = 2
 
         # set current known snapshot.json version to 2
-        timestamp = self.modify_metadata("timestamp", bump_snapshot_version)
+        timestamp = self.modify_metadata(Timestamp.type, bump_snapshot_version)
         self.trusted_set.update_timestamp(timestamp)
 
         # newtimestamp.meta.version < trusted_timestamp.meta.version
         with self.assertRaises(exceptions.ReplayedMetadataError):
-            self.trusted_set.update_timestamp(self.metadata["timestamp"])
+            self.trusted_set.update_timestamp(self.metadata[Timestamp.type])
 
     def test_update_timestamp_expired(self) -> None:
         # new_timestamp has expired
@@ -288,29 +288,29 @@ class TestTrustedMetadataSet(unittest.TestCase):
 
         # expired intermediate timestamp is loaded but raises
         timestamp = self.modify_metadata(
-            "timestamp", timestamp_expired_modifier
+            Timestamp.type, timestamp_expired_modifier
         )
         with self.assertRaises(exceptions.ExpiredMetadataError):
             self.trusted_set.update_timestamp(timestamp)
 
         # snapshot update does start but fails because timestamp is expired
         with self.assertRaises(exceptions.ExpiredMetadataError):
-            self.trusted_set.update_snapshot(self.metadata["snapshot"])
+            self.trusted_set.update_snapshot(self.metadata[Snapshot.type])
 
     def test_update_snapshot_length_or_hash_mismatch(self) -> None:
         def modify_snapshot_length(timestamp: Timestamp) -> None:
             timestamp.snapshot_meta.length = 1
 
         # set known snapshot.json length to 1
-        timestamp = self.modify_metadata("timestamp", modify_snapshot_length)
+        timestamp = self.modify_metadata(Timestamp.type, modify_snapshot_length)
         self.trusted_set.update_timestamp(timestamp)
 
         with self.assertRaises(exceptions.RepositoryError):
-            self.trusted_set.update_snapshot(self.metadata["snapshot"])
+            self.trusted_set.update_snapshot(self.metadata[Snapshot.type])
 
     def test_update_snapshot_fail_threshold_verification(self) -> None:
-        self.trusted_set.update_timestamp(self.metadata["timestamp"])
-        snapshot = Metadata.from_bytes(self.metadata["snapshot"])
+        self.trusted_set.update_timestamp(self.metadata[Timestamp.type])
+        snapshot = Metadata.from_bytes(self.metadata[Snapshot.type])
         snapshot.signatures.clear()
         with self.assertRaises(exceptions.UnsignedMetadataError):
             self.trusted_set.update_snapshot(snapshot.to_bytes())
@@ -322,55 +322,55 @@ class TestTrustedMetadataSet(unittest.TestCase):
             timestamp.snapshot_meta.version = 2
 
         timestamp = self.modify_metadata(
-            "timestamp", timestamp_version_modifier
+            Timestamp.type, timestamp_version_modifier
         )
         self.trusted_set.update_timestamp(timestamp)
 
         # if intermediate snapshot version is incorrect, load it but also raise
         with self.assertRaises(exceptions.BadVersionNumberError):
-            self.trusted_set.update_snapshot(self.metadata["snapshot"])
+            self.trusted_set.update_snapshot(self.metadata[Snapshot.type])
 
         # targets update starts but fails if snapshot version does not match
         with self.assertRaises(exceptions.BadVersionNumberError):
-            self.trusted_set.update_targets(self.metadata["targets"])
+            self.trusted_set.update_targets(self.metadata[Targets.type])
 
     def test_update_snapshot_file_removed_from_meta(self) -> None:
-        self._update_all_besides_targets(self.metadata["timestamp"])
+        self._update_all_besides_targets(self.metadata[Timestamp.type])
 
         def remove_file_from_meta(snapshot: Snapshot) -> None:
             del snapshot.meta["targets.json"]
 
         # Test removing a meta_file in new_snapshot compared to the old snapshot
-        snapshot = self.modify_metadata("snapshot", remove_file_from_meta)
+        snapshot = self.modify_metadata(Snapshot.type, remove_file_from_meta)
         with self.assertRaises(exceptions.RepositoryError):
             self.trusted_set.update_snapshot(snapshot)
 
     def test_update_snapshot_meta_version_decreases(self) -> None:
-        self.trusted_set.update_timestamp(self.metadata["timestamp"])
+        self.trusted_set.update_timestamp(self.metadata[Timestamp.type])
 
         def version_meta_modifier(snapshot: Snapshot) -> None:
             snapshot.meta["targets.json"].version += 1
 
-        snapshot = self.modify_metadata("snapshot", version_meta_modifier)
+        snapshot = self.modify_metadata(Snapshot.type, version_meta_modifier)
         self.trusted_set.update_snapshot(snapshot)
 
         with self.assertRaises(exceptions.BadVersionNumberError):
-            self.trusted_set.update_snapshot(self.metadata["snapshot"])
+            self.trusted_set.update_snapshot(self.metadata[Snapshot.type])
 
     def test_update_snapshot_expired_new_snapshot(self) -> None:
-        self.trusted_set.update_timestamp(self.metadata["timestamp"])
+        self.trusted_set.update_timestamp(self.metadata[Timestamp.type])
 
         def snapshot_expired_modifier(snapshot: Snapshot) -> None:
             snapshot.expires = datetime(1970, 1, 1)
 
         # expired intermediate snapshot is loaded but will raise
-        snapshot = self.modify_metadata("snapshot", snapshot_expired_modifier)
+        snapshot = self.modify_metadata(Snapshot.type, snapshot_expired_modifier)
         with self.assertRaises(exceptions.ExpiredMetadataError):
             self.trusted_set.update_snapshot(snapshot)
 
         # targets update does start but fails because snapshot is expired
         with self.assertRaises(exceptions.ExpiredMetadataError):
-            self.trusted_set.update_targets(self.metadata["targets"])
+            self.trusted_set.update_targets(self.metadata[Targets.type])
 
     def test_update_snapshot_successful_rollback_checks(self) -> None:
         def meta_version_bump(timestamp: Timestamp) -> None:
@@ -380,51 +380,51 @@ class TestTrustedMetadataSet(unittest.TestCase):
             snapshot.version += 1
 
         # load a "local" timestamp, then update to newer one:
-        self.trusted_set.update_timestamp(self.metadata["timestamp"])
-        new_timestamp = self.modify_metadata("timestamp", meta_version_bump)
+        self.trusted_set.update_timestamp(self.metadata[Timestamp.type])
+        new_timestamp = self.modify_metadata(Timestamp.type, meta_version_bump)
         self.trusted_set.update_timestamp(new_timestamp)
 
         # load a "local" snapshot with mismatching version (loading happens but
         # BadVersionNumberError is raised), then update to newer one:
         with self.assertRaises(exceptions.BadVersionNumberError):
-            self.trusted_set.update_snapshot(self.metadata["snapshot"])
-        new_snapshot = self.modify_metadata("snapshot", version_bump)
+            self.trusted_set.update_snapshot(self.metadata[Snapshot.type])
+        new_snapshot = self.modify_metadata(Snapshot.type, version_bump)
         self.trusted_set.update_snapshot(new_snapshot)
 
         # update targets to trigger final snapshot meta version check
-        self.trusted_set.update_targets(self.metadata["targets"])
+        self.trusted_set.update_targets(self.metadata[Targets.type])
 
     def test_update_targets_no_meta_in_snapshot(self) -> None:
         def no_meta_modifier(snapshot: Snapshot) -> None:
             snapshot.meta = {}
 
-        snapshot = self.modify_metadata("snapshot", no_meta_modifier)
-        self._update_all_besides_targets(self.metadata["timestamp"], snapshot)
+        snapshot = self.modify_metadata(Snapshot.type, no_meta_modifier)
+        self._update_all_besides_targets(self.metadata[Timestamp.type], snapshot)
         # remove meta information with information about targets from snapshot
         with self.assertRaises(exceptions.RepositoryError):
-            self.trusted_set.update_targets(self.metadata["targets"])
+            self.trusted_set.update_targets(self.metadata[Targets.type])
 
     def test_update_targets_hash_diverge_from_snapshot_meta_hash(self) -> None:
         def meta_length_modifier(snapshot: Snapshot) -> None:
             for metafile_path in snapshot.meta:
                 snapshot.meta[metafile_path] = MetaFile(version=1, length=1)
 
-        snapshot = self.modify_metadata("snapshot", meta_length_modifier)
-        self._update_all_besides_targets(self.metadata["timestamp"], snapshot)
+        snapshot = self.modify_metadata(Snapshot.type, meta_length_modifier)
+        self._update_all_besides_targets(self.metadata[Timestamp.type], snapshot)
         # observed_hash != stored hash in snapshot meta for targets
         with self.assertRaises(exceptions.RepositoryError):
-            self.trusted_set.update_targets(self.metadata["targets"])
+            self.trusted_set.update_targets(self.metadata[Targets.type])
 
     def test_update_targets_version_diverge_snapshot_meta_version(self) -> None:
         def meta_modifier(snapshot: Snapshot) -> None:
             for metafile_path in snapshot.meta:
                 snapshot.meta[metafile_path] = MetaFile(version=2)
 
-        snapshot = self.modify_metadata("snapshot", meta_modifier)
-        self._update_all_besides_targets(self.metadata["timestamp"], snapshot)
+        snapshot = self.modify_metadata(Snapshot.type, meta_modifier)
+        self._update_all_besides_targets(self.metadata[Timestamp.type], snapshot)
         # new_delegate.signed.version != meta.version stored in snapshot
         with self.assertRaises(exceptions.BadVersionNumberError):
-            self.trusted_set.update_targets(self.metadata["targets"])
+            self.trusted_set.update_targets(self.metadata[Targets.type])
 
     def test_update_targets_expired_new_target(self) -> None:
         self._update_all_besides_targets()
@@ -432,7 +432,7 @@ class TestTrustedMetadataSet(unittest.TestCase):
         def target_expired_modifier(target: Targets) -> None:
             target.expires = datetime(1970, 1, 1)
 
-        targets = self.modify_metadata("targets", target_expired_modifier)
+        targets = self.modify_metadata(Targets.type, target_expired_modifier)
         with self.assertRaises(exceptions.ExpiredMetadataError):
             self.trusted_set.update_targets(targets)
 

--- a/tests/test_updater_key_rotations.py
+++ b/tests/test_updater_key_rotations.py
@@ -17,7 +17,7 @@ from securesystemslib.signer import SSlibSigner
 from tests import utils
 from tests.repository_simulator import RepositorySimulator
 from tests.utils import run_sub_tests_with_dataset
-from tuf.api.metadata import Key
+from tuf.api.metadata import Key, Root
 from tuf.exceptions import UnsignedMetadataError
 from tuf.ngclient import Updater
 
@@ -176,14 +176,14 @@ class TestUpdaterKeyRotations(unittest.TestCase):
         # Publish all remote root versions defined in root_versions
         for rootver in root_versions:
             # clear root keys, signers
-            self.sim.root.roles["root"].keyids.clear()
-            self.sim.signers["root"].clear()
+            self.sim.root.roles[Root.type].keyids.clear()
+            self.sim.signers[Root.type].clear()
 
-            self.sim.root.roles["root"].threshold = rootver.threshold
+            self.sim.root.roles[Root.type].threshold = rootver.threshold
             for i in rootver.keys:
-                self.sim.root.add_key("root", self.keys[i])
+                self.sim.root.add_key(Root.type, self.keys[i])
             for i in rootver.sigs:
-                self.sim.add_signer("root", self.signers[i])
+                self.sim.add_signer(Root.type, self.signers[i])
             self.sim.root.version += 1
             self.sim.publish_root()
 

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -19,7 +19,7 @@ from securesystemslib.signer import SSlibSigner
 
 from tests import utils
 from tuf import exceptions, ngclient, unittest_toolbox
-from tuf.api.metadata import Metadata, Root, TargetFile
+from tuf.api.metadata import Metadata, Root, Snapshot, TargetFile, Targets, Timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -180,17 +180,17 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
         # top-level metadata is in local directory already
         self.updater.refresh()
-        self._assert_files(["root", "snapshot", "targets", "timestamp"])
+        self._assert_files([Root.type, Snapshot.type, Targets.type, Timestamp.type])
 
         # Get targetinfos, assert that cache does not contain files
         info1 = self.updater.get_targetinfo("file1.txt")
         assert isinstance(info1, TargetFile)
-        self._assert_files(["root", "snapshot", "targets", "timestamp"])
+        self._assert_files([Root.type, Snapshot.type, Targets.type, Timestamp.type])
 
         # Get targetinfo for 'file3.txt' listed in the delegated role1
         info3 = self.updater.get_targetinfo("file3.txt")
         assert isinstance(info3, TargetFile)
-        expected_files = ["role1", "root", "snapshot", "targets", "timestamp"]
+        expected_files = ["role1", Root.type, Snapshot.type, Targets.type, Timestamp.type]
         self._assert_files(expected_files)
         self.assertIsNone(self.updater.find_cached_target(info1))
         self.assertIsNone(self.updater.find_cached_target(info3))
@@ -214,14 +214,14 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         os.remove(os.path.join(self.client_directory, "role1.json"))
         os.remove(os.path.join(self.client_directory, "role2.json"))
         os.remove(os.path.join(self.client_directory, "1.root.json"))
-        self._assert_files(["root"])
+        self._assert_files([Root.type])
 
         self.updater.refresh()
-        self._assert_files(["root", "snapshot", "targets", "timestamp"])
+        self._assert_files([Root.type, Snapshot.type, Targets.type, Timestamp.type])
 
         # Get targetinfo for 'file3.txt' listed in the delegated role1
         self.updater.get_targetinfo("file3.txt")
-        expected_files = ["role1", "root", "snapshot", "targets", "timestamp"]
+        expected_files = ["role1", Root.type, Snapshot.type, Targets.type, Timestamp.type]
         self._assert_files(expected_files)
 
     def test_implicit_refresh_with_only_local_root(self) -> None:

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -61,6 +61,11 @@ from tuf.api.serialization import (
     SignedSerializer,
 )
 
+_ROOT: str = "root"
+_SNAPSHOT: str = "snapshot"
+_TARGETS: str = "targets"
+_TIMESTAMP: str = "timestamp"
+
 # pylint: disable=too-many-lines
 
 logger = logging.getLogger(__name__)
@@ -68,7 +73,7 @@ logger = logging.getLogger(__name__)
 # We aim to support SPECIFICATION_VERSION and require the input metadata
 # files to have the same major version (the first number) as ours.
 SPECIFICATION_VERSION = ["1", "0", "19"]
-TOP_LEVEL_ROLE_NAMES = {"root", "timestamp", "snapshot", "targets"}
+TOP_LEVEL_ROLE_NAMES = {_ROOT, _TIMESTAMP, _SNAPSHOT, _TARGETS}
 
 # T is a Generic type constraint for Metadata.signed
 T = TypeVar("T", "Root", "Timestamp", "Snapshot", "Targets")
@@ -130,13 +135,13 @@ class Metadata(Generic[T]):
         # Dispatch to contained metadata class on metadata _type field.
         _type = metadata["signed"]["_type"]
 
-        if _type == "targets":
+        if _type == _TARGETS:
             inner_cls: Type[Signed] = Targets
-        elif _type == "snapshot":
+        elif _type == _SNAPSHOT:
             inner_cls = Snapshot
-        elif _type == "timestamp":
+        elif _type == _TIMESTAMP:
             inner_cls = Timestamp
-        elif _type == "root":
+        elif _type == _ROOT:
             inner_cls = Root
         else:
             raise ValueError(f'unrecognized metadata type "{_type}"')
@@ -394,18 +399,13 @@ class Signed(metaclass=abc.ABCMeta):
         unrecognized_fields: Dictionary of all unrecognized fields.
     """
 
-    # Signed implementations are expected to override this
-    _signed_type: ClassVar[str] = "signed"
+    # type is required for static reference without changing the API
+    type: ClassVar[str] = "signed"
 
     # _type and type are identical: 1st replicates file format, 2nd passes lint
     @property
     def _type(self) -> str:
-        return self._signed_type
-
-    @property
-    def type(self) -> str:
-        """Metadata type as string."""
-        return self._signed_type
+        return self.type
 
     # NOTE: Signed is a stupid name, because this might not be signed yet, but
     # we keep it to match spec terminology (I often refer to this as "payload",
@@ -458,8 +458,8 @@ class Signed(metaclass=abc.ABCMeta):
 
         """
         _type = signed_dict.pop("_type")
-        if _type != cls._signed_type:
-            raise ValueError(f"Expected type {cls._signed_type}, got {_type}")
+        if _type != cls.type:
+            raise ValueError(f"Expected type {cls.type}, got {_type}")
 
         version = signed_dict.pop("version")
         spec_version = signed_dict.pop("spec_version")
@@ -712,7 +712,7 @@ class Root(Signed):
         unrecognized_fields: Dictionary of all unrecognized fields.
     """
 
-    _signed_type = "root"
+    type = _ROOT
 
     # TODO: determine an appropriate value for max-args
     # pylint: disable=too-many-arguments
@@ -965,7 +965,7 @@ class Timestamp(Signed):
         snapshot_meta: Meta information for snapshot metadata.
     """
 
-    _signed_type = "timestamp"
+    type = _TIMESTAMP
 
     def __init__(
         self,
@@ -1015,7 +1015,7 @@ class Snapshot(Signed):
         meta: A dictionary of target metadata filenames to MetaFile objects.
     """
 
-    _signed_type = "snapshot"
+    type = _SNAPSHOT
 
     def __init__(
         self,
@@ -1416,7 +1416,7 @@ class Targets(Signed):
         unrecognized_fields: Dictionary of all unrecognized fields.
     """
 
-    _signed_type = "targets"
+    type = _TARGETS
 
     # TODO: determine an appropriate value for max-args
     # pylint: disable=too-many-arguments
@@ -1437,7 +1437,7 @@ class Targets(Signed):
     def from_dict(cls, signed_dict: Dict[str, Any]) -> "Targets":
         """Creates Targets object from its dict representation."""
         common_args = cls._common_fields_from_dict(signed_dict)
-        targets = signed_dict.pop("targets")
+        targets = signed_dict.pop(_TARGETS)
         try:
             delegations_dict = signed_dict.pop("delegations")
         except KeyError:
@@ -1458,7 +1458,7 @@ class Targets(Signed):
         targets = {}
         for target_path, target_file_obj in self.targets.items():
             targets[target_path] = target_file_obj.to_dict()
-        targets_dict["targets"] = targets
+        targets_dict[_TARGETS] = targets
         if self.delegations is not None:
             targets_dict["delegations"] = self.delegations.to_dict()
         return targets_dict

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -61,10 +61,10 @@ from tuf.api.serialization import (
     SignedSerializer,
 )
 
-_ROOT: str = "root"
-_SNAPSHOT: str = "snapshot"
-_TARGETS: str = "targets"
-_TIMESTAMP: str = "timestamp"
+_ROOT = "root"
+_SNAPSHOT = "snapshot"
+_TARGETS = "targets"
+_TIMESTAMP = "timestamp"
 
 # pylint: disable=too-many-lines
 

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -68,7 +68,7 @@ from urllib import parse
 from securesystemslib import util as sslib_util
 
 from tuf import exceptions
-from tuf.api.metadata import Metadata, TargetFile, Targets
+from tuf.api.metadata import Metadata, Root, Snapshot, TargetFile, Targets, Timestamp
 from tuf.ngclient._internal import requests_fetcher, trusted_metadata_set
 from tuf.ngclient.config import UpdaterConfig
 from tuf.ngclient.fetcher import FetcherInterface
@@ -114,7 +114,7 @@ class Updater:
             self._target_base_url = _ensure_trailing_slash(target_base_url)
 
         # Read trusted local root metadata
-        data = self._load_local_metadata("root")
+        data = self._load_local_metadata(Root.type)
         self._trusted_set = trusted_metadata_set.TrustedMetadataSet(data)
         self._fetcher = fetcher or requests_fetcher.RequestsFetcher()
         self.config = config or UpdaterConfig()
@@ -146,7 +146,7 @@ class Updater:
         self._load_root()
         self._load_timestamp()
         self._load_snapshot()
-        self._load_targets("targets", "root")
+        self._load_targets(Targets.type, Root.type)
 
     def _generate_target_file_path(self, targetinfo: TargetFile) -> str:
         if self.target_dir is None:
@@ -320,10 +320,12 @@ class Updater:
         for next_version in range(lower_bound, upper_bound):
             try:
                 data = self._download_metadata(
-                    "root", self.config.root_max_length, next_version
+                    Root.type,
+                    self.config.root_max_length,
+                    next_version,
                 )
                 self._trusted_set.update_root(data)
-                self._persist_metadata("root", data)
+                self._persist_metadata(Root.type, data)
 
             except exceptions.FetcherHTTPError as exception:
                 if exception.status_code not in {403, 404}:
@@ -334,7 +336,7 @@ class Updater:
     def _load_timestamp(self) -> None:
         """Load local and remote timestamp metadata"""
         try:
-            data = self._load_local_metadata("timestamp")
+            data = self._load_local_metadata(Timestamp.type)
             self._trusted_set.update_timestamp(data)
         except (OSError, exceptions.RepositoryError) as e:
             # Local timestamp does not exist or is invalid
@@ -342,15 +344,15 @@ class Updater:
 
         # Load from remote (whether local load succeeded or not)
         data = self._download_metadata(
-            "timestamp", self.config.timestamp_max_length
+            Timestamp.type, self.config.timestamp_max_length
         )
         self._trusted_set.update_timestamp(data)
-        self._persist_metadata("timestamp", data)
+        self._persist_metadata(Timestamp.type, data)
 
     def _load_snapshot(self) -> None:
         """Load local (and if needed remote) snapshot metadata"""
         try:
-            data = self._load_local_metadata("snapshot")
+            data = self._load_local_metadata(Snapshot.type)
             self._trusted_set.update_snapshot(data, trusted=True)
             logger.debug("Local snapshot is valid: not downloading new one")
         except (OSError, exceptions.RepositoryError) as e:
@@ -364,9 +366,9 @@ class Updater:
             if self._trusted_set.root.signed.consistent_snapshot:
                 version = snapshot_meta.version
 
-            data = self._download_metadata("snapshot", length, version)
+            data = self._download_metadata(Snapshot.type, length, version)
             self._trusted_set.update_snapshot(data)
-            self._persist_metadata("snapshot", data)
+            self._persist_metadata(Snapshot.type, data)
 
     def _load_targets(self, role: str, parent_role: str) -> Metadata[Targets]:
         """Load local (and if needed remote) metadata for 'role'."""
@@ -412,7 +414,7 @@ class Updater:
 
         # List of delegations to be interrogated. A (role, parent role) pair
         # is needed to load and verify the delegated targets metadata.
-        delegations_to_visit = [("targets", "root")]
+        delegations_to_visit = [(Targets.type, Root.type)]
         visited_role_names: Set[str] = set()
         number_of_delegations = self.config.max_delegations
 

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -68,7 +68,14 @@ from urllib import parse
 from securesystemslib import util as sslib_util
 
 from tuf import exceptions
-from tuf.api.metadata import Metadata, Root, Snapshot, TargetFile, Targets, Timestamp
+from tuf.api.metadata import (
+    Metadata,
+    Root,
+    Snapshot,
+    TargetFile,
+    Targets,
+    Timestamp,
+)
 from tuf.ngclient._internal import requests_fetcher, trusted_metadata_set
 from tuf.ngclient.config import UpdaterConfig
 from tuf.ngclient.fetcher import FetcherInterface


### PR DESCRIPTION
Fixes #1648

This is a change in the metadata API to remove hardcoded role names
and use constants instead.

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature - updated only
- [ ] Docs have been added for the bug fix or new feature - n/a


