### PR TITLE
test: add missing return type hint in test method

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -87,7 +87,7 @@ class TestRepoExamples(unittest.TestCase):
             ],
         )
 
-    def test_hashed_bin_delegation(self):
+    def test_hashed_bin_delegation(self) -> None:
         """Run 'hashed_bin_delegation.py' and assert creation of metadata files."""
         self._run_script_and_assert_files(
             "hashed_bin_delegation.py",


### PR DESCRIPTION
Fixes #<ISSUE NUMBER>

**Description of the changes being introduced by the pull request**:

Following parallel merges of #1700 (added new test method), and #1710 (started running mypy on tests), ci/cd fails in the develop branch. This is fixed in this patch.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


