### PR TITLE
Re-add setup.py to fix dependabot

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,6 @@ include LICENSE*
 
 # Development and testing
 include *.txt
-global-include pylintrc
 include tox.ini
 graft tests
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+# This file exists to keep dependabot happy:
+# https://github.com/dependabot/dependabot-core/issues/4483
+from setuptools import setup
+setup()


### PR DESCRIPTION
This seems to fix the issue with dependabot (#1828) in my fork... There's also a unrelated trivial packaging fix included.

Also, reading the dependabot log I noticed there is one more dependency update I did not include in my latest dependency update PR (pycparser): I'll leave that unfixed for now, we can use it as confirmation that dependabot actually works.