### PR TITLE
verify_signature(): handle SerializationError

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -60,6 +60,7 @@ from tuf.api import exceptions
 from tuf.api.serialization import (
     MetadataDeserializer,
     MetadataSerializer,
+    SerializationError,
     SignedSerializer,
 )
 
@@ -670,6 +671,7 @@ class Key:
             sslib_exceptions.CryptoError,
             sslib_exceptions.FormatError,
             sslib_exceptions.UnsupportedAlgorithmError,
+            SerializationError,
         ) as e:
             raise exceptions.UnsignedMetadataError(
                 f"Failed to verify {self.keyid} signature"


### PR DESCRIPTION
Fixes #1816

**Description of the changes being introduced by the pull request**:

We should handle the possible SerializationError inside
Key.verify_signature(), because the user of this API is not interested
in SerializationError when he is trying to verify his signature.

Note that the SerializationError can be thrown when calling
signed_serializer.serialize() on the metadata signed part.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


