### PR TITLE
Improve docstrings language in Metadata API

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -107,9 +107,9 @@ class Metadata(Generic[T]):
     instance attributes.*
 
     Args:
-        signed: The actual metadata payload, i.e. one of ``Targets``,
+        signed: Actual metadata payload, i.e. one of ``Targets``,
             ``Snapshot``, ``Timestamp`` or ``Root``.
-        signatures: An ordered dictionary of keyids to ``Signature`` objects, each
+        signatures: Ordered dictionary of keyids to ``Signature`` objects, each
             signing the canonical serialized representation of ``signed``.
     """
 
@@ -131,7 +131,7 @@ class Metadata(Generic[T]):
             Destroys the metadata dict passed by reference.
 
         Returns:
-            A TUF ``Metadata`` object.
+            TUF ``Metadata`` object.
         """
 
         # Dispatch to contained metadata class on metadata _type field.
@@ -174,11 +174,11 @@ class Metadata(Generic[T]):
         """Loads TUF metadata from file storage.
 
         Args:
-            filename: The path to read the file from.
-            deserializer: A ``MetadataDeserializer`` subclass instance that
+            filename: Path to read the file from.
+            deserializer: ``MetadataDeserializer`` subclass instance that
                 implements the desired wireline format deserialization. Per
                 default a ``JSONDeserializer`` is used.
-            storage_backend: An object that implements
+            storage_backend: Object that implements
                 ``securesystemslib.storage.StorageBackendInterface``.
                 Default is ``FilesystemBackend`` (i.e. a local file).
         Raises:
@@ -187,7 +187,7 @@ class Metadata(Generic[T]):
                 The file cannot be deserialized.
 
         Returns:
-            A TUF ``Metadata`` object.
+            TUF ``Metadata`` object.
         """
 
         if storage_backend is None:
@@ -205,7 +205,7 @@ class Metadata(Generic[T]):
         """Loads TUF metadata from raw data.
 
         Args:
-            data: metadata content.
+            data: Metadata content.
             deserializer: ``MetadataDeserializer`` implementation to use.
                 Default is ``JSONDeserializer``.
 
@@ -214,7 +214,7 @@ class Metadata(Generic[T]):
                 The file cannot be deserialized.
 
         Returns:
-            A TUF ``Metadata`` object.
+            TUF ``Metadata`` object.
         """
 
         if deserializer is None:
@@ -239,7 +239,7 @@ class Metadata(Generic[T]):
         instead of re-serializing.
 
         Args:
-            serializer: A ``MetadataSerializer`` instance that implements the
+            serializer: ``MetadataSerializer`` instance that implements the
                 desired serialization format. Default is ``JSONSerializer``.
 
         Raises:
@@ -279,10 +279,10 @@ class Metadata(Generic[T]):
         instead of re-serializing.
 
         Args:
-            filename: The path to write the file to.
-            serializer: A ``MetadataSerializer`` instance that implements the
+            filename: Path to write the file to.
+            serializer: ``MetadataSerializer`` instance that implements the
                 desired serialization format. Default is ``JSONSerializer``.
-            storage_backend: A ``StorageBackendInterface`` implementation. Default
+            storage_backend: ``StorageBackendInterface`` implementation. Default
                 is ``FilesystemBackend`` (i.e. a local file).
 
         Raises:
@@ -307,11 +307,11 @@ class Metadata(Generic[T]):
         """Creates signature over ``signed`` and assigns it to ``signatures``.
 
         Args:
-            signer: A securesystemslib.signer.Signer implementation.
+            signer: ``securesystemslib.signer.Signer`` implementation.
             append: ``True`` if the signature should be appended to
                 the list of signatures or replace any existing signatures. The
                 default behavior is to replace signatures.
-            signed_serializer: A ``SignedSerializer`` that implements the desired
+            signed_serializer: ``SignedSerializer`` that implements the desired
                 serialization format. Default is ``CanonicalJSONSerializer``.
 
         Raises:
@@ -320,7 +320,8 @@ class Metadata(Generic[T]):
             exceptions.UnsignedMetadataError: Signing errors.
 
         Returns:
-            ``securesystemslib.signer.Signature`` object that was added into signatures.
+            ``securesystemslib.signer.Signature`` object that was added into
+            signatures.
         """
 
         if signed_serializer is None:
@@ -357,8 +358,8 @@ class Metadata(Generic[T]):
 
         Args:
             delegated_role: Name of the delegated role to verify
-            delegated_metadata: The ``Metadata`` object for the delegated role
-            signed_serializer: serializer used for delegate
+            delegated_metadata: ``Metadata`` object for the delegated role
+            signed_serializer: Serializer used for delegate
                 serialization. Default is ``CanonicalJSONSerializer``.
 
         Raises:
@@ -411,9 +412,9 @@ class Signed(metaclass=abc.ABCMeta):
     instance attributes.*
 
     Args:
-        version: The metadata version number.
-        spec_version: The supported TUF specification version number.
-        expires: The metadata expiry date.
+        version: Metadata version number.
+        spec_version: Supported TUF specification version number.
+        expires: Metadata expiry date.
         unrecognized_fields: Dictionary of all unrecognized fields.
 
     Raises:
@@ -524,7 +525,7 @@ class Signed(metaclass=abc.ABCMeta):
         """Checks metadata expiration against a reference time.
 
         Args:
-            reference_time: The time to check expiration date against. A naive
+            reference_time: Time to check expiration date against. A naive
                 datetime in UTC expected. Default is current UTC date and time.
 
         Returns:
@@ -549,8 +550,8 @@ class Key:
         keyid: Key identifier that is unique within the metadata it is used in.
             Keyid is not verified to be the hash of a specific representation
             of the key.
-        keytype: key type, e.g. "rsa", "ed25519" or "ecdsa-sha2-nistp256".
-        scheme: signature scheme. For example:
+        keytype: Key type, e.g. "rsa", "ed25519" or "ecdsa-sha2-nistp256".
+        scheme: Signature scheme. For example:
             "rsassa-pss-sha256", "ed25519", and "ecdsa-sha2-nistp256".
         keyval: Opaque key content
         unrecognized_fields: Dictionary of all unrecognized fields.
@@ -614,7 +615,7 @@ class Key:
         removing the private key from keyval.
 
         Args:
-            key_dict: A key in securesystemlib dict representation.
+            key_dict: Key in securesystemlib dict representation.
         """
         key_meta = sslib_keys.format_keyval_to_metadata(
             key_dict["keytype"],
@@ -687,7 +688,7 @@ class Role:
     instance attributes.*
 
     Args:
-        keyids: The roles signing key identifiers.
+        keyids: Roles signing key identifiers.
         threshold: Number of keys required to sign this role's metadata.
         unrecognized_fields: Dictionary of all unrecognized fields.
 
@@ -736,9 +737,9 @@ class Root(Signed):
     Parameters listed below are also instance attributes.
 
     Args:
-        version: The metadata version number.
-        spec_version: The supported TUF specification version number.
-        expires: The metadata expiry date.
+        version: Metadata version number.
+        spec_version: Supported TUF specification version number.
+        expires: Metadata expiry date.
         keys: Dictionary of keyids to Keys. Defines the keys used in ``roles``.
         roles: Dictionary of role names to Roles. Defines which keys are
             required to sign the metadata for a specific role.
@@ -812,8 +813,8 @@ class Root(Signed):
         """Adds new signing key for delegated role ``role``.
 
         Args:
-            role: The name of the role, for which ``key`` is added.
-            key: The signing key to be added for ``role``.
+            role: Name of the role, for which ``key`` is added.
+            key: Signing key to be added for ``role``.
 
         Raises:
             ValueError: If ``role`` doesn't exist.
@@ -828,8 +829,8 @@ class Root(Signed):
         """Removes key from ``role`` and updates the key store.
 
         Args:
-            role: The name of the role, for which a signing key is removed.
-            keyid: The identifier of the key to be removed for ``role``.
+            role: Name of the role, for which a signing key is removed.
+            keyid: Identifier of the key to be removed for ``role``.
 
         Raises:
             ValueError: If ``role`` doesn't exist or if ``role`` doesn't include
@@ -1007,9 +1008,9 @@ class Timestamp(Signed):
     instance attributes.*
 
     Args:
-        version: The metadata version number.
-        spec_version: The supported TUF specification version number.
-        expires: The metadata expiry date.
+        version: Metadata version number.
+        spec_version: Supported TUF specification version number.
+        expires: Metadata expiry date.
         unrecognized_fields: Dictionary of all unrecognized fields.
         snapshot_meta: Meta information for snapshot metadata.
 
@@ -1059,11 +1060,11 @@ class Snapshot(Signed):
     instance attributes.*
 
     Args:
-        version: The metadata version number.
-        spec_version: The supported TUF specification version number.
-        expires: The metadata expiry date.
+        version: Metadata version number.
+        spec_version: Supported TUF specification version number.
+        expires: Metadata expiry date.
         unrecognized_fields: Dictionary of all unrecognized fields.
-        meta: A dictionary of target metadata filenames to ``MetaFile`` objects.
+        meta: Dictionary of target metadata filenames to ``MetaFile`` objects.
 
     Raises:
         ValueError: Invalid arguments.
@@ -1332,7 +1333,7 @@ class TargetFile(BaseFile):
 
     Args:
         length: Length of the target file in bytes.
-        hashes: A dictionary of hash algorithm names to hashes of the target
+        hashes: Dictionary of hash algorithm names to hashes of the target
             file content.
         path: URL path to a target file, relative to a base targets URL.
         unrecognized_fields: Dictionary of all unrecognized fields.
@@ -1396,8 +1397,8 @@ class TargetFile(BaseFile):
         Args:
             target_file_path: URL path to a target file, relative to a base
                 targets URL.
-            local_path: The local path to target file content.
-            hash_algorithms: hash algorithms to calculate hashes with. If not
+            local_path: Local path to target file content.
+            hash_algorithms: Hash algorithms to calculate hashes with. If not
                 specified the securesystemslib default hash algorithm is used.
         Raises:
             FileNotFoundError: The file doesn't exist.
@@ -1419,7 +1420,7 @@ class TargetFile(BaseFile):
         Args:
             target_file_path: URL path to a target file, relative to a base
                 targets URL.
-            data: The target file content.
+            data: Target file content.
             hash_algorithms: Hash algorithms to create the hashes with. If not
                 specified the securesystemslib default hash algorithm is used.
 
@@ -1481,10 +1482,10 @@ class Targets(Signed):
     instance attributes.*
 
     Args:
-        version: The metadata version number.
-        spec_version: The supported TUF specification version number.
-        expires: The metadata expiry date.
-        targets: A dictionary of target filenames to TargetFiles
+        version: Metadata version number.
+        spec_version: Supported TUF specification version number.
+        expires: Metadata expiry date.
+        targets: Dictionary of target filenames to TargetFiles
         delegations: Defines how this Targets delegates responsibility to other
             Targets Metadata files.
         unrecognized_fields: Dictionary of all unrecognized fields.
@@ -1547,8 +1548,8 @@ class Targets(Signed):
         """Adds new signing key for delegated role ``role``.
 
         Args:
-            role: The name of the role, for which ``key`` is added.
-            key: The signing key to be added for ``role``.
+            role: Name of the role, for which ``key`` is added.
+            key: Signing key to be added for ``role``.
 
         Raises:
             ValueError: If there are no delegated roles or if ``role`` is not
@@ -1565,8 +1566,8 @@ class Targets(Signed):
         key store.
 
         Args:
-            role: The name of the role, for which a signing key is removed.
-            keyid: The identifier of the key to be removed for ``role``.
+            role: Name of the role, for which a signing key is removed.
+            keyid: Identifier of the key to be removed for ``role``.
 
         Raises:
             ValueError: If there are no delegated roles or if ``role`` is not

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -121,7 +121,7 @@ class Metadata(Generic[T]):
     def from_dict(cls, metadata: Dict[str, Any]) -> "Metadata[T]":
         """Creates ``Metadata`` object from its dict representation.
 
-        Arguments:
+        Args:
             metadata: TUF metadata in dict representation.
 
         Raises:
@@ -173,15 +173,14 @@ class Metadata(Generic[T]):
     ) -> "Metadata[T]":
         """Loads TUF metadata from file storage.
 
-        Arguments:
+        Args:
             filename: The path to read the file from.
             deserializer: A ``MetadataDeserializer`` subclass instance that
                 implements the desired wireline format deserialization. Per
                 default a ``JSONDeserializer`` is used.
             storage_backend: An object that implements
                 ``securesystemslib.storage.StorageBackendInterface``.
-                Per default a (local) ``FilesystemBackend`` is used.
-
+                Default is ``FilesystemBackend`` (i.e. a local file).
         Raises:
             exceptions.StorageError: The file cannot be read.
             tuf.api.serialization.DeserializationError:
@@ -205,7 +204,7 @@ class Metadata(Generic[T]):
     ) -> "Metadata[T]":
         """Loads TUF metadata from raw data.
 
-        Arguments:
+        Args:
             data: metadata content.
             deserializer: ``MetadataDeserializer`` implementation to use.
                 Default is ``JSONDeserializer``.
@@ -239,7 +238,7 @@ class Metadata(Generic[T]):
         hashes are used in other metadata), the original content should be used
         instead of re-serializing.
 
-        Arguments:
+        Args:
             serializer: A ``MetadataSerializer`` instance that implements the
                 desired serialization format. Default is ``JSONSerializer``.
 
@@ -279,7 +278,7 @@ class Metadata(Generic[T]):
         hashes are used in other metadata), the original file should be used
         instead of re-serializing.
 
-        Arguments:
+        Args:
             filename: The path to write the file to.
             serializer: A ``MetadataSerializer`` instance that implements the
                 desired serialization format. Default is ``JSONSerializer``.
@@ -307,9 +306,9 @@ class Metadata(Generic[T]):
     ) -> Signature:
         """Creates signature over ``signed`` and assigns it to ``signatures``.
 
-        Arguments:
+        Args:
             signer: A securesystemslib.signer.Signer implementation.
-            append: A boolean indicating if the signature should be appended to
+            append: ``True`` if the signature should be appended to
                 the list of signatures or replace any existing signatures. The
                 default behavior is to replace signatures.
             signed_serializer: A ``SignedSerializer`` that implements the desired
@@ -637,7 +636,7 @@ class Key:
         """Verifies that the ``metadata.signatures`` contains a signature made
         with this key, correctly signing ``metadata.signed``.
 
-        Arguments:
+        Args:
             metadata: Metadata to verify
             signed_serializer: ``SignedSerializer`` to serialize
                 ``metadata.signed`` with. Default is ``CanonicalJSONSerializer``.
@@ -830,7 +829,7 @@ class Root(Signed):
 
         Args:
             role: The name of the role, for which a signing key is removed.
-            key: The identifier of the key to be removed for ``role``.
+            keyid: The identifier of the key to be removed for ``role``.
 
         Raises:
             ValueError: If ``role`` doesn't exist or if ``role`` doesn't include
@@ -923,7 +922,7 @@ class MetaFile(BaseFile):
 
     Args:
         version: Version of the metadata file.
-        length: Length of the metadata file.
+        length: Length of the metadata file in bytes.
         hashes: Dictionary of hash algorithm names to hashes of the metadata
             file content.
         unrecognized_fields: Dictionary of all unrecognized fields.
@@ -1206,8 +1205,8 @@ class DelegatedRole(Role):
 
     @staticmethod
     def _is_target_in_pathpattern(targetpath: str, pathpattern: str) -> bool:
-        """Determines whether ``targetname`` matches the ``pathpattern``."""
-        # We need to make sure that targetname and pathpattern are pointing to
+        """Determines whether ``targetpath`` matches the ``pathpattern``."""
+        # We need to make sure that targetpath and pathpattern are pointing to
         # the same directory as fnmatch doesn't threat "/" as a special symbol.
         target_parts = targetpath.split("/")
         pattern_parts = pathpattern.split("/")
@@ -1332,7 +1331,7 @@ class TargetFile(BaseFile):
     instance attributes.*
 
     Args:
-        length: Length in bytes.
+        length: Length of the target file in bytes.
         hashes: A dictionary of hash algorithm names to hashes of the target
             file content.
         path: URL path to a target file, relative to a base targets URL.
@@ -1394,7 +1393,7 @@ class TargetFile(BaseFile):
     ) -> "TargetFile":
         """Creates ``TargetFile`` object from a file.
 
-        Arguments:
+        Args:
             target_file_path: URL path to a target file, relative to a base
                 targets URL.
             local_path: The local path to target file content.
@@ -1417,7 +1416,7 @@ class TargetFile(BaseFile):
     ) -> "TargetFile":
         """Creates ``TargetFile`` object from bytes.
 
-        Arguments:
+        Args:
             target_file_path: URL path to a target file, relative to a base
                 targets URL.
             data: The target file content.
@@ -1462,7 +1461,7 @@ class TargetFile(BaseFile):
         """Verifies that length and hashes of ``data`` match expected values.
 
         Args:
-            data: File object or its content in bytes.
+            data: Target file object or its content in bytes.
 
         Raises:
             LengthOrHashMismatchError: Calculated length or hashes do not
@@ -1567,7 +1566,7 @@ class Targets(Signed):
 
         Args:
             role: The name of the role, for which a signing key is removed.
-            key: The identifier of the key to be removed for ``role``.
+            keyid: The identifier of the key to be removed for ``role``.
 
         Raises:
             ValueError: If there are no delegated roles or if ``role`` is not

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -307,7 +307,7 @@ class Metadata(Generic[T]):
         """Creates signature over ``signed`` and assigns it to ``signatures``.
 
         Args:
-            signer: ``securesystemslib.signer.Signer`` implementation.
+            signer: A securesystemslib.signer.Signer implementation.
             append: ``True`` if the signature should be appended to
                 the list of signatures or replace any existing signatures. The
                 default behavior is to replace signatures.
@@ -415,7 +415,8 @@ class Signed(metaclass=abc.ABCMeta):
         version: Metadata version number.
         spec_version: Supported TUF specification version number.
         expires: Metadata expiry date.
-        unrecognized_fields: Dictionary of all unrecognized fields.
+        unrecognized_fields: Dictionary of all attributes that are not managed
+            by TUF Metadata API
 
     Raises:
         ValueError: Invalid arguments.
@@ -554,7 +555,8 @@ class Key:
         scheme: Signature scheme. For example:
             "rsassa-pss-sha256", "ed25519", and "ecdsa-sha2-nistp256".
         keyval: Opaque key content
-        unrecognized_fields: Dictionary of all unrecognized fields.
+        unrecognized_fields: Dictionary of all attributes that are not managed
+            by TUF Metadata API
 
     Raises:
         TypeError: Invalid type for an argument.
@@ -690,7 +692,8 @@ class Role:
     Args:
         keyids: Roles signing key identifiers.
         threshold: Number of keys required to sign this role's metadata.
-        unrecognized_fields: Dictionary of all unrecognized fields.
+        unrecognized_fields: Dictionary of all attributes that are not managed
+            by TUF Metadata API
 
     Raises:
         ValueError: Invalid arguments.
@@ -744,7 +747,8 @@ class Root(Signed):
         roles: Dictionary of role names to Roles. Defines which keys are
             required to sign the metadata for a specific role.
         consistent_snapshot: ``True`` if repository supports consistent snapshots.
-        unrecognized_fields: Dictionary of all unrecognized fields.
+        unrecognized_fields: Dictionary of all attributes that are not managed
+            by TUF Metadata API
 
     Raises:
         ValueError: Invalid arguments.
@@ -926,7 +930,8 @@ class MetaFile(BaseFile):
         length: Length of the metadata file in bytes.
         hashes: Dictionary of hash algorithm names to hashes of the metadata
             file content.
-        unrecognized_fields: Dictionary of all unrecognized fields.
+        unrecognized_fields: Dictionary of all attributes that are not managed
+            by TUF Metadata API
 
     Raises:
         ValueError, TypeError: Invalid arguments.
@@ -1011,7 +1016,8 @@ class Timestamp(Signed):
         version: Metadata version number.
         spec_version: Supported TUF specification version number.
         expires: Metadata expiry date.
-        unrecognized_fields: Dictionary of all unrecognized fields.
+        unrecognized_fields: Dictionary of all attributes that are not managed
+            by TUF Metadata API
         snapshot_meta: Meta information for snapshot metadata.
 
     Raises:
@@ -1063,7 +1069,8 @@ class Snapshot(Signed):
         version: Metadata version number.
         spec_version: Supported TUF specification version number.
         expires: Metadata expiry date.
-        unrecognized_fields: Dictionary of all unrecognized fields.
+        unrecognized_fields: Dictionary of all attributes that are not managed
+            by TUF Metadata API
         meta: Dictionary of target metadata filenames to ``MetaFile`` objects.
 
     Raises:
@@ -1131,7 +1138,8 @@ class DelegatedRole(Role):
         terminating: ``True`` if this delegation terminates a target lookup.
         paths: Path patterns. See note above.
         path_hash_prefixes: Hash prefixes. See note above.
-        unrecognized_fields: Attributes not managed by TUF Metadata API.
+        unrecognized_fields: Dictionary of all attributes that are not managed
+            by TUF Metadata API
 
     Raises:
         ValueError: Invalid arguments.
@@ -1270,7 +1278,8 @@ class Delegations:
             defines which keys are required to sign the metadata for a specific
             role. The roles order also defines the order that role delegations
             are considered during target searches.
-        unrecognized_fields: Dictionary of all unrecognized fields.
+        unrecognized_fields: Dictionary of all attributes that are not managed
+            by TUF Metadata API
 
     Raises:
         ValueError: Invalid arguments.
@@ -1336,7 +1345,8 @@ class TargetFile(BaseFile):
         hashes: Dictionary of hash algorithm names to hashes of the target
             file content.
         path: URL path to a target file, relative to a base targets URL.
-        unrecognized_fields: Dictionary of all unrecognized fields.
+        unrecognized_fields: Dictionary of all attributes that are not managed
+            by TUF Metadata API
 
     Raises:
         ValueError, TypeError: Invalid arguments.
@@ -1488,7 +1498,8 @@ class Targets(Signed):
         targets: Dictionary of target filenames to TargetFiles
         delegations: Defines how this Targets delegates responsibility to other
             Targets Metadata files.
-        unrecognized_fields: Dictionary of all unrecognized fields.
+        unrecognized_fields: Dictionary of all attributes that are not managed
+            by TUF Metadata API
 
     Raises:
         ValueError: Invalid arguments.

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -18,8 +18,8 @@ attributes generally follow the JSON format used in the specification.
 
 The above principle means that a ``Metadata`` object represents a single
 metadata file, and has a ``signed`` attribute that is an instance of one of the
-four top level signed classes (Root, Timestamp, Snapshot and Targets). To make
-Python type annotations useful Metadata can be type constrained: e.g. the
+four top level signed classes (``Root``, ``Timestamp``, ``Snapshot`` and ``Targets``).
+To make Python type annotations useful ``Metadata`` can be type constrained: e.g. the
 signed attribute of ``Metadata[Root]`` is known to be ``Root``.
 
 Currently Metadata API supports JSON as the file format.
@@ -87,9 +87,10 @@ class Metadata(Generic[T]):
     Provides methods to convert to and from dictionary, read and write to and
     from file and to create and verify metadata signatures.
 
-    Metadata[T] is a generic container type where T can be any one type of
-    [Root, Timestamp, Snapshot, Targets]. The purpose of this is to allow
-    static type checking of the signed attribute in code using Metadata::
+    ``Metadata[T]`` is a generic container type where T can be any one type of
+    [``Root``, ``Timestamp``, ``Snapshot``, ``Targets``]. The purpose of this
+    is to allow static type checking of the signed attribute in code using
+    Metadata::
 
         root_md = Metadata[Root].from_file("root.json")
         # root_md type is now Metadata[Root]. This means signed and its
@@ -99,17 +100,17 @@ class Metadata(Generic[T]):
 
     Using a type constraint is not required but not doing so means T is not a
     specific type so static typing cannot happen. Note that the type constraint
-    "[Root]" is not validated at runtime (as pure annotations are not available
+    ``[Root]`` is not validated at runtime (as pure annotations are not available
     then).
 
     *All parameters named below are not just constructor arguments but also
     instance attributes.*
 
     Args:
-        signed: The actual metadata payload, i.e. one of Targets, Snapshot,
-            Timestamp or Root.
-        signatures: An ordered dictionary of keyids to Signature objects, each
-            signing the canonical serialized representation of 'signed'.
+        signed: The actual metadata payload, i.e. one of ``Targets``,
+            ``Snapshot``, ``Timestamp`` or ``Root``.
+        signatures: An ordered dictionary of keyids to ``Signature`` objects, each
+            signing the canonical serialized representation of ``signed``.
     """
 
     def __init__(self, signed: T, signatures: Dict[str, Signature]):
@@ -118,7 +119,7 @@ class Metadata(Generic[T]):
 
     @classmethod
     def from_dict(cls, metadata: Dict[str, Any]) -> "Metadata[T]":
-        """Creates Metadata object from its dict representation.
+        """Creates ``Metadata`` object from its dict representation.
 
         Arguments:
             metadata: TUF metadata in dict representation.
@@ -130,7 +131,7 @@ class Metadata(Generic[T]):
             Destroys the metadata dict passed by reference.
 
         Returns:
-            A TUF Metadata object.
+            A TUF ``Metadata`` object.
         """
 
         # Dispatch to contained metadata class on metadata _type field.
@@ -174,12 +175,12 @@ class Metadata(Generic[T]):
 
         Arguments:
             filename: The path to read the file from.
-            deserializer: A MetadataDeserializer subclass instance that
+            deserializer: A ``MetadataDeserializer`` subclass instance that
                 implements the desired wireline format deserialization. Per
-                default a JSONDeserializer is used.
+                default a ``JSONDeserializer`` is used.
             storage_backend: An object that implements
-                securesystemslib.storage.StorageBackendInterface. Per default
-                a (local) FilesystemBackend is used.
+                ``securesystemslib.storage.StorageBackendInterface``.
+                Per default a (local) ``FilesystemBackend`` is used.
 
         Raises:
             exceptions.StorageError: The file cannot be read.
@@ -187,7 +188,7 @@ class Metadata(Generic[T]):
                 The file cannot be deserialized.
 
         Returns:
-            A TUF Metadata object.
+            A TUF ``Metadata`` object.
         """
 
         if storage_backend is None:
@@ -206,15 +207,15 @@ class Metadata(Generic[T]):
 
         Arguments:
             data: metadata content.
-            deserializer: MetadataDeserializer implementation to use. Default
-                is JSONDeserializer.
+            deserializer: ``MetadataDeserializer`` implementation to use.
+                Default is ``JSONDeserializer``.
 
         Raises:
             tuf.api.serialization.DeserializationError:
                 The file cannot be deserialized.
 
         Returns:
-            A TUF Metadata object.
+            A TUF ``Metadata`` object.
         """
 
         if deserializer is None:
@@ -239,8 +240,8 @@ class Metadata(Generic[T]):
         instead of re-serializing.
 
         Arguments:
-            serializer: A MetadataSerializer instance that implements the
-                desired serialization format. Default is JSONSerializer.
+            serializer: A ``MetadataSerializer`` instance that implements the
+                desired serialization format. Default is ``JSONSerializer``.
 
         Raises:
             tuf.api.serialization.SerializationError:
@@ -280,10 +281,10 @@ class Metadata(Generic[T]):
 
         Arguments:
             filename: The path to write the file to.
-            serializer: A MetadataSerializer instance that implements the
-                desired serialization format. Default is JSONSerializer.
-            storage_backend: A StorageBackendInterface implementation. Default
-                is FilesystemBackend (i.e. a local file).
+            serializer: A ``MetadataSerializer`` instance that implements the
+                desired serialization format. Default is ``JSONSerializer``.
+            storage_backend: A ``StorageBackendInterface`` implementation. Default
+                is ``FilesystemBackend`` (i.e. a local file).
 
         Raises:
             tuf.api.serialization.SerializationError:
@@ -304,23 +305,23 @@ class Metadata(Generic[T]):
         append: bool = False,
         signed_serializer: Optional[SignedSerializer] = None,
     ) -> Signature:
-        """Creates signature over 'signed' and assigns it to 'signatures'.
+        """Creates signature over ``signed`` and assigns it to ``signatures``.
 
         Arguments:
             signer: A securesystemslib.signer.Signer implementation.
             append: A boolean indicating if the signature should be appended to
                 the list of signatures or replace any existing signatures. The
                 default behavior is to replace signatures.
-            signed_serializer: A SignedSerializer that implements the desired
-                serialization format. Default is CanonicalJSONSerializer.
+            signed_serializer: A ``SignedSerializer`` that implements the desired
+                serialization format. Default is ``CanonicalJSONSerializer``.
 
         Raises:
             tuf.api.serialization.SerializationError:
-                'signed' cannot be serialized.
+                ``signed`` cannot be serialized.
             exceptions.UnsignedMetadataError: Signing errors.
 
         Returns:
-            Securesystemslib Signature object that was added into signatures.
+            ``securesystemslib.signer.Signature`` object that was added into signatures.
         """
 
         if signed_serializer is None:
@@ -352,18 +353,18 @@ class Metadata(Generic[T]):
         delegated_metadata: "Metadata",
         signed_serializer: Optional[SignedSerializer] = None,
     ) -> None:
-        """Verifies that 'delegated_metadata' is signed with the required
-        threshold of keys for the delegated role 'delegated_role'.
+        """Verifies that ``delegated_metadata`` is signed with the required
+        threshold of keys for the delegated role ``delegated_role``.
 
         Args:
             delegated_role: Name of the delegated role to verify
-            delegated_metadata: The Metadata object for the delegated role
+            delegated_metadata: The ``Metadata`` object for the delegated role
             signed_serializer: serializer used for delegate
-                serialization. Default is CanonicalJSONSerializer.
+                serialization. Default is ``CanonicalJSONSerializer``.
 
         Raises:
-            UnsignedMetadataError: 'delegate' was not signed with required
-                threshold of keys for 'role_name'
+            UnsignedMetadataError: ``delegated_role`` was not signed with
+                required threshold of keys for ``role_name``
         """
 
         # Find the keys and role in delegator metadata
@@ -403,7 +404,7 @@ class Metadata(Generic[T]):
 class Signed(metaclass=abc.ABCMeta):
     """A base class for the signed part of TUF metadata.
 
-    Objects with base class Signed are usually included in a Metadata object
+    Objects with base class Signed are usually included in a ``Metadata`` object
     on the signed attribute. This class provides attributes and methods that
     are common for all TUF metadata types (roles).
 
@@ -485,11 +486,11 @@ class Signed(metaclass=abc.ABCMeta):
     def _common_fields_from_dict(
         cls, signed_dict: Dict[str, Any]
     ) -> Tuple[int, str, datetime]:
-        """Returns common fields of 'Signed' instances from the passed dict
+        """Returns common fields of ``Signed`` instances from the passed dict
         representation, and returns an ordered list to be passed as leading
         positional arguments to a subclass constructor.
 
-        See '{Root, Timestamp, Snapshot, Targets}.from_dict' methods for usage.
+        See ``{Root, Timestamp, Snapshot, Targets}.from_dict`` methods for usage.
 
         """
         _type = signed_dict.pop("_type")
@@ -507,9 +508,9 @@ class Signed(metaclass=abc.ABCMeta):
         return version, spec_version, expires
 
     def _common_fields_to_dict(self) -> Dict[str, Any]:
-        """Returns dict representation of common fields of 'Signed' instances.
+        """Returns dict representation of common fields of ``Signed`` instances.
 
-        See '{Root, Timestamp, Snapshot, Targets}.to_dict' methods for usage.
+        See ``{Root, Timestamp, Snapshot, Targets}.to_dict`` methods for usage.
 
         """
         return {
@@ -528,7 +529,7 @@ class Signed(metaclass=abc.ABCMeta):
                 datetime in UTC expected. Default is current UTC date and time.
 
         Returns:
-            True if expiration time is less than the reference time.
+            ``True`` if expiration time is less than the reference time.
         """
         if reference_time is None:
             reference_time = datetime.utcnow()
@@ -540,7 +541,7 @@ class Key:
     """A container class representing the public portion of a Key.
 
     Supported key content (type, scheme and keyval) is defined in
-    Securesystemslib.
+    `` Securesystemslib``.
 
     *All parameters named below are not just constructor arguments but also
     instance attributes.*
@@ -579,7 +580,7 @@ class Key:
 
     @classmethod
     def from_dict(cls, keyid: str, key_dict: Dict[str, Any]) -> "Key":
-        """Creates Key object from its dict representation.
+        """Creates ``Key`` object from its dict representation.
 
         Raises:
             KeyError, TypeError: Invalid arguments.
@@ -600,7 +601,7 @@ class Key:
         }
 
     def to_securesystemslib_key(self) -> Dict[str, Any]:
-        """Returns a Securesystemslib compatible representation of self."""
+        """Returns a ``Securesystemslib`` compatible representation of self."""
         return {
             "keyid": self.keyid,
             "keytype": self.keytype,
@@ -610,7 +611,7 @@ class Key:
 
     @classmethod
     def from_securesystemslib_key(cls, key_dict: Dict[str, Any]) -> "Key":
-        """Creates a Key object from a securesystemlib key dict representation
+        """Creates a ``Key`` object from a securesystemlib key dict representation
         removing the private key from keyval.
 
         Args:
@@ -633,13 +634,13 @@ class Key:
         metadata: Metadata,
         signed_serializer: Optional[SignedSerializer] = None,
     ) -> None:
-        """Verifies that the 'metadata.signatures' contains a signature made
-        with this key, correctly signing 'metadata.signed'.
+        """Verifies that the ``metadata.signatures`` contains a signature made
+        with this key, correctly signing ``metadata.signed``.
 
         Arguments:
             metadata: Metadata to verify
-            signed_serializer: SignedSerializer to serialize
-                'metadata.signed' with. Default is CanonicalJSONSerializer.
+            signed_serializer: ``SignedSerializer`` to serialize
+                ``metadata.signed`` with. Default is ``CanonicalJSONSerializer``.
 
         Raises:
             UnsignedMetadataError: The signature could not be verified for a
@@ -711,7 +712,7 @@ class Role:
 
     @classmethod
     def from_dict(cls, role_dict: Dict[str, Any]) -> "Role":
-        """Creates Role object from its dict representation.
+        """Creates ``Role`` object from its dict representation.
 
         Raises:
             ValueError, KeyError: Invalid arguments.
@@ -739,10 +740,10 @@ class Root(Signed):
         version: The metadata version number.
         spec_version: The supported TUF specification version number.
         expires: The metadata expiry date.
-        keys: Dictionary of keyids to Keys. Defines the keys used in 'roles'.
+        keys: Dictionary of keyids to Keys. Defines the keys used in ``roles``.
         roles: Dictionary of role names to Roles. Defines which keys are
             required to sign the metadata for a specific role.
-        consistent_snapshot: Does repository support consistent snapshots.
+        consistent_snapshot: ``True`` if repository supports consistent snapshots.
         unrecognized_fields: Dictionary of all unrecognized fields.
 
     Raises:
@@ -772,7 +773,7 @@ class Root(Signed):
 
     @classmethod
     def from_dict(cls, signed_dict: Dict[str, Any]) -> "Root":
-        """Creates Root object from its dict representation.
+        """Creates ``Root`` object from its dict representation.
 
         Raises:
             ValueError, KeyError, TypeError: Invalid arguments.
@@ -809,14 +810,14 @@ class Root(Signed):
         return root_dict
 
     def add_key(self, role: str, key: Key) -> None:
-        """Adds new signing key for delegated role 'role'.
+        """Adds new signing key for delegated role ``role``.
 
         Args:
-            role: The name of the role, for which 'key' is added.
-            key: The signing key to be added for 'role'.
+            role: The name of the role, for which ``key`` is added.
+            key: The signing key to be added for ``role``.
 
         Raises:
-            ValueError: If 'role' doesn't exist.
+            ValueError: If ``role`` doesn't exist.
         """
         if role not in self.roles:
             raise ValueError(f"Role {role} doesn't exist")
@@ -825,14 +826,14 @@ class Root(Signed):
         self.keys[key.keyid] = key
 
     def remove_key(self, role: str, keyid: str) -> None:
-        """Removes key from 'role' and updates the key store.
+        """Removes key from ``role`` and updates the key store.
 
         Args:
             role: The name of the role, for which a signing key is removed.
-            key: The identifier of the key to be removed for 'role'.
+            key: The identifier of the key to be removed for ``role``.
 
         Raises:
-            ValueError: If 'role' doesn't exist or if 'role' doesn't include
+            ValueError: If ``role`` doesn't exist or if ``role`` doesn't include
                 the key.
         """
         if role not in self.roles:
@@ -848,7 +849,7 @@ class Root(Signed):
 
 
 class BaseFile:
-    """A base class of MetaFile and TargetFile.
+    """A base class of ``MetaFile`` and ``TargetFile``.
 
     Encapsulates common static methods for length and hash verification.
     """
@@ -857,7 +858,7 @@ class BaseFile:
     def _verify_hashes(
         data: Union[bytes, IO[bytes]], expected_hashes: Dict[str, str]
     ) -> None:
-        """Verifies that the hash of 'data' matches 'expected_hashes'"""
+        """Verifies that the hash of ``data`` matches ``expected_hashes``"""
         is_bytes = isinstance(data, bytes)
         for algo, exp_hash in expected_hashes.items():
             try:
@@ -886,7 +887,7 @@ class BaseFile:
     def _verify_length(
         data: Union[bytes, IO[bytes]], expected_length: int
     ) -> None:
-        """Verifies that the length of 'data' matches 'expected_length'"""
+        """Verifies that the length of ``data`` matches ``expected_length``"""
         if isinstance(data, bytes):
             observed_length = len(data)
         else:
@@ -953,7 +954,7 @@ class MetaFile(BaseFile):
 
     @classmethod
     def from_dict(cls, meta_dict: Dict[str, Any]) -> "MetaFile":
-        """Creates MetaFile object from its dict representation.
+        """Creates ``MetaFile`` object from its dict representation.
 
         Raises:
             ValueError, KeyError: Invalid arguments.
@@ -981,7 +982,7 @@ class MetaFile(BaseFile):
         return res_dict
 
     def verify_length_and_hashes(self, data: Union[bytes, IO[bytes]]) -> None:
-        """Verifies that the length and hashes of "data" match expected values.
+        """Verifies that the length and hashes of ``data`` match expected values.
 
         Args:
             data: File object or its content in bytes.
@@ -1001,7 +1002,7 @@ class Timestamp(Signed):
     """A container for the signed part of timestamp metadata.
 
     TUF file format uses a dictionary to contain the snapshot information:
-    this is not the case with Timestamp.snapshot_meta which is a MetaFile.
+    this is not the case with ``Timestamp.snapshot_meta`` which is a ``MetaFile``.
 
     *All parameters named below are not just constructor arguments but also
     instance attributes.*
@@ -1032,7 +1033,7 @@ class Timestamp(Signed):
 
     @classmethod
     def from_dict(cls, signed_dict: Dict[str, Any]) -> "Timestamp":
-        """Creates Timestamp object from its dict representation.
+        """Creates ``Timestamp`` object from its dict representation.
 
         Raises:
             ValueError, KeyError: Invalid arguments.
@@ -1063,7 +1064,7 @@ class Snapshot(Signed):
         spec_version: The supported TUF specification version number.
         expires: The metadata expiry date.
         unrecognized_fields: Dictionary of all unrecognized fields.
-        meta: A dictionary of target metadata filenames to MetaFile objects.
+        meta: A dictionary of target metadata filenames to ``MetaFile`` objects.
 
     Raises:
         ValueError: Invalid arguments.
@@ -1084,7 +1085,7 @@ class Snapshot(Signed):
 
     @classmethod
     def from_dict(cls, signed_dict: Dict[str, Any]) -> "Snapshot":
-        """Creates Snapshot object from its dict representation.
+        """Creates ``Snapshot`` object from its dict representation.
 
         Raises:
             ValueError, KeyError: Invalid arguments.
@@ -1113,12 +1114,12 @@ class DelegatedRole(Role):
 
     A delegation can happen in two ways:
 
-        - paths is set: delegates targets matching any path pattern in paths
-        - path_hash_prefixes is set: delegates targets whose target path hash
-          starts with any of the prefixes in path_hash_prefixes
+        - ``paths`` is set: delegates targets matching any path pattern in ``paths``
+        - ``path_hash_prefixes`` is set: delegates targets whose target path hash
+          starts with any of the prefixes in ``path_hash_prefixes``
 
-        paths and path_hash_prefixes are mutually exclusive: both cannot be set,
-        at least one of them must be set.
+        ``paths`` and ``path_hash_prefixes`` are mutually exclusive: both cannot be
+        set, at least one of them must be set.
 
     *All parameters named below are not just constructor arguments but also
     instance attributes.*
@@ -1127,7 +1128,7 @@ class DelegatedRole(Role):
         name: Delegated role name.
         keyids: Delegated role signing key identifiers.
         threshold: Number of keys required to sign this role's metadata.
-        terminating: Does this delegation terminate a target lookup.
+        terminating: ``True`` if this delegation terminates a target lookup.
         paths: Path patterns. See note above.
         path_hash_prefixes: Hash prefixes. See note above.
         unrecognized_fields: Attributes not managed by TUF Metadata API.
@@ -1167,7 +1168,7 @@ class DelegatedRole(Role):
 
     @classmethod
     def from_dict(cls, role_dict: Dict[str, Any]) -> "DelegatedRole":
-        """Creates DelegatedRole object from its dict representation.
+        """Creates ``DelegatedRole`` object from its dict representation.
 
         Raises:
             ValueError, KeyError: Invalid arguments.
@@ -1205,7 +1206,7 @@ class DelegatedRole(Role):
 
     @staticmethod
     def _is_target_in_pathpattern(targetpath: str, pathpattern: str) -> bool:
-        """Determines whether "targetname" matches the "pathpattern"."""
+        """Determines whether ``targetname`` matches the ``pathpattern``."""
         # We need to make sure that targetname and pathpattern are pointing to
         # the same directory as fnmatch doesn't threat "/" as a special symbol.
         target_parts = targetpath.split("/")
@@ -1222,11 +1223,11 @@ class DelegatedRole(Role):
         return True
 
     def is_delegated_path(self, target_filepath: str) -> bool:
-        """Determines whether the given 'target_filepath' is in one of
-        the paths that DelegatedRole is trusted to provide.
+        """Determines whether the given ``target_filepath`` is in one of
+        the paths that ``DelegatedRole`` is trusted to provide.
 
-        The target_filepath and the DelegatedRole paths are expected to be in
-        their canonical forms, so e.g. "a/b" instead of "a//b" . Only "/" is
+        The ``target_filepath`` and the ``DelegatedRole`` paths are expected to be
+        in their canonical forms, so e.g. "a/b" instead of "a//b" . Only "/" is
         supported as target path separator. Leading separators are not handled
         as special cases (see `TUF specification on targetpath
         <https://theupdateframework.github.io/specification/latest/#targetpath>`_).
@@ -1264,7 +1265,7 @@ class Delegations:
     instance attributes.*
 
     Args:
-        keys: Dictionary of keyids to Keys. Defines the keys used in 'roles'.
+        keys: Dictionary of keyids to Keys. Defines the keys used in ``roles``.
         roles: Ordered dictionary of role names to DelegatedRoles instances. It
             defines which keys are required to sign the metadata for a specific
             role. The roles order also defines the order that role delegations
@@ -1294,7 +1295,7 @@ class Delegations:
 
     @classmethod
     def from_dict(cls, delegations_dict: Dict[str, Any]) -> "Delegations":
-        """Creates Delegations object from its dict representation.
+        """Creates ``Delegations`` object from its dict representation.
 
         Raises:
             ValueError, KeyError, TypeError: Invalid arguments.
@@ -1365,7 +1366,7 @@ class TargetFile(BaseFile):
 
     @classmethod
     def from_dict(cls, target_dict: Dict[str, Any], path: str) -> "TargetFile":
-        """Creates TargetFile object from its dict representation.
+        """Creates ``TargetFile`` object from its dict representation.
 
         Raises:
             ValueError, KeyError, TypeError: Invalid arguments.
@@ -1391,7 +1392,7 @@ class TargetFile(BaseFile):
         local_path: str,
         hash_algorithms: Optional[List[str]] = None,
     ) -> "TargetFile":
-        """Creates TargetFile object from a file.
+        """Creates ``TargetFile`` object from a file.
 
         Arguments:
             target_file_path: URL path to a target file, relative to a base
@@ -1414,7 +1415,7 @@ class TargetFile(BaseFile):
         data: Union[bytes, IO[bytes]],
         hash_algorithms: Optional[List[str]] = None,
     ) -> "TargetFile":
-        """Creates TargetFile object from bytes.
+        """Creates ``TargetFile`` object from bytes.
 
         Arguments:
             target_file_path: URL path to a target file, relative to a base
@@ -1458,7 +1459,7 @@ class TargetFile(BaseFile):
         return cls(length, hashes, target_file_path)
 
     def verify_length_and_hashes(self, data: Union[bytes, IO[bytes]]) -> None:
-        """Verifies that length and hashes of "data" match expected values.
+        """Verifies that length and hashes of ``data`` match expected values.
 
         Args:
             data: File object or its content in bytes.
@@ -1511,7 +1512,7 @@ class Targets(Signed):
 
     @classmethod
     def from_dict(cls, signed_dict: Dict[str, Any]) -> "Targets":
-        """Creates Targets object from its dict representation.
+        """Creates ``Targets`` object from its dict representation.
 
         Raises:
             ValueError, KeyError, TypeError: Invalid arguments.
@@ -1544,14 +1545,14 @@ class Targets(Signed):
         return targets_dict
 
     def add_key(self, role: str, key: Key) -> None:
-        """Adds new signing key for delegated role 'role'.
+        """Adds new signing key for delegated role ``role``.
 
         Args:
-            role: The name of the role, for which 'key' is added.
-            key: The signing key to be added for 'role'.
+            role: The name of the role, for which ``key`` is added.
+            key: The signing key to be added for ``role``.
 
         Raises:
-            ValueError: If there are no delegated roles or if 'role' is not
+            ValueError: If there are no delegated roles or if ``role`` is not
                 delegated by this Target.
         """
         if self.delegations is None or role not in self.delegations.roles:
@@ -1561,16 +1562,16 @@ class Targets(Signed):
         self.delegations.keys[key.keyid] = key
 
     def remove_key(self, role: str, keyid: str) -> None:
-        """Removes key from delegated role 'role' and updates the delegations
+        """Removes key from delegated role ``role`` and updates the delegations
         key store.
 
         Args:
             role: The name of the role, for which a signing key is removed.
-            key: The identifier of the key to be removed for 'role'.
+            key: The identifier of the key to be removed for ``role``.
 
         Raises:
-            ValueError: If there are no delegated roles or if 'role' is not
-                delegated by this Target or if key is not used by 'role'.
+            ValueError: If there are no delegated roles or if ``role`` is not
+                delegated by this ``Target`` or if key is not used by ``role``.
         """
         if self.delegations is None or role not in self.delegations.roles:
             raise ValueError(f"Delegated role {role} doesn't exist")


### PR DESCRIPTION
This change updates some obvious and unnecessary fields docs in the
Metadata API with more despriptive details, as well as unifies
syntax between different classes and methods

Addresses #1600

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [n/a] Tests have been added for the bug fix or new feature
- [n/a] Docs have been added for the bug fix or new feature


