### PR TITLE
Start linting the examples folder

### DIFF
--- a/examples/repo_example/basic_repo.py
+++ b/examples/repo_example/basic_repo.py
@@ -28,6 +28,7 @@ import tempfile
 from collections import OrderedDict
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Any, Dict
 
 from securesystemslib.keys import generate_ed25519_key
 from securesystemslib.signer import SSlibSigner
@@ -48,7 +49,7 @@ from tuf.api.metadata import (
 from tuf.api.serialization.json import JSONSerializer
 
 
-def _in(days):
+def _in(days: float) -> datetime:
     """Adds 'days' to now and returns datetime object w/o microseconds."""
     return datetime.utcnow().replace(microsecond=0) + timedelta(days=days)
 
@@ -89,8 +90,8 @@ SPEC_VERSION = "1.0.19"
 
 # Define containers for role objects and cryptographic keys created below. This
 # allows us to sign and write metadata in a batch more easily.
-roles = {}
-keys = {}
+roles: Dict[str, Metadata] = {}
+keys: Dict[str, Dict[str, Any]] = {}
 
 
 # Targets (integrity)
@@ -117,7 +118,7 @@ roles["targets"] = Metadata[Targets](
 local_path = Path(__file__).resolve()
 target_path = f"{local_path.parts[-2]}/{local_path.parts[-1]}"
 
-target_file_info = TargetFile.from_file(target_path, local_path)
+target_file_info = TargetFile.from_file(target_path, str(local_path))
 roles["targets"].signed.targets[target_path] = target_file_info
 
 # Snapshot (consistency)
@@ -332,7 +333,7 @@ roles["targets"].signed.delegations = Delegations(
 del roles["targets"].signed.targets[target_path]
 
 # Increase expiry (delegators should be less volatile)
-roles["targets"].expires = _in(365)
+roles["targets"].signed.expires = _in(365)
 
 
 # Snapshot + Timestamp + Sign + Persist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,12 +76,6 @@ strict_equality = "True"
 disallow_untyped_defs = "True"
 disallow_untyped_calls = "True"
 show_error_codes = "True"
-files = [
-  "tuf/api/",
-  "tuf/ngclient",
-  "tuf/exceptions.py",
-  "examples/",
-]
 
 [[tool.mypy.overrides]]
 module = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,8 @@ show_error_codes = "True"
 files = [
   "tuf/api/",
   "tuf/ngclient",
-  "tuf/exceptions.py"
+  "tuf/exceptions.py",
+  "examples/",
 ]
 
 [[tool.mypy.overrides]]

--- a/tox.ini
+++ b/tox.ini
@@ -38,17 +38,18 @@ commands =
 
 [testenv:lint]
 changedir = {toxinidir}
+lint_dirs = tuf/api tuf/ngclient examples
 commands =
     # Use different configs for new (tuf/api/*) and legacy code
-    black --check --diff tuf/api tuf/ngclient examples
-    isort --check --diff tuf/api tuf/ngclient examples
-    pylint -j 0 tuf/api tuf/ngclient --rcfile=pyproject.toml examples
+    black --check --diff {[testenv:lint]lint_dirs}
+    isort --check --diff {[testenv:lint]lint_dirs}
+    pylint -j 0 --rcfile=pyproject.toml {[testenv:lint]lint_dirs}
 
     # NOTE: Contrary to what the pylint docs suggest, ignoring full paths does
     # work, unfortunately each subdirectory has to be ignored explicitly.
     pylint -j 0 tuf --ignore=tuf/api,tuf/api/serialization,tuf/ngclient,tuf/ngclient/_internal
 
-    mypy
+    mypy {[testenv:lint]lint_dirs} tuf/exceptions.py
 
     bandit -r tuf
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,9 +40,9 @@ commands =
 changedir = {toxinidir}
 commands =
     # Use different configs for new (tuf/api/*) and legacy code
-    black --check --diff tuf/api tuf/ngclient
-    isort --check --diff tuf/api tuf/ngclient
-    pylint -j 0 tuf/api tuf/ngclient --rcfile=pyproject.toml
+    black --check --diff tuf/api tuf/ngclient examples
+    isort --check --diff tuf/api tuf/ngclient examples
+    pylint -j 0 tuf/api tuf/ngclient --rcfile=pyproject.toml examples
 
     # NOTE: Contrary to what the pylint docs suggest, ignoring full paths does
     # work, unfortunately each subdirectory has to be ignored explicitly.


### PR DESCRIPTION
Fixes #1697

**Description of the changes being introduced by the pull request**:

The examples folder currently contains a repository example and it's
good if we start linting its content and as a result add type
annotations.

I run all of the linters on the example folder instead of only using `mypy`
as I thought that will be better for the code included there.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


