### PR TITLE
Add missing small tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -639,6 +639,13 @@ class TestMetadata(unittest.TestCase):
         with self.assertRaises(ValueError):
             TargetFile.from_file(file_path, file_path, ["123"])
 
+    def test_targetfile_custom(self) -> None:
+        # Test creating TargetFile and accessing custom.
+        targetfile = TargetFile(
+            100, {"sha256": "abc"}, "file.txt", {"custom": "foo"}
+        )
+        self.assertEqual(targetfile.custom, "foo")
+
     def test_targetfile_from_data(self) -> None:
         data = b"Inline test content"
         target_file_path = os.path.join(

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -214,6 +214,7 @@ class TestSerialization(unittest.TestCase):
 
     invalid_metafiles: utils.DataSet = {
         "wrong length type": '{"version": 1, "length": "a", "hashes": {"sha256" : "abc"}}',
+        "version 0": '{"version": 0, "length": 1, "hashes": {"sha256" : "abc"}}',
         "length 0": '{"version": 1, "length": 0, "hashes": {"sha256" : "abc"}}',
         "length below 0": '{"version": 1, "length": -1, "hashes": {"sha256" : "abc"}}',
         "empty hashes dict": '{"version": 1, "length": 1, "hashes": {}}',


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

After running coveralls locally I noticed we don't test the MetaFile version
validation: https://github.com/theupdateframework/python-tuf/blob/ba911e07b21f69f10ade729216047f32e9b8c5b0/tuf/api/metadata.py#L915
and TargetFile custom access: https://github.com/theupdateframework/python-tuf/blob/ba911e07b21f69f10ade729216047f32e9b8c5b0/tuf/api/metadata.py#L1302
and I thought I will add them.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


