### PR TITLE
docs: add examples to the RTD

### DIFF
--- a/docs/api/api-reference.rst
+++ b/docs/api/api-reference.rst
@@ -18,6 +18,10 @@ TUF provides multiple APIs:
   is implemented on top of the Metadata API and can be used to implement
   various TUF clients with relatively little effort.
 
+Code `examples <https://github.com/theupdateframework/python-tuf/tree/develop/examples>`_
+are available for client implementation using ngclient and a
+basic repository using Metadata API.
+
 .. note:: Major API changes are unlikely but these APIs are not yet
    considered stable, and a higher-level repository operations API is not yet
    included.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,5 +15,6 @@ systems.
    :caption: Contents:
 
    api/api-reference
-   CONTRIBUTORS
    INSTALLATION
+   Usage examples <https://github.com/theupdateframework/python-tuf/tree/develop/examples>
+   CONTRIBUTORS

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# Usage examples
+
+* [client](client_example)
+* [repository](repo_example)
+

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -23,6 +23,9 @@ Python type annotations useful Metadata can be type constrained: e.g. the
 signed attribute of ``Metadata[Root]`` is known to be ``Root``.
 
 Currently Metadata API supports JSON as the file format.
+
+A basic example of repository implementation using the Metadata is available in
+`examples/repo_example <https://github.com/theupdateframework/python-tuf/tree/develop/examples/repo_example>`_.
 """
 import abc
 import fnmatch

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -28,35 +28,9 @@ High-level description of Updater functionality:
       * ``Updater.download_target()`` downloads a target file and ensures it is
         verified correct by the metadata.
 
-Below is a simple example of using the Updater to download and verify
-"file.txt" from a remote repository. The required environment for this example
-is:
-
-    * A webserver running on http://localhost:8000, serving TUF repository
-      metadata at "/tuf-repo/" and targets at "/targets/"
-    * Local metadata directory "~/tufclient/metadata/" is writable and contains
-      a root metadata version for the remote repository
-    * Download directory "~/tufclient/downloads/" is writable
-
-Example::
-
-    from tuf.ngclient import Updater
-
-    # Load trusted local root metadata from client metadata cache. Define
-    # where metadata and targets will be downloaded from.
-    updater = Updater(
-        metadata_dir="~/tufclient/metadata/",
-        metadata_base_url="http://localhost:8000/tuf-repo/",
-        target_dir="~/tufclient/downloads/",
-        target_base_url="http://localhost:8000/targets/",
-    )
-
-    # Update metadata, then download target if needed
-    info = updater.get_targetinfo("file.txt")
-    path = updater.find_cached_target(info)
-    if path is None:
-        path = updater.download_target(info)
-    print(f"Local file {path} contains target {info.path}")
+A simple example of using the Updater to implement a Python TUF client that
+downloads target files is available in `examples/client_example
+<https://github.com/theupdateframework/python-tuf/tree/develop/examples/client_example>`_.
 """
 
 import logging


### PR DESCRIPTION
This commit adds to the RTD the links references to source code
examples.
The examples are added to TUF ngclient Updater and Metadata.

Fixes #1716

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>


- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


