### PR TITLE
Test expired metadata from cache

### DIFF
--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -44,11 +44,11 @@ Example::
     updater.refresh()
 """
 
+import datetime
 import logging
 import os
 import tempfile
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
 from typing import Dict, Iterator, List, Optional, Tuple
 from urllib import parse
 
@@ -125,8 +125,10 @@ class RepositorySimulator(FetcherInterface):
 
         self.fetch_tracker = FetchTracker()
 
-        now = datetime.utcnow()
-        self.safe_expiry = now.replace(microsecond=0) + timedelta(days=30)
+        now = datetime.datetime.utcnow()
+        self.safe_expiry = now.replace(microsecond=0) + datetime.timedelta(
+            days=30
+        )
 
         self._initialize()
 

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -59,9 +59,9 @@ Example of loading root, timestamp and snapshot:
 >>>         trusted_set.update_snapshot(f.read())
 """
 
+import datetime
 import logging
 from collections import abc
-from datetime import datetime
 from typing import Dict, Iterator, Optional
 
 from tuf.api import exceptions
@@ -91,7 +91,7 @@ class TrustedMetadataSet(abc.Mapping):
                 error type and content will contain more details.
         """
         self._trusted_set: Dict[str, Metadata] = {}
-        self.reference_time = datetime.utcnow()
+        self.reference_time = datetime.datetime.utcnow()
 
         # Load and validate the local root metadata. Valid initial trusted root
         # metadata is required


### PR DESCRIPTION
This tests that an expired timestamp/snapshot/targets when loaded
from cache is not stored as final but is used to verify the new
timestamp

Addresses #1681

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [n/a] Docs have been added for the bug fix or new feature


