### PR TITLE
Delegations: paths & path_hash_prefixes validation

### DIFF
--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -310,6 +310,10 @@ class TestSerialization(unittest.TestCase):
         "missing hash prefixes and paths": '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false}',
         "both hash prefixes and paths": '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false, \
             "paths": ["fn1", "fn2"], "path_hash_prefixes": ["h1", "h2"]}',
+        "invalid path type": '{"keyids": ["keyid"], "name": "a", "paths": [1,2,3], \
+            "terminating": false, "threshold": 1}',
+        "invalid path_hash_prefixes type": '{"keyids": ["keyid"], "name": "a", "path_hash_prefixes": [1,2,3], \
+            "terminating": false, "threshold": 1}',
     }
 
     @utils.run_sub_tests_with_dataset(invalid_delegated_roles)

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1100,6 +1100,13 @@ class DelegatedRole(Role):
         if paths is None and path_hash_prefixes is None:
             raise ValueError("One of paths or path_hash_prefixes must be set")
 
+        if paths is not None and any(not isinstance(p, str) for p in paths):
+            raise ValueError("Paths must be strings")
+        if path_hash_prefixes is not None and any(
+            not isinstance(p, str) for p in path_hash_prefixes
+        ):
+            raise ValueError("Path_hash_prefixes must be strings")
+
         self.paths = paths
         self.path_hash_prefixes = path_hash_prefixes
 


### PR DESCRIPTION
Fixes #1461

**Description of the changes being introduced by the pull request**:

Add sanity types checks on Targets delegation `paths` and
`path_hash_prefixes` making sure that they are strings.

I tried using a lambda function in tuf/api/metadata.py to validate
`paths` and `path_hash_prefixes` types in order to make the checks in single lines,
but the lambda didn't have type annotations and `tox -e lint` failed with mypy warnings.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


