### PR TITLE
Review and document ngclient exceptions

### DIFF
--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -150,6 +150,7 @@ class TrustedMetadataSet(abc.Mapping):
             data: unverified new root metadata as bytes
 
         Raises:
+            RuntimeError: This function is called after updating timestamp.
             RepositoryError: Metadata failed to load or verify. The actual
                 error type and content will contain more details.
 
@@ -198,6 +199,7 @@ class TrustedMetadataSet(abc.Mapping):
             data: unverified new timestamp metadata as bytes
 
         Raises:
+            RuntimeError: This function is called after updating snapshot.
             RepositoryError: Metadata failed to load or verify as final
                 timestamp. The actual error type and content will contain
                 more details.
@@ -281,6 +283,8 @@ class TrustedMetadataSet(abc.Mapping):
                 match data. Default is False.
 
         Raises:
+            RuntimeError: This function is called before updating timestamp
+                or after updating targets.
             RepositoryError: data failed to load or verify as final snapshot.
                 The actual error type and content will contain more details.
 
@@ -385,6 +389,7 @@ class TrustedMetadataSet(abc.Mapping):
             delegator_name: The name of the role delegating to the new metadata
 
         Raises:
+            RuntimeError: This function is called before updating snapshot.
             RepositoryError: Metadata failed to load or verify. The actual
                 error type and content will contain more details.
 

--- a/tuf/ngclient/fetcher.py
+++ b/tuf/ngclient/fetcher.py
@@ -90,6 +90,17 @@ class FetcherInterface:
         """Download bytes from given url
 
         Returns the downloaded bytes, otherwise like download_file()
+
+        Args:
+            url: a URL string that represents the location of the file.
+            max_length: upper bound of data size in bytes.
+
+        Raises:
+            exceptions.DownloadLengthMismatchError: downloaded bytes exceed
+                'max_length'.
+
+        Returns:
+            The content of the file in bytes.
         """
         with self.download_file(url, max_length) as dl_file:
             return dl_file.read()

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -248,12 +248,7 @@ class Updater:
         with self._fetcher.download_file(
             full_url, targetinfo.length
         ) as target_file:
-            try:
-                targetinfo.verify_length_and_hashes(target_file)
-            except exceptions.LengthOrHashMismatchError as e:
-                raise exceptions.RepositoryError(
-                    f"{target_filepath} length or hashes do not match"
-                ) from e
+            targetinfo.verify_length_and_hashes(target_file)
 
             sslib_util.persist_temp_file(target_file, filepath)
 

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -121,7 +121,7 @@ class Updater:
         Raises:
             OSError: New metadata could not be written to disk
             RepositoryError: Metadata failed to verify in some way
-            TODO: download-related errors
+            DownloadError: Download of a metadata file failed in some way
         """
 
         self._load_root()
@@ -157,7 +157,7 @@ class Updater:
         Raises:
             OSError: New metadata could not be written to disk
             RepositoryError: Metadata failed to verify in some way
-            TODO: download-related errors
+            DownloadError: Download of a metadata file failed in some way
 
         Returns:
             A TargetFile instance or None.
@@ -216,8 +216,10 @@ class Updater:
 
         Raises:
             ValueError: Invalid arguments
-            TODO: download-related errors
-            TODO: file write errors
+            DownloadError: Download of the target file failed in some way
+            RepositoryError: Downloaded target failed to be verified in some way
+            exceptions.StorageError: Downloaded target could not be written
+                to disk
 
         Returns:
             Local path to downloaded file


### PR DESCRIPTION
Fixes #1312

**Description of the changes being introduced by the pull request**:

I made a review on all files inside `tuf/ngclient` to see which of them
needs additions or changes in their function docstrings regarding
exceptions.

I didn't find any changes required inside the `request_fetcher.py`
and of course inside the config module.
Other than that multiple additions had to be made.

For `trusted_metadata_set.py` we had a discussion with Jussi that there is
no need to list each of the specific `RepositoryError`s one by one as
this is an internal module and this will only create a bigger
maintenance burden.

For `updater.py` we had discussions with Jussi and Lukas that we want to
document only those exceptions that could be potentially handled.
This means there is no point in documenting each of the `RepositoryError`s
or `DownloadError`s separately.

Finally, I added a little documentation for `download_bytes()` inside
`fetcher.py`, as it's naming, suggests it's not an internal function.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


