### PR TITLE
Metadata API: Remove Signed.bump_expiration() method

### DIFF
--- a/docs/api/tuf.api.rst
+++ b/docs/api/tuf.api.rst
@@ -17,3 +17,4 @@ Metadata API
 
 .. automodule:: tuf.api.metadata
    :no-members:
+   :no-inherited-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,5 +66,6 @@ autodoc_typehints = "description"
 
 autodoc_default_options = {
     'members': True,
+    'inherited-members': 'Exception', # excl. members inherited from 'Exception'
     'exclude-members': 'to_dict, from_dict'
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -264,10 +264,6 @@ class TestMetadata(unittest.TestCase):
         md.signed.bump_version()
         self.assertEqual(md.signed.version, 2)
         self.assertEqual(md.signed.expires, datetime(2030, 1, 1, 0, 0))
-        md.signed.bump_expiration()
-        self.assertEqual(md.signed.expires, datetime(2030, 1, 2, 0, 0))
-        md.signed.bump_expiration(timedelta(days=365))
-        self.assertEqual(md.signed.expires, datetime(2031, 1, 2, 0, 0))
 
         # Test is_expired with reference_time provided
         is_expired = md.signed.is_expired(md.signed.expires)
@@ -329,7 +325,7 @@ class TestMetadata(unittest.TestCase):
 
         # verify fails when delegate content is modified
         expires = snapshot.signed.expires
-        snapshot.signed.bump_expiration()
+        snapshot.signed.expires = expires + timedelta(days=1)
         with self.assertRaises(exceptions.UnsignedMetadataError):
             root.verify_delegate(Snapshot.type, snapshot)
         snapshot.signed.expires = expires

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -30,7 +30,7 @@ import io
 import logging
 import tempfile
 from collections import OrderedDict
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import (
     IO,
     Any,
@@ -409,6 +409,11 @@ class Signed(metaclass=abc.ABCMeta):
 
     @property
     def expires(self) -> datetime:
+        """The metadata expiry date::
+
+        # Use 'datetime' module to e.g. expire in seven days from now
+        obj.expires = utcnow() + timedelta(days=7)
+        """
         return self._expires
 
     @expires.setter
@@ -507,11 +512,6 @@ class Signed(metaclass=abc.ABCMeta):
             reference_time = datetime.utcnow()
 
         return reference_time >= self.expires
-
-    # Modification.
-    def bump_expiration(self, delta: timedelta = timedelta(days=1)) -> None:
-        """Increments the expires attribute by the passed timedelta."""
-        self.expires += delta
 
     def bump_version(self) -> None:
         """Increments the metadata version number by 1."""


### PR DESCRIPTION
Fixes #1727

**Description of the changes being introduced by the pull request**:

Remove `bump_expiration()` method, which is unlikely to be used as is, i.e. bump to "current expiration date plus delta". A more realistic use case is to bump to "now plus delta" (see #1727 for details).

Moreover, bump_expiration can either way easily be replaced by a one-liner expression using the 'datetime' module. A corresponding code snippet is added to the `expires` property's docstring.
Note: `expires` became a property with a millisec-removing setter (for spec conformance) in  #1712, which further reduces the need for a convenience bump_expiration method.

This patch also 
- removes a related unit test and updates another one, and
- updates rtd/sphinx config to display inherited members, most notably the `expires` property with said code snippet (see e.g. [`Root.expires`](https://theupdateframework--1743.org.readthedocs.build/en/1743/api/tuf.api.metadata.root.html#tuf.api.metadata.Root.expires))

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


