### PR TITLE
Prevents delegate role name as top-level role name

### DIFF
--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -330,6 +330,11 @@ class TestSerialization(unittest.TestCase):
                 {"keyids": ["keyid2"], "name": "a", "paths": ["fn3"], "terminating": false, "threshold": 2}    \
                 ] \
             }',
+        "using empty string role name": '{"keys": { \
+                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
+            "roles": [ \
+                {"keyids": ["keyid1"], "name": "", "terminating": true, "paths": ["fn1"], "threshold": 3}] \
+            }',
         "using root as delegate role name": '{"keys": { \
                 "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
             "roles": [ \

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -330,6 +330,33 @@ class TestSerialization(unittest.TestCase):
                 {"keyids": ["keyid2"], "name": "a", "paths": ["fn3"], "terminating": false, "threshold": 2}    \
                 ] \
             }',
+        "using root as delegate role name": '{"keys": { \
+                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
+            "roles": [ \
+                {"keyids": ["keyid1"], "name": "root", "terminating": true, "paths": ["fn1"], "threshold": 3}] \
+            }',
+        "using snapshot as delegate role name": '{"keys": { \
+                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
+            "roles": [ \
+                {"keyids": ["keyid1"], "name": "snapshot", "terminating": true, "paths": ["fn1"], "threshold": 3}] \
+            }',
+        "using targets as delegate role name": '{"keys": { \
+                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
+            "roles": [ \
+                {"keyids": ["keyid1"], "name": "targets", "terminating": true, "paths": ["fn1"], "threshold": 3}] \
+            }',
+        "using timestamp as delegate role name": '{"keys": { \
+                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
+            "roles": [ \
+                {"keyids": ["keyid1"], "name": "timestamp", "terminating": true, "paths": ["fn1"], "threshold": 3}] \
+            }',
+        "using valid and top-level role name": '{"keys": { \
+                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}, \
+                "keyid2" : {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "bar"}}}, \
+            "roles": [ \
+                {"keyids": ["keyid1"], "name": "b", "terminating": true, "paths": ["fn1"], "threshold": 3}, \
+                {"keyids": ["keyid2"], "name": "root", "terminating": true, "paths": ["fn2"], "threshold": 4} ] \
+            }',
     }
 
     @utils.run_sub_tests_with_dataset(invalid_delegations)
@@ -359,43 +386,6 @@ class TestSerialization(unittest.TestCase):
         case_dict = json.loads(test_case_data)
         delegation = Delegations.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, delegation.to_dict())
-
-    valid_delegations: utils.DataSet = {
-        "using root as delegate role name": '{"keys": { \
-                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
-            "roles": [ \
-                {"keyids": ["keyid"], "name": "root", "terminating": true, "paths": ["fn1"], "threshold": 3}] \
-            }',
-        "using snapshot as delegate role name": '{"keys": { \
-                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
-            "roles": [ \
-                {"keyids": ["keyid"], "name": "snapshot", "terminating": true, "paths": ["fn1"], "threshold": 3}] \
-            }',
-        "using targets as delegate role name": '{"keys": { \
-                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
-            "roles": [ \
-                {"keyids": ["keyid"], "name": "targets", "terminating": true, "paths": ["fn1"], "threshold": 3}] \
-            }',
-        "using timestamp as delegate role name": '{"keys": { \
-                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
-            "roles": [ \
-                {"keyids": ["keyid"], "name": "root", "terminating": true, "paths": ["fn1"], "threshold": 3}] \
-            }',
-        "using valid and top-level role name": '{"keys": { \
-                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}, \
-                "keyid2" : {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "bar"}}}, \
-            "roles": [ \
-                {"keyids": ["keyid"], "name": "b", "terminating": true, "paths": ["fn1"], "threshold": 3}, \
-                {"keyids": ["keyid2"], "name": "root", "terminating": true, "paths": ["fn2"], "threshold": 4} ] \
-            }',
-    }
-
-    @utils.run_sub_tests_with_dataset(valid_delegations)
-    def test_delegation_top_role_names(self, test_case_data: str):
-        case_dict = json.loads(test_case_data)
-        with self.assertRaises(ValueError):
-            Delegations.from_dict(copy.deepcopy(case_dict))
-
 
     invalid_targetfiles: utils.DataSet = {
         "no hashes": '{"length": 1}',

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -360,6 +360,43 @@ class TestSerialization(unittest.TestCase):
         delegation = Delegations.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, delegation.to_dict())
 
+    valid_delegations: utils.DataSet = {
+        "using root as delegate role name": '{"keys": { \
+                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
+            "roles": [ \
+                {"keyids": ["keyid"], "name": "root", "terminating": true, "paths": ["fn1"], "threshold": 3}] \
+            }',
+        "using snapshot as delegate role name": '{"keys": { \
+                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
+            "roles": [ \
+                {"keyids": ["keyid"], "name": "snapshot", "terminating": true, "paths": ["fn1"], "threshold": 3}] \
+            }',
+        "using targets as delegate role name": '{"keys": { \
+                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
+            "roles": [ \
+                {"keyids": ["keyid"], "name": "targets", "terminating": true, "paths": ["fn1"], "threshold": 3}] \
+            }',
+        "using timestamp as delegate role name": '{"keys": { \
+                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
+            "roles": [ \
+                {"keyids": ["keyid"], "name": "root", "terminating": true, "paths": ["fn1"], "threshold": 3}] \
+            }',
+        "using valid and top-level role name": '{"keys": { \
+                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}, \
+                "keyid2" : {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "bar"}}}, \
+            "roles": [ \
+                {"keyids": ["keyid"], "name": "b", "terminating": true, "paths": ["fn1"], "threshold": 3}, \
+                {"keyids": ["keyid2"], "name": "root", "terminating": true, "paths": ["fn2"], "threshold": 4} ] \
+            }',
+    }
+
+    @utils.run_sub_tests_with_dataset(valid_delegations)
+    def test_delegation_top_role_names(self, test_case_data: str):
+        case_dict = json.loads(test_case_data)
+        with self.assertRaises(ValueError):
+            Delegations.from_dict(copy.deepcopy(case_dict))
+
+
     invalid_targetfiles: utils.DataSet = {
         "no hashes": '{"length": 1}',
         "no length": '{"hashes": {"sha256": "abc"}}'

--- a/tests/test_updater_with_simulator.py
+++ b/tests/test_updater_with_simulator.py
@@ -137,7 +137,6 @@ class TestUpdater(unittest.TestCase):
     def test_fishy_rolenames(self):
         roles_to_filenames = {
             "../a": "..%2Fa.json",
-            "": ".json",
             ".": "..json",
             "/": "%2F.json",
             "ö": "%C3%B6.json",

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1213,8 +1213,12 @@ class Delegations:
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ):
         self.keys = keys
-        if [role for role in set(roles) if role in TOP_LEVEL_ROLE_NAMES]:
-            raise ValueError("Delegated roles cannot use top-level role names")
+
+        for role in set(roles):
+            if not role or role in TOP_LEVEL_ROLE_NAMES:
+                raise ValueError(
+                    "Delegated roles cannot be empty or use top-level role names"
+                )
 
         self.roles = roles
         self.unrecognized_fields = unrecognized_fields or {}

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1214,7 +1214,7 @@ class Delegations:
     ):
         self.keys = keys
 
-        for role in set(roles):
+        for role in roles:
             if not role or role in TOP_LEVEL_ROLE_NAMES:
                 raise ValueError(
                     "Delegated roles cannot be empty or use top-level role names"

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1213,6 +1213,12 @@ class Delegations:
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ):
         self.keys = keys
+        if [role for role in set(roles) if role in TOP_LEVEL_ROLE_NAMES]:
+            raise ValueError(
+                "A delegated role can not use top-level role names ("
+                f"{', '.join(TOP_LEVEL_ROLE_NAMES)})"
+            )
+
         self.roles = roles
         self.unrecognized_fields = unrecognized_fields or {}
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1214,10 +1214,7 @@ class Delegations:
     ):
         self.keys = keys
         if [role for role in set(roles) if role in TOP_LEVEL_ROLE_NAMES]:
-            raise ValueError(
-                "A delegated role can not use top-level role names ("
-                f"{', '.join(TOP_LEVEL_ROLE_NAMES)})"
-            )
+            raise ValueError("Delegated roles cannot use top-level role names")
 
         self.roles = roles
         self.unrecognized_fields = unrecognized_fields or {}


### PR DESCRIPTION
This commit adds the validation in the ``metadata.Delegations``
to prevent that one of the delegate role names given is a top-level
role name.

A ``ValueError`` will be raised if one of the roles names in the
the list given to as delegated contains the role name as one of the
top-level roles.

The _mirrors role_ is not covered in this PR.

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

Fixes #1558 

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following
requirements**:

- [X] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [X] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


