### PR TITLE
Explicit encode role names

### DIFF
--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -259,6 +259,8 @@ class RepositorySimulator(FetcherInterface):
         If version is None, non-versioned metadata is being requested.
         """
         self.fetch_tracker.metadata.append((role, version))
+        # decode role for the metadata
+        role = parse.unquote(role, encoding="utf-8")
 
         if role == Root.type:
             # return a version previously serialized in publish_root()

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -290,10 +290,11 @@ class Updater:
         self, rolename: str, length: int, version: Optional[int] = None
     ) -> bytes:
         """Download a metadata file and return it as bytes"""
+        encoded_name = parse.quote(rolename, "")
         if version is None:
-            url = f"{self._metadata_base_url}{rolename}.json"
+            url = f"{self._metadata_base_url}{encoded_name}.json"
         else:
-            url = f"{self._metadata_base_url}{version}.{rolename}.json"
+            url = f"{self._metadata_base_url}{version}.{encoded_name}.json"
         return self._fetcher.download_bytes(url, length)
 
     def _load_local_metadata(self, rolename: str) -> bytes:


### PR DESCRIPTION
This commit explicitly encodes role names.
Also, a slight change in the RepositorySimulator will align
with the tests.

This commit partially covers issue #1634

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>

- [X] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [X] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


