### PR TITLE
Add Metadata.signatures serialization tests

### DIFF
--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -6,6 +6,6 @@ idna==3.3                 # via requests
 pycparser==2.21           # via cffi
 pynacl==1.5.0             # via securesystemslib
 requests==2.27.1
-securesystemslib[crypto,pynacl]==0.21.0
+securesystemslib[crypto,pynacl]==0.22.0
 six==1.16.0               # via pynacl, securesystemslib
 urllib3==1.26.8           # via requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ packages = find:
 python_requires = ~=3.7
 install_requires =
   requests>=2.19.1
-  securesystemslib>=0.20.0
+  securesystemslib>=0.22.0
 
 [options.packages.find]
 exclude = tests

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -276,7 +276,7 @@ class TestMetadata(unittest.TestCase):
             timestamp_key.verify_signature(md_obj)
         sig.signature = correct_sig
 
-    def test_metadata_base(self) -> None:
+    def test_metadata_signed_is_expired(self) -> None:
         # Use of Snapshot is arbitrary, we're just testing the base class
         # features with real data
         snapshot_path = os.path.join(self.repo_dir, "metadata", "snapshot.json")
@@ -302,14 +302,6 @@ class TestMetadata(unittest.TestCase):
         is_expired = md.signed.is_expired()
         self.assertFalse(is_expired)
         md.signed.expires = expires
-
-        # Test deserializing metadata with non-unique signatures:
-        data = md.to_dict()
-        data["signatures"].append(
-            {"keyid": data["signatures"][0]["keyid"], "sig": "foo"}
-        )
-        with self.assertRaises(ValueError):
-            Metadata.from_dict(data)
 
     def test_metadata_verify_delegate(self) -> None:
         root_path = os.path.join(self.repo_dir, "metadata", "root.json")

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -42,11 +42,16 @@ class TestSerialization(unittest.TestCase):
             { "_type": "timestamp", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
             "meta": {"snapshot.json": {"hashes": {"sha256" : "abc"}, "version": 1}}} \
         }',
+        "non unique duplicating signatures": b'{"signed": \
+                { "_type": "timestamp", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
+                "meta": {"snapshot.json": {"hashes": {"sha256" : "abc"}, "version": 1}}}, \
+            "signatures": [{"keyid": "id", "sig": "b"}, {"keyid": "id", "sig": "b"}] \
+        }',
     }
 
     @utils.run_sub_tests_with_dataset(invalid_metadata)
     def test_invalid_metadata_serialization(self, test_data: bytes) -> None:
-        # We expect a DeserializationError reraised from KeyError.
+        # We expect a DeserializationError reraised from ValueError or KeyError.
         with self.assertRaises(DeserializationError):
             Metadata.from_bytes(test_data)
 

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -122,7 +122,7 @@ class TestSerialization(unittest.TestCase):
     def test_invalid_signed_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises((KeyError, ValueError, TypeError)):
-            Snapshot.from_dict(copy.deepcopy(case_dict))
+            Snapshot.from_dict(case_dict)
 
     valid_keys: utils.DataSet = {
         "all": '{"keytype": "rsa", "scheme": "rsassa-pss-sha256", \
@@ -155,7 +155,7 @@ class TestSerialization(unittest.TestCase):
         case_dict = json.loads(test_case_data)
         with self.assertRaises((TypeError, KeyError)):
             keyid = case_dict.pop("keyid")
-            Key.from_dict(keyid, copy.copy(case_dict))
+            Key.from_dict(keyid, case_dict)
 
     invalid_roles: utils.DataSet = {
         "no threshold": '{"keyids": ["keyid"]}',
@@ -169,7 +169,7 @@ class TestSerialization(unittest.TestCase):
     def test_invalid_role_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises((KeyError, TypeError, ValueError)):
-            Role.from_dict(copy.deepcopy(case_dict))
+            Role.from_dict(case_dict)
 
     valid_roles: utils.DataSet = {
         "all": '{"keyids": ["keyid"], "threshold": 3}',
@@ -276,7 +276,7 @@ class TestSerialization(unittest.TestCase):
     def test_invalid_root_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises(ValueError):
-            Root.from_dict(copy.deepcopy(case_dict))
+            Root.from_dict(case_dict)
 
     invalid_metafiles: utils.DataSet = {
         "wrong length type": '{"version": 1, "length": "a", "hashes": {"sha256" : "abc"}}',
@@ -292,7 +292,7 @@ class TestSerialization(unittest.TestCase):
     def test_invalid_metafile_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises((TypeError, ValueError, AttributeError)):
-            MetaFile.from_dict(copy.deepcopy(case_dict))
+            MetaFile.from_dict(case_dict)
 
     valid_metafiles: utils.DataSet = {
         "all": '{"hashes": {"sha256" : "abc"}, "length": 12, "version": 1}',
@@ -316,7 +316,7 @@ class TestSerialization(unittest.TestCase):
     def test_invalid_timestamp_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises((ValueError, KeyError)):
-            Timestamp.from_dict(copy.deepcopy(case_dict))
+            Timestamp.from_dict(case_dict)
 
     valid_timestamps: utils.DataSet = {
         "all": '{ "_type": "timestamp", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
@@ -392,7 +392,7 @@ class TestSerialization(unittest.TestCase):
     ) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises(ValueError):
-            DelegatedRole.from_dict(copy.copy(case_dict))
+            DelegatedRole.from_dict(case_dict)
 
     invalid_delegations: utils.DataSet = {
         "empty delegations": "{}",
@@ -453,7 +453,7 @@ class TestSerialization(unittest.TestCase):
     ) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises((ValueError, KeyError, AttributeError)):
-            Delegations.from_dict(copy.deepcopy(case_dict))
+            Delegations.from_dict(case_dict)
 
     valid_delegations: utils.DataSet = {
         "all": '{"keys": { \
@@ -490,7 +490,7 @@ class TestSerialization(unittest.TestCase):
     ) -> None:
         case_dict = json.loads(test_case_data)
         with self.assertRaises(KeyError):
-            TargetFile.from_dict(copy.deepcopy(case_dict), "file1.txt")
+            TargetFile.from_dict(case_dict, "file1.txt")
 
     valid_targetfiles: utils.DataSet = {
         "all": '{"length": 12, "hashes": {"sha256" : "abc"}, \


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

In a conversation with @jku he pointed out we don't have serialization
tests for `Metadata.signatures`.
That's how we decided it's worth adding such tests inside
`test_metadata_serialization.py` and moving the
test case about duplicating signatures inside the same test file.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


