### PR TITLE
Remove TODOs about too-many-arguments

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -713,7 +713,6 @@ class Root(Signed):
 
     type = _ROOT
 
-    # TODO: determine an appropriate value for max-args
     # pylint: disable=too-many-arguments
     def __init__(
         self,
@@ -1409,7 +1408,6 @@ class Targets(Signed):
 
     type = _TARGETS
 
-    # TODO: determine an appropriate value for max-args
     # pylint: disable=too-many-arguments
     def __init__(
         self,


### PR DESCRIPTION
The lint warning about argument count is useful in general but in these
two cases we want to break the rule: remove TODOs.

Improves #1764


