### PR TITLE
Update ngclient to return loaded metadata

### DIFF
--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -129,6 +129,22 @@ class TestTrustedMetadataSet(unittest.TestCase):
 
         self.assertTrue(count, 6)
 
+    def test_update_metadata_output(self):
+        timestamp = self.trusted_set.update_timestamp(self.metadata["timestamp"])
+        snapshot = self.trusted_set.update_snapshot(self.metadata["snapshot"])
+        targets = self.trusted_set.update_targets(self.metadata["targets"])
+        delegeted_targets_1 = self.trusted_set.update_delegated_targets(
+            self.metadata["role1"], "role1", "targets"
+        )
+        delegeted_targets_2 = self.trusted_set.update_delegated_targets(
+            self.metadata["role2"], "role2", "role1"
+        )
+        self.assertIsInstance(timestamp.signed, Timestamp)
+        self.assertIsInstance(snapshot.signed, Snapshot)
+        self.assertIsInstance(targets.signed, Targets)
+        self.assertIsInstance(delegeted_targets_1.signed, Targets)
+        self.assertIsInstance(delegeted_targets_2.signed, Targets)
+
     def test_out_of_order_ops(self):
         # Update snapshot before timestamp
         with self.assertRaises(RuntimeError):


### PR DESCRIPTION
This changes `TrustedMetadataSet` to return new trusted Metadata
on successful calls of the `update_<role>` functions and also
changes `Updater._load_targets` to return loaded metadata as well

Fixes #1507 

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature - n/a


