### PR TITLE
Key.from_securesystemslib_key() raise ValueError

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -379,6 +379,11 @@ class TestMetadata(unittest.TestCase):
         key = Key.from_securesystemslib_key(sslib_key)
         self.assertFalse("private" in key.keyval.keys())
 
+        # Test raising ValueError with non-existent keytype
+        sslib_key["keytype"] = "bad keytype"
+        with self.assertRaises(ValueError):
+            Key.from_securesystemslib_key(sslib_key)
+
     def test_root_add_key_and_remove_key(self) -> None:
         root_path = os.path.join(self.repo_dir, "metadata", "root.json")
         root = Metadata[Root].from_file(root_path)

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -618,12 +618,22 @@ class Key:
 
         Args:
             key_dict: Key in securesystemlib dict representation.
+
+        Raises:
+            ValueError: ``key_dict`` value is not following the securesystemslib
+                format.
         """
-        key_meta = sslib_keys.format_keyval_to_metadata(
-            key_dict["keytype"],
-            key_dict["scheme"],
-            key_dict["keyval"],
-        )
+        try:
+            key_meta = sslib_keys.format_keyval_to_metadata(
+                key_dict["keytype"],
+                key_dict["scheme"],
+                key_dict["keyval"],
+            )
+        except sslib_exceptions.FormatError as e:
+            raise ValueError(
+                "key_dict value is not following the securesystemslib format"
+            ) from e
+
         return cls(
             key_dict["keyid"],
             key_meta["keytype"],


### PR DESCRIPTION
Fixes #1818 

**Description of the changes being introduced by the pull request**:

If a `securesystemslib.FormatError` is raised inside
`Key.from_securesystemslib_key()` then reraise `ValueError`.
This is done so that our users don't have to import securesystemslib
in order to handle the error and because the securesystemslib error
itself is securesystemslib implementation-specific.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


