### PR TITLE
ngclient: Make DownloadErrors more consistent

### DIFF
--- a/examples/client_example/client_example.py
+++ b/examples/client_example/client_example.py
@@ -10,7 +10,7 @@ import os
 import shutil
 from pathlib import Path
 
-from tuf.api.exceptions import RepositoryError
+from tuf.api.exceptions import DownloadError, RepositoryError
 from tuf.ngclient import Updater
 
 # constants
@@ -73,8 +73,8 @@ def download(target: str) -> bool:
         path = updater.download_target(info)
         print(f"Target downloaded and available in {path}")
 
-    except (OSError, RepositoryError) as e:
-        print(str(e))
+    except (OSError, RepositoryError, DownloadError) as e:
+        print(f"Failed to download target {target}: {e}")
         return False
 
     return True

--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -205,7 +205,7 @@ class RepositorySimulator(FetcherInterface):
         self.signed_roots.append(self.md_root.to_bytes(JSONSerializer()))
         logger.debug("Published root v%d", self.root.version)
 
-    def fetch(self, url: str) -> Iterator[bytes]:
+    def _fetch(self, url: str) -> Iterator[bytes]:
         """Fetches data from the given url and returns an Iterator (or yields
         bytes).
         """

--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -56,7 +56,7 @@ import securesystemslib.hash as sslib_hash
 from securesystemslib.keys import generate_ed25519_key
 from securesystemslib.signer import SSlibSigner
 
-from tuf.api.exceptions import FetcherHTTPError
+from tuf.api.exceptions import DownloadHTTPError
 from tuf.api.metadata import (
     SPECIFICATION_VERSION,
     TOP_LEVEL_ROLE_NAMES,
@@ -238,7 +238,7 @@ class RepositorySimulator(FetcherInterface):
 
             yield self.fetch_target(target_path, prefix)
         else:
-            raise FetcherHTTPError(f"Unknown path '{path}'", 404)
+            raise DownloadHTTPError(f"Unknown path '{path}'", 404)
 
     def fetch_target(
         self, target_path: str, target_hash: Optional[str]
@@ -251,12 +251,12 @@ class RepositorySimulator(FetcherInterface):
 
         repo_target = self.target_files.get(target_path)
         if repo_target is None:
-            raise FetcherHTTPError(f"No target {target_path}", 404)
+            raise DownloadHTTPError(f"No target {target_path}", 404)
         if (
             target_hash
             and target_hash not in repo_target.target_file.hashes.values()
         ):
-            raise FetcherHTTPError(f"hash mismatch for {target_path}", 404)
+            raise DownloadHTTPError(f"hash mismatch for {target_path}", 404)
 
         logger.debug("fetched target %s", target_path)
         return repo_target.data
@@ -273,7 +273,7 @@ class RepositorySimulator(FetcherInterface):
         if role == Root.type:
             # return a version previously serialized in publish_root()
             if version is None or version > len(self.signed_roots):
-                raise FetcherHTTPError(f"Unknown root version {version}", 404)
+                raise DownloadHTTPError(f"Unknown root version {version}", 404)
             logger.debug("fetched root version %d", version)
             return self.signed_roots[version - 1]
 
@@ -289,7 +289,7 @@ class RepositorySimulator(FetcherInterface):
             md = self.md_delegates.get(role)
 
         if md is None:
-            raise FetcherHTTPError(f"Unknown role {role}", 404)
+            raise DownloadHTTPError(f"Unknown role {role}", 404)
 
         md.signatures.clear()
         for signer in self.signers[role].values():

--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -101,7 +101,7 @@ class TestFetcher(unittest.TestCase):
 
     # File not found error
     def test_http_error(self) -> None:
-        with self.assertRaises(exceptions.FetcherHTTPError) as cm:
+        with self.assertRaises(exceptions.DownloadHTTPError) as cm:
             self.url = f"{self.url_prefix}/non-existing-path"
             self.fetcher.fetch(self.url)
         self.assertEqual(cm.exception.status_code, 404)

--- a/tuf/api/exceptions.py
+++ b/tuf/api/exceptions.py
@@ -52,7 +52,7 @@ class SlowRetrievalError(DownloadError):
     """Indicate that downloading a file took an unreasonably long time."""
 
 
-class FetcherHTTPError(DownloadError):
+class DownloadHTTPError(DownloadError):
     """
     Returned by FetcherInterface implementations for HTTP errors.
 

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -60,7 +60,7 @@ class RequestsFetcher(FetcherInterface):
         Raises:
             exceptions.SlowRetrievalError: A timeout occurs while receiving
                 data.
-            exceptions.FetcherHTTPError: An HTTP error code is received.
+            exceptions.DownloadHTTPError: An HTTP error code is received.
 
         Returns:
             A bytes iterator
@@ -88,7 +88,7 @@ class RequestsFetcher(FetcherInterface):
         except requests.HTTPError as e:
             response.close()
             status = e.response.status_code
-            raise exceptions.FetcherHTTPError(str(e), status)
+            raise exceptions.DownloadHTTPError(str(e), status)
 
         return self._chunks(response)
 

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -121,7 +121,7 @@ class RequestsFetcher(FetcherInterface):
         parsed_url = parse.urlparse(url)
 
         if not parsed_url.scheme or not parsed_url.hostname:
-            raise exceptions.DownloadError("Failed to parse URL {url}")
+            raise exceptions.DownloadError(f"Failed to parse URL {url}")
 
         session_index = f"{parsed_url.scheme}+{parsed_url.hostname}"
         session = self._sessions.get(session_index)

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -51,7 +51,7 @@ class RequestsFetcher(FetcherInterface):
         self.socket_timeout: int = 4  # seconds
         self.chunk_size: int = 400000  # bytes
 
-    def fetch(self, url: str) -> Iterator[bytes]:
+    def _fetch(self, url: str) -> Iterator[bytes]:
         """Fetches the contents of HTTP/HTTPS url from a remote server
 
         Arguments:
@@ -61,7 +61,6 @@ class RequestsFetcher(FetcherInterface):
             exceptions.SlowRetrievalError: A timeout occurs while receiving
                 data.
             exceptions.FetcherHTTPError: An HTTP error code is received.
-            exceptions.DownloadError: When there is a problem parsing the url.
 
         Returns:
             A bytes iterator

--- a/tuf/ngclient/fetcher.py
+++ b/tuf/ngclient/fetcher.py
@@ -77,8 +77,7 @@ class FetcherInterface:
 
         Args:
             url: a URL string that represents the location of the file.
-            max_length: an integer value representing the length of
-                the file or an upper bound.
+            max_length: upper bound of file size in bytes.
 
         Raises:
             exceptions.DownloadError: An error occurred during download.

--- a/tuf/ngclient/fetcher.py
+++ b/tuf/ngclient/fetcher.py
@@ -31,7 +31,7 @@ class FetcherInterface:
     def _fetch(self, url: str) -> Iterator[bytes]:
         """Fetches the contents of HTTP/HTTPS url from a remote server.
 
-        Implementations must raise FetcherHTTPError if they receive an
+        Implementations must raise DownloadHTTPError if they receive an
         HTTP error code.
 
         Implementations may raise any errors but the ones that are not
@@ -41,7 +41,7 @@ class FetcherInterface:
             url: A URL string that represents a file location.
 
         Raises:
-            exceptions.FetcherHTTPError: An HTTP error code was received.
+            exceptions.DownloadHTTPError: An HTTP error code was received.
 
         Returns:
             A bytes iterator
@@ -56,7 +56,7 @@ class FetcherInterface:
 
         Raises:
             exceptions.DownloadError: An error occurred during download.
-            exceptions.FetcherHTTPError: An HTTP error code was received.
+            exceptions.DownloadHTTPError: An HTTP error code was received.
 
         Returns:
             A bytes iterator
@@ -84,7 +84,7 @@ class FetcherInterface:
             exceptions.DownloadError: An error occurred during download.
             exceptions.DownloadLengthMismatchError: downloaded bytes exceed
                 'max_length'.
-            exceptions.FetcherHTTPError: An HTTP error code was received.
+            exceptions.DownloadHTTPError: An HTTP error code was received.
 
         Yields:
             A TemporaryFile object that points to the contents of 'url'.
@@ -127,7 +127,7 @@ class FetcherInterface:
             exceptions.DownloadError: An error occurred during download.
             exceptions.DownloadLengthMismatchError: downloaded bytes exceed
                 'max_length'.
-            exceptions.FetcherHTTPError: An HTTP error code was received.
+            exceptions.DownloadHTTPError: An HTTP error code was received.
 
         Returns:
             The content of the file in bytes.

--- a/tuf/ngclient/fetcher.py
+++ b/tuf/ngclient/fetcher.py
@@ -65,9 +65,9 @@ class FetcherInterface:
         # fetcher implementation
         try:
             return self._fetch(url)
+        except exceptions.DownloadError as e:
+            raise e
         except Exception as e:
-            if isinstance(e, exceptions.DownloadError):
-                raise e
             raise exceptions.DownloadError(f"Failed to download {url}") from e
 
     @contextmanager

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -315,7 +315,7 @@ class Updater:
                 self._trusted_set.update_root(data)
                 self._persist_metadata(Root.type, data)
 
-            except exceptions.FetcherHTTPError as exception:
+            except exceptions.DownloadHTTPError as exception:
                 if exception.status_code not in {403, 404}:
                     raise
                 # 404/403 means current root is newest available


### PR DESCRIPTION
* Make fetch() wrap non-DownloadErrors in a DownloadError
* Try to be more consistent in docstrings
* rename FetcherHTTPError to DownloadHTTPError

As a result calling any public fetcher methods is now guaranteed to only raise DownloadError (or something derived from it). I think this looks cleaner, makes it easier understand and implementing a fetcher is not more complex: Fetcher implementations are allowed to raise whatever errors (like RequestsError in the default case) but `FetcherInterface.fetch()` will automatically wrap errors so that only DownloadErrors are raised to calling code.

This is strictly speaking an API change (because of the rename) but that error is meant for mostly internal use.

Fixes #1714

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


