### PR TITLE
CI: Use builtin package cache support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,20 +47,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Find pip cache dir
-        id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
-
-      - name: pip cache
-        uses: actions/cache@v2
-        with:
-          # Use the os dependent pip cache directory found above
-          path: ${{ steps.pip-cache.outputs.dir }}
-          # A match with 'key' counts as cache hit
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
-          # A match with 'restore-keys' is used as fallback
-          restore-keys: ${{ runner.os }}-pip-
+          cache: 'pip'
+          cache-dependency-path: 'requirements*.txt'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
actions/setup-python now supports pip cache: use that instead of
handling cache locations manually.

Cache invalidates when any requirements file changes (same as before):
this is a bit over cautious but probably harder to break.

Fixes #1692

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>
