### PR TITLE
Tests: add tests for non-root key rotations

### DIFF
--- a/tests/test_updater_key_rotations.py
+++ b/tests/test_updater_key_rotations.py
@@ -36,23 +36,25 @@ class TestUpdaterKeyRotations(unittest.TestCase):
     # set dump_dir to trigger repository state dumps
     dump_dir: Optional[str] = None
 
-    def setUp(self) -> None:
-        self.sim: RepositorySimulator
-        self.metadata_dir: str
-        self.subtest_count = 0
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.sim: RepositorySimulator
+        cls.metadata_dir: str
+        cls.subtest_count = 0
         # pylint: disable-next=consider-using-with
-        self.temp_dir = tempfile.TemporaryDirectory()
+        cls.temp_dir = tempfile.TemporaryDirectory()
 
         # Pre-create a bunch of keys and signers
-        self.keys: List[Key] = []
-        self.signers: List[SSlibSigner] = []
+        cls.keys: List[Key] = []
+        cls.signers: List[SSlibSigner] = []
         for _ in range(10):
             key, signer = RepositorySimulator.create_key()
-            self.keys.append(key)
-            self.signers.append(signer)
+            cls.keys.append(key)
+            cls.signers.append(signer)
 
-    def tearDown(self) -> None:
-        self.temp_dir.cleanup()
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.temp_dir.cleanup()
 
     def setup_subtest(self) -> None:
         self.subtest_count += 1

--- a/tests/test_updater_key_rotations.py
+++ b/tests/test_updater_key_rotations.py
@@ -23,7 +23,7 @@ from tuf.ngclient import Updater
 
 
 @dataclass
-class RootVersion:
+class MdVersion:
     keys: List[int]
     threshold: int
     sigs: List[int]
@@ -88,82 +88,82 @@ class TestUpdaterKeyRotations(unittest.TestCase):
     # fmt: off
     root_rotation_cases = {
         "1-of-1 key rotation": [
-            RootVersion(keys=[1], threshold=1, sigs=[1]),
-            RootVersion(keys=[2], threshold=1, sigs=[2, 1]),
-            RootVersion(keys=[2], threshold=1, sigs=[2]),
+            MdVersion(keys=[1], threshold=1, sigs=[1]),
+            MdVersion(keys=[2], threshold=1, sigs=[2, 1]),
+            MdVersion(keys=[2], threshold=1, sigs=[2]),
         ],
         "1-of-1 key rotation, unused signatures": [
-            RootVersion(keys=[1], threshold=1, sigs=[3, 1, 4]),
-            RootVersion(keys=[2], threshold=1, sigs=[3, 2, 1, 4]),
-            RootVersion(keys=[2], threshold=1, sigs=[3, 2, 4]),
+            MdVersion(keys=[1], threshold=1, sigs=[3, 1, 4]),
+            MdVersion(keys=[2], threshold=1, sigs=[3, 2, 1, 4]),
+            MdVersion(keys=[2], threshold=1, sigs=[3, 2, 4]),
         ],
         "1-of-1 key rotation fail: not signed with old key": [
-            RootVersion(keys=[1], threshold=1, sigs=[1]),
-            RootVersion(keys=[2], threshold=1, sigs=[2, 3, 4], res=UnsignedMetadataError),
+            MdVersion(keys=[1], threshold=1, sigs=[1]),
+            MdVersion(keys=[2], threshold=1, sigs=[2, 3, 4], res=UnsignedMetadataError),
         ],
         "1-of-1 key rotation fail: not signed with new key": [
-            RootVersion(keys=[1], threshold=1, sigs=[1]),
-            RootVersion(keys=[2], threshold=1, sigs=[1, 3, 4], res=UnsignedMetadataError),
+            MdVersion(keys=[1], threshold=1, sigs=[1]),
+            MdVersion(keys=[2], threshold=1, sigs=[1, 3, 4], res=UnsignedMetadataError),
         ],
         "3-of-5, sign with different keycombos": [
-            RootVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 2, 4]),
-            RootVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 4, 1]),
-            RootVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 1, 3]),
-            RootVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 1, 3]),
+            MdVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 2, 4]),
+            MdVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 4, 1]),
+            MdVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 1, 3]),
+            MdVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 1, 3]),
         ],
         "3-of-5, one key rotated": [
-            RootVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 2, 4]),
-            RootVersion(keys=[0, 1, 3, 4, 5], threshold=3, sigs=[0, 4, 1]),
+            MdVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 2, 4]),
+            MdVersion(keys=[0, 1, 3, 4, 5], threshold=3, sigs=[0, 4, 1]),
         ],
         "3-of-5, one key rotate fails: not signed with 3 new keys": [
-            RootVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 2, 4]),
-            RootVersion(keys=[0, 1, 3, 4, 5], threshold=3, sigs=[0, 2, 4], res=UnsignedMetadataError),
+            MdVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 2, 4]),
+            MdVersion(keys=[0, 1, 3, 4, 5], threshold=3, sigs=[0, 2, 4], res=UnsignedMetadataError),
         ],
         "3-of-5, one key rotate fails: not signed with 3 old keys": [
-            RootVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 2, 4]),
-            RootVersion(keys=[0, 1, 3, 4, 5], threshold=3, sigs=[0, 4, 5], res=UnsignedMetadataError),
+            MdVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 2, 4]),
+            MdVersion(keys=[0, 1, 3, 4, 5], threshold=3, sigs=[0, 4, 5], res=UnsignedMetadataError),
         ],
         "3-of-5, one key rotated, with intermediate step": [
-            RootVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 2, 4]),
-            RootVersion(keys=[0, 1, 3, 4, 5], threshold=3, sigs=[0, 2, 4, 5]),
-            RootVersion(keys=[0, 1, 3, 4, 5], threshold=3, sigs=[0, 4, 5]),
+            MdVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 2, 4]),
+            MdVersion(keys=[0, 1, 3, 4, 5], threshold=3, sigs=[0, 2, 4, 5]),
+            MdVersion(keys=[0, 1, 3, 4, 5], threshold=3, sigs=[0, 4, 5]),
         ],
         "3-of-5, all keys rotated, with intermediate step": [
-            RootVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 2, 4]),
-            RootVersion(keys=[5, 6, 7, 8, 9], threshold=3, sigs=[0, 2, 4, 5, 6, 7]),
-            RootVersion(keys=[5, 6, 7, 8, 9], threshold=3, sigs=[5, 6, 7]),
+            MdVersion(keys=[0, 1, 2, 3, 4], threshold=3, sigs=[0, 2, 4]),
+            MdVersion(keys=[5, 6, 7, 8, 9], threshold=3, sigs=[0, 2, 4, 5, 6, 7]),
+            MdVersion(keys=[5, 6, 7, 8, 9], threshold=3, sigs=[5, 6, 7]),
         ],
         "1-of-3 threshold increase to 2-of-3": [
-            RootVersion(keys=[1, 2, 3], threshold=1, sigs=[1]),
-            RootVersion(keys=[1, 2, 3], threshold=2, sigs=[1, 2]),
+            MdVersion(keys=[1, 2, 3], threshold=1, sigs=[1]),
+            MdVersion(keys=[1, 2, 3], threshold=2, sigs=[1, 2]),
         ],
         "1-of-3 threshold bump to 2-of-3 fails: new threshold not reached": [
-            RootVersion(keys=[1, 2, 3], threshold=1, sigs=[1]),
-            RootVersion(keys=[1, 2, 3], threshold=2, sigs=[2], res=UnsignedMetadataError),
+            MdVersion(keys=[1, 2, 3], threshold=1, sigs=[1]),
+            MdVersion(keys=[1, 2, 3], threshold=2, sigs=[2], res=UnsignedMetadataError),
         ],
         "2-of-3 threshold decrease to 1-of-3": [
-            RootVersion(keys=[1, 2, 3], threshold=2, sigs=[1, 2]),
-            RootVersion(keys=[1, 2, 3], threshold=1, sigs=[1, 2]),
-            RootVersion(keys=[1, 2, 3], threshold=1, sigs=[1]),
+            MdVersion(keys=[1, 2, 3], threshold=2, sigs=[1, 2]),
+            MdVersion(keys=[1, 2, 3], threshold=1, sigs=[1, 2]),
+            MdVersion(keys=[1, 2, 3], threshold=1, sigs=[1]),
         ],
         "2-of-3 threshold decr. to 1-of-3 fails: old threshold not reached": [
-            RootVersion(keys=[1, 2, 3], threshold=2, sigs=[1, 2]),
-            RootVersion(keys=[1, 2, 3], threshold=1, sigs=[1], res=UnsignedMetadataError),
+            MdVersion(keys=[1, 2, 3], threshold=2, sigs=[1, 2]),
+            MdVersion(keys=[1, 2, 3], threshold=1, sigs=[1], res=UnsignedMetadataError),
         ],
         "1-of-2 threshold increase to 2-of-2": [
-            RootVersion(keys=[1], threshold=1, sigs=[1]),
-            RootVersion(keys=[1, 2], threshold=2, sigs=[1, 2]),
+            MdVersion(keys=[1], threshold=1, sigs=[1]),
+            MdVersion(keys=[1, 2], threshold=2, sigs=[1, 2]),
         ],
     }
     # fmt: on
 
     @run_sub_tests_with_dataset(root_rotation_cases)
-    def test_root_rotation(self, root_versions: List[RootVersion]) -> None:
+    def test_root_rotation(self, root_versions: List[MdVersion]) -> None:
         """Test Updater.refresh() with various sequences of root updates
 
-        Each RootVersion in the list describes root keys and signatures of a
+        Each MdVersion in the list describes root keys and signatures of a
         remote root metadata version. As an example:
-            RootVersion([1,2,3], 2, [1,2])
+            MdVersion([1,2,3], 2, [1,2])
         defines a root that contains keys 1, 2 and 3 with threshold 2. The
         metadata is signed with keys 1 and 2.
 

--- a/tests/test_updater_key_rotations.py
+++ b/tests/test_updater_key_rotations.py
@@ -188,13 +188,13 @@ class TestUpdaterKeyRotations(unittest.TestCase):
             self.sim.publish_root()
 
         # run client workflow, assert success/failure
-        expected_result = root_versions[-1].res
-        if expected_result is None:
+        expected_error = root_versions[-1].res
+        if expected_error is None:
             self._run_refresh()
             expected_local_root = self.sim.signed_roots[-1]
         else:
             # failure expected: local root should be the root before last
-            with self.assertRaises(expected_result):
+            with self.assertRaises(expected_error):
                 self._run_refresh()
             expected_local_root = self.sim.signed_roots[-2]
 

--- a/tests/test_updater_key_rotations.py
+++ b/tests/test_updater_key_rotations.py
@@ -40,7 +40,6 @@ class TestUpdaterKeyRotations(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.sim: RepositorySimulator
         cls.metadata_dir: str
-        cls.subtest_count = 0
         # pylint: disable-next=consider-using-with
         cls.temp_dir = tempfile.TemporaryDirectory()
 
@@ -57,8 +56,6 @@ class TestUpdaterKeyRotations(unittest.TestCase):
         cls.temp_dir.cleanup()
 
     def setup_subtest(self) -> None:
-        self.subtest_count += 1
-
         # Setup repository for subtest: make sure no roots have been published
         self.sim = RepositorySimulator()
         self.sim.signed_roots.clear()
@@ -66,7 +63,7 @@ class TestUpdaterKeyRotations(unittest.TestCase):
 
         if self.dump_dir is not None:
             # create subtest dumpdir
-            name = f"{self.id().split('.')[-1]}-{self.subtest_count}"
+            name = f"{self.id().split('.')[-1]}-{self.case_name}"
             self.sim.dump_dir = os.path.join(self.dump_dir, name)
             os.mkdir(self.sim.dump_dir)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -57,6 +57,8 @@ def run_sub_tests_with_dataset(
         def wrapper(test_cls: unittest.TestCase) -> None:
             for case, data in dataset.items():
                 with test_cls.subTest(case=case):
+                    # Save case name for future reference
+                    test_cls.case_name = case.replace(" ", "_")
                     function(test_cls, data)
         return wrapper
     return real_decorator


### PR DESCRIPTION
Fixes #1647

**Description of the changes being introduced by the pull request**:

The amount of non-root key rotations is lower than the one for root as
the repository stores all root versions in order to be able to do
rollback check compared to timestamp, snapshot, and targets where it
stores only one version.

All of the root roles are needed in those tests again as root
delegates the keys for each of the other three top-level metadata roles.

Additionally, this pr contains some small fixes in the test_updater_key_rotations.py module.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


