### PR TITLE
build: add license field to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ classifiers =
   Topic :: Security
   Topic :: Software Development
 keywords = update updater secure authentication key compromise revocation
+license = 'MIT or Apache License 2.0'
 license_files = LICENSE LICENSE-MIT
 
 [options]


### PR DESCRIPTION
List our licenses in the license field of setup.cfg

While the PyPA packaging documentation states that the license field is
optional[1] and that classifiers should be the main way to indicate
license, this field is used to populate the License printed by pip show.

1. https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#license

Fixes #1833

Signed-off-by: Joshua Lock <jlock@vmware.com>

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

Fixes #<ISSUE NUMBER>

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


