### PR TITLE
Tests on the new implementation: address mypy warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ warn_unreachable = True
 strict_equality = True
 disallow_untyped_defs = True
 disallow_untyped_calls = True
+show_error_codes = True
 files =
   tuf/api/,
   tuf/ngclient,

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -53,7 +53,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_signed)
-    def test_invalid_signed_serialization(self, test_case_data: str):
+    def test_invalid_signed_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises((KeyError, ValueError, TypeError)):
             Snapshot.from_dict(copy.deepcopy(case_dict))
@@ -68,7 +68,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(valid_keys)
-    def test_valid_key_serialization(self, test_case_data: str):
+    def test_valid_key_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         key = Key.from_dict("id", copy.copy(case_dict))
         self.assertDictEqual(case_dict, key.to_dict())
@@ -85,7 +85,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_keys)
-    def test_invalid_key_serialization(self, test_case_data: str):
+    def test_invalid_key_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises((TypeError, KeyError)):
             keyid = case_dict.pop("keyid")
@@ -100,7 +100,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_roles)
-    def test_invalid_role_serialization(self, test_case_data: str):
+    def test_invalid_role_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises((KeyError, TypeError, ValueError)):
             Role.from_dict(copy.deepcopy(case_dict))
@@ -113,7 +113,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(valid_roles)
-    def test_role_serialization(self, test_case_data: str):
+    def test_role_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         role = Role.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, role.to_dict())
@@ -161,7 +161,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(valid_roots)
-    def test_root_serialization(self, test_case_data: str):
+    def test_root_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         root = Root.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, root.to_dict())
@@ -203,7 +203,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_roots)
-    def test_invalid_root_serialization(self, test_case_data: str):
+    def test_invalid_root_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises(ValueError):
             Root.from_dict(copy.deepcopy(case_dict))
@@ -218,7 +218,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_metafiles)
-    def test_invalid_metafile_serialization(self, test_case_data: str):
+    def test_invalid_metafile_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises((TypeError, ValueError, AttributeError)):
             MetaFile.from_dict(copy.deepcopy(case_dict))
@@ -232,7 +232,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(valid_metafiles)
-    def test_metafile_serialization(self, test_case_data: str):
+    def test_metafile_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         metafile = MetaFile.from_dict(copy.copy(case_dict))
         self.assertDictEqual(case_dict, metafile.to_dict())
@@ -242,7 +242,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_timestamps)
-    def test_invalid_timestamp_serialization(self, test_case_data: str):
+    def test_invalid_timestamp_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises((ValueError, KeyError)):
             Timestamp.from_dict(copy.deepcopy(case_dict))
@@ -255,7 +255,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(valid_timestamps)
-    def test_timestamp_serialization(self, test_case_data: str):
+    def test_timestamp_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         timestamp = Timestamp.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, timestamp.to_dict())
@@ -274,7 +274,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(valid_snapshots)
-    def test_snapshot_serialization(self, test_case_data: str):
+    def test_snapshot_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         snapshot = Snapshot.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, snapshot.to_dict())
@@ -295,7 +295,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(valid_delegated_roles)
-    def test_delegated_role_serialization(self, test_case_data: str):
+    def test_delegated_role_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         deserialized_role = DelegatedRole.from_dict(copy.copy(case_dict))
         self.assertDictEqual(case_dict, deserialized_role.to_dict())
@@ -312,7 +312,9 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_delegated_roles)
-    def test_invalid_delegated_role_serialization(self, test_case_data: str):
+    def test_invalid_delegated_role_serialization(
+        self, test_case_data: str
+    ) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises(ValueError):
             DelegatedRole.from_dict(copy.copy(case_dict))
@@ -339,7 +341,9 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_delegations)
-    def test_invalid_delegation_serialization(self, test_case_data: str):
+    def test_invalid_delegation_serialization(
+        self, test_case_data: str
+    ) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises((ValueError, KeyError, AttributeError)):
             Delegations.from_dict(copy.deepcopy(case_dict))
@@ -361,7 +365,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(valid_delegations)
-    def test_delegation_serialization(self, test_case_data: str):
+    def test_delegation_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         delegation = Delegations.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, delegation.to_dict())
@@ -374,7 +378,9 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_targetfiles)
-    def test_invalid_targetfile_serialization(self, test_case_data: str):
+    def test_invalid_targetfile_serialization(
+        self, test_case_data: str
+    ) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises(KeyError):
             TargetFile.from_dict(copy.deepcopy(case_dict), "file1.txt")
@@ -388,7 +394,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(valid_targetfiles)
-    def test_targetfile_serialization(self, test_case_data: str):
+    def test_targetfile_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         target_file = TargetFile.from_dict(copy.copy(case_dict), "file1.txt")
         self.assertDictEqual(case_dict, target_file.to_dict())
@@ -420,7 +426,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(valid_targets)
-    def test_targets_serialization(self, test_case_data: str):
+    def test_targets_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         targets = Targets.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, targets.to_dict())

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -11,7 +11,6 @@ import json
 import logging
 import sys
 import unittest
-from typing import Dict
 
 from tests import utils
 from tuf.api.metadata import (
@@ -54,7 +53,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_signed)
-    def test_invalid_signed_serialization(self, test_case_data: Dict[str, str]):
+    def test_invalid_signed_serialization(self, test_case_data: str):
         case_dict = json.loads(test_case_data)
         with self.assertRaises((KeyError, ValueError, TypeError)):
             Snapshot.from_dict(copy.deepcopy(case_dict))
@@ -86,7 +85,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_keys)
-    def test_invalid_key_serialization(self, test_case_data: Dict[str, str]):
+    def test_invalid_key_serialization(self, test_case_data: str):
         case_dict = json.loads(test_case_data)
         with self.assertRaises((TypeError, KeyError)):
             keyid = case_dict.pop("keyid")
@@ -101,7 +100,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_roles)
-    def test_invalid_role_serialization(self, test_case_data: Dict[str, str]):
+    def test_invalid_role_serialization(self, test_case_data: str):
         case_dict = json.loads(test_case_data)
         with self.assertRaises((KeyError, TypeError, ValueError)):
             Role.from_dict(copy.deepcopy(case_dict))
@@ -204,7 +203,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_roots)
-    def test_invalid_root_serialization(self, test_case_data: Dict[str, str]):
+    def test_invalid_root_serialization(self, test_case_data: str):
         case_dict = json.loads(test_case_data)
         with self.assertRaises(ValueError):
             Root.from_dict(copy.deepcopy(case_dict))
@@ -219,9 +218,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_metafiles)
-    def test_invalid_metafile_serialization(
-        self, test_case_data: Dict[str, str]
-    ):
+    def test_invalid_metafile_serialization(self, test_case_data: str):
         case_dict = json.loads(test_case_data)
         with self.assertRaises((TypeError, ValueError, AttributeError)):
             MetaFile.from_dict(copy.deepcopy(case_dict))
@@ -245,9 +242,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_timestamps)
-    def test_invalid_timestamp_serialization(
-        self, test_case_data: Dict[str, str]
-    ):
+    def test_invalid_timestamp_serialization(self, test_case_data: str):
         case_dict = json.loads(test_case_data)
         with self.assertRaises((ValueError, KeyError)):
             Timestamp.from_dict(copy.deepcopy(case_dict))
@@ -372,9 +367,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(invalid_targetfiles)
-    def test_invalid_targetfile_serialization(
-        self, test_case_data: Dict[str, str]
-    ):
+    def test_invalid_targetfile_serialization(self, test_case_data: str):
         case_dict = json.loads(test_case_data)
         with self.assertRaises(KeyError):
             TargetFile.from_dict(copy.deepcopy(case_dict), "file1.txt")
@@ -420,7 +413,7 @@ class TestSerialization(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(valid_targets)
-    def test_targets_serialization(self, test_case_data):
+    def test_targets_serialization(self, test_case_data: str):
         case_dict = json.loads(test_case_data)
         targets = Targets.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, targets.to_dict())

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -319,6 +319,13 @@ class TestSerialization(unittest.TestCase):
 
     invalid_delegations: utils.DataSet = {
         "empty delegations": "{}",
+        "missing keys": '{ "roles": [ \
+                {"keyids": ["keyid"], "name": "a", "terminating": true, "paths": ["fn1"], "threshold": 3}, \
+                {"keyids": ["keyid2"], "name": "b", "terminating": true, "paths": ["fn2"], "threshold": 4} ] \
+            }',
+        "missing roles": '{"keys": { \
+                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}, \
+                "keyid2" : {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "bar"}}}}',
         "bad keys": '{"keys": "foo", \
             "roles": [{"keyids": ["keyid"], "name": "a", "paths": ["fn1", "fn2"], "terminating": false, "threshold": 3}]}',
         "bad roles": '{"keys": {"keyid" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \

--- a/tests/test_updater_key_rotations.py
+++ b/tests/test_updater_key_rotations.py
@@ -37,8 +37,8 @@ class TestUpdaterKeyRotations(unittest.TestCase):
     dump_dir: Optional[str] = None
 
     def setUp(self) -> None:
-        self.sim = None
-        self.metadata_dir = None
+        self.sim: RepositorySimulator
+        self.metadata_dir: str
         self.subtest_count = 0
         # pylint: disable-next=consider-using-with
         self.temp_dir = tempfile.TemporaryDirectory()

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -12,14 +12,14 @@ import shutil
 import sys
 import tempfile
 import unittest
-from typing import List
+from typing import Callable, ClassVar, List
 
 from securesystemslib.interface import import_rsa_privatekey_from_file
 from securesystemslib.signer import SSlibSigner
 
 from tests import utils
 from tuf import exceptions, ngclient, unittest_toolbox
-from tuf.api.metadata import Metadata, TargetFile
+from tuf.api.metadata import Metadata, Root, TargetFile
 
 logger = logging.getLogger(__name__)
 
@@ -27,8 +27,11 @@ logger = logging.getLogger(__name__)
 class TestUpdater(unittest_toolbox.Modified_TestCase):
     """Test the Updater class from 'tuf/ngclient/updater.py'."""
 
+    temporary_directory: ClassVar[str]
+    server_process_handler: ClassVar[utils.TestServerProcess]
+
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         # Create a temporary directory to store the repository, metadata, and
         # target files. 'temporary_directory' must be deleted in
         # TearDownModule() so that temporary files are always removed, even when
@@ -38,18 +41,18 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         # Needed because in some tests simple_server.py cannot be found.
         # The reason is that the current working directory
         # has been changed when executing a subprocess.
-        cls.SIMPLE_SERVER_PATH = os.path.join(os.getcwd(), "simple_server.py")
+        SIMPLE_SERVER_PATH = os.path.join(os.getcwd(), "simple_server.py")
 
         # Launch a SimpleHTTPServer (serves files in the current directory).
         # Test cases will request metadata and target files that have been
         # pre-generated in 'tuf/tests/repository_data', which will be served
         # by the SimpleHTTPServer launched here.
         cls.server_process_handler = utils.TestServerProcess(
-            log=logger, server=cls.SIMPLE_SERVER_PATH
+            log=logger, server=SIMPLE_SERVER_PATH
         )
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         # Cleans the resources and flush the logged lines (if any).
         cls.server_process_handler.clean()
 
@@ -57,7 +60,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         # the metadata, targets, and key files generated for the test cases
         shutil.rmtree(cls.temporary_directory)
 
-    def setUp(self):
+    def setUp(self) -> None:
         # We are inheriting from custom class.
         unittest_toolbox.Modified_TestCase.setUp(self)
 
@@ -124,7 +127,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
             target_base_url=self.targets_url,
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         # We are inheriting from custom class.
         unittest_toolbox.Modified_TestCase.tearDown(self)
 
@@ -132,7 +135,9 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         self.server_process_handler.flush_log()
 
     def _modify_repository_root(
-        self, modification_func, bump_version=False
+        self,
+        modification_func: Callable[[Metadata], None],
+        bump_version: bool = False,
     ) -> None:
         """Apply 'modification_func' to root and persist it."""
         role_path = os.path.join(
@@ -159,13 +164,13 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
             )
         )
 
-    def _assert_files(self, roles: List[str]):
+    def _assert_files(self, roles: List[str]) -> None:
         """Assert that local metadata files exist for 'roles'"""
         expected_files = [f"{role}.json" for role in roles]
         client_files = sorted(os.listdir(self.client_directory))
         self.assertEqual(client_files, expected_files)
 
-    def test_refresh_and_download(self):
+    def test_refresh_and_download(self) -> None:
         # Test refresh without consistent targets - targets without hash prefix.
 
         # top-level targets are already in local cache (but remove others)
@@ -179,10 +184,12 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
         # Get targetinfos, assert that cache does not contain files
         info1 = self.updater.get_targetinfo("file1.txt")
+        assert isinstance(info1, TargetFile)
         self._assert_files(["root", "snapshot", "targets", "timestamp"])
 
         # Get targetinfo for 'file3.txt' listed in the delegated role1
         info3 = self.updater.get_targetinfo("file3.txt")
+        assert isinstance(info3, TargetFile)
         expected_files = ["role1", "root", "snapshot", "targets", "timestamp"]
         self._assert_files(expected_files)
         self.assertIsNone(self.updater.find_cached_target(info1))
@@ -200,7 +207,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         path = self.updater.find_cached_target(info3)
         self.assertEqual(path, os.path.join(self.dl_dir, info3.path))
 
-    def test_refresh_with_only_local_root(self):
+    def test_refresh_with_only_local_root(self) -> None:
         os.remove(os.path.join(self.client_directory, "timestamp.json"))
         os.remove(os.path.join(self.client_directory, "snapshot.json"))
         os.remove(os.path.join(self.client_directory, "targets.json"))
@@ -217,7 +224,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         expected_files = ["role1", "root", "snapshot", "targets", "timestamp"]
         self._assert_files(expected_files)
 
-    def test_implicit_refresh_with_only_local_root(self):
+    def test_implicit_refresh_with_only_local_root(self) -> None:
         os.remove(os.path.join(self.client_directory, "timestamp.json"))
         os.remove(os.path.join(self.client_directory, "snapshot.json"))
         os.remove(os.path.join(self.client_directory, "targets.json"))
@@ -231,7 +238,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         expected_files = ["role1", "root", "snapshot", "targets", "timestamp"]
         self._assert_files(expected_files)
 
-    def test_both_target_urls_not_set(self):
+    def test_both_target_urls_not_set(self) -> None:
         # target_base_url = None and Updater._target_base_url = None
         updater = ngclient.Updater(
             self.client_directory, self.metadata_url, self.dl_dir
@@ -240,7 +247,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         with self.assertRaises(ValueError):
             updater.download_target(info)
 
-    def test_no_target_dir_no_filepath(self):
+    def test_no_target_dir_no_filepath(self) -> None:
         # filepath = None and Updater.target_dir = None
         updater = ngclient.Updater(self.client_directory, self.metadata_url)
         info = TargetFile(1, {"sha256": ""}, "targetpath")
@@ -249,15 +256,17 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         with self.assertRaises(ValueError):
             updater.download_target(info)
 
-    def test_external_targets_url(self):
+    def test_external_targets_url(self) -> None:
         self.updater.refresh()
         info = self.updater.get_targetinfo("file1.txt")
+        assert isinstance(info, TargetFile)
 
         self.updater.download_target(info, target_base_url=self.targets_url)
 
-    def test_length_hash_mismatch(self):
+    def test_length_hash_mismatch(self) -> None:
         self.updater.refresh()
         targetinfo = self.updater.get_targetinfo("file1.txt")
+        assert isinstance(targetinfo, TargetFile)
 
         length = targetinfo.length
         with self.assertRaises(exceptions.RepositoryError):
@@ -270,13 +279,13 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
             self.updater.download_target(targetinfo)
 
     # pylint: disable=protected-access
-    def test_updating_root(self):
+    def test_updating_root(self) -> None:
         # Bump root version, resign and refresh
         self._modify_repository_root(lambda root: None, bump_version=True)
         self.updater.refresh()
         self.assertEqual(self.updater._trusted_set.root.signed.version, 2)
 
-    def test_missing_targetinfo(self):
+    def test_missing_targetinfo(self) -> None:
         self.updater.refresh()
 
         # Get targetinfo for non-existing file

--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -349,7 +349,7 @@ class TestRefresh(unittest.TestCase):
 
         self._assert_files_exist(["root", "timestamp"])
 
-    def test_new_snapshot_version_mismatch(self):
+    def test_new_snapshot_version_mismatch(self) -> None:
         # Check against timestamp role’s snapshot version
 
         # Increase snapshot version without updating timestamp
@@ -414,7 +414,7 @@ class TestRefresh(unittest.TestCase):
 
         self._assert_files_exist(["root", "timestamp", "snapshot"])
 
-    def test_new_targets_version_mismatch(self):
+    def test_new_targets_version_mismatch(self) -> None:
         # Check against snapshot role’s targets version
 
         # Increase targets version without updating snapshot

--- a/tests/test_updater_with_simulator.py
+++ b/tests/test_updater_with_simulator.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 from tests import utils
 from tests.repository_simulator import RepositorySimulator
-from tuf.api.metadata import SPECIFICATION_VERSION, Targets
+from tuf.api.metadata import SPECIFICATION_VERSION, TargetFile, Targets
 from tuf.exceptions import BadVersionNumberError, UnsignedMetadataError
 from tuf.ngclient import Updater
 
@@ -27,7 +27,7 @@ class TestUpdater(unittest.TestCase):
     # set dump_dir to trigger repository state dumps
     dump_dir: Optional[str] = None
 
-    def setUp(self):
+    def setUp(self) -> None:
         # pylint: disable-next=consider-using-with
         self.temp_dir = tempfile.TemporaryDirectory()
         self.metadata_dir = os.path.join(self.temp_dir.name, "metadata")
@@ -49,7 +49,7 @@ class TestUpdater(unittest.TestCase):
             self.sim.dump_dir = os.path.join(self.dump_dir, name)
             os.mkdir(self.sim.dump_dir)
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         self.temp_dir.cleanup()
 
     def _run_refresh(self) -> Updater:
@@ -67,7 +67,7 @@ class TestUpdater(unittest.TestCase):
         updater.refresh()
         return updater
 
-    def test_refresh(self):
+    def test_refresh(self) -> None:
         # Update top level metadata
         self._run_refresh()
 
@@ -99,7 +99,7 @@ class TestUpdater(unittest.TestCase):
     }
 
     @utils.run_sub_tests_with_dataset(targets)
-    def test_targets(self, test_case_data: Tuple[str, bytes, str]):
+    def test_targets(self, test_case_data: Tuple[str, bytes, str]) -> None:
         targetpath, content, encoded_path = test_case_data
         path = os.path.join(self.targets_dir, encoded_path)
 
@@ -117,7 +117,7 @@ class TestUpdater(unittest.TestCase):
         updater = self._run_refresh()
         # target now exists, is not in cache yet
         info = updater.get_targetinfo(targetpath)
-        self.assertIsNotNone(info)
+        assert info is not None
         # Test without and with explicit local filepath
         self.assertIsNone(updater.find_cached_target(info))
         self.assertIsNone(updater.find_cached_target(info, path))
@@ -136,7 +136,7 @@ class TestUpdater(unittest.TestCase):
         self.assertEqual(path, updater.find_cached_target(info))
         self.assertEqual(path, updater.find_cached_target(info, path))
 
-    def test_fishy_rolenames(self):
+    def test_fishy_rolenames(self) -> None:
         roles_to_filenames = {
             "../a": "..%2Fa.json",
             "": ".json",
@@ -162,7 +162,7 @@ class TestUpdater(unittest.TestCase):
         for fname in roles_to_filenames.values():
             self.assertTrue(fname in local_metadata)
 
-    def test_keys_and_signatures(self):
+    def test_keys_and_signatures(self) -> None:
         """Example of the two trickiest test areas: keys and root updates"""
 
         # Update top level metadata
@@ -202,7 +202,7 @@ class TestUpdater(unittest.TestCase):
 
         self._run_refresh()
 
-    def test_snapshot_rollback_with_local_snapshot_hash_mismatch(self):
+    def test_snapshot_rollback_with_local_snapshot_hash_mismatch(self) -> None:
         # Test triggering snapshot rollback check on a newly downloaded snapshot
         # when the local snapshot is loaded even when there is a hash mismatch
         # with timestamp.snapshot_meta.
@@ -233,7 +233,7 @@ class TestUpdater(unittest.TestCase):
             self._run_refresh()
 
     @patch.object(builtins, "open", wraps=builtins.open)
-    def test_not_loading_targets_twice(self, wrapped_open: MagicMock):
+    def test_not_loading_targets_twice(self, wrapped_open: MagicMock) -> None:
         # Do not load targets roles more than once when traversing
         # the delegations tree
 

--- a/tuf/log.py
+++ b/tuf/log.py
@@ -182,7 +182,7 @@ class ConsoleFilter(logging.Filter):
 
 
 
-def set_log_level(log_level=_DEFAULT_LOG_LEVEL):
+def set_log_level(log_level: int=_DEFAULT_LOG_LEVEL):
   """
   <Purpose>
     Allow the default log level to be overridden.  If 'log_level' is not

--- a/tuf/unittest_toolbox.py
+++ b/tuf/unittest_toolbox.py
@@ -29,6 +29,7 @@ import tempfile
 import random
 import string
 
+from typing import Optional
 
 class Modified_TestCase(unittest.TestCase):
   """
@@ -70,12 +71,12 @@ class Modified_TestCase(unittest.TestCase):
   """
 
 
-  def setUp(self):
+  def setUp(self) -> None:
     self._cleanup = []
 
 
 
-  def tearDown(self):
+  def tearDown(self) -> None:
     for cleanup_function in self._cleanup:
       # Perform clean up by executing clean-up functions.
       try:
@@ -87,7 +88,7 @@ class Modified_TestCase(unittest.TestCase):
 
 
 
-  def make_temp_directory(self, directory=None):
+  def make_temp_directory(self, directory: Optional[str]=None) -> str:
     """Creates and returns an absolute path of a directory."""
 
     prefix = self.__class__.__name__+'_'
@@ -102,7 +103,9 @@ class Modified_TestCase(unittest.TestCase):
 
 
 
-  def make_temp_file(self, suffix='.txt', directory=None):
+  def make_temp_file(
+    self,suffix: str='.txt', directory: Optional[str]=None
+  ) -> str:
     """Creates and returns an absolute path of an empty file."""
     prefix='tmp_file_'+self.__class__.__name__+'_'
     temp_file = tempfile.mkstemp(suffix=suffix, prefix=prefix, dir=directory)
@@ -113,7 +116,9 @@ class Modified_TestCase(unittest.TestCase):
 
 
 
-  def make_temp_data_file(self, suffix='', directory=None, data = 'junk data'):
+  def make_temp_data_file(
+    self, suffix: str='', directory: Optional[str]=None, data: str = 'junk data'
+  ) -> str:
     """Returns an absolute path of a temp file containing data."""
     temp_file_path = self.make_temp_file(suffix=suffix, directory=directory)
     temp_file = open(temp_file_path, 'wt', encoding='utf8')
@@ -123,7 +128,7 @@ class Modified_TestCase(unittest.TestCase):
 
 
 
-  def random_path(self, length = 7):
+  def random_path(self, length: int = 7) -> str:
     """Generate a 'random' path consisting of random n-length strings."""
 
     rand_path = '/' + self.random_string(length)
@@ -136,7 +141,7 @@ class Modified_TestCase(unittest.TestCase):
 
 
   @staticmethod
-  def random_string(length=15):
+  def random_string(length: int=15) -> str:
     """Generate a random string of specified length."""
 
     rand_str = ''


### PR DESCRIPTION
Fixes #1657 
Related to #1582.

**Description of the changes being introduced by the pull request**:

This pr includes:
- configure `mypy` to show error codes
- fixed type annotations in test_metadata_serialization
- two additional invalid serialization tests
- manual fixes for a lot of `mypy` warnings.

When there were `mypy` warnings that we are calling non-annotated function
in annotated context, I decided to add annotations instead of ignoring
those warnings.
That's how I end up adding annotations in the whole tests/utils.py
module.

**NOTE:** Those changes are not done by automatic tool, but instead are manual.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


