### PR TITLE
Sanitize repo simulator role names when writing

### DIFF
--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -397,5 +397,6 @@ class RepositorySimulator(FetcherInterface):
                 f.write(self.fetch_metadata(role))
 
         for role in self.md_delegates:
-            with open(os.path.join(dest_dir, f"{role}.json"), "wb") as f:
+            quoted_role = parse.quote(role, "")
+            with open(os.path.join(dest_dir, f"{quoted_role}.json"), "wb") as f:
                 f.write(self.fetch_metadata(role))


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Sanitize the role names in the repo simulator when dumping in a
directory the same way the ngclient does.
That's necessary because when testing fishy role names from `test_updater_with_simulator` leads to an
error:
`PermissionError: [Errno 13] Permission denied: '/.json'`

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


