### PR TITLE
ngclient: Rename constructor arg

### DIFF
--- a/examples/client_example/client_example.py
+++ b/examples/client_example/client_example.py
@@ -52,7 +52,7 @@ def download(target: str) -> bool:
     """
     try:
         updater = Updater(
-            repository_dir=METADATA_DIR,
+            metadata_dir=METADATA_DIR,
             metadata_base_url=f"{BASE_URL}/metadata/",
             target_base_url=f"{BASE_URL}/targets/",
             target_dir=DOWNLOAD_DIR,

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -128,7 +128,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         # Creating a repository instance.  The test cases will use this client
         # updater to refresh metadata, fetch target files, etc.
         self.updater = ngclient.Updater(
-            repository_dir=self.client_directory,
+            metadata_dir=self.client_directory,
             metadata_base_url=self.metadata_url,
             target_dir=self.dl_dir,
             target_base_url=self.targets_url,

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -45,7 +45,7 @@ Example::
     # Load trusted local root metadata from client metadata cache. Define
     # where metadata and targets will be downloaded from.
     updater = Updater(
-        repository_dir="~/tufclient/metadata/",
+        metadata_dir="~/tufclient/metadata/",
         metadata_base_url="http://localhost:8000/tuf-repo/",
         target_dir="~/tufclient/downloads/",
         target_base_url="http://localhost:8000/targets/",
@@ -87,7 +87,7 @@ class Updater:
     """Creates a new Updater instance and loads trusted root metadata.
 
     Args:
-        repository_dir: Local metadata directory. Directory must be
+        metadata_dir: Local metadata directory. Directory must be
             writable and it must contain a trusted root.json file.
         metadata_base_url: Base URL for all remote metadata downloads
         target_dir: Local targets directory. Directory must be writable. It
@@ -105,14 +105,14 @@ class Updater:
 
     def __init__(
         self,
-        repository_dir: str,
+        metadata_dir: str,
         metadata_base_url: str,
         target_dir: Optional[str] = None,
         target_base_url: Optional[str] = None,
         fetcher: Optional[FetcherInterface] = None,
         config: Optional[UpdaterConfig] = None,
     ):
-        self._dir = repository_dir
+        self._dir = metadata_dir
         self._metadata_base_url = _ensure_trailing_slash(metadata_base_url)
         self.target_dir = target_dir
         if target_base_url is None:


### PR DESCRIPTION
metadata_dir matches metadata_base_url better.

This is an API break for anyone using ngclient with named arguments.

Fixes #1638

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

---

I've considered the other ideas mentioned in the issue but I think this is the only one that seems clearly worth the change.