### PR TITLE
Update supported specification version to 1.0.28

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -74,7 +74,7 @@ logger = logging.getLogger(__name__)
 
 # We aim to support SPECIFICATION_VERSION and require the input metadata
 # files to have the same major version (the first number) as ours.
-SPECIFICATION_VERSION = ["1", "0", "19"]
+SPECIFICATION_VERSION = ["1", "0", "28"]
 TOP_LEVEL_ROLE_NAMES = {_ROOT, _TIMESTAMP, _SNAPSHOT, _TARGETS}
 
 # T is a Generic type constraint for Metadata.signed


### PR DESCRIPTION
Fixes #1763

**Description of the changes being introduced by the pull request**:

I looked into all changes between our current version 1.0.19 and the
current version of the specification 1.0.28 and I agree with Jussi that
the only one not fully resolved is:
"8dafd00 (tag: v1.0.24) Clarify optional attributes" and more precisely
the changes from commit:
https://github.com/theupdateframework/specification/pull/165/commits/4dd279bc318afaea9c069b265c0468e235df0192

It doesn't make sense to have a target file without "paths" or
"path_hash_prefixes", so our `python-tuf` requirement to have at least
one of them set makes sense.

Both with Jussi we agreed that we can easily loosen this requirement if
when solving https://github.com/theupdateframework/specification/issues/200
it's decided that both of them can be omitted, but for now,
we decided it's better to stick to our current requirement to have one of them set.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


