### PR TITLE
Metadata API: Make Role.keyids ordered

### DIFF
--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -108,6 +108,7 @@ class TestSerialization(unittest.TestCase):
     valid_roles: utils.DataSet = {
         "all": '{"keyids": ["keyid"], "threshold": 3}',
         "many keyids": '{"keyids": ["a", "b", "c", "d", "e"], "threshold": 1}',
+        "ordered keyids": '{"keyids": ["c", "b", "a"], "threshold": 1}',
         "empty keyids": '{"keyids": [], "threshold": 1}',
         "unrecognized field": '{"keyids": ["keyid"], "threshold": 3, "foo": "bar"}',
     }
@@ -294,6 +295,8 @@ class TestSerialization(unittest.TestCase):
             "path_hash_prefixes": [], "threshold": 99}',
         "unrecognized field": '{"keyids": ["keyid"], "name": "a", "terminating": true, "paths": ["fn1"], "threshold": 3, "foo": "bar"}',
         "many keyids": '{"keyids": ["keyid1", "keyid2"], "name": "a", "paths": ["fn1", "fn2"], \
+            "terminating": false, "threshold": 1}',
+        "ordered keyids": '{"keyids": ["keyid2", "keyid1"], "name": "a", "paths": ["fn1", "fn2"], \
             "terminating": false, "threshold": 1}',
     }
 

--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -240,7 +240,7 @@ class TestTrustedMetadataSet(unittest.TestCase):
         # new_root data with threshold which cannot be verified.
         root = Metadata.from_bytes(self.metadata[Root.type])
         # remove root role keyids representing root signatures
-        root.signed.roles[Root.type].keyids = set()
+        root.signed.roles[Root.type].keyids.clear()
         with self.assertRaises(exceptions.UnsignedMetadataError):
             self.trusted_set.update_root(root.to_bytes())
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -676,15 +676,11 @@ class Role:
         threshold: int,
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ):
-        keyids_set = set(keyids)
-        if len(keyids_set) != len(keyids):
-            raise ValueError(
-                f"keyids should be a list of unique strings,"
-                f" instead got {keyids}"
-            )
+        if len(set(keyids)) != len(keyids):
+            raise ValueError(f"Nonunique keyids: {keyids}")
         if threshold < 1:
             raise ValueError("threshold should be at least 1!")
-        self.keyids = keyids_set
+        self.keyids = keyids
         self.threshold = threshold
         self.unrecognized_fields: Mapping[str, Any] = unrecognized_fields or {}
 
@@ -699,7 +695,7 @@ class Role:
     def to_dict(self) -> Dict[str, Any]:
         """Returns the dictionary representation of self."""
         return {
-            "keyids": sorted(self.keyids),
+            "keyids": self.keyids,
             "threshold": self.threshold,
             **self.unrecognized_fields,
         }
@@ -789,7 +785,8 @@ class Root(Signed):
         """
         if role not in self.roles:
             raise ValueError(f"Role {role} doesn't exist")
-        self.roles[role].keyids.add(key.keyid)
+        if key.keyid not in self.roles[role].keyids:
+            self.roles[role].keyids.append(key.keyid)
         self.keys[key.keyid] = key
 
     def remove_key(self, role: str, keyid: str) -> None:
@@ -1474,7 +1471,8 @@ class Targets(Signed):
         """
         if self.delegations is None or role not in self.delegations.roles:
             raise ValueError(f"Delegated role {role} doesn't exist")
-        self.delegations.roles[role].keyids.add(key.keyid)
+        if key.keyid not in self.delegations.roles[role].keyids:
+            self.delegations.roles[role].keyids.append(key.keyid)
         self.delegations.keys[key.keyid] = key
 
     def remove_key(self, role: str, keyid: str) -> None:


### PR DESCRIPTION
keyids are ordered in the data we deserialize: Not preserving that order
breaks canonicalization. Set does not preserve order.

Change Role.keyids type from Set to List. This is strictly speaking
an API change but a minor one: keyids are supposed to be changed
via add_key()/remove_key().

Add tests for this for both Role and DelegatedRole. Shorten a related
exception message.

Fix #1752

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

---

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature


