### PR TITLE
doc: Remove trailing whitespaces from docs files

### DIFF
--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -10,11 +10,11 @@ The project is maintained by the people indicated in
 review GitHub pull requests and (2) open issues or [submit vulnerability
 reports](https://github.com/theupdateframework/python-tuf#security-issues-and-bugs).
 A maintainer has the authority to approve or reject pull requests submitted by
-contributors.    
+contributors.
 
 More significant changes in the project, such as those that require a TAP or
-changes in governance, are guided by a maintainer called the Consensus 
-Builder (CB).  The project's Consensus Builder (CB) is Justin Cappos 
+changes in governance, are guided by a maintainer called the Consensus
+Builder (CB).  The project's Consensus Builder (CB) is Justin Cappos
 <jcappos@nyu.edu, @JustinCappos>, who has a lifetime appointment.
 
 ## Contributions
@@ -54,7 +54,7 @@ The CB has the authority to add or remove maintainers.
 
 ## Changes in governance
 
-The CB supervises changes in governance, but a majority of maintainers must vote +1 on the PR.  
+The CB supervises changes in governance, but a majority of maintainers must vote +1 on the PR.
 
 ## Changes in the consensus builder
 

--- a/docs/MAINTAINERS.txt
+++ b/docs/MAINTAINERS.txt
@@ -24,7 +24,7 @@ Maintainers:
     GitHub username: @trishankatdatadog
     PGP fingerprint: 8C48 08B5 B684 53DE 06A3  08FD 5C09 0ED7 318B 6C1E
     Keybase username: trishankdatadog
-  
+
   Lukas Puehringer
     Email: lukas.puehringer@nyu.edu
     GitHub username: @lukpueh

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ systems.
 .. toctree::
    :maxdepth: 1
    :caption: Contents:
-   
+
    api/api-reference
    CONTRIBUTORS
    INSTALLATION


### PR DESCRIPTION
This commit is a simple trailing whitespaces cleanup from the files
inside the docs folder.
The files on docs sub-directories are not part of this commit.

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


