### PR TITLE
Add to CI check for specification version.

### DIFF
--- a/.github/workflows/specification-version.yml
+++ b/.github/workflows/specification-version.yml
@@ -1,0 +1,55 @@
+name: Specification version check
+
+on:
+  schedule:
+    - cron: '0 13 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-spec-version:
+    name: Open an issue when spec version bumps
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - name: Get supported version
+      id: get-version
+      run: |
+        python3 -m pip install -e .
+        script="from tuf.api.metadata import SPECIFICATION_VERSION; \
+                print(f\"v{'.'.join(SPECIFICATION_VERSION)}\")"
+        ver=$(python3 -c "$script")
+        echo "::set-output name=version::$ver"
+    - name: Open issue (if needed)
+      uses: actions/github-script@v5
+      with:
+        script: |
+          const release = await github.rest.repos.getLatestRelease({
+            owner: "theupdateframework",
+            repo: "specification"
+          });
+          const spec_version = release.data.tag_name
+          const supported_version = "${{ steps.get-version.outputs.version }}"
+          if (spec_version != supported_version) {
+            console.log("Specification version does not match...")
+            const repo = context.repo.owner + "/" + context.repo.repo
+            const issues = await github.rest.search.issuesAndPullRequests({
+              q: "specification+has+new+version+in:title+state:open+type:issue:" + repo,
+            })
+            if (issues.data.total_count > 0) {
+              console.log("Issue is already open, not creating.")
+            } else {
+              console.log("Creating a new issue...")
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: "specification has new version",
+                body: "It seems specification " +
+                      "(https://github.com/theupdateframework/specification/blob/master/tuf-spec.md) " +
+                      "has new version. \n" +
+                      "Please review the version."
+              })
+            }
+          } else {
+            console.log("Spec version and supported version match")
+          }

--- a/.github/workflows/specification-version.yml
+++ b/.github/workflows/specification-version.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 13 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   check-spec-version:
     name: Open an issue when spec version bumps

--- a/.github/workflows/specification-version.yml
+++ b/.github/workflows/specification-version.yml
@@ -31,7 +31,10 @@ jobs:
           const spec_version = release.data.tag_name
           const supported_version = "${{ steps.get-version.outputs.version }}"
           if (spec_version != supported_version) {
-            console.log("Specification version does not match...")
+            console.log(
+              "Specification (" + spec_version + ") version does not matches with python-tuf supported (" +
+               supported_version + ") version."
+            )
             const repo = context.repo.owner + "/" + context.repo.repo
             const issues = await github.rest.search.issuesAndPullRequests({
               q: "specification+has+new+version+in:title+state:open+type:issue+repo:" + repo,
@@ -39,7 +42,6 @@ jobs:
             if (issues.data.total_count > 0) {
               console.log("Issue is already open, not creating.")
             } else {
-              console.log("Creating a new issue...")
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -49,7 +51,11 @@ jobs:
                       "has new version. \n" +
                       "Please review the version."
               })
+              console.log("New issue created.")
             }
           } else {
-            console.log("Spec version and supported version match")
+            console.log(
+              "Specification (" + spec_version + ") version matches with python-tuf supported (" +
+               supported_version + ") version."
+            )
           }

--- a/.github/workflows/specification-version.yml
+++ b/.github/workflows/specification-version.yml
@@ -34,7 +34,7 @@ jobs:
             console.log("Specification version does not match...")
             const repo = context.repo.owner + "/" + context.repo.repo
             const issues = await github.rest.search.issuesAndPullRequests({
-              q: "specification+has+new+version+in:title+state:open+type:issue:" + repo,
+              q: "specification+has+new+version+in:title+state:open+type:issue+repo:" + repo,
             })
             if (issues.data.total_count > 0) {
               console.log("Issue is already open, not creating.")


### PR DESCRIPTION
This commit adds to the CI an automatic check for the TUF
specification version and compares it with the python-tuf metadata
API version.

If the version does not match and there is not a issue already open,
a new issue is opened.

Closes #1598

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>

- [X] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


