### PR TITLE
Metadata API: remove dateutil requirement

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,9 +3,6 @@
 # pinned tuf runtime dependencies (should auto-update and -trigger ci/cd)
 -r requirements-pinned.txt
 
-# tuf.api tests use python-dateutil
-python-dateutil
-
 # additional test tools for linting and coverage measurement
 coverage
 black
@@ -14,4 +11,3 @@ pylint
 mypy
 bandit
 types-requests
-types-python-dateutil

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,7 +16,6 @@ import unittest
 from datetime import datetime, timedelta
 from typing import ClassVar, Dict
 
-from dateutil.relativedelta import relativedelta
 from securesystemslib import hash as sslib_hash
 from securesystemslib.interface import (
     import_ed25519_privatekey_from_file,
@@ -332,15 +331,6 @@ class TestMetadata(unittest.TestCase):
         self.assertEqual(timestamp.signed.expires, datetime(2030, 1, 2, 0, 0))
         timestamp.signed.bump_expiration(timedelta(days=365))
         self.assertEqual(timestamp.signed.expires, datetime(2031, 1, 2, 0, 0))
-
-        # Test whether dateutil.relativedelta works, this provides a much
-        # easier to use interface for callers
-        delta = relativedelta(days=1)
-        timestamp.signed.bump_expiration(delta)
-        self.assertEqual(timestamp.signed.expires, datetime(2031, 1, 3, 0, 0))
-        delta = relativedelta(years=5)
-        timestamp.signed.bump_expiration(delta)
-        self.assertEqual(timestamp.signed.expires, datetime(2036, 1, 3, 0, 0))
 
         # Create a MetaFile instance representing what we expect
         # the updated data to be.

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -47,7 +47,6 @@ from typing import (
     cast,
 )
 
-from dateutil.relativedelta import relativedelta
 from securesystemslib import exceptions as sslib_exceptions
 from securesystemslib import hash as sslib_hash
 from securesystemslib import keys as sslib_keys
@@ -501,9 +500,7 @@ class Signed(metaclass=abc.ABCMeta):
         return reference_time >= self.expires
 
     # Modification.
-    def bump_expiration(
-        self, delta: Union[timedelta, relativedelta] = timedelta(days=1)
-    ) -> None:
+    def bump_expiration(self, delta: timedelta = timedelta(days=1)) -> None:
         """Increments the expires attribute by the passed timedelta."""
         self.expires += delta
 


### PR DESCRIPTION
Fixes #1722

**Description of the changes being introduced by the pull request**:

I added `dateutil` as a possible argument type for
`Signed.bump_expiration()` as we are already testing for this and
implying it should be supported.
The problem is that `dateutil` is not added as a nontest requirement
and after a discussion, we decided we don't want to add it as well.

That's why we decided to remove `dateutil` mentions from the code
and not confuse our users we support it.

We will create a separate issue discussing the validity of
`Metadata.bump_expiration()`.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


