### PR TITLE
doc: fix broken links in 1.0.0-ANNOUNCEMENT.md

### DIFF
--- a/docs/1.0.0-ANNOUNCEMENT.md
+++ b/docs/1.0.0-ANNOUNCEMENT.md
@@ -10,7 +10,7 @@ stable 1.0.0 release scheduled for January 2022. The release *will* include:
   serving as a more robust and yet more flexible stand-in replacement
   for the legacy client updater
 
-As discussed in [ADR 2](docs/adr/0002-pre-1-0-deprecation-strategy.md), this
+As discussed in [ADR 2](https://github.com/theupdateframework/python-tuf/blob/develop/docs/adr/0002-pre-1-0-deprecation-strategy.md), this
 release *will not* include any legacy code, as its maintenance has become
 infeasible for the python-tuf team. The pre-1.0.0 deprecation strategy from ADR
 2 applies as follows:
@@ -21,7 +21,7 @@ prior to 1.0.0 will be considered, and merged (subject to normal review
 processes). Note that there may be delays due to the lack of developer resources
 for reviewing such pull requests.*
 
-For the reasons outlined in [ADR 10](docs/adr/0010-repository-library-design.md
+For the reasons outlined in [ADR 10](https://github.com/theupdateframework/python-tuf/blob/develop/docs/adr/0010-repository-library-design.md
 ), this release *will not yet* include a new *repository tool*. However, the new
 *metadata API* makes it easy to replicate the desired functionality tailored to
 the specific needs of any given repository (see *Migration* for details).
@@ -36,7 +36,7 @@ following migration support:
 
 - detailed code documentation on
   [https://theupdateframework.readthedocs.io](https://theupdateframework.readthedocs.io/)
-- verbose [code examples](examples/) for *client updater* usage, and
+- verbose [code examples](https://github.com/theupdateframework/python-tuf/tree/develop/examples) for *client updater* usage, and
   repository-side operations based on the low-level *metadata API*
 - individual migration support upon
   [request](https://github.com/theupdateframework/python-tuf#contact)


### PR DESCRIPTION
Fixes #<ISSUE NUMBER>

**Description of the changes being introduced by the pull request**:
The recent move of 1.0.0-ANNOUNCEMENT.md (#1732) broke the relative links in the document.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


