### PR TITLE
Fix typo on fast forward test functions

### DIFF
--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -343,7 +343,7 @@ class TestRefresh(unittest.TestCase):
 
         self._assert_files_exist([Root.type])
 
-    def test_new_timestamp_fast_foward_recovery(self) -> None:
+    def test_new_timestamp_fast_forward_recovery(self) -> None:
         """Test timestamp fast-forward recovery using key rotation.
 
         The timestamp recovery is made by the following steps
@@ -428,7 +428,7 @@ class TestRefresh(unittest.TestCase):
 
         self._assert_version_equals(Snapshot.type, 2)
 
-    def test_new_snapshot_fast_foward_recovery(self) -> None:
+    def test_new_snapshot_fast_forward_recovery(self) -> None:
         """Test snapshot fast-forward recovery using key rotation.
 
         The snapshot recovery requires the snapshot and timestamp key rotation.


### PR DESCRIPTION
Fix typo on fast forward test functions name.

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>

- [X] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [X] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


