### PR TITLE
docs: simplify examples on repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,8 @@ Documentation
 -------------
 * [Introduction to TUF's Design](https://theupdateframework.io/overview/)
 * [The TUF Specification](https://theupdateframework.github.io/specification/latest/)
-* Examples: [client](https://github.com/theupdateframework/python-tuf/tree/develop/examples/client_example)
-and [repository](https://github.com/theupdateframework/python-tuf/tree/develop/examples/repo_example)
 * [API Reference](https://theupdateframework.readthedocs.io/)
+* [Usage examples](https://github.com/theupdateframework/python-tuf/tree/develop/examples/)
 * [Governance](https://github.com/theupdateframework/python-tuf/blob/develop/docs/GOVERNANCE.md)
 and [Maintainers](https://github.com/theupdateframework/python-tuf/blob/develop/docs/MAINTAINERS.txt)
 for the reference implementation


### PR DESCRIPTION
The code examples now have a simple README.md. This commit simplifies
the README.md examples to the example folder instead of listing each
example.

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


