### PR TITLE
test snapshot fast-forward attack recovery

### DIFF
--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -357,11 +357,11 @@ class TestRefresh(unittest.TestCase):
         self._assert_version_equals(Timestamp.type, 99999)
 
         # repo add new timestamp keys and recovers the timestamp version
-        self.sim.root.roles["timestamp"].keyids.clear()
-        self.sim.signers["timestamp"].clear()
+        self.sim.root.roles[Timestamp.type].keyids.clear()
+        self.sim.signers[Timestamp.type].clear()
         key, signer = self.sim.create_key()
-        self.sim.root.add_key("timestamp", key)
-        self.sim.add_signer("timestamp", signer)
+        self.sim.root.add_key(Timestamp.type, key)
+        self.sim.add_signer(Timestamp.type, signer)
         self.sim.root.version += 1
         self.sim.publish_root()
         self.sim.timestamp.version = 1
@@ -445,20 +445,20 @@ class TestRefresh(unittest.TestCase):
         self._assert_version_equals(Snapshot.type, 99999)
 
         # repo add new snapshot and timestamp keys and recovers snapshot version
-        self.sim.root.roles["snapshot"].keyids.clear()
-        self.sim.signers["snapshot"].clear()
-        self.sim.root.roles["timestamp"].keyids.clear()
-        self.sim.signers["timestamp"].clear()
+        self.sim.root.roles[Snapshot.type].keyids.clear()
+        self.sim.signers[Snapshot.type].clear()
+        self.sim.root.roles[Timestamp.type].keyids.clear()
+        self.sim.signers[Timestamp.type].clear()
         snapshot_key, snapshot_signer = self.sim.create_key()
-        self.sim.root.add_key("snapshot", snapshot_key)
-        self.sim.add_signer("snapshot", snapshot_signer)
+        self.sim.root.add_key(Snapshot.type, snapshot_key)
+        self.sim.add_signer(Snapshot.type, snapshot_signer)
         timestamp_key, timestamp_signer = self.sim.create_key()
-        self.sim.root.add_key("timestamp", timestamp_key)
-        self.sim.add_signer("timestamp", timestamp_signer)
-        self.sim.snapshot.version = 1
+        self.sim.root.add_key(Timestamp.type, timestamp_key)
+        self.sim.add_signer(Timestamp.type, timestamp_signer)
         self.sim.root.version += 1
         self.sim.publish_root()
 
+        self.sim.snapshot.version = 1
         self.sim.update_timestamp()
 
         # client refresh the metadata and see the initial snapshot version
@@ -530,15 +530,15 @@ class TestRefresh(unittest.TestCase):
         self.sim.compute_metafile_hashes_length = True
         self.sim.update_snapshot()
         self._run_refresh()
-        self._assert_version_equals("timestamp", 2)
-        self._assert_version_equals("snapshot", 2)
+        self._assert_version_equals(Timestamp.type, 2)
+        self._assert_version_equals(Snapshot.type, 2)
 
         self.sim.compute_metafile_hashes_length = False
         self.sim.update_snapshot()
         self._run_refresh()
 
-        self._assert_version_equals("timestamp", 3)
-        self._assert_version_equals("snapshot", 3)
+        self._assert_version_equals(Timestamp.type, 3)
+        self._assert_version_equals(Snapshot.type, 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This test simulates the snapshot fast-forward attack recovery.
It simulates that the snapshot keys were compromised, the attacker
generated a new high version of the snapshot.

The repository generates new keys for snapshot and timestamp and
rollbacks the snapshot version to the initial version.

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>

Part of #1713 

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


