### PR TITLE
Remove URL normalisation

### DIFF
--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -112,7 +112,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
             + utils.TEST_HOST_ADDRESS
             + ":"
             + str(self.server_process_handler.port)
-            + repository_basepath
+            + repository_basepath.replace("\\","/")
         )
 
         self.metadata_url = f"{url_prefix}/metadata/"

--- a/tuf/ngclient/fetcher.py
+++ b/tuf/ngclient/fetcher.py
@@ -10,7 +10,6 @@ import logging
 import tempfile
 from contextlib import contextmanager
 from typing import IO, Iterator
-from urllib import parse
 
 from tuf import exceptions
 
@@ -61,13 +60,6 @@ class FetcherInterface:
         Yields:
           A TemporaryFile object that points to the contents of 'url'.
         """
-        # 'url.replace('\\', '/')' is needed for compatibility with
-        # Windows-based systems, because they might use back-slashes in place
-        # of forward-slashes. This converts it to the common format.
-        # unquote() replaces %xx escapes in a url with their single-character
-        # equivalent. A back-slash may beencoded as %5c in the url, which
-        # should also be replaced with a forward slash.
-        url = parse.unquote(url).replace("\\", "/")
         logger.debug("Downloading: %s", url)
 
         number_of_bytes_received = 0


### PR DESCRIPTION
As a target path is a URL path it's not correct to consider it as
interchangeable with a filepath within every operation system. The
unquote is also removed as the ngclient cannot assume correctly
which encoding is intended and which not

Fixes #1483

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [n/a] Tests have been added for the bug fix or new feature
- [n/a] Docs have been added for the bug fix or new feature


