### PR TITLE
Metadata API: Remove 3 'update' methods + tests

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -993,11 +993,6 @@ class Timestamp(Signed):
         res_dict["meta"] = {"snapshot.json": self.snapshot_meta.to_dict()}
         return res_dict
 
-    # Modification.
-    def update(self, snapshot_meta: MetaFile) -> None:
-        """Assigns passed info about snapshot metadata."""
-        self.snapshot_meta = snapshot_meta
-
 
 class Snapshot(Signed):
     """A container for the signed part of snapshot metadata.
@@ -1048,12 +1043,6 @@ class Snapshot(Signed):
 
         snapshot_dict["meta"] = meta_dict
         return snapshot_dict
-
-    # Modification.
-    def update(self, rolename: str, role_info: MetaFile) -> None:
-        """Assigns passed (delegated) targets role info to meta dict."""
-        metadata_fn = f"{rolename}.json"
-        self.meta[metadata_fn] = role_info
 
 
 class DelegatedRole(Role):
@@ -1462,11 +1451,6 @@ class Targets(Signed):
         if self.delegations is not None:
             targets_dict["delegations"] = self.delegations.to_dict()
         return targets_dict
-
-    # Modification.
-    def update(self, fileinfo: TargetFile) -> None:
-        """Assigns passed target file info to meta dict."""
-        self.targets[fileinfo.path] = fileinfo
 
     def add_key(self, role: str, key: Key) -> None:
         """Adds new signing key for delegated role 'role'.


### PR DESCRIPTION
Fixes #1627

**Description of the changes being introduced by the pull request**:
Remove ambiguous, unspecific, opinionated and trivial 'update' methods, which can be replaced by feasible one-liners that assign values directly to the object attribute to be *updated*. (see #1627 for details).

Reasons to have these methods would be increased usability in terms of
- reduced work
- immediate feedback on invalid assignments

However, given above described issues, the reasons against the methods as they are now seem to outweigh the reasons for them. Furthermore, it seems easier to re-add similar methods, which addressed these issues, after the upcoming 1.0.0 release than to remove or modify them.

This patch also removes the corresponding tests as they become irrelevant (there is no need to test object assignment).  In the case of the timestamp test, the removal also includes redundant test logic, which is already tested in `test_metadata_base`.


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


