### PR TITLE
Fix inconsistent behaviour of compute_metafile_hashes_length

### DIFF
--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -294,12 +294,15 @@ class RepositorySimulator(FetcherInterface):
         """Update timestamp and assign snapshot version to snapshot_meta
         version.
         """
-        self.timestamp.snapshot_meta.version = self.snapshot.version
 
+        hashes = None
+        length = None
         if self.compute_metafile_hashes_length:
             hashes, length = self._compute_hashes_and_length(Snapshot.type)
-            self.timestamp.snapshot_meta.hashes = hashes
-            self.timestamp.snapshot_meta.length = length
+
+        self.timestamp.snapshot_meta = MetaFile(
+            self.snapshot.version, length, hashes
+        )
 
         self.timestamp.version += 1
 

--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -434,6 +434,20 @@ class TestRefresh(unittest.TestCase):
 
         self._assert_files_exist([Root.type, Timestamp.type, Snapshot.type])
 
+    def test_compute_metafile_hashes_length(self) -> None:
+        self.sim.compute_metafile_hashes_length = True
+        self.sim.update_snapshot()
+        self._run_refresh()
+        self._assert_version_equals("timestamp", 2)
+        self._assert_version_equals("snapshot", 2)
+
+        self.sim.compute_metafile_hashes_length = False
+        self.sim.update_snapshot()
+        self._run_refresh()
+
+        self._assert_version_equals("timestamp", 3)
+        self._assert_version_equals("snapshot", 3)
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
Previously when `compute_metafile_hashes_length` was set to `False`
`update_timestamp` did not set the hash and length values to `None`
as expected. This change fixes that, so they are not `None` when
`compute_metafile_hashes_length=True` and `None` when
`compute_metafile_hashes_length=False`

Fixes #1651

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [n/a] Docs have been added for the bug fix or new feature
