### PR TITLE
test: stop using unittest_toolbox in new tests

### DIFF
--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -54,7 +54,7 @@ class TestTrustedMetadataSet(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.repo_dir = os.path.join(
-            os.getcwd(), "repository_data", "repository", "metadata"
+            utils.TESTS_DIR, "repository_data", "repository", "metadata"
         )
         cls.metadata = {}
         for md in [
@@ -68,7 +68,9 @@ class TestTrustedMetadataSet(unittest.TestCase):
             with open(os.path.join(cls.repo_dir, f"{md}.json"), "rb") as f:
                 cls.metadata[md] = f.read()
 
-        keystore_dir = os.path.join(os.getcwd(), "repository_data", "keystore")
+        keystore_dir = os.path.join(
+            utils.TESTS_DIR, "repository_data", "keystore"
+        )
         cls.keystore = {}
         root_key_dict = import_rsa_privatekey_from_file(
             os.path.join(keystore_dir, Root.type + "_key"), password="password"

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -19,7 +19,7 @@ from securesystemslib.interface import import_rsa_privatekey_from_file
 from securesystemslib.signer import SSlibSigner
 
 from tests import utils
-from tuf import ngclient, unittest_toolbox
+from tuf import ngclient
 from tuf.api import exceptions
 from tuf.api.metadata import (
     Metadata,
@@ -33,58 +33,41 @@ from tuf.api.metadata import (
 logger = logging.getLogger(__name__)
 
 
-class TestUpdater(unittest_toolbox.Modified_TestCase):
+class TestUpdater(unittest.TestCase):
     """Test the Updater class from 'tuf/ngclient/updater.py'."""
 
-    temporary_directory: ClassVar[str]
+    # pylint: disable=too-many-instance-attributes
     server_process_handler: ClassVar[utils.TestServerProcess]
 
     @classmethod
     def setUpClass(cls) -> None:
-        # Create a temporary directory to store the repository, metadata, and
-        # target files. 'temporary_directory' must be deleted in
-        # TearDownModule() so that temporary files are always removed, even when
-        # exceptions occur.
-        cls.temporary_directory = tempfile.mkdtemp(dir=os.getcwd())
+        cls.tmp_test_root_dir = tempfile.mkdtemp(dir=os.getcwd())
 
-        # Needed because in some tests simple_server.py cannot be found.
-        # The reason is that the current working directory
-        # has been changed when executing a subprocess.
-        simple_server_path = os.path.join(os.getcwd(), "simple_server.py")
-
-        # Launch a SimpleHTTPServer (serves files in the current directory).
+        # Launch a SimpleHTTPServer
         # Test cases will request metadata and target files that have been
-        # pre-generated in 'tuf/tests/repository_data', which will be served
-        # by the SimpleHTTPServer launched here.
-        cls.server_process_handler = utils.TestServerProcess(
-            log=logger, server=simple_server_path
-        )
+        # pre-generated in 'tuf/tests/repository_data', and are copied to
+        # CWD/tmp_test_root_dir/*
+        cls.server_process_handler = utils.TestServerProcess(log=logger)
 
     @classmethod
     def tearDownClass(cls) -> None:
-        # Cleans the resources and flush the logged lines (if any).
+        # Cleans resources, flush the logged lines (if any) and remove test dir
         cls.server_process_handler.clean()
-
-        # Remove the temporary repository directory, which should contain all
-        # the metadata, targets, and key files generated for the test cases
-        shutil.rmtree(cls.temporary_directory)
+        shutil.rmtree(cls.tmp_test_root_dir)
 
     def setUp(self) -> None:
-        # We are inheriting from custom class.
-        unittest_toolbox.Modified_TestCase.setUp(self)
+        # Create tmp test dir inside of tmp test root dir to independently serve
+        # new repository files for each test. We delete all tmp dirs at once in
+        # tearDownClass after the server has released all resources.
+        self.tmp_test_dir = tempfile.mkdtemp(dir=self.tmp_test_root_dir)
 
         # Copy the original repository files provided in the test folder so that
         # any modifications are restricted to the copies.
         # The 'repository_data' directory is expected to exist in 'tuf.tests/'.
-        temporary_repository_root = self.make_temp_directory(
-            directory=self.temporary_directory
-        )
         original_repository_files = os.path.join(
             utils.TESTS_DIR, "repository_data"
         )
 
-        # The original repository, keystore, and client directories will be
-        # copied for each test case.
         original_repository = os.path.join(
             original_repository_files, "repository"
         )
@@ -100,15 +83,10 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         # Save references to the often-needed client repository directories.
         # Test cases need these references to access metadata and target files.
         self.repository_directory = os.path.join(
-            temporary_repository_root, "repository"
+            self.tmp_test_dir, "repository"
         )
-        self.keystore_directory = os.path.join(
-            temporary_repository_root, "keystore"
-        )
-
-        self.client_directory = os.path.join(
-            temporary_repository_root, "client"
-        )
+        self.keystore_directory = os.path.join(self.tmp_test_dir, "keystore")
+        self.client_directory = os.path.join(self.tmp_test_dir, "client")
 
         # Copy the original 'repository', 'client', and 'keystore' directories
         # to the temporary repository the test cases can use.
@@ -128,7 +106,7 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
 
         self.metadata_url = f"{url_prefix}/metadata/"
         self.targets_url = f"{url_prefix}/targets/"
-        self.dl_dir = self.make_temp_directory()
+        self.dl_dir = tempfile.mkdtemp(dir=self.tmp_test_dir)
         # Creating a repository instance.  The test cases will use this client
         # updater to refresh metadata, fetch target files, etc.
         self.updater = ngclient.Updater(
@@ -139,9 +117,6 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         )
 
     def tearDown(self) -> None:
-        # We are inheriting from custom class.
-        unittest_toolbox.Modified_TestCase.tearDown(self)
-
         # Logs stdout and stderr from the sever subprocess.
         self.server_process_handler.flush_log()
 

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -76,9 +76,11 @@ class TestUpdater(unittest_toolbox.Modified_TestCase):
         # Copy the original repository files provided in the test folder so that
         # any modifications are restricted to the copies.
         # The 'repository_data' directory is expected to exist in 'tuf.tests/'.
-        original_repository_files = os.path.join(os.getcwd(), "repository_data")
         temporary_repository_root = self.make_temp_directory(
             directory=self.temporary_directory
+        )
+        original_repository_files = os.path.join(
+            utils.TESTS_DIR, "repository_data"
         )
 
         # The original repository, keystore, and client directories will be

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,7 +27,6 @@ import sys
 import unittest
 
 from tests import utils
-from tuf import unittest_toolbox
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +46,7 @@ def can_connect(port: int) -> bool:
             sock.close()
 
 
-class TestServerProcess(unittest_toolbox.Modified_TestCase):
+class TestServerProcess(unittest.TestCase):
     """Test functionality provided in TestServerProcess from tests/utils.py."""
 
     def test_simple_server_startup(self) -> None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -39,9 +39,11 @@ import tuf.log
 
 logger = logging.getLogger(__name__)
 
+# May may be used to reliably read other files in tests dir regardless of cwd
+TESTS_DIR = os.path.dirname(os.path.realpath(__file__))
+
 # Used when forming URLs on the client side
 TEST_HOST_ADDRESS = "127.0.0.1"
-
 
 # DataSet is only here so type hints can be used.
 DataSet = Dict[str, Any]
@@ -183,7 +185,7 @@ class TestServerProcess:
     def __init__(
         self,
         log: logging.Logger,
-        server: str = "simple_server.py",
+        server: str = os.path.join(TESTS_DIR, "simple_server.py"),
         timeout: int = 10,
         popen_cwd: str = ".",
         extra_cmd_args: Optional[List[str]] = None,


### PR DESCRIPTION
Fixes parts of #1745

**Description of the changes being introduced by the pull request**:

Update new test modules to stop using unittest_toolbox in preparation for its removal in #1790.

The tools provided by unittest_toolbox can easily (in a more obvious way) be replaced by using the standard library modules `tempfile` and `random` (no more used) directly.

In the case of tempdir and -file creation/removal, skipping the use of unittest_toolbox, which creates/removes a tmp dir for each test by default, also uncovers some test cleanup failures, which would occur when temporary test directories were removed while a test server hadn't released them.
(see `except OSError: pass` in unittest_toolbox's tearDown method)

**Change details**

**test_fetcher_ng.py:**
- Stop implicitly creating (setUp) and removing (tearDown) tmp test dirs.
- Move now manual creation of an exemplary targets file to setUpClass, as the same file is used by all tests. And remove it explicitly in tearDownClass after killing the server (see note about failure above).
- Trigger URL parsing error with a hardcoded invalid URL string instead of a random string.


**test_updater_ng.py**
- Stop implicitly creating (setUp) and removing (tearDown) tmp test dirs.
- Explicitly create tmp test dirs in setUp, but don't remove them in tearDown to avoid above mentioned failures. They will be removed all at once when removing the tmp root test dir in tearDownClass


--

unrelated change: define a TESTS_DIR constant for convenience

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


