### PR TITLE
turn doc build warnings into errors

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,7 @@ version: 2
 sphinx:
    builder: html
    configuration: docs/conf.py
+   fail_on_warning: true
 
 # Optionally build your docs in additional formats such as PDF
 formats: []

--- a/docs/CONTRIBUTORS.rst
+++ b/docs/CONTRIBUTORS.rst
@@ -184,10 +184,9 @@ a *venv*), and then install ``securesystemslib`` in editable mode too (in the sa
     $ python3 -m pip install -r requirements-dev.txt
 
 
-With `tox <https://testrun.org/tox/>`_ the test suite can be executed in a
-separate *venv* for each supported Python version. While the supported
-Python versions must already be available, ``tox`` will install ``tuf`` and its
-dependencies anew in each environment.
+With `tox <https://testrun.org/tox/>`_, the test suite can be executed in a
+separate *venv*. While a supported Python version must already be available,
+``tox`` will install ``tuf`` and dependencies.
 ::
 
     $ tox

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = lint,py{36,37,38,39,310}
+envlist = lint,docs,py
 skipsdist = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -59,4 +59,4 @@ deps =
 
 changedir = {toxinidir}
 commands =
-    sphinx-build -b html docs docs/build/html
+    sphinx-build -b html docs docs/build/html -W


### PR DESCRIPTION
This commit adds to the docs tox session the flag ``-W``, which
turns the warnings into errors.

The CI will fail once it gets errors.

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>

Linked to #1722

- [X] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


