### PR TITLE
Metadata API: Add missing space in 2 err messages

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -839,7 +839,7 @@ class BaseFile:
             observed_hash = digest_object.hexdigest()
             if observed_hash != exp_hash:
                 raise exceptions.LengthOrHashMismatchError(
-                    f"Observed hash {observed_hash} does not match"
+                    f"Observed hash {observed_hash} does not match "
                     f"expected hash {exp_hash}"
                 )
 
@@ -857,7 +857,7 @@ class BaseFile:
 
         if observed_length != expected_length:
             raise exceptions.LengthOrHashMismatchError(
-                f"Observed length {observed_length} does not match"
+                f"Observed length {observed_length} does not match "
                 f"expected length {expected_length}"
             )
 


### PR DESCRIPTION
Fixes #<ISSUE NUMBER>

**Description of the changes being introduced by the pull request**:
Just came across two instances where line-continued strings missed a separating whitespace and fixed them.

Note: I also checked the entire repo for more such cases using the regex `[^ ]["']\n *f?["'][^ ]` but didn't find any.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


