### PR TITLE
doc: Remove inactive maintainers from MAINTAINERS

### DIFF
--- a/docs/MAINTAINERS.txt
+++ b/docs/MAINTAINERS.txt
@@ -35,3 +35,10 @@ Maintainers:
     Email: jkukkonen@vmware.com
     GitHub username: @jku
     PGP fingerprint: 1343 C98F AB84 859F E5EC  9E37 0527 D8A3 7F52 1A2F
+
+Emeritus Maintainers:
+
+  Sebastien Awwad
+  Vladimir Diaz
+  Teodora Sechkova
+  Santiago Torres-Arias

--- a/docs/MAINTAINERS.txt
+++ b/docs/MAINTAINERS.txt
@@ -10,11 +10,6 @@ Consensus Builder:
 
 Maintainers:
 
-  Sebastien Awwad
-    Email: sebastien.awwad@nyu.edu
-    GitHub username: @awwad
-    PGP fingerprint: C2FB 9C91 0758 B682 7BC4  3233 BC0C 6DED D5E5 CC03
-
   Marina Moore
     Email: mm9693@nyu.edu
     GitHub username: @mnm678
@@ -30,11 +25,6 @@ Maintainers:
     GitHub username: @lukpueh
     PGP fingerprint: 8BA6 9B87 D43B E294 F23E  8120 89A2 AD3C 07D9 62E8
 
-  Santiago Torres-Arias
-    Email: santiago@nyu.edu
-    GitHub username: @SantiagoTorres
-    PGP fingerprint: 903B AB73 640E B6D6 5533  EFF3 468F 122C E816 2295
-
   Joshua Lock
     Email: jlock@vmware.com
     GitHub username: @joshuagl
@@ -45,7 +35,3 @@ Maintainers:
     Email: jkukkonen@vmware.com
     GitHub username: @jku
     PGP fingerprint: 1343 C98F AB84 859F E5EC  9E37 0527 D8A3 7F52 1A2F
-
-  Teodora Sechkova
-    Email: tsechkova@vmware.com
-    GitHub username: @sechkova


### PR DESCRIPTION
Fixes #1793

**Description of the changes being introduced by the pull request**:
As discussed in detail in #1793, maintainer-level (GitHub) permissions should be granted to those who need them, i.e. who actively maintain the project at the moment. The MAINTAINERS.txt file should reflect that state.

It will be reviewed regularly (#1803), and can be changed (e.g. reverted to a prior state) at any time as need arises.

To express our appreciation for past efforts, we might use the [Acknowledgement section of the README](https://github.com/theupdateframework/python-tuf#acknowledgements), and also update it regularly.

In the case of this update: Big kudos to @awwad, @SantiagoTorres and @sechkova for all their valuable contributions to python-tuf!



**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


