### PR TITLE
Fix two new pylint warnings

### DIFF
--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -125,7 +125,7 @@ class TestFetcher(unittest_toolbox.Modified_TestCase):
         mock_response = Mock()
         attr = {
             "raw.read.side_effect": urllib3.exceptions.ReadTimeoutError(
-                None, None, "Read timed out."
+                urllib3.HTTPConnectionPool("localhost"), "", "Read timed out."
             )
         }
         mock_response.configure_mock(**attr)


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

New pylint warnings appeared related to changes
in urlib3:
- tests/test_fetcher_ng.py:128: error: Argument 1 to "ReadTimeoutError"
has incompatible type "None"; expected "ConnectionPool"  [arg-type]
- tests/test_fetcher_ng.py:128: error: Argument 2 to "ReadTimeoutError"
has incompatible type "None"; expected "str"  [arg-type]

I noticed these errors in this CI run:
https://github.com/theupdateframework/python-tuf/runs/4764931441?check_suite_focus=true

I fixed them by creating a urllib3.HTTPConnectionPool() instance as
the first argument and replaced the second argument with an empty
string.
This seems to do the job.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


