### PR TITLE
Metadata API: Avoid raising securesystemslib exceptions

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,7 @@ import sys
 import tempfile
 import unittest
 from datetime import datetime, timedelta
-from typing import ClassVar, Dict
+from typing import Any, ClassVar, Dict
 
 from securesystemslib import hash as sslib_hash
 from securesystemslib.interface import (
@@ -51,7 +51,7 @@ class TestMetadata(unittest.TestCase):
     temporary_directory: ClassVar[str]
     repo_dir: ClassVar[str]
     keystore_dir: ClassVar[str]
-    keystore: ClassVar[Dict[str, str]]
+    keystore: ClassVar[Dict[str, Dict[str, Any]]]
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/tuf/api/exceptions.py
+++ b/tuf/api/exceptions.py
@@ -10,6 +10,8 @@ there is a good reason not to, and provide that reason in those cases.
 
 #### Repository errors ####
 
+from securesystemslib.exceptions import StorageError
+
 
 class RepositoryError(Exception):
     """An error with a repository's state, such as a missing file.

--- a/tuf/api/exceptions.py
+++ b/tuf/api/exceptions.py
@@ -10,6 +10,7 @@ there is a good reason not to, and provide that reason in those cases.
 
 #### Repository errors ####
 
+# pylint: disable=unused-import
 from securesystemslib.exceptions import StorageError
 
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -304,9 +304,7 @@ class Metadata(Generic[T]):
         Raises:
             tuf.api.serialization.SerializationError:
                 'signed' cannot be serialized.
-            securesystemslib.exceptions.CryptoError, \
-                    securesystemslib.exceptions.UnsupportedAlgorithmError:
-                Signing errors.
+            exceptions.UnsignedMetadataError: Signing errors.
 
         Returns:
             Securesystemslib Signature object that was added into signatures.
@@ -319,7 +317,14 @@ class Metadata(Generic[T]):
 
             signed_serializer = CanonicalJSONSerializer()
 
-        signature = signer.sign(signed_serializer.serialize(self.signed))
+        bytes_data = signed_serializer.serialize(self.signed)
+
+        try:
+            signature = signer.sign(bytes_data)
+        except Exception as e:
+            raise exceptions.UnsignedMetadataError(
+                "Problem signing the metadata"
+            ) from e
 
         if not append:
             self.signatures.clear()

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -183,7 +183,7 @@ class Metadata(Generic[T]):
                 a (local) FilesystemBackend is used.
 
         Raises:
-            securesystemslib.exceptions.StorageError: The file cannot be read.
+            exceptions.StorageError: The file cannot be read.
             tuf.api.serialization.DeserializationError:
                 The file cannot be deserialized.
 
@@ -275,8 +275,7 @@ class Metadata(Generic[T]):
         Raises:
             tuf.api.serialization.SerializationError:
                 The metadata object cannot be serialized.
-            securesystemslib.exceptions.StorageError:
-                The file cannot be written.
+            exceptions.StorageError: The file cannot be written.
         """
 
         bytes_data = self.to_bytes(serializer)


### PR DESCRIPTION
Fixes #1646 

**Description of the changes being introduced by the pull request**:

In this pr, I aim to remove the need of our users to import securesystemslib
in order to catch the exceptions thrown by `tuf/metadata/api.py`. 
I either reexport securesystemslib exceptions or
reraise them by using tuf exceptions.

Reexporting securesystemslib exceptions is required so that users
of code that throws these exceptions doesn't have to import
securesystemslib to handle them.

A couple of additional fixes are added to this pr as well.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


