### PR TITLE
Metadata API: Remove Signed.bump_version() method

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -260,9 +260,6 @@ class TestMetadata(unittest.TestCase):
         snapshot_path = os.path.join(self.repo_dir, "metadata", "snapshot.json")
         md = Metadata.from_file(snapshot_path)
 
-        self.assertEqual(md.signed.version, 1)
-        md.signed.bump_version()
-        self.assertEqual(md.signed.version, 2)
         self.assertEqual(md.signed.expires, datetime(2030, 1, 1, 0, 0))
 
         # Test is_expired with reference_time provided

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -153,7 +153,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         root = Metadata.from_file(role_path)
         modification_func(root)
         if bump_version:
-            root.signed.bump_version()
+            root.signed.version += 1
         root_key_path = os.path.join(self.keystore_directory, "root_key")
         root_key_dict = import_rsa_privatekey_from_file(
             root_key_path, password="password"

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -513,10 +513,6 @@ class Signed(metaclass=abc.ABCMeta):
 
         return reference_time >= self.expires
 
-    def bump_version(self) -> None:
-        """Increments the metadata version number by 1."""
-        self.version += 1
-
 
 class Key:
     """A container class representing the public portion of a Key.


### PR DESCRIPTION
Related to #1736 (see https://github.com/theupdateframework/python-tuf/pull/1736#pullrequestreview-837214238)

**Description of the changes being introduced by the pull request**:

Remove `bump_version()` method, which is just an alias for "+= 1" on the version attribute. For a slim low-level API it seems okay to just directly access/modify the attribute.

The extra level of abstraction of "bumping a version" is more appropriate for a repository library (see #1136).

This patch also removes a related unit test and updates another one to directly do `(...).version += 1`.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


