### PR TITLE
doc: remove spec "forwarder" docs

### DIFF
--- a/docs/tuf-spec.0.9.txt
+++ b/docs/tuf-spec.0.9.txt
@@ -1,1 +1,0 @@
-The TUF specification file has been moved to https://github.com/theupdateframework/specification/blob/master/historical/tuf-spec.0.9.txt

--- a/docs/tuf-spec.md
+++ b/docs/tuf-spec.md
@@ -1,1 +1,0 @@
-The TUF specification file has been moved to https://github.com/theupdateframework/specification/blob/master/tuf-spec.md

--- a/docs/tuf-spec.txt
+++ b/docs/tuf-spec.txt
@@ -1,1 +1,0 @@
-The TUF specification file has been moved to https://github.com/theupdateframework/specification/blob/master/tuf-spec.md


### PR DESCRIPTION
Fixes #1770

**Description of the changes being introduced by the pull request**:
Remove old doc/tuf-spec* documents, which are merely pointers to the theupdateframework/specification repo (created in late 2017).

They were likely kept in place to avoid 404s of old links, but the up-to-date TUF specification location should be discoverable enough to get rid of the pointers.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


