### PR TITLE
Revert "github: disable pip caching temporarily"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-          # cache: 'pip'
-          # cache-dependency-path: 'requirements*.txt'
+          cache: 'pip'
+          cache-dependency-path: 'requirements*.txt'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This reverts commit 55d6cb47da9d2eb3bd6ebdbc3b93a5b8884d9454.

According to changelog setup-python v2.3.2 should include a workaround
for the issue.
