### PR TITLE
Remove microseconds from metadata API Signed.expires

### DIFF
--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -200,6 +200,9 @@ class TestSerialization(unittest.TestCase):
                 "snapshot": {"keyids": ["keyid2"], "threshold": 1}, \
                 "foo": {"keyids": ["keyid2"], "threshold": 1}} \
             }',
+        "invalid expiry with microsecond    s": '{"_type": "root", "spec_version": "1.0.0", "version": 1, \
+            "expires": "2030-01-01T12:00:00.123456Z", "consistent_snapshot": false, \
+            "keys": {}, "roles": {"root": {}, "timestamp": {}, "targets": {}, "snapshot": {}}}',
     }
 
     @utils.run_sub_tests_with_dataset(invalid_roots)

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -408,6 +408,14 @@ class Signed(metaclass=abc.ABCMeta):
     def _type(self) -> str:
         return self.type
 
+    @property
+    def expires(self) -> datetime:
+        return self._expires
+
+    @expires.setter
+    def expires(self, value: datetime) -> None:
+        self._expires = value.replace(microsecond=0)
+
     # NOTE: Signed is a stupid name, because this might not be signed yet, but
     # we keep it to match spec terminology (I often refer to this as "payload",
     # or "inner metadata")
@@ -469,6 +477,7 @@ class Signed(metaclass=abc.ABCMeta):
         # what the constructor expects and what we store. The inverse operation
         # is implemented in '_common_fields_to_dict'.
         expires = datetime.strptime(expires_str, "%Y-%m-%dT%H:%M:%SZ")
+
         return version, spec_version, expires
 
     def _common_fields_to_dict(self) -> Dict[str, Any]:


### PR DESCRIPTION
This change removes microseconds from expiry in order to fit TUF
specification

Fixes #1678

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [n/a] Tests have been added for the bug fix or new feature
- [n/a] Docs have been added for the bug fix or new feature


