### PR TITLE
Add new exceptions file for exceptions in the new code

### DIFF
--- a/examples/client_example/client_example.py
+++ b/examples/client_example/client_example.py
@@ -10,7 +10,7 @@ import os
 import shutil
 from pathlib import Path
 
-from tuf.exceptions import RepositoryError
+from tuf.api.exceptions import RepositoryError
 from tuf.ngclient import Updater
 
 # constants

--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -57,6 +57,7 @@ import securesystemslib.hash as sslib_hash
 from securesystemslib.keys import generate_ed25519_key
 from securesystemslib.signer import SSlibSigner
 
+from tuf.api.exceptions import FetcherHTTPError
 from tuf.api.metadata import (
     SPECIFICATION_VERSION,
     TOP_LEVEL_ROLE_NAMES,
@@ -73,7 +74,6 @@ from tuf.api.metadata import (
     Timestamp,
 )
 from tuf.api.serialization.json import JSONSerializer
-from tuf.exceptions import FetcherHTTPError
 from tuf.ngclient.fetcher import FetcherInterface
 
 logger = logging.getLogger(__name__)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -614,7 +614,7 @@ class TestMetadata(unittest.TestCase):
 
         # Test with an unsupported algorithm
         file_path = os.path.join(self.repo_dir, Targets.type, "file1.txt")
-        with self.assertRaises(exceptions.UnsupportedAlgorithmError):
+        with self.assertRaises(ValueError):
             TargetFile.from_file(file_path, file_path, ["123"])
 
     def test_targetfile_from_data(self) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -25,7 +25,7 @@ from securesystemslib.keys import generate_ed25519_key
 from securesystemslib.signer import Signature, SSlibSigner
 
 from tests import utils
-from tuf import exceptions
+from tuf.api import exceptions
 from tuf.api.metadata import (
     TOP_LEVEL_ROLE_NAMES,
     DelegatedRole,

--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -110,7 +110,7 @@ class TestFetcher(unittest_toolbox.Modified_TestCase):
 
     # Incorrect URL parsing
     def test_url_parsing(self) -> None:
-        with self.assertRaises(exceptions.URLParsingError):
+        with self.assertRaises(exceptions.DownloadError):
             self.fetcher.fetch(self.random_string())
 
     # File not found error

--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -20,7 +20,8 @@ import requests
 import urllib3.exceptions
 
 from tests import utils
-from tuf import exceptions, unittest_toolbox
+from tuf import unittest_toolbox
+from tuf.api import exceptions
 from tuf.ngclient._internal.requests_fetcher import RequestsFetcher
 
 logger = logging.getLogger(__name__)

--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -13,7 +13,7 @@ from securesystemslib.interface import (
 from securesystemslib.signer import SSlibSigner
 
 from tests import utils
-from tuf import exceptions
+from tuf.api import exceptions
 from tuf.api.metadata import (
     Metadata,
     MetaFile,

--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -245,7 +245,7 @@ class TestTrustedMetadataSet(unittest.TestCase):
             self.trusted_set.update_root(root.to_bytes())
 
     def test_update_root_new_root_ver_same_as_trusted_root_ver(self) -> None:
-        with self.assertRaises(exceptions.ReplayedMetadataError):
+        with self.assertRaises(exceptions.BadVersionNumberError):
             self.trusted_set.update_root(self.metadata[Root.type])
 
     def test_root_expired_final_root(self) -> None:
@@ -266,7 +266,7 @@ class TestTrustedMetadataSet(unittest.TestCase):
 
         timestamp = self.modify_metadata(Timestamp.type, version_modifier)
         self.trusted_set.update_timestamp(timestamp)
-        with self.assertRaises(exceptions.ReplayedMetadataError):
+        with self.assertRaises(exceptions.BadVersionNumberError):
             self.trusted_set.update_timestamp(self.metadata[Timestamp.type])
 
     def test_update_timestamp_snapshot_ver_below_current(self) -> None:
@@ -278,7 +278,7 @@ class TestTrustedMetadataSet(unittest.TestCase):
         self.trusted_set.update_timestamp(timestamp)
 
         # newtimestamp.meta.version < trusted_timestamp.meta.version
-        with self.assertRaises(exceptions.ReplayedMetadataError):
+        with self.assertRaises(exceptions.BadVersionNumberError):
             self.trusted_set.update_timestamp(self.metadata[Timestamp.type])
 
     def test_update_timestamp_expired(self) -> None:

--- a/tests/test_updater_delegation_graphs.py
+++ b/tests/test_updater_delegation_graphs.py
@@ -15,13 +15,13 @@ from typing import Iterable, List, Optional
 
 from tests import utils
 from tests.repository_simulator import RepositorySimulator
+from tuf.api.exceptions import UnsignedMetadataError
 from tuf.api.metadata import (
     SPECIFICATION_VERSION,
     TOP_LEVEL_ROLE_NAMES,
     DelegatedRole,
     Targets,
 )
-from tuf.exceptions import UnsignedMetadataError
 from tuf.ngclient import Updater
 
 

--- a/tests/test_updater_fetch_target.py
+++ b/tests/test_updater_fetch_target.py
@@ -15,7 +15,7 @@ from typing import Optional
 
 from tests import utils
 from tests.repository_simulator import RepositorySimulator
-from tuf.exceptions import RepositoryError
+from tuf.api.exceptions import RepositoryError
 from tuf.ngclient import Updater
 
 

--- a/tests/test_updater_key_rotations.py
+++ b/tests/test_updater_key_rotations.py
@@ -17,8 +17,8 @@ from securesystemslib.signer import SSlibSigner
 from tests import utils
 from tests.repository_simulator import RepositorySimulator
 from tests.utils import run_sub_tests_with_dataset
+from tuf.api.exceptions import UnsignedMetadataError
 from tuf.api.metadata import Key, Root
-from tuf.exceptions import UnsignedMetadataError
 from tuf.ngclient import Updater
 
 

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -19,7 +19,8 @@ from securesystemslib.interface import import_rsa_privatekey_from_file
 from securesystemslib.signer import SSlibSigner
 
 from tests import utils
-from tuf import exceptions, ngclient, unittest_toolbox
+from tuf import ngclient, unittest_toolbox
+from tuf.api import exceptions
 from tuf.api.metadata import (
     Metadata,
     Root,

--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -19,7 +19,6 @@ from tests.repository_simulator import RepositorySimulator
 from tuf.api.exceptions import (
     BadVersionNumberError,
     ExpiredMetadataError,
-    ReplayedMetadataError,
     RepositoryError,
     UnsignedMetadataError,
 )
@@ -267,7 +266,7 @@ class TestRefresh(unittest.TestCase):
         # Check for a rollback_attack
         # Repository serves a root file with the same version as previous
         self.sim.publish_root()
-        with self.assertRaises(ReplayedMetadataError):
+        with self.assertRaises(BadVersionNumberError):
             self._run_refresh()
 
         # The update failed, latest root version is v1
@@ -278,7 +277,7 @@ class TestRefresh(unittest.TestCase):
         # Repository serves non-consecutive root version
         self.sim.root.version += 2
         self.sim.publish_root()
-        with self.assertRaises(ReplayedMetadataError):
+        with self.assertRaises(BadVersionNumberError):
             self._run_refresh()
 
         # The update failed, latest root version is v1
@@ -313,7 +312,7 @@ class TestRefresh(unittest.TestCase):
         self._run_refresh()
 
         self.sim.timestamp.version = 1
-        with self.assertRaises(ReplayedMetadataError):
+        with self.assertRaises(BadVersionNumberError):
             self._run_refresh()
 
         self._assert_version_equals(Timestamp.type, 2)
@@ -328,7 +327,7 @@ class TestRefresh(unittest.TestCase):
         self.sim.timestamp.snapshot_meta.version = 1
         self.sim.timestamp.version += 1  # timestamp v3
 
-        with self.assertRaises(ReplayedMetadataError):
+        with self.assertRaises(BadVersionNumberError):
             self._run_refresh()
 
         self._assert_version_equals(Timestamp.type, 2)
@@ -423,7 +422,7 @@ class TestRefresh(unittest.TestCase):
         self.sim.snapshot.version = 1
         self.sim.update_timestamp()
 
-        with self.assertRaises(ReplayedMetadataError):
+        with self.assertRaises(BadVersionNumberError):
             self._run_refresh()
 
         self._assert_version_equals(Snapshot.type, 2)

--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -19,7 +19,7 @@ from tests.repository_simulator import RepositorySimulator
 from tuf.api.exceptions import (
     BadVersionNumberError,
     ExpiredMetadataError,
-    RepositoryError,
+    LengthOrHashMismatchError,
     UnsignedMetadataError,
 )
 from tuf.api.metadata import (
@@ -389,7 +389,7 @@ class TestRefresh(unittest.TestCase):
         self.sim.timestamp.version += 1  # timestamp v3
 
         # Hash mismatch error
-        with self.assertRaises(RepositoryError):
+        with self.assertRaises(LengthOrHashMismatchError):
             self._run_refresh()
 
         self._assert_version_equals(Timestamp.type, 3)
@@ -495,7 +495,7 @@ class TestRefresh(unittest.TestCase):
         self.sim.snapshot.version += 1
         self.sim.update_timestamp()
 
-        with self.assertRaises(RepositoryError):
+        with self.assertRaises(LengthOrHashMismatchError):
             self._run_refresh()
 
         self._assert_version_equals(Snapshot.type, 3)

--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -16,6 +16,13 @@ from unittest.mock import MagicMock, call, patch
 
 from tests import utils
 from tests.repository_simulator import RepositorySimulator
+from tuf.api.exceptions import (
+    BadVersionNumberError,
+    ExpiredMetadataError,
+    ReplayedMetadataError,
+    RepositoryError,
+    UnsignedMetadataError,
+)
 from tuf.api.metadata import (
     SPECIFICATION_VERSION,
     TOP_LEVEL_ROLE_NAMES,
@@ -25,13 +32,6 @@ from tuf.api.metadata import (
     Snapshot,
     Targets,
     Timestamp,
-)
-from tuf.exceptions import (
-    BadVersionNumberError,
-    ExpiredMetadataError,
-    ReplayedMetadataError,
-    RepositoryError,
-    UnsignedMetadataError,
 )
 from tuf.ngclient import Updater
 

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ commands =
     # work, unfortunately each subdirectory has to be ignored explicitly.
     pylint -j 0 tuf --ignore=tuf/api,tuf/api/serialization,tuf/ngclient,tuf/ngclient/_internal
 
-    mypy {[testenv:lint]lint_dirs} tuf/exceptions.py
+    mypy {[testenv:lint]lint_dirs}
 
     bandit -r tuf
 

--- a/tuf/api/exceptions.py
+++ b/tuf/api/exceptions.py
@@ -8,13 +8,6 @@ there is a good reason not to, and provide that reason in those cases.
 """
 
 
-#### General errors ####
-
-
-class UnsupportedAlgorithmError(Exception):
-    """An error while trying to identify a user-specified algorithm."""
-
-
 class LengthOrHashMismatchError(Exception):
     """An error while checking the length and hash values of an object."""
 

--- a/tuf/api/exceptions.py
+++ b/tuf/api/exceptions.py
@@ -19,20 +19,6 @@ class LengthOrHashMismatchError(Exception):
     """An error while checking the length and hash values of an object."""
 
 
-class FetcherHTTPError(Exception):
-    """
-    Returned by FetcherInterface implementations for HTTP errors.
-
-    Args:
-        message: The HTTP error messsage
-        status_code: The HTTP status code
-    """
-
-    def __init__(self, message: str, status_code: int):
-        super().__init__(message)
-        self.status_code = status_code
-
-
 class URLParsingError(Exception):
     """If we are unable to parse a URL -- for example, if a hostname element
     cannot be isoalted."""
@@ -97,3 +83,17 @@ class DownloadLengthMismatchError(DownloadError):
 
 class SlowRetrievalError(DownloadError):
     """Indicate that downloading a file took an unreasonably long time."""
+
+
+class FetcherHTTPError(DownloadError):
+    """
+    Returned by FetcherInterface implementations for HTTP errors.
+
+    Args:
+        message: The HTTP error messsage
+        status_code: The HTTP status code
+    """
+
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code

--- a/tuf/api/exceptions.py
+++ b/tuf/api/exceptions.py
@@ -19,11 +19,6 @@ class LengthOrHashMismatchError(Exception):
     """An error while checking the length and hash values of an object."""
 
 
-class URLParsingError(Exception):
-    """If we are unable to parse a URL -- for example, if a hostname element
-    cannot be isoalted."""
-
-
 #### Repository errors ####
 
 

--- a/tuf/api/exceptions.py
+++ b/tuf/api/exceptions.py
@@ -1,0 +1,155 @@
+# Copyright New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""
+Define TUF exceptions used inside the new modern implementation.
+The names chosen for TUF Exception classes should end in 'Error' except where
+there is a good reason not to, and provide that reason in those cases.
+"""
+
+from typing import Optional
+
+#### General errors ####
+
+
+class UnsupportedAlgorithmError(Exception):
+    """An error while trying to identify a user-specified algorithm."""
+
+
+class LengthOrHashMismatchError(Exception):
+    """An error while checking the length and hash values of an object."""
+
+
+class FetcherHTTPError(Exception):
+    """
+    Returned by FetcherInterface implementations for HTTP errors.
+
+    Args:
+        message: The HTTP error messsage
+        status_code: The HTTP status code
+    """
+
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class URLParsingError(Exception):
+    """If we are unable to parse a URL -- for example, if a hostname element
+    cannot be isoalted."""
+
+
+class RepositoryError(Exception):
+    """An error with a repository's state, such as a missing file."""
+
+
+#### Repository errors ####
+
+
+class UnsignedMetadataError(RepositoryError):
+    """An error about metadata object with insufficient threshold of signatures.
+
+    Args:
+        message: The error message
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__()
+        self.exception_message = message
+
+    def __str__(self) -> str:
+        return self.exception_message
+
+    def __repr__(self) -> str:
+        return self.__class__.__name__ + " : " + str(self)
+
+
+class BadVersionNumberError(RepositoryError):
+    """An error for metadata that contains an invalid version number."""
+
+
+class ExpiredMetadataError(RepositoryError):
+    """Indicate that a TUF Metadata file has expired."""
+
+
+class ReplayedMetadataError(RepositoryError):
+    """Indicate that some metadata has been replayed to the client.
+
+    Args:
+        metadata_role: Name of the role that has been replayed
+        downloaded_version: The replayed downloaded version of the metadata
+        current_version: The current locally available version.
+    """
+
+    def __init__(
+        self, metadata_role: str, downloaded_version: int, current_version: int
+    ) -> None:
+        super().__init__()
+
+        self.metadata_role = metadata_role
+        self.downloaded_version = downloaded_version
+        self.current_version = current_version
+
+    def __str__(self) -> str:
+        return (
+            "Downloaded "
+            + repr(self.metadata_role)
+            + " is older ("
+            + repr(self.downloaded_version)
+            + ") than the version currently "
+            "installed (" + repr(self.current_version) + ")."
+        )
+
+    def __repr__(self) -> str:
+        return self.__class__.__name__ + " : " + str(self)
+
+
+#### Download Errors ####
+
+
+class DownloadError(Exception):
+    """An error occurred while attempting to download a file."""
+
+
+class DownloadLengthMismatchError(DownloadError):
+    """Indicate that a mismatch of lengths was seen while downloading a file."""
+
+    def __init__(self, expected_length: int, observed_length: int) -> None:
+        super().__init__()
+
+        self.expected_length = expected_length  # bytes
+        self.observed_length = observed_length  # bytes
+
+    def __str__(self) -> str:
+        return (
+            "Observed length ("
+            + repr(self.observed_length)
+            + ") < expected length ("
+            + repr(self.expected_length)
+            + ")."
+        )
+
+    def __repr__(self) -> str:
+        return self.__class__.__name__ + " : " + str(self)
+
+
+class SlowRetrievalError(DownloadError):
+    """ "Indicate that downloading a file took an unreasonably long time."""
+
+    def __init__(self, average_download_speed: Optional[int] = None) -> None:
+        super().__init__()
+        self.__average_download_speed = average_download_speed  # bytes/second
+
+    def __str__(self) -> str:
+        msg = "Download was too slow."
+        if self.__average_download_speed is not None:
+            msg = (
+                "Download was too slow. Average speed: "
+                + repr(self.__average_download_speed)
+                + " bytes per second."
+            )
+
+        return msg
+
+    def __repr__(self) -> str:
+        return self.__class__.__name__ + " : " + str(self)

--- a/tuf/api/exceptions.py
+++ b/tuf/api/exceptions.py
@@ -8,10 +8,6 @@ there is a good reason not to, and provide that reason in those cases.
 """
 
 
-class LengthOrHashMismatchError(Exception):
-    """An error while checking the length and hash values of an object."""
-
-
 #### Repository errors ####
 
 
@@ -30,6 +26,10 @@ class BadVersionNumberError(RepositoryError):
 
 class ExpiredMetadataError(RepositoryError):
     """Indicate that a TUF Metadata file has expired."""
+
+
+class LengthOrHashMismatchError(RepositoryError):
+    """An error while checking the length and hash values of an object."""
 
 
 #### Download Errors ####

--- a/tuf/api/exceptions.py
+++ b/tuf/api/exceptions.py
@@ -12,7 +12,9 @@ there is a good reason not to, and provide that reason in those cases.
 
 
 class RepositoryError(Exception):
-    """An error with a repository's state, such as a missing file."""
+    """An error with a repository's state, such as a missing file.
+    It covers all exceptions that come from the repository side when
+    looking from the perspective of users of metadata API or ngclient."""
 
 
 class UnsignedMetadataError(RepositoryError):

--- a/tuf/api/exceptions.py
+++ b/tuf/api/exceptions.py
@@ -39,32 +39,6 @@ class ExpiredMetadataError(RepositoryError):
     """Indicate that a TUF Metadata file has expired."""
 
 
-class ReplayedMetadataError(RepositoryError):
-    """Indicate that some metadata has been replayed to the client.
-
-    Args:
-        metadata_role: Name of the role that has been replayed
-        downloaded_version: The replayed downloaded version of the metadata
-        current_version: The current locally available version.
-    """
-
-    def __init__(
-        self, metadata_role: str, downloaded_version: int, current_version: int
-    ) -> None:
-        super().__init__()
-
-        self.metadata_role = metadata_role
-        self.downloaded_version = downloaded_version
-        self.current_version = current_version
-
-    def __str__(self) -> str:
-        return (
-            f"Downloaded {self.metadata_role} is older ("
-            f"{self.downloaded_version}) than the version currently installed"
-            f"({self.current_version})"
-        )
-
-
 #### Download Errors ####
 
 

--- a/tuf/api/exceptions.py
+++ b/tuf/api/exceptions.py
@@ -7,7 +7,6 @@ The names chosen for TUF Exception classes should end in 'Error' except where
 there is a good reason not to, and provide that reason in those cases.
 """
 
-from typing import Optional
 
 #### General errors ####
 
@@ -39,29 +38,16 @@ class URLParsingError(Exception):
     cannot be isoalted."""
 
 
+#### Repository errors ####
+
+
 class RepositoryError(Exception):
     """An error with a repository's state, such as a missing file."""
 
 
-#### Repository errors ####
-
-
 class UnsignedMetadataError(RepositoryError):
-    """An error about metadata object with insufficient threshold of signatures.
-
-    Args:
-        message: The error message
-    """
-
-    def __init__(self, message: str) -> None:
-        super().__init__()
-        self.exception_message = message
-
-    def __str__(self) -> str:
-        return self.exception_message
-
-    def __repr__(self) -> str:
-        return self.__class__.__name__ + " : " + str(self)
+    """An error about metadata object with insufficient threshold of
+    signatures."""
 
 
 class BadVersionNumberError(RepositoryError):
@@ -92,16 +78,10 @@ class ReplayedMetadataError(RepositoryError):
 
     def __str__(self) -> str:
         return (
-            "Downloaded "
-            + repr(self.metadata_role)
-            + " is older ("
-            + repr(self.downloaded_version)
-            + ") than the version currently "
-            "installed (" + repr(self.current_version) + ")."
+            f"Downloaded {self.metadata_role} is older ("
+            f"{self.downloaded_version}) than the version currently installed"
+            f"({self.current_version})"
         )
-
-    def __repr__(self) -> str:
-        return self.__class__.__name__ + " : " + str(self)
 
 
 #### Download Errors ####
@@ -114,42 +94,6 @@ class DownloadError(Exception):
 class DownloadLengthMismatchError(DownloadError):
     """Indicate that a mismatch of lengths was seen while downloading a file."""
 
-    def __init__(self, expected_length: int, observed_length: int) -> None:
-        super().__init__()
-
-        self.expected_length = expected_length  # bytes
-        self.observed_length = observed_length  # bytes
-
-    def __str__(self) -> str:
-        return (
-            "Observed length ("
-            + repr(self.observed_length)
-            + ") < expected length ("
-            + repr(self.expected_length)
-            + ")."
-        )
-
-    def __repr__(self) -> str:
-        return self.__class__.__name__ + " : " + str(self)
-
 
 class SlowRetrievalError(DownloadError):
-    """ "Indicate that downloading a file took an unreasonably long time."""
-
-    def __init__(self, average_download_speed: Optional[int] = None) -> None:
-        super().__init__()
-        self.__average_download_speed = average_download_speed  # bytes/second
-
-    def __str__(self) -> str:
-        msg = "Download was too slow."
-        if self.__average_download_speed is not None:
-            msg = (
-                "Download was too slow. Average speed: "
-                + repr(self.__average_download_speed)
-                + " bytes per second."
-            )
-
-        return msg
-
-    def __repr__(self) -> str:
-        return self.__class__.__name__ + " : " + str(self)
+    """Indicate that downloading a file took an unreasonably long time."""

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -57,7 +57,7 @@ from securesystemslib.signer import Signature, Signer
 from securesystemslib.storage import FilesystemBackend, StorageBackendInterface
 from securesystemslib.util import persist_temp_file
 
-from tuf import exceptions
+from tuf.api import exceptions
 from tuf.api.serialization import (
     MetadataDeserializer,
     MetadataSerializer,
@@ -381,7 +381,6 @@ class Metadata(Generic[T]):
             raise exceptions.UnsignedMetadataError(
                 f"{delegated_role} was signed by {len(signing_keys)}/"
                 f"{role.threshold} keys",
-                delegated_metadata.signed,
             )
 
 
@@ -623,8 +622,7 @@ class Key:
             signature = metadata.signatures[self.keyid]
         except KeyError:
             raise exceptions.UnsignedMetadataError(
-                f"no signature for key {self.keyid} found in metadata",
-                metadata.signed,
+                f"no signature for key {self.keyid} found in metadata"
             ) from None
 
         if signed_serializer is None:
@@ -640,8 +638,7 @@ class Key:
                 signed_serializer.serialize(metadata.signed),
             ):
                 raise exceptions.UnsignedMetadataError(
-                    f"Failed to verify {self.keyid} signature",
-                    metadata.signed,
+                    f"Failed to verify {self.keyid} signature"
                 )
         except (
             sslib_exceptions.CryptoError,
@@ -649,8 +646,7 @@ class Key:
             sslib_exceptions.UnsupportedAlgorithmError,
         ) as e:
             raise exceptions.UnsignedMetadataError(
-                f"Failed to verify {self.keyid} signature",
-                metadata.signed,
+                f"Failed to verify {self.keyid} signature"
             ) from e
 
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -622,7 +622,7 @@ class Key:
             signature = metadata.signatures[self.keyid]
         except KeyError:
             raise exceptions.UnsignedMetadataError(
-                f"no signature for key {self.keyid} found in metadata"
+                f"No signature for key {self.keyid} found in metadata"
             ) from None
 
         if signed_serializer is None:

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1319,8 +1319,8 @@ class TargetFile(BaseFile):
                 specified the securesystemslib default hash algorithm is used.
         Raises:
             FileNotFoundError: The file doesn't exist.
-            UnsupportedAlgorithmError: The hash algorithms list
-                contains an unsupported algorithm.
+            ValueError: The hash algorithms list contains an unsupported
+                algorithm.
         """
         with open(local_path, "rb") as file:
             return cls.from_data(target_file_path, file, hash_algorithms)
@@ -1342,8 +1342,8 @@ class TargetFile(BaseFile):
                 specified the securesystemslib default hash algorithm is used.
 
         Raises:
-            UnsupportedAlgorithmError: The hash algorithms list
-                contains an unsupported algorithm.
+            ValueError: The hash algorithms list contains an unsupported
+                algorithm.
         """
         if isinstance(data, bytes):
             length = len(data)
@@ -1369,9 +1369,7 @@ class TargetFile(BaseFile):
                 sslib_exceptions.UnsupportedAlgorithmError,
                 sslib_exceptions.FormatError,
             ) as e:
-                raise exceptions.UnsupportedAlgorithmError(
-                    f"Unsupported algorithm '{algorithm}'"
-                ) from e
+                raise ValueError(f"Unsupported algorithm '{algorithm}'") from e
 
             hashes[algorithm] = digest_object.hexdigest()
 

--- a/tuf/api/serialization/__init__.py
+++ b/tuf/api/serialization/__init__.py
@@ -17,17 +17,18 @@ API objects.
 import abc
 from typing import TYPE_CHECKING
 
+from tuf.api.exceptions import RepositoryError
+
 if TYPE_CHECKING:
     # pylint: disable=cyclic-import
     from tuf.api.metadata import Metadata, Signed
 
 
-# TODO: Should these be in tuf.exceptions or inherit from tuf.exceptions.Error?
-class SerializationError(Exception):
+class SerializationError(RepositoryError):
     """Error during serialization."""
 
 
-class DeserializationError(Exception):
+class DeserializationError(RepositoryError):
     """Error during deserialization."""
 
 

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -14,7 +14,7 @@ import requests
 import urllib3.exceptions
 
 import tuf
-from tuf import exceptions
+from tuf.api import exceptions
 from tuf.ngclient.fetcher import FetcherInterface
 
 # Globals

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -132,9 +132,7 @@ class RequestsFetcher(FetcherInterface):
         parsed_url = parse.urlparse(url)
 
         if not parsed_url.scheme or not parsed_url.hostname:
-            raise exceptions.URLParsingError(
-                "Could not get scheme and hostname from URL: " + url
-            )
+            raise exceptions.DownloadError("Failed to parse URL")
 
         session_index = parsed_url.scheme + "+" + parsed_url.hostname
         session = self._sessions.get(session_index)

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -61,6 +61,7 @@ class RequestsFetcher(FetcherInterface):
             exceptions.SlowRetrievalError: A timeout occurs while receiving
                 data.
             exceptions.FetcherHTTPError: An HTTP error code is received.
+            exceptions.DownloadError: When there is a problem parsing the url.
 
         Returns:
             A bytes iterator
@@ -126,13 +127,16 @@ class RequestsFetcher(FetcherInterface):
     def _get_session(self, url: str) -> requests.Session:
         """Returns a different customized requests.Session per schema+hostname
         combination.
+
+        Raises:
+            exceptions.DownloadError: When there is a problem parsing the url.
         """
         # Use a different requests.Session per schema+hostname combination, to
         # reuse connections while minimizing subtle security issues.
         parsed_url = parse.urlparse(url)
 
         if not parsed_url.scheme or not parsed_url.hostname:
-            raise exceptions.DownloadError("Failed to parse URL")
+            raise exceptions.DownloadError("Failed to parse URL {url}")
 
         session_index = parsed_url.scheme + "+" + parsed_url.hostname
         session = self._sessions.get(session_index)

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -74,7 +74,6 @@ from typing import Dict, Iterator, Optional
 
 from tuf.api import exceptions
 from tuf.api.metadata import Metadata, Root, Snapshot, Targets, Timestamp
-from tuf.api.serialization import DeserializationError
 
 logger = logging.getLogger(__name__)
 
@@ -161,10 +160,7 @@ class TrustedMetadataSet(abc.Mapping):
             raise RuntimeError("Cannot update root after timestamp")
         logger.debug("Updating root")
 
-        try:
-            new_root = Metadata[Root].from_bytes(data)
-        except DeserializationError as e:
-            raise exceptions.RepositoryError("Failed to load root") from e
+        new_root = Metadata[Root].from_bytes(data)
 
         if new_root.signed.type != Root.type:
             raise exceptions.RepositoryError(
@@ -218,10 +214,7 @@ class TrustedMetadataSet(abc.Mapping):
         # No need to check for 5.3.11 (fast forward attack recovery):
         # timestamp/snapshot can not yet be loaded at this point
 
-        try:
-            new_timestamp = Metadata[Timestamp].from_bytes(data)
-        except DeserializationError as e:
-            raise exceptions.RepositoryError("Failed to load timestamp") from e
+        new_timestamp = Metadata[Timestamp].from_bytes(data)
 
         if new_timestamp.signed.type != Timestamp.type:
             raise exceptions.RepositoryError(
@@ -311,10 +304,7 @@ class TrustedMetadataSet(abc.Mapping):
         if not trusted:
             snapshot_meta.verify_length_and_hashes(data)
 
-        try:
-            new_snapshot = Metadata[Snapshot].from_bytes(data)
-        except DeserializationError as e:
-            raise exceptions.RepositoryError("Failed to load snapshot") from e
+        new_snapshot = Metadata[Snapshot].from_bytes(data)
 
         if new_snapshot.signed.type != Snapshot.type:
             raise exceptions.RepositoryError(
@@ -423,10 +413,7 @@ class TrustedMetadataSet(abc.Mapping):
 
         meta.verify_length_and_hashes(data)
 
-        try:
-            new_delegate = Metadata[Targets].from_bytes(data)
-        except DeserializationError as e:
-            raise exceptions.RepositoryError("Failed to load snapshot") from e
+        new_delegate = Metadata[Targets].from_bytes(data)
 
         if new_delegate.signed.type != Targets.type:
             raise exceptions.RepositoryError(
@@ -455,10 +442,7 @@ class TrustedMetadataSet(abc.Mapping):
         Note that an expired initial root is considered valid: expiry is
         only checked for the final root in update_timestamp().
         """
-        try:
-            new_root = Metadata[Root].from_bytes(data)
-        except DeserializationError as e:
-            raise exceptions.RepositoryError("Failed to load root") from e
+        new_root = Metadata[Root].from_bytes(data)
 
         if new_root.signed.type != Root.type:
             raise exceptions.RepositoryError(

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -309,12 +309,7 @@ class TrustedMetadataSet(abc.Mapping):
         # Verify non-trusted data against the hashes in timestamp, if any.
         # Trusted snapshot data has already been verified once.
         if not trusted:
-            try:
-                snapshot_meta.verify_length_and_hashes(data)
-            except exceptions.LengthOrHashMismatchError as e:
-                raise exceptions.RepositoryError(
-                    "Snapshot length or hashes do not match"
-                ) from e
+            snapshot_meta.verify_length_and_hashes(data)
 
         try:
             new_snapshot = Metadata[Snapshot].from_bytes(data)
@@ -426,12 +421,7 @@ class TrustedMetadataSet(abc.Mapping):
                 f"Snapshot does not contain information for '{role_name}'"
             )
 
-        try:
-            meta.verify_length_and_hashes(data)
-        except exceptions.LengthOrHashMismatchError as e:
-            raise exceptions.RepositoryError(
-                f"{role_name} length or hashes do not match"
-            ) from e
+        meta.verify_length_and_hashes(data)
 
         try:
             new_delegate = Metadata[Targets].from_bytes(data)

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -72,7 +72,7 @@ from collections import abc
 from datetime import datetime
 from typing import Dict, Iterator, Optional
 
-from tuf import exceptions
+from tuf.api import exceptions
 from tuf.api.metadata import Metadata, Root, Snapshot, Targets, Timestamp
 from tuf.api.serialization import DeserializationError
 

--- a/tuf/ngclient/fetcher.py
+++ b/tuf/ngclient/fetcher.py
@@ -71,7 +71,8 @@ class FetcherInterface:
                 number_of_bytes_received += len(chunk)
                 if number_of_bytes_received > max_length:
                     raise exceptions.DownloadLengthMismatchError(
-                        max_length, number_of_bytes_received
+                        f"Downloaded {number_of_bytes_received} bytes exceeding"
+                        f" the maximum allowed length of {max_length}"
                     )
 
                 temp_file.write(chunk)

--- a/tuf/ngclient/fetcher.py
+++ b/tuf/ngclient/fetcher.py
@@ -11,7 +11,7 @@ import tempfile
 from contextlib import contextmanager
 from typing import IO, Iterator
 
-from tuf import exceptions
+from tuf.api import exceptions
 
 logger = logging.getLogger(__name__)
 
@@ -35,9 +35,9 @@ class FetcherInterface:
             url: A URL string that represents a file location.
 
         Raises:
-            tuf.exceptions.SlowRetrievalError: A timeout occurs while receiving
+            exceptions.SlowRetrievalError: A timeout occurs while receiving
                 data.
-            tuf.exceptions.FetcherHTTPError: An HTTP error code is received.
+            exceptions.FetcherHTTPError: An HTTP error code is received.
 
         Returns:
             A bytes iterator
@@ -55,7 +55,8 @@ class FetcherInterface:
               the file or an upper bound.
 
         Raises:
-          DownloadLengthMismatchError: downloaded bytes exceed 'max_length'.
+          exceptions.DownloadLengthMismatchError: downloaded bytes exceed
+            'max_length'.
 
         Yields:
           A TemporaryFile object that points to the contents of 'url'.

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -41,7 +41,7 @@ from urllib import parse
 
 from securesystemslib import util as sslib_util
 
-from tuf import exceptions
+from tuf.api import exceptions
 from tuf.api.metadata import (
     Metadata,
     Root,


### PR DESCRIPTION
Addresses @jku comment here: https://github.com/theupdateframework/python-tuf/pull/1721#issuecomment-992311731

**Description of the changes being introduced by the pull request**:

Add tuf/api/exceptions.py for exceptions in the new code.
I copied the exceptions from tuf/exceptions.py with a few important
decisions:
1. I only added the exceptions that are used in the new code. 
2. I removed the general "Error" class as we can directly inherit
Exceptions. 
3. I tried grouping the exceptions by relevance. 
4. I removed the second argument `signable` in `UnsignedMetadataError` as it was only
kept for backward compatibility and is not used. (See https://github.com/theupdateframework/python-tuf/commit/929b4b2a6b5c499ab741feb1233fdd7f4036b759 where it was added in `tuf/exceptions.py`)
5. I tried following the new code style guidelines and linted the file
with our linters.
6. Made `FetcherHTTPError` a `DownloadError` 
7. Removed `URLParsingError` and replaced it with a `DownloadError`
8. Removed `ReplayedMetadataError`  and replaced it with `BadVersionNumberError`

Additionally, I stopped linting tuf/exceptions.py with `mypy` as we are going to use
`tuf/api/exceptions.py` for exceptions in the new code.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


