### PR TITLE
Allow compressed metadata in flight

### DIFF
--- a/tests/simple_server.py
+++ b/tests/simple_server.py
@@ -3,64 +3,16 @@
 # Copyright 2012 - 2017, New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""
-<Program>
-  simple_server.py
-
-<Author>
-  Konstantin Andrianov.
-
-<Started>
-  February 15, 2012.
-
-<Copyright>
-  See LICENSE-MIT or LICENSE for licensing information.
-
-<Purpose>
-  This is a basic server that was designed to be used in conjunction with
-  test_download.py to test download.py module.
-
-<Reference>
-  SimpleHTTPServer:
-    http://docs.python.org/library/simplehttpserver.html#module-SimpleHTTPServer
-"""
+"""Simple HTTP server for python-tuf tests"""
 
 import socketserver
-import sys
 from http.server import SimpleHTTPRequestHandler
-from typing import Type, Union
-
-
-class QuietHTTPRequestHandler(SimpleHTTPRequestHandler):
-    """A SimpleHTTPRequestHandler that does not write incoming requests to
-    stderr."""
-
-    def log_request(
-        self, code: Union[int, str] = "-", size: Union[int, str] = "-"
-    ) -> None:
-        pass
-
-
-# NOTE: On Windows/Python2 tests that use this simple_server.py in a
-# subprocesses hang after a certain amount of requests (~68), if a PIPE is
-# passed as Popen's stderr argument. This problem doesn't emerge if
-# we silence the HTTP messages.
-# If you decide to receive the HTTP messages, then this bug
-# could reappear.
-
-# pylint: disable=invalid-name
-handler: Type[Union[SimpleHTTPRequestHandler, QuietHTTPRequestHandler]]
-
-if len(sys.argv) > 2 and sys.argv[2]:
-    handler = QuietHTTPRequestHandler
-else:
-    handler = SimpleHTTPRequestHandler
 
 # Allow re-use so you can re-run tests as often as you want even if the
 # tests re-use ports. Otherwise TCP TIME-WAIT prevents reuse for ~1 minute
 socketserver.TCPServer.allow_reuse_address = True
 
-httpd = socketserver.TCPServer(("localhost", 0), handler)
+httpd = socketserver.TCPServer(("localhost", 0), SimpleHTTPRequestHandler)
 port_message = "bind succeeded, server port is: " + str(httpd.server_address[1])
 print(port_message)
 httpd.serve_forever()

--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -17,7 +17,6 @@ from typing import Any, ClassVar, Iterator
 from unittest.mock import Mock, patch
 
 import requests
-import urllib3.exceptions
 
 from tests import utils
 from tuf import unittest_toolbox
@@ -125,8 +124,8 @@ class TestFetcher(unittest_toolbox.Modified_TestCase):
     def test_response_read_timeout(self, mock_session_get: Any) -> None:
         mock_response = Mock()
         attr = {
-            "raw.read.side_effect": urllib3.exceptions.ReadTimeoutError(
-                urllib3.HTTPConnectionPool("localhost"), "", "Read timed out."
+            "iter_content.side_effect": requests.exceptions.ConnectionError(
+                "Simulated timeout"
             )
         }
         mock_response.configure_mock(**attr)
@@ -134,11 +133,13 @@ class TestFetcher(unittest_toolbox.Modified_TestCase):
 
         with self.assertRaises(exceptions.SlowRetrievalError):
             next(self.fetcher.fetch(self.url))
-        mock_response.raw.read.assert_called_once()
+        mock_response.iter_content.assert_called_once()
 
     # Read/connect session timeout error
     @patch.object(
-        requests.Session, "get", side_effect=urllib3.exceptions.TimeoutError
+        requests.Session,
+        "get",
+        side_effect=requests.exceptions.Timeout("Simulated timeout"),
     )
     def test_session_get_timeout(self, mock_session_get: Any) -> None:
         with self.assertRaises(exceptions.SlowRetrievalError):


### PR DESCRIPTION
from commit description:
> This commit tries to deal with two interests:
>     * metadata is highly repetitive and compressible: allowing compression
>       would be good
>     * there may be broken web servers (see
>       https://github.com/pypa/pip/blob/404838abcca467648180b358598c597b74d568c9/src/pip/_internal/download.py#L842)
>       that have problems with compression on already compressed target files
>     
>  We can make things better for that first interest while we have no real
>     data for the second interest -- our current workarounds to avoid
>     compression are based on hearsay, not testing.
>     
>  Now that individual fetchers are possible I suggest we simplify
>     ngclient and allow compression. As an example the pip Fetcher
>     could still use the pip response chunking code with all their
>     workarounds -- pip certainly has better capability to maintain
>     a mountain of workarounds and also has endless amounts of real-world
>     testing compared to python-tuf.
>     
>  Details:
>     * Stop modifying Accept-Encoding (Requests default includes gzip)
>     * Don't use response.raw in RequestsFetcher as there is no need anymore
>     * Fix issue in test_session_get_timeout(): it's not mocking the error that requests really raises in this case
> 


Fixes #1251

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


