### PR TITLE
Start linting tuf/exceptions.py with all linters

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands =
 
 [testenv:lint]
 changedir = {toxinidir}
-lint_dirs = tuf/api tuf/ngclient examples tests
+lint_dirs = tuf/api tuf/ngclient examples tests tuf/exceptions.py
 commands =
     # Use different configs for new (tuf/api/*) and legacy code
     black --check --diff {[testenv:lint]lint_dirs}
@@ -47,9 +47,9 @@ commands =
 
     # NOTE: Contrary to what the pylint docs suggest, ignoring full paths does
     # work, unfortunately each subdirectory has to be ignored explicitly.
-    pylint -j 0 tuf --ignore=tuf/api,tuf/api/serialization,tuf/ngclient,tuf/ngclient/_internal
+    pylint -j 0 tuf --ignore=tuf/api,tuf/api/serialization,tuf/ngclient,tuf/ngclient/_internal --disable=W tuf/exceptions.py
 
-    mypy {[testenv:lint]lint_dirs} tuf/exceptions.py
+    mypy {[testenv:lint]lint_dirs}
 
     bandit -r tuf
 

--- a/tuf/exceptions.py
+++ b/tuf/exceptions.py
@@ -22,317 +22,346 @@
   there is a good reason not to, and provide that reason in those cases.
 """
 
+import logging
+from typing import Any, Dict, Optional
 from urllib import parse
 
-from typing import Any, Dict, Optional
-
-import logging
 logger = logging.getLogger(__name__)
 
 
 class Error(Exception):
-  """Indicate a generic error."""
+    """Indicate a generic error."""
 
 
 class UnsupportedSpecificationError(Error):
-  """
-  Metadata received claims to conform to a version of the specification that is
-  not supported by this client.
-  """
+    """Metadata received claims to conform to a version of the specification
+    that is not supported by this client."""
+
 
 class FormatError(Error):
-  """Indicate an error while validating an object's format."""
+    """Indicate an error while validating an object's format."""
 
 
 class InvalidMetadataJSONError(FormatError):
-  """Indicate that a metadata file is not valid JSON."""
+    """Indicate that a metadata file is not valid JSON."""
 
-  def __init__(self, exception: BaseException):
-    super(InvalidMetadataJSONError, self).__init__()
+    def __init__(self, exception: BaseException):
+        super(InvalidMetadataJSONError, self).__init__()
 
-    # Store the original exception.
-    self.exception = exception
+        # Store the original exception.
+        self.exception = exception
 
-  def __str__(self) -> str:
-    return repr(self)
+    def __str__(self) -> str:
+        return repr(self)
 
-  def __repr__(self) -> str:
-    # Show the original exception.
-    return self.__class__.__name__ + ' : wraps error: ' + repr(self.exception)
+    def __repr__(self) -> str:
+        # Show the original exception.
+        return (
+            self.__class__.__name__ + " : wraps error: " + repr(self.exception)
+        )
 
-    # # Directly instance-reproducing:
-    # return self.__class__.__name__ + '(' + repr(self.exception) + ')'
+        # # Directly instance-reproducing:
+        # return self.__class__.__name__ + '(' + repr(self.exception) + ')'
 
 
 class UnsupportedAlgorithmError(Error):
-  """Indicate an error while trying to identify a user-specified algorithm."""
+    """Indicate an error while trying to identify a user-specified algorithm."""
+
 
 class LengthOrHashMismatchError(Error):
-  """Indicate an error while checking the length and hash values of an object"""
+    """Indicate an error while checking the length and hash values of an
+    object."""
+
 
 class RepositoryError(Error):
-  """Indicate an error with a repository's state, such as a missing file."""
+    """Indicate an error with a repository's state, such as a missing file."""
+
 
 class BadHashError(RepositoryError):
-  """Indicate an error while checking the value of a hash object."""
+    """Indicate an error while checking the value of a hash object."""
 
-  def __init__(self, expected_hash: str, observed_hash: str):
-    super(BadHashError, self).__init__()
+    def __init__(self, expected_hash: str, observed_hash: str):
+        super(BadHashError, self).__init__()
 
-    self.expected_hash = expected_hash
-    self.observed_hash = observed_hash
+        self.expected_hash = expected_hash
+        self.observed_hash = observed_hash
 
-  def __str__(self) -> str:
-    return (
-        'Observed hash (' + repr(self.observed_hash) + ') != expected hash (' +
-        repr(self.expected_hash) + ')')
+    def __str__(self) -> str:
+        return (
+            "Observed hash ("
+            + repr(self.observed_hash)
+            + ") != expected hash ("
+            + repr(self.expected_hash)
+            + ")"
+        )
 
-  def __repr__(self) -> str:
-    return self.__class__.__name__ + ' : ' + str(self)
+    def __repr__(self) -> str:
+        return self.__class__.__name__ + " : " + str(self)
 
-    # # Directly instance-reproducing:
-    # return (
-    #     self.__class__.__name__ + '(' + repr(self.expected_hash) + ', ' +
-    #     repr(self.observed_hash) + ')')
+        # # Directly instance-reproducing:
+        # return (
+        #     self.__class__.__name__ + '(' + repr(self.expected_hash) + ', ' +
+        #     repr(self.observed_hash) + ')')
 
 
 class BadPasswordError(Error):
-  """Indicate an error after encountering an invalid password."""
+    """Indicate an error after encountering an invalid password."""
 
 
 class UnknownKeyError(Error):
-  """Indicate an error while verifying key-like objects (e.g., keyids)."""
+    """Indicate an error while verifying key-like objects (e.g., keyids)."""
 
 
 class BadVersionNumberError(RepositoryError):
-  """Indicate an error for metadata that contains an invalid version number."""
+    """Indicate an error for metadata that contains an invalid
+    version number."""
 
 
 class MissingLocalRepositoryError(RepositoryError):
-  """Raised when a local repository could not be found."""
+    """Raised when a local repository could not be found."""
 
 
 class InsufficientKeysError(Error):
-  """Indicate that metadata role lacks a threshold of pubic or private keys."""
+    """Indicate that metadata role lacks a threshold of pubic or
+    private keys."""
 
 
 class ForbiddenTargetError(RepositoryError):
-  """Indicate that a role signed for a target that it was not delegated to."""
+    """Indicate that a role signed for a target that it was not delegated to."""
 
 
 class ExpiredMetadataError(RepositoryError):
-  """Indicate that a TUF Metadata file has expired."""
+    """Indicate that a TUF Metadata file has expired."""
 
 
 class ReplayedMetadataError(RepositoryError):
-  """Indicate that some metadata has been replayed to the client."""
+    """Indicate that some metadata has been replayed to the client."""
 
-  def __init__(self, metadata_role: str, downloaded_version: int, current_version: int):
-    super(ReplayedMetadataError, self).__init__()
+    def __init__(
+        self, metadata_role: str, downloaded_version: int, current_version: int
+    ):
+        super(ReplayedMetadataError, self).__init__()
 
-    self.metadata_role = metadata_role
-    self.downloaded_version = downloaded_version
-    self.current_version = current_version
+        self.metadata_role = metadata_role
+        self.downloaded_version = downloaded_version
+        self.current_version = current_version
 
-  def __str__(self) -> str:
-    return (
-        'Downloaded ' + repr(self.metadata_role) + ' is older (' +
-        repr(self.downloaded_version) + ') than the version currently '
-        'installed (' + repr(self.current_version) + ').')
+    def __str__(self) -> str:
+        return (
+            "Downloaded "
+            + repr(self.metadata_role)
+            + " is older ("
+            + repr(self.downloaded_version)
+            + ") than the version currently "
+            "installed (" + repr(self.current_version) + ")."
+        )
 
-  def __repr__(self) -> str:
-    return self.__class__.__name__ + ' : ' + str(self)
+    def __repr__(self) -> str:
+        return self.__class__.__name__ + " : " + str(self)
 
 
 class CryptoError(Error):
-  """Indicate any cryptography-related errors."""
+    """Indicate any cryptography-related errors."""
 
 
 class BadSignatureError(CryptoError):
-  """Indicate that some metadata file has a bad signature."""
+    """Indicate that some metadata file has a bad signature."""
 
-  def __init__(self, metadata_role_name: str):
-    super(BadSignatureError, self).__init__()
+    def __init__(self, metadata_role_name: str):
+        super(BadSignatureError, self).__init__()
 
-    self.metadata_role_name = metadata_role_name
+        self.metadata_role_name = metadata_role_name
 
-  def __str__(self) -> str:
-    return repr(self.metadata_role_name) + ' metadata has a bad signature.'
+    def __str__(self) -> str:
+        return repr(self.metadata_role_name) + " metadata has a bad signature."
 
-  def __repr__(self) -> str:
-    return self.__class__.__name__ + ' : ' + str(self)
+    def __repr__(self) -> str:
+        return self.__class__.__name__ + " : " + str(self)
 
-    # # Directly instance-reproducing:
-    # return (
-    #     self.__class__.__name__ + '(' + repr(self.metadata_role_name) + ')')
+        # # Directly instance-reproducing:
+        # return (
+        #     self.__class__.__name__ + '(' + repr(self.metadata_role_name) + ')')
 
 
 class UnknownMethodError(CryptoError):
-  """Indicate that a user-specified cryptograpthic method is unknown."""
+    """Indicate that a user-specified cryptograpthic method is unknown."""
 
 
 class UnsupportedLibraryError(Error):
-  """Indicate that a supported library could not be located or imported."""
+    """Indicate that a supported library could not be located or imported."""
 
 
 class DownloadError(Error):
-  """Indicate an error occurred while attempting to download a file."""
+    """Indicate an error occurred while attempting to download a file."""
 
 
 class DownloadLengthMismatchError(DownloadError):
-  """Indicate that a mismatch of lengths was seen while downloading a file."""
+    """Indicate that a mismatch of lengths was seen while downloading a file."""
 
-  def __init__(self, expected_length: int, observed_length: int):
-    super(DownloadLengthMismatchError, self).__init__()
+    def __init__(self, expected_length: int, observed_length: int):
+        super(DownloadLengthMismatchError, self).__init__()
 
-    self.expected_length = expected_length #bytes
-    self.observed_length = observed_length #bytes
+        self.expected_length = expected_length  # bytes
+        self.observed_length = observed_length  # bytes
 
-  def __str__(self) -> str:
-    return (
-        'Observed length (' + repr(self.observed_length) +
-        ') < expected length (' + repr(self.expected_length) + ').')
+    def __str__(self) -> str:
+        return (
+            "Observed length ("
+            + repr(self.observed_length)
+            + ") < expected length ("
+            + repr(self.expected_length)
+            + ")."
+        )
 
-  def __repr__(self) -> str:
-    return self.__class__.__name__ + ' : ' + str(self)
+    def __repr__(self) -> str:
+        return self.__class__.__name__ + " : " + str(self)
 
-    # # Directly instance-reproducing:
-    # return (
-    #     self.__class__.__name__ + '(' + repr(self.expected_length) + ', ' +
-    #     self.observed_length + ')')
-
+        # # Directly instance-reproducing:
+        # return (
+        #     self.__class__.__name__ + '(' + repr(self.expected_length) + ', ' +
+        #     self.observed_length + ')')
 
 
 class SlowRetrievalError(DownloadError):
-  """"Indicate that downloading a file took an unreasonably long time."""
+    """ "Indicate that downloading a file took an unreasonably long time."""
 
-  def __init__(self, average_download_speed: Optional[int] = None):
-    super(SlowRetrievalError, self).__init__()
+    def __init__(self, average_download_speed: Optional[int] = None):
+        super(SlowRetrievalError, self).__init__()
 
-    self.__average_download_speed = average_download_speed #bytes/second
+        self.__average_download_speed = average_download_speed  # bytes/second
 
-  def __str__(self) -> str:
-    msg = 'Download was too slow.'
-    if self.__average_download_speed is not None:
-      msg = ('Download was too slow. Average speed: ' +
-         repr(self.__average_download_speed) + ' bytes per second.')
+    def __str__(self) -> str:
+        msg = "Download was too slow."
+        if self.__average_download_speed is not None:
+            msg = (
+                "Download was too slow. Average speed: "
+                + repr(self.__average_download_speed)
+                + " bytes per second."
+            )
 
-    return msg
+        return msg
 
-  def __repr__(self) -> str:
-    return self.__class__.__name__ + ' : ' + str(self)
+    def __repr__(self) -> str:
+        return self.__class__.__name__ + " : " + str(self)
 
-    # # Directly instance-reproducing:
-    # return (
-    #     self.__class__.__name__ + '(' + repr(self.__average_download_speed + ')')
+        # # Directly instance-reproducing:
+        # return (
+        #     self.__class__.__name__ + '(' + repr(self.__average_download_speed + ')')
 
 
 class KeyAlreadyExistsError(Error):
-  """Indicate that a key already exists and cannot be added."""
+    """Indicate that a key already exists and cannot be added."""
 
 
 class RoleAlreadyExistsError(Error):
-  """Indicate that a role already exists and cannot be added."""
+    """Indicate that a role already exists and cannot be added."""
 
 
 class UnknownRoleError(Error):
-  """Indicate an error trying to locate or identify a specified TUF role."""
+    """Indicate an error trying to locate or identify a specified TUF role."""
 
 
 class UnknownTargetError(Error):
-  """Indicate an error trying to locate or identify a specified target."""
+    """Indicate an error trying to locate or identify a specified target."""
 
 
 class InvalidNameError(Error):
-  """Indicate an error while trying to validate any type of named object."""
+    """Indicate an error while trying to validate any type of named object."""
 
 
 class UnsignedMetadataError(RepositoryError):
-  """Indicate metadata object with insufficient threshold of signatures."""
+    """Indicate metadata object with insufficient threshold of signatures."""
 
-  # signable is not used but kept in method signature for backwards compat
-  def __init__(self, message: str, signable: Any = None):
-    super(UnsignedMetadataError, self).__init__()
+    # signable is not used but kept in method signature for backwards compat
+    def __init__(self, message: str, signable: Any = None):
+        super(UnsignedMetadataError, self).__init__()
 
-    self.exception_message = message
-    self.signable = signable
+        self.exception_message = message
+        self.signable = signable
 
-  def __str__(self) -> str:
-    return self.exception_message
+    def __str__(self) -> str:
+        return self.exception_message
 
-  def __repr__(self) -> str:
-    return self.__class__.__name__ + ' : ' + str(self)
+    def __repr__(self) -> str:
+        return self.__class__.__name__ + " : " + str(self)
 
-    # # Directly instance-reproducing:
-    # return (
-    #     self.__class__.__name__ + '(' + repr(self.exception_message) + ', ' +
-    #     repr(self.signable) + ')')
+        # # Directly instance-reproducing:
+        # return (
+        #     self.__class__.__name__ + '(' + repr(self.exception_message) + ', ' +
+        #     repr(self.signable) + ')')
 
 
 class NoWorkingMirrorError(Error):
-  """
+    """
     An updater will throw this exception in case it could not download a
     metadata or target file.
-    A dictionary of Exception instances indexed by every mirror URL will also be
-    provided.
-  """
+    A dictionary of Exception instances indexed by every mirror URL will also
+    be provided.
+    """
 
-  def __init__(self, mirror_errors: Dict[str, BaseException]):
-    super(NoWorkingMirrorError, self).__init__()
+    def __init__(self, mirror_errors: Dict[str, BaseException]):
+        super(NoWorkingMirrorError, self).__init__()
 
-    # Dictionary of URL strings to Exception instances
-    self.mirror_errors = mirror_errors
+        # Dictionary of URL strings to Exception instances
+        self.mirror_errors = mirror_errors
 
-  def __str__(self) -> str:
-    all_errors = 'No working mirror was found:'
+    def __str__(self) -> str:
+        all_errors = "No working mirror was found:"
 
-    for mirror_url, mirror_error in self.mirror_errors.items():
-      try:
-        # http://docs.python.org/2/library/urlparse.html#urlparse.urlparse
-        mirror_url_tokens = parse.urlparse(mirror_url)
+        for mirror_url, mirror_error in self.mirror_errors.items():
+            try:
+                # http://docs.python.org/2/library/urlparse.html#urlparse.urlparse
+                mirror_url_tokens = parse.urlparse(mirror_url)
 
-      except Exception:
-        logger.exception('Failed to parse mirror URL: ' + repr(mirror_url))
-        mirror_netloc = mirror_url
+            except Exception:
+                logger.exception(
+                    "Failed to parse mirror URL: " + repr(mirror_url)
+                )
+                mirror_netloc = mirror_url
 
-      else:
-        mirror_netloc = mirror_url_tokens.netloc
+            else:
+                mirror_netloc = mirror_url_tokens.netloc
 
-      all_errors += '\n  ' + repr(mirror_netloc) + ': ' + repr(mirror_error)
+            all_errors += (
+                "\n  " + repr(mirror_netloc) + ": " + repr(mirror_error)
+            )
 
-    return all_errors
+        return all_errors
 
-  def __repr__(self) -> str:
-    return self.__class__.__name__ + ' : ' + str(self)
+    def __repr__(self) -> str:
+        return self.__class__.__name__ + " : " + str(self)
 
-    # # Directly instance-reproducing:
-    # return (
-    #     self.__class__.__name__ + '(' + repr(self.mirror_errors) + ')')
-
+        # # Directly instance-reproducing:
+        # return (
+        #     self.__class__.__name__ + '(' + repr(self.mirror_errors) + ')')
 
 
 class NotFoundError(Error):
-  """If a required configuration or resource is not found."""
+    """If a required configuration or resource is not found."""
 
 
 class URLMatchesNoPatternError(Error):
-  """If a URL does not match a user-specified regular expression."""
+    """If a URL does not match a user-specified regular expression."""
+
 
 class URLParsingError(Error):
-  """If we are unable to parse a URL -- for example, if a hostname element
-  cannot be isoalted."""
+    """If we are unable to parse a URL -- for example, if a hostname element
+    cannot be isoalted."""
+
 
 class InvalidConfigurationError(Error):
-  """If a configuration object does not match the expected format."""
+    """If a configuration object does not match the expected format."""
+
 
 class FetcherHTTPError(Exception):
-  """
-  Returned by FetcherInterface implementations for HTTP errors.
+    """
+    Returned by FetcherInterface implementations for HTTP errors.
 
-  Args:
-    message (str): The HTTP error messsage
-    status_code (int): The HTTP status code
-  """
-  def __init__(self, message: str, status_code: int):
-    super(FetcherHTTPError, self).__init__(message)
-    self.status_code = status_code
+    Args:
+      message (str): The HTTP error messsage
+      status_code (int): The HTTP status code
+    """
+
+    def __init__(self, message: str, status_code: int):
+        super(FetcherHTTPError, self).__init__(message)
+        self.status_code = status_code

--- a/tuf/exceptions.py
+++ b/tuf/exceptions.py
@@ -46,7 +46,7 @@ class InvalidMetadataJSONError(FormatError):
     """Indicate that a metadata file is not valid JSON."""
 
     def __init__(self, exception: BaseException):
-        super(InvalidMetadataJSONError, self).__init__()
+        super().__init__()
 
         # Store the original exception.
         self.exception = exception
@@ -81,7 +81,7 @@ class BadHashError(RepositoryError):
     """Indicate an error while checking the value of a hash object."""
 
     def __init__(self, expected_hash: str, observed_hash: str):
-        super(BadHashError, self).__init__()
+        super().__init__()
 
         self.expected_hash = expected_hash
         self.observed_hash = observed_hash
@@ -140,7 +140,7 @@ class ReplayedMetadataError(RepositoryError):
     def __init__(
         self, metadata_role: str, downloaded_version: int, current_version: int
     ):
-        super(ReplayedMetadataError, self).__init__()
+        super().__init__()
 
         self.metadata_role = metadata_role
         self.downloaded_version = downloaded_version
@@ -168,7 +168,7 @@ class BadSignatureError(CryptoError):
     """Indicate that some metadata file has a bad signature."""
 
     def __init__(self, metadata_role_name: str):
-        super(BadSignatureError, self).__init__()
+        super().__init__()
 
         self.metadata_role_name = metadata_role_name
 
@@ -199,7 +199,7 @@ class DownloadLengthMismatchError(DownloadError):
     """Indicate that a mismatch of lengths was seen while downloading a file."""
 
     def __init__(self, expected_length: int, observed_length: int):
-        super(DownloadLengthMismatchError, self).__init__()
+        super().__init__()
 
         self.expected_length = expected_length  # bytes
         self.observed_length = observed_length  # bytes
@@ -226,7 +226,7 @@ class SlowRetrievalError(DownloadError):
     """ "Indicate that downloading a file took an unreasonably long time."""
 
     def __init__(self, average_download_speed: Optional[int] = None):
-        super(SlowRetrievalError, self).__init__()
+        super().__init__()
 
         self.__average_download_speed = average_download_speed  # bytes/second
 
@@ -274,7 +274,7 @@ class UnsignedMetadataError(RepositoryError):
 
     # signable is not used but kept in method signature for backwards compat
     def __init__(self, message: str, signable: Any = None):
-        super(UnsignedMetadataError, self).__init__()
+        super().__init__()
 
         self.exception_message = message
         self.signable = signable
@@ -300,7 +300,7 @@ class NoWorkingMirrorError(Error):
     """
 
     def __init__(self, mirror_errors: Dict[str, BaseException]):
-        super(NoWorkingMirrorError, self).__init__()
+        super().__init__()
 
         # Dictionary of URL strings to Exception instances
         self.mirror_errors = mirror_errors
@@ -310,12 +310,12 @@ class NoWorkingMirrorError(Error):
 
         for mirror_url, mirror_error in self.mirror_errors.items():
             try:
-                # http://docs.python.org/2/library/urlparse.html#urlparse.urlparse
+                # https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlparse
                 mirror_url_tokens = parse.urlparse(mirror_url)
 
-            except Exception:
+            except ValueError:
                 logger.exception(
-                    "Failed to parse mirror URL: " + repr(mirror_url)
+                    "Failed to parse mirror URL: %s", repr(mirror_url)
                 )
                 mirror_netloc = mirror_url
 
@@ -363,5 +363,5 @@ class FetcherHTTPError(Exception):
     """
 
     def __init__(self, message: str, status_code: int):
-        super(FetcherHTTPError, self).__init__(message)
+        super().__init__(message)
         self.status_code = status_code


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

We are already using tuf/exceptions.py inside
- `tuf/api/metadata.py`
- `tuf/ngclient/__internal__/trusted_metadata_set.py`
- `tuf/ngclient/fetcher.py`
- `tuf/ngclient/updater.py`
- and in our tests using the new code base

This means that we are most likely going to use that
module after we remove the old code.

It makes sense to lint it with the other three
linters besides `mypy` (we already lint tuf/exceptions.py with `mypy`).

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


