### PR TITLE
build: Remove docs build requirement version pin

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
-# Install requirements needed in for the documentation build
+# Install documentation build requirements
 
 # pinned tuf runtime dependencies (should auto-update and -trigger ci/cd)
 -r requirements-pinned.txt
@@ -6,9 +6,3 @@
 # install sphinx and its extensions
 sphinx
 sphinx-rtd-theme
-
-# Docutils versions >=0.17.0 have incompatibilites with
-# sphinx-rtd-theme and fail to render some features.
-# Pin the version until readthedocs release their fix
-# (readthedocs/sphinx_rtd_theme#1113).
-docutils<0.17.0


### PR DESCRIPTION
docutils is a sphinx-rtd-theme requirement: pinning was done
to workaround a bug that seems to now be fixed.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>
