### PR TITLE
ngtests: Test fetch target

### DIFF
--- a/tests/test_updater_fetch_target.py
+++ b/tests/test_updater_fetch_target.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+
+# Copyright 2021, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""Test 'Fetch target' from 'Detailed client workflow' as well as
+target files storing/loading from cache.
+"""
+import os
+import sys
+import tempfile
+import unittest
+from typing import Optional, Tuple
+
+from tests import utils
+from tests.repository_simulator import RepositorySimulator
+from tuf.ngclient import Updater
+
+
+class TestFetchTarget(unittest.TestCase):
+    """Test ngclient downloading and caching target files."""
+
+    # set dump_dir to trigger repository state dumps
+    dump_dir: Optional[str] = None
+
+    def setUp(self) -> None:
+        # pylint: disable-next=consider-using-with
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.metadata_dir = os.path.join(self.temp_dir.name, "metadata")
+        self.targets_dir = os.path.join(self.temp_dir.name, "targets")
+        os.mkdir(self.metadata_dir)
+        os.mkdir(self.targets_dir)
+
+        # Setup the repository, bootstrap client root.json
+        self.sim = RepositorySimulator()
+        with open(os.path.join(self.metadata_dir, "root.json"), "bw") as f:
+            f.write(self.sim.signed_roots[0])
+
+        if self.dump_dir is not None:
+            # create test specific dump directory
+            name = self.id().split(".")[-1]
+            self.sim.dump_dir = os.path.join(self.dump_dir, name)
+            os.mkdir(self.sim.dump_dir)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _run_refresh(self) -> Updater:
+        """Creates a new updater and runs refresh."""
+        if self.sim.dump_dir is not None:
+            self.sim.write()
+
+        updater = Updater(
+            self.metadata_dir,
+            "https://example.com/metadata/",
+            self.targets_dir,
+            "https://example.com/targets/",
+            self.sim,
+        )
+        updater.refresh()
+        return updater
+
+    targets: utils.DataSet = {
+        "standard case": ("targetpath", b"content", "targetpath"),
+        "non-asci case": ("åäö", b"more content", "%C3%A5%C3%A4%C3%B6"),
+        "subdirectory case": (
+            "a/b/c/targetpath",
+            b"dir target content",
+            "a%2Fb%2Fc%2Ftargetpath",
+        ),
+    }
+
+    @utils.run_sub_tests_with_dataset(targets)
+    def test_targets(self, test_case_data: Tuple[str, bytes, str]) -> None:
+        targetpath, content, encoded_path = test_case_data
+        path = os.path.join(self.targets_dir, encoded_path)
+
+        updater = self._run_refresh()
+        # target does not exist yet, configuration is what we expect
+        self.assertIsNone(updater.get_targetinfo(targetpath))
+        self.assertTrue(self.sim.root.consistent_snapshot)
+        self.assertTrue(updater.config.prefix_targets_with_hash)
+
+        # Add targets to repository
+        self.sim.targets.version += 1
+        self.sim.add_target("targets", content, targetpath)
+        self.sim.update_snapshot()
+
+        updater = self._run_refresh()
+        # target now exists, is not in cache yet
+        info = updater.get_targetinfo(targetpath)
+        assert info is not None
+        # Test without and with explicit local filepath
+        self.assertIsNone(updater.find_cached_target(info))
+        self.assertIsNone(updater.find_cached_target(info, path))
+
+        # download target, assert it is in cache and content is correct
+        self.assertEqual(path, updater.download_target(info))
+        self.assertEqual(path, updater.find_cached_target(info))
+        self.assertEqual(path, updater.find_cached_target(info, path))
+
+        with open(path, "rb") as f:
+            self.assertEqual(f.read(), content)
+
+        # download using explicit filepath as well
+        os.remove(path)
+        self.assertEqual(path, updater.download_target(info, path))
+        self.assertEqual(path, updater.find_cached_target(info))
+        self.assertEqual(path, updater.find_cached_target(info, path))
+
+
+if __name__ == "__main__":
+    if "--dump" in sys.argv:
+        TestFetchTarget.dump_dir = tempfile.mkdtemp()
+        print(f"Repository Simulator dumps in {TestFetchTarget.dump_dir}")
+        sys.argv.remove("--dump")
+
+    utils.configure_test_logging(sys.argv)
+    unittest.main()


### PR DESCRIPTION
Fixes #1642 

**Description of the changes being introduced by the pull request**:

Adds tests for 'Fetch target' from 'Detailed client workflow' and target files storing/loading from cache.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


