### PR TITLE
github: disable pip caching temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: 'requirements*.txt'
+          # cache: 'pip'
+          # cache-dependency-path: 'requirements*.txt'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This is a temporary workaround until Github fixes either setup-python or the Windows image... If we merge this, let's file an issue to revert the workaround later.


---

setup-python fails on Windows currently
(https://github.com/actions/virtual-environments/issues/5009)
Disable caching to workaround the failure.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>
