### PR TITLE
Tests: address new pylint warnings

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,6 +43,7 @@ from tuf.api.serialization.json import CanonicalJSONSerializer, JSONSerializer
 logger = logging.getLogger(__name__)
 
 
+# pylint: disable=too-many-public-methods
 class TestMetadata(unittest.TestCase):
     """Tests for public API of all classes in 'tuf/api/metadata.py'."""
 

--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -25,6 +25,7 @@ from tuf.exceptions import (
 from tuf.ngclient import Updater
 
 
+# pylint: disable=too-many-public-methods
 class TestRefresh(unittest.TestCase):
     """Test update of top-level metadata following
     'Detailed client workflow' in the specification."""
@@ -81,6 +82,7 @@ class TestRefresh(unittest.TestCase):
         self, role: str, version: Optional[int] = None
     ) -> None:
         """Assert that local file content is the expected"""
+        # pylint: disable=protected-access
         expected_content = self.sim._fetch_metadata(role, version)
         with open(os.path.join(self.metadata_dir, f"{role}.json"), "rb") as f:
             self.assertEqual(f.read(), expected_content)


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:
After the recent changes, there are a couple of new pylint warnings that
appeared.
They are caused by the new test file that was added
test_updater_top_level_update.py and the limit of public functions was
reached in the TestMetadata class in test_api.py
The warnings should be addressed before enabling all of the linters
on the tests files.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


