### PR TITLE
Advertize type annotations with py.typed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,9 @@ install_requires =
 [options.packages.find]
 exclude = tests
 
+[options.package_data]
+tuf = py.typed
+
 [check-manifest]
 ignore =
   .fossa.yml


### PR DESCRIPTION
Existence of py.typed in the top-level package tells users of the
packages that all packages are annotated.

This should fix mypy errors like this in downstream projects:
> error: Skipping analyzing "tuf.api.metadata":
> found module but no type hints or library stubs

Fixes #1633

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

