### PR TITLE
github: Pin actions hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,10 @@ jobs:
 
     steps:
       - name: Checkout TUF
-        uses: actions/checkout@v2
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/.github/workflows/maintainer-permissions-reminder.yml
+++ b/.github/workflows/maintainer-permissions-reminder.yml
@@ -13,7 +13,7 @@ jobs:
     name: File issue to review maintainer permissions
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/github-script@v5
+    - uses: actions/github-script@e3cbab99d3a9b271e1b79fc96d103a4a5534998c
       with:
         script: |
           await github.rest.issues.create({

--- a/.github/workflows/specification-version.yml
+++ b/.github/workflows/specification-version.yml
@@ -14,8 +14,8 @@ jobs:
     name: Open an issue when spec version bumps
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+    - uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a
     - name: Get supported version
       id: get-version
       run: |
@@ -25,7 +25,7 @@ jobs:
         ver=$(python3 -c "$script")
         echo "::set-output name=version::$ver"
     - name: Open issue (if needed)
-      uses: actions/github-script@v5
+      uses: actions/github-script@e3cbab99d3a9b271e1b79fc96d103a4a5534998c
       with:
         script: |
           const release = await github.rest.repos.getLatestRelease({


### PR DESCRIPTION
This allows us to control when our workflows change.
Dependabot should now open PRs when the actions update.

This still leaves the actual OS image as a variable but Github does not
support pinning that: we'd have to start using our own containers (and
installing our own pythons, etc) to do that -- not worth the trouble.

Fixes #1826

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>
