### PR TITLE
Add TargetFile.custom() documentation when building readthedocs

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1287,7 +1287,7 @@ class TargetFile(BaseFile):
 
     @property
     def custom(self) -> Any:
-        return self.unrecognized_fields.get("custom", None)
+        return self.unrecognized_fields.get("custom")
 
     @classmethod
     def from_dict(cls, target_dict: Dict[str, Any], path: str) -> "TargetFile":

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1287,6 +1287,8 @@ class TargetFile(BaseFile):
 
     @property
     def custom(self) -> Any:
+        """Can be used to provide implementation specific data related to the
+        target. python-tuf does not use or validate this data."""
         return self.unrecognized_fields.get("custom")
 
     @classmethod


### PR DESCRIPTION
Fixes #1602

**Description of the changes being introduced by the pull request**:

Add the missing `Targetfile.custom()` property to the RTD documentation.
This property is not documented and is not visible in RTD documentation: 
I think it would be useful to expose as the "supported" way for a client app to read custom metadata for a target.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


