### PR TITLE
tests: Refactor client bootstrap

### DIFF
--- a/tests/test_updater_consistent_snapshot.py
+++ b/tests/test_updater_consistent_snapshot.py
@@ -48,10 +48,7 @@ class TestConsistentSnapshot(unittest.TestCase):
 
         # Init trusted root with the latest consistent_snapshot
         with open(os.path.join(self.metadata_dir, "root.json"), "bw") as f:
-            root = sim.download_bytes(
-                "https://example.com/metadata/2.root.json", 100000
-            )
-            f.write(root)
+            f.write(sim.signed_roots[-1])
 
         return sim
 

--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -41,11 +41,9 @@ class TestRefresh(unittest.TestCase):
 
         self.sim = RepositorySimulator()
 
+        # boostrap client with initial root metadata
         with open(os.path.join(self.metadata_dir, "root.json"), "bw") as f:
-            root = self.sim.download_bytes(
-                "https://example.com/metadata/1.root.json", 100000
-            )
-            f.write(root)
+            f.write(self.sim.signed_roots[0])
 
     def tearDown(self) -> None:
         self.temp_dir.cleanup()

--- a/tests/test_updater_with_simulator.py
+++ b/tests/test_updater_with_simulator.py
@@ -38,10 +38,7 @@ class TestUpdater(unittest.TestCase):
         # Setup the repository, bootstrap client root.json
         self.sim = RepositorySimulator()
         with open(os.path.join(self.metadata_dir, "root.json"), "bw") as f:
-            root = self.sim.download_bytes(
-                "https://example.com/metadata/1.root.json", 100000
-            )
-            f.write(root)
+            f.write(self.sim.signed_roots[0])
 
         if self.dump_dir is not None:
             # create test specific dump directory


### PR DESCRIPTION
Setting up the client (when using RepositorySimulator) can be a bit
cleaner.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

---

just tiny test refactor