### PR TITLE
Ngclient docstrings improvement

### DIFF
--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -1,8 +1,8 @@
 # Copyright 2021, New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""Provides an implementation of FetcherInterface using the Requests HTTP
-  library.
+"""Provides an implementation of ``FetcherInterface`` using the Requests
+  HTTP library.
 """
 
 import logging
@@ -22,11 +22,11 @@ logger = logging.getLogger(__name__)
 
 # Classes
 class RequestsFetcher(FetcherInterface):
-    """A concrete implementation of FetcherInterface based on the Requests
+    """A concrete implementation of ``FetcherInterface`` based on the Requests
     library.
 
     Attributes:
-        _sessions: A dictionary of Requests.Session objects storing a separate
+        _sessions: A dictionary of ``Requests.Session`` objects storing a separate
             session per scheme+hostname combination.
     """
 

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -22,8 +22,7 @@ logger = logging.getLogger(__name__)
 
 # Classes
 class RequestsFetcher(FetcherInterface):
-    """A concrete implementation of ``FetcherInterface`` based on the Requests
-    library.
+    """An implementation of ``FetcherInterface`` based on the requests library.
 
     Attributes:
         _sessions: Dictionary of ``Requests.Session`` objects storing a separate

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -54,7 +54,7 @@ class RequestsFetcher(FetcherInterface):
     def _fetch(self, url: str) -> Iterator[bytes]:
         """Fetches the contents of HTTP/HTTPS url from a remote server
 
-        Arguments:
+        Args:
             url: URL string that represents a file location.
 
         Raises:

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -26,7 +26,7 @@ class RequestsFetcher(FetcherInterface):
     library.
 
     Attributes:
-        _sessions: A dictionary of ``Requests.Session`` objects storing a separate
+        _sessions: Dictionary of ``Requests.Session`` objects storing a separate
             session per scheme+hostname combination.
     """
 
@@ -55,15 +55,15 @@ class RequestsFetcher(FetcherInterface):
         """Fetches the contents of HTTP/HTTPS url from a remote server
 
         Arguments:
-            url: A URL string that represents a file location.
+            url: URL string that represents a file location.
 
         Raises:
-            exceptions.SlowRetrievalError: A timeout occurs while receiving
+            exceptions.SlowRetrievalError: Timeout occurs while receiving
                 data.
-            exceptions.DownloadHTTPError: An HTTP error code is received.
+            exceptions.DownloadHTTPError: HTTP error code is received.
 
         Returns:
-            A bytes iterator
+            Bytes iterator
         """
         # Get a customized session for each new schema+hostname combination.
         session = self._get_session(url)

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -3,17 +3,17 @@
 
 """Trusted collection of client-side TUF Metadata
 
-TrustedMetadataSet keeps track of the current valid set of metadata for the
+``TrustedMetadataSet`` keeps track of the current valid set of metadata for the
 client, and handles almost every step of the "Detailed client workflow" (
 https://theupdateframework.github.io/specification/latest#detailed-client-workflow)
 in the TUF specification: the remaining steps are related to filesystem and
 network IO, which are not handled here.
 
 Loaded metadata can be accessed via index access with rolename as key
-(trusted_set[Root.type]) or, in the case of top-level metadata, using the helper
-properties (trusted_set.root).
+(``trusted_set[Root.type]``) or, in the case of top-level metadata, using the helper
+properties (``trusted_set.root``).
 
-The rules that TrustedMetadataSet follows for top-level metadata are
+The rules that ``TrustedMetadataSet`` follows for top-level metadata are
  * Metadata must be loaded in order:
    root -> timestamp -> snapshot -> targets -> (delegated targets).
  * Metadata can be loaded even if it is expired (or in the snapshot case if the
@@ -71,20 +71,20 @@ logger = logging.getLogger(__name__)
 
 
 class TrustedMetadataSet(abc.Mapping):
-    """Internal class to keep track of trusted metadata in Updater
+    """Internal class to keep track of trusted metadata in ``Updater``
 
-    TrustedMetadataSet ensures that the collection of metadata in it is valid
+    ``TrustedMetadataSet`` ensures that the collection of metadata in it is valid
     and trusted through the whole client update workflow. It provides easy ways
     to update the metadata with the caller making decisions on what is updated.
     """
 
     def __init__(self, root_data: bytes):
-        """Initialize TrustedMetadataSet by loading trusted root metadata
+        """Initialize ``TrustedMetadataSet`` by loading trusted root metadata
 
         Args:
             root_data: Trusted root metadata as bytes. Note that this metadata
                 will only be verified by itself: it is the source of trust for
-                all metadata in the TrustedMetadataSet
+                all metadata in the ``TrustedMetadataSet``
 
         Raises:
             RepositoryError: Metadata failed to load or verify. The actual
@@ -99,44 +99,44 @@ class TrustedMetadataSet(abc.Mapping):
         self._load_trusted_root(root_data)
 
     def __getitem__(self, role: str) -> Metadata:
-        """Returns current Metadata for 'role'"""
+        """Returns current ``Metadata`` for ``role``"""
         return self._trusted_set[role]
 
     def __len__(self) -> int:
-        """Returns number of Metadata objects in TrustedMetadataSet"""
+        """Returns number of ``Metadata`` objects in ``TrustedMetadataSet``"""
         return len(self._trusted_set)
 
     def __iter__(self) -> Iterator[Metadata]:
-        """Returns iterator over all Metadata objects in TrustedMetadataSet"""
+        """Returns iterator over all ``Metadata`` objects in ``TrustedMetadataSet``"""
         return iter(self._trusted_set.values())
 
     # Helper properties for top level metadata
     @property
     def root(self) -> Metadata[Root]:
-        """Current root Metadata"""
+        """Current root ``Metadata``"""
         return self._trusted_set[Root.type]
 
     @property
     def timestamp(self) -> Optional[Metadata[Timestamp]]:
-        """Current timestamp Metadata or None"""
+        """Current timestamp ``Metadata`` or ``None``"""
         return self._trusted_set.get(Timestamp.type)
 
     @property
     def snapshot(self) -> Optional[Metadata[Snapshot]]:
-        """Current snapshot Metadata or None"""
+        """Current snapshot ``Metadata`` or ``None``"""
         return self._trusted_set.get(Snapshot.type)
 
     @property
     def targets(self) -> Optional[Metadata[Targets]]:
-        """Current targets Metadata or None"""
+        """Current targets ``Metadata`` or ``None``"""
         return self._trusted_set.get(Targets.type)
 
     # Methods for updating metadata
     def update_root(self, data: bytes) -> Metadata[Root]:
-        """Verifies and loads 'data' as new root metadata.
+        """Verifies and loads ``data`` as new root metadata.
 
         Note that an expired intermediate root is considered valid: expiry is
-        only checked for the final root in update_timestamp().
+        only checked for the final root in ``update_timestamp()``.
 
         Args:
             data: unverified new root metadata as bytes
@@ -147,7 +147,7 @@ class TrustedMetadataSet(abc.Mapping):
                 error type and content will contain more details.
 
         Returns:
-            Deserialized and verified root Metadata object
+            Deserialized and verified root ``Metadata`` object
         """
         if self.timestamp is not None:
             raise RuntimeError("Cannot update root after timestamp")
@@ -178,14 +178,14 @@ class TrustedMetadataSet(abc.Mapping):
         return new_root
 
     def update_timestamp(self, data: bytes) -> Metadata[Timestamp]:
-        """Verifies and loads 'data' as new timestamp metadata.
+        """Verifies and loads ``data`` as new timestamp metadata.
 
         Note that an intermediate timestamp is allowed to be expired:
-        TrustedMetadataSet will throw an ExpiredMetadataError in this case
-        but the intermediate timestamp will be loaded. This way a newer
-        timestamp can still be loaded (and the intermediate timestamp will
-        be used for rollback protection). Expired timestamp will prevent
-        loading snapshot metadata.
+        ``TrustedMetadataSet`` will throw an ``ExpiredMetadataError`` in
+        this case but the intermediate timestamp will be loaded. This way
+        a newer timestamp can still be loaded (and the intermediate
+        timestamp will be used for rollback protection). Expired timestamp
+        will prevent loading snapshot metadata.
 
         Args:
             data: unverified new timestamp metadata as bytes
@@ -197,7 +197,7 @@ class TrustedMetadataSet(abc.Mapping):
                 more details.
 
         Returns:
-            Deserialized and verified timestamp Metadata object
+            Deserialized and verified timestamp ``Metadata`` object
         """
         if self.snapshot is not None:
             raise RuntimeError("Cannot update timestamp after snapshot")
@@ -256,12 +256,12 @@ class TrustedMetadataSet(abc.Mapping):
     def update_snapshot(
         self, data: bytes, trusted: Optional[bool] = False
     ) -> Metadata[Snapshot]:
-        """Verifies and loads 'data' as new snapshot metadata.
+        """Verifies and loads ``data`` as new snapshot metadata.
 
         Note that an intermediate snapshot is allowed to be expired and version
         is allowed to not match timestamp meta version: TrustedMetadataSet will
-        throw an ExpiredMetadataError/BadVersionNumberError in these cases
-        but the intermediate snapshot will be loaded. This way a newer
+        throw an ``ExpiredMetadataError``/``BadVersionNumberError`` in these
+        cases but the intermediate snapshot will be loaded. This way a newer
         snapshot can still be loaded (and the intermediate snapshot will
         be used for rollback protection). Expired snapshot or snapshot that
         does not match timestamp meta version will prevent loading targets.
@@ -269,8 +269,8 @@ class TrustedMetadataSet(abc.Mapping):
         Args:
             data: unverified new snapshot metadata as bytes
             trusted: whether data has at some point been verified by
-                TrustedMetadataSet as a valid snapshot. Purpose of trusted is
-                to allow loading of locally stored snapshot as intermediate
+                ``TrustedMetadataSet`` as a valid snapshot. Purpose of trusted
+                is to allow loading of locally stored snapshot as intermediate
                 snapshot even if hashes in current timestamp meta no longer
                 match data. Default is False.
 
@@ -281,7 +281,7 @@ class TrustedMetadataSet(abc.Mapping):
                 The actual error type and content will contain more details.
 
         Returns:
-            Deserialized and verified snapshot Metadata object
+            Deserialized and verified snapshot ``Metadata`` object
         """
 
         if self.timestamp is None:
@@ -356,7 +356,7 @@ class TrustedMetadataSet(abc.Mapping):
             )
 
     def update_targets(self, data: bytes) -> Metadata[Targets]:
-        """Verifies and loads 'data' as new top-level targets metadata.
+        """Verifies and loads ``data`` as new top-level targets metadata.
 
         Args:
             data: unverified new targets metadata as bytes
@@ -366,14 +366,14 @@ class TrustedMetadataSet(abc.Mapping):
                 error type and content will contain more details.
 
         Returns:
-            Deserialized and verified targets Metadata object
+            Deserialized and verified targets ``Metadata`` object
         """
         return self.update_delegated_targets(data, Targets.type, Root.type)
 
     def update_delegated_targets(
         self, data: bytes, role_name: str, delegator_name: str
     ) -> Metadata[Targets]:
-        """Verifies and loads 'data' as new metadata for target 'role_name'.
+        """Verifies and loads ``data`` as new metadata for target ``role_name``.
 
         Args:
             data: unverified new metadata as bytes
@@ -386,7 +386,7 @@ class TrustedMetadataSet(abc.Mapping):
                 error type and content will contain more details.
 
         Returns:
-            Deserialized and verified targets Metadata object
+            Deserialized and verified targets ``Metadata`` object
         """
         if self.snapshot is None:
             raise RuntimeError("Cannot load targets before snapshot")
@@ -434,10 +434,10 @@ class TrustedMetadataSet(abc.Mapping):
         return new_delegate
 
     def _load_trusted_root(self, data: bytes) -> None:
-        """Verifies and loads 'data' as trusted root metadata.
+        """Verifies and loads ``data`` as trusted root metadata.
 
         Note that an expired initial root is considered valid: expiry is
-        only checked for the final root in update_timestamp().
+        only checked for the final root in ``update_timestamp()``.
         """
         new_root = Metadata[Root].from_bytes(data)
 

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -10,8 +10,8 @@ in the TUF specification: the remaining steps are related to filesystem and
 network IO, which are not handled here.
 
 Loaded metadata can be accessed via index access with rolename as key
-(``trusted_set[Root.type]``) or, in the case of top-level metadata, using the helper
-properties (``trusted_set.root``).
+(``trusted_set[Root.type]``) or, in the case of top-level metadata, using the
+helper properties (``trusted_set.root``).
 
 The rules that ``TrustedMetadataSet`` follows for top-level metadata are
  * Metadata must be loaded in order:
@@ -107,7 +107,7 @@ class TrustedMetadataSet(abc.Mapping):
         return len(self._trusted_set)
 
     def __iter__(self) -> Iterator[Metadata]:
-        """Returns iterator over all ``Metadata`` objects in ``TrustedMetadataSet``"""
+        """Returns iterator over ``Metadata`` objects in ``TrustedMetadataSet``"""
         return iter(self._trusted_set.values())
 
     # Helper properties for top level metadata
@@ -259,10 +259,10 @@ class TrustedMetadataSet(abc.Mapping):
         """Verifies and loads ``data`` as new snapshot metadata.
 
         Note that an intermediate snapshot is allowed to be expired and version
-        is allowed to not match timestamp meta version: TrustedMetadataSet will
-        throw an ``ExpiredMetadataError``/``BadVersionNumberError`` in these
-        cases but the intermediate snapshot will be loaded. This way a newer
-        snapshot can still be loaded (and the intermediate snapshot will
+        is allowed to not match timestamp meta version: ``TrustedMetadataSet``
+        will throw an ``ExpiredMetadataError``/``BadVersionNumberError`` in
+        these cases but the intermediate snapshot will be loaded. This way a
+        newer snapshot can still be loaded (and the intermediate snapshot will
         be used for rollback protection). Expired snapshot or snapshot that
         does not match timestamp meta version will prevent loading targets.
 

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -139,7 +139,7 @@ class TrustedMetadataSet(abc.Mapping):
         only checked for the final root in ``update_timestamp()``.
 
         Args:
-            data: unverified new root metadata as bytes
+            data: Unverified new root metadata as bytes
 
         Raises:
             RuntimeError: This function is called after updating timestamp.
@@ -188,7 +188,7 @@ class TrustedMetadataSet(abc.Mapping):
         will prevent loading snapshot metadata.
 
         Args:
-            data: unverified new timestamp metadata as bytes
+            data: Unverified new timestamp metadata as bytes
 
         Raises:
             RuntimeError: This function is called after updating snapshot.
@@ -267,8 +267,8 @@ class TrustedMetadataSet(abc.Mapping):
         does not match timestamp meta version will prevent loading targets.
 
         Args:
-            data: unverified new snapshot metadata as bytes
-            trusted: whether data has at some point been verified by
+            data: Unverified new snapshot metadata as bytes
+            trusted: ``True`` if data has at some point been verified by
                 ``TrustedMetadataSet`` as a valid snapshot. Purpose of trusted
                 is to allow loading of locally stored snapshot as intermediate
                 snapshot even if hashes in current timestamp meta no longer
@@ -277,7 +277,7 @@ class TrustedMetadataSet(abc.Mapping):
         Raises:
             RuntimeError: This function is called before updating timestamp
                 or after updating targets.
-            RepositoryError: data failed to load or verify as final snapshot.
+            RepositoryError: Data failed to load or verify as final snapshot.
                 The actual error type and content will contain more details.
 
         Returns:
@@ -359,7 +359,7 @@ class TrustedMetadataSet(abc.Mapping):
         """Verifies and loads ``data`` as new top-level targets metadata.
 
         Args:
-            data: unverified new targets metadata as bytes
+            data: Unverified new targets metadata as bytes
 
         Raises:
             RepositoryError: Metadata failed to load or verify. The actual
@@ -376,9 +376,9 @@ class TrustedMetadataSet(abc.Mapping):
         """Verifies and loads ``data`` as new metadata for target ``role_name``.
 
         Args:
-            data: unverified new metadata as bytes
-            role_name: The role name of the new metadata
-            delegator_name: The name of the role delegating to the new metadata
+            data: Unverified new metadata as bytes
+            role_name: Role name of the new metadata
+            delegator_name: Name of the role delegating to the new metadata
 
         Raises:
             RuntimeError: This function is called before updating snapshot.

--- a/tuf/ngclient/config.py
+++ b/tuf/ngclient/config.py
@@ -12,12 +12,12 @@ class UpdaterConfig:
     """Used to store ``Updater`` configuration.
 
     Arguments:
-        max_root_rotations: The maximum number of root rotations.
-        max_delegations: The maximum number of delegations.
-        root_max_length: The maxmimum length of a root metadata file.
-        timestamp_max_length: The maximum length of a timestamp metadata file.
-        snapshot_max_length: The maximum length of a snapshot metadata file.
-        targets_max_length: The maximum length of a targets metadata file.
+        max_root_rotations: Maximum number of root rotations.
+        max_delegations: Maximum number of delegations.
+        root_max_length: Maxmimum length of a root metadata file.
+        timestamp_max_length: Maximum length of a timestamp metadata file.
+        snapshot_max_length: Maximum length of a snapshot metadata file.
+        targets_max_length: Maximum length of a targets metadata file.
         prefix_targets_with_hash: When `consistent snapshots
             <https://theupdateframework.github.io/specification/latest/#consistent-snapshots>`_
             are used, target download URLs are formed by prefixing the filename

--- a/tuf/ngclient/config.py
+++ b/tuf/ngclient/config.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 class UpdaterConfig:
     """Used to store ``Updater`` configuration.
 
-    Arguments:
+    Args:
         max_root_rotations: Maximum number of root rotations.
         max_delegations: Maximum number of delegations.
         root_max_length: Maxmimum length of a root metadata file.

--- a/tuf/ngclient/config.py
+++ b/tuf/ngclient/config.py
@@ -1,7 +1,7 @@
 # Copyright 2021, New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""Configuration options for Updater class
+"""Configuration options for ``Updater`` class
 """
 
 from dataclasses import dataclass
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 
 @dataclass
 class UpdaterConfig:
-    """Used to store Updater configuration.
+    """Used to store ``Updater`` configuration.
 
     Arguments:
         max_root_rotations: The maximum number of root rotations.
@@ -22,7 +22,7 @@ class UpdaterConfig:
             <https://theupdateframework.github.io/specification/latest/#consistent-snapshots>`_
             are used, target download URLs are formed by prefixing the filename
             with a hash digest of file content by default. This can be
-            overridden by setting prefix_targets_with_hash to False.
+            overridden by setting ``prefix_targets_with_hash`` to ``False``.
 
     """
 

--- a/tuf/ngclient/fetcher.py
+++ b/tuf/ngclient/fetcher.py
@@ -31,11 +31,12 @@ class FetcherInterface:
     def _fetch(self, url: str) -> Iterator[bytes]:
         """Fetches the contents of HTTP/HTTPS url from a remote server.
 
-        Implementations must raise DownloadHTTPError if they receive an
-        HTTP error code.
+        Implementations must raise ``DownloadHTTPError`` if they receive
+        an HTTP error code.
 
         Implementations may raise any errors but the ones that are not
-        DownloadErrors will be wrapped in a DownloadError by fetch().
+        ``DownloadErrors`` will be wrapped in a ``DownloadError`` by
+        ``fetch()``.
 
         Arguments:
             url: A URL string that represents a file location.
@@ -72,8 +73,8 @@ class FetcherInterface:
 
     @contextmanager
     def download_file(self, url: str, max_length: int) -> Iterator[IO]:
-        """Opens a connection to 'url' and downloads the content
-        up to 'max_length'.
+        """Opens a connection to ``url`` and downloads the content
+        up to ``max_length``.
 
         Args:
             url: a URL string that represents the location of the file.
@@ -82,11 +83,11 @@ class FetcherInterface:
         Raises:
             exceptions.DownloadError: An error occurred during download.
             exceptions.DownloadLengthMismatchError: downloaded bytes exceed
-                'max_length'.
+                ``max_length``.
             exceptions.DownloadHTTPError: An HTTP error code was received.
 
         Yields:
-            A TemporaryFile object that points to the contents of 'url'.
+            A ``TemporaryFile`` object that points to the contents of ``url``.
         """
         logger.debug("Downloading: %s", url)
 
@@ -116,7 +117,7 @@ class FetcherInterface:
     def download_bytes(self, url: str, max_length: int) -> bytes:
         """Download bytes from given url
 
-        Returns the downloaded bytes, otherwise like download_file()
+        Returns the downloaded bytes, otherwise like ``download_file()``
 
         Args:
             url: a URL string that represents the location of the file.
@@ -125,7 +126,7 @@ class FetcherInterface:
         Raises:
             exceptions.DownloadError: An error occurred during download.
             exceptions.DownloadLengthMismatchError: downloaded bytes exceed
-                'max_length'.
+                ``max_length``.
             exceptions.DownloadHTTPError: An HTTP error code was received.
 
         Returns:

--- a/tuf/ngclient/fetcher.py
+++ b/tuf/ngclient/fetcher.py
@@ -29,7 +29,7 @@ class FetcherInterface:
 
     @abc.abstractmethod
     def _fetch(self, url: str) -> Iterator[bytes]:
-        """Fetches the contents of HTTP/HTTPS url from a remote server.
+        """Fetches the contents of HTTP/HTTPS ``url`` from a remote server.
 
         Implementations must raise ``DownloadHTTPError`` if they receive
         an HTTP error code.
@@ -50,7 +50,7 @@ class FetcherInterface:
         raise NotImplementedError  # pragma: no cover
 
     def fetch(self, url: str) -> Iterator[bytes]:
-        """Fetches the contents of HTTP/HTTPS url from a remote server.
+        """Fetches the contents of HTTP/HTTPS ``url`` from a remote server.
 
         Args:
             url: URL string that represents a file location.
@@ -73,8 +73,11 @@ class FetcherInterface:
 
     @contextmanager
     def download_file(self, url: str, max_length: int) -> Iterator[IO]:
-        """Opens a connection to ``url`` and downloads the content
-        up to ``max_length``.
+        """Download file from given ``url``.
+
+        It is recommended to use ``download_file()`` within a ``with``
+        block to guarantee that allocated file resources will always
+        be released even if download fails.
 
         Args:
             url: URL string that represents the location of the file.
@@ -115,9 +118,9 @@ class FetcherInterface:
             yield temp_file
 
     def download_bytes(self, url: str, max_length: int) -> bytes:
-        """Download bytes from given url
+        """Download bytes from given ``url``.
 
-        Returns the downloaded bytes, otherwise like ``download_file()``
+        Returns the downloaded bytes, otherwise like ``download_file()``.
 
         Args:
             url: URL string that represents the location of the file.

--- a/tuf/ngclient/fetcher.py
+++ b/tuf/ngclient/fetcher.py
@@ -39,13 +39,13 @@ class FetcherInterface:
         ``fetch()``.
 
         Arguments:
-            url: A URL string that represents a file location.
+            url: URL string that represents a file location.
 
         Raises:
-            exceptions.DownloadHTTPError: An HTTP error code was received.
+            exceptions.DownloadHTTPError: HTTP error code was received.
 
         Returns:
-            A bytes iterator
+            Bytes iterator
         """
         raise NotImplementedError  # pragma: no cover
 
@@ -53,14 +53,14 @@ class FetcherInterface:
         """Fetches the contents of HTTP/HTTPS url from a remote server.
 
         Arguments:
-            url: A URL string that represents a file location.
+            url: URL string that represents a file location.
 
         Raises:
             exceptions.DownloadError: An error occurred during download.
             exceptions.DownloadHTTPError: An HTTP error code was received.
 
         Returns:
-            A bytes iterator
+            Bytes iterator
         """
         # Ensure that fetch() only raises DownloadErrors, regardless of the
         # fetcher implementation
@@ -77,17 +77,17 @@ class FetcherInterface:
         up to ``max_length``.
 
         Args:
-            url: a URL string that represents the location of the file.
-            max_length: upper bound of file size in bytes.
+            url: URL string that represents the location of the file.
+            max_length: Upper bound of file size in bytes.
 
         Raises:
             exceptions.DownloadError: An error occurred during download.
-            exceptions.DownloadLengthMismatchError: downloaded bytes exceed
+            exceptions.DownloadLengthMismatchError: Downloaded bytes exceed
                 ``max_length``.
             exceptions.DownloadHTTPError: An HTTP error code was received.
 
         Yields:
-            A ``TemporaryFile`` object that points to the contents of ``url``.
+            ``TemporaryFile`` object that points to the contents of ``url``.
         """
         logger.debug("Downloading: %s", url)
 
@@ -120,8 +120,8 @@ class FetcherInterface:
         Returns the downloaded bytes, otherwise like ``download_file()``
 
         Args:
-            url: a URL string that represents the location of the file.
-            max_length: upper bound of data size in bytes.
+            url: URL string that represents the location of the file.
+            max_length: Upper bound of data size in bytes.
 
         Raises:
             exceptions.DownloadError: An error occurred during download.
@@ -130,7 +130,7 @@ class FetcherInterface:
             exceptions.DownloadHTTPError: An HTTP error code was received.
 
         Returns:
-            The content of the file in bytes.
+            Content of the file in bytes.
         """
         with self.download_file(url, max_length) as dl_file:
             return dl_file.read()

--- a/tuf/ngclient/fetcher.py
+++ b/tuf/ngclient/fetcher.py
@@ -38,7 +38,7 @@ class FetcherInterface:
         ``DownloadErrors`` will be wrapped in a ``DownloadError`` by
         ``fetch()``.
 
-        Arguments:
+        Args:
             url: URL string that represents a file location.
 
         Raises:
@@ -52,7 +52,7 @@ class FetcherInterface:
     def fetch(self, url: str) -> Iterator[bytes]:
         """Fetches the contents of HTTP/HTTPS url from a remote server.
 
-        Arguments:
+        Args:
             url: URL string that represents a file location.
 
         Raises:
@@ -125,7 +125,7 @@ class FetcherInterface:
 
         Raises:
             exceptions.DownloadError: An error occurred during download.
-            exceptions.DownloadLengthMismatchError: downloaded bytes exceed
+            exceptions.DownloadLengthMismatchError: Downloaded bytes exceed
                 ``max_length``.
             exceptions.DownloadHTTPError: An HTTP error code was received.
 

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -3,13 +3,13 @@
 
 """Client update workflow implementation
 
-The Updater class provides an implementation of the
+The ``Updater`` class provides an implementation of the
 `TUF client workflow
 <https://theupdateframework.github.io/specification/latest/#detailed-client-workflow>`_.
-Updater provides an API to query available targets and to download them in a
+``Updater`` provides an API to query available targets and to download them in a
 secure manner: All downloaded files are verified by signed metadata.
 
-High-level description of Updater functionality:
+High-level description of ``Updater`` functionality:
   * Initializing an ``Updater`` loads and validates the trusted local root
     metadata: This root metadata is used as the source of trust for all other
     metadata.
@@ -18,7 +18,7 @@ High-level description of Updater functionality:
     metadata and metadata downloaded from the remote repository. If refresh is
     not done explicitly, it will happen automatically during the first target
     info lookup.
-  * Updater can be used to download targets. For each target:
+  * ``Updater`` can be used to download targets. For each target:
 
       * ``Updater.get_targetinfo()`` is first used to find information about a
         specific target. This will load new targets metadata as needed (from
@@ -57,19 +57,19 @@ logger = logging.getLogger(__name__)
 
 
 class Updater:
-    """Creates a new Updater instance and loads trusted root metadata.
+    """Creates a new ``Updater`` instance and loads trusted root metadata.
 
     Args:
         metadata_dir: Local metadata directory. Directory must be
-            writable and it must contain a trusted root.json file.
+            writable and it must contain a trusted root.json file
         metadata_base_url: Base URL for all remote metadata downloads
         target_dir: Local targets directory. Directory must be writable. It
             will be used as the default target download directory by
             ``find_cached_target()`` and ``download_target()``
-        target_base_url: Optional; Default base URL for all remote target
-            downloads. Can be individually set in download_target()
-        fetcher: Optional; FetcherInterface implementation used to download
-            both metadata and targets. Default is RequestsFetcher
+        target_base_url: ``Optional``; Default base URL for all remote target
+            downloads. Can be individually set in ``download_target()``
+        fetcher: ``Optional``; ``FetcherInterface`` implementation used to
+            download both metadata and targets. Default is ``RequestsFetcher``
 
     Raises:
         OSError: Local root.json cannot be read
@@ -137,7 +137,7 @@ class Updater:
         return os.path.join(self.target_dir, filename)
 
     def get_targetinfo(self, target_path: str) -> Optional[TargetFile]:
-        """Returns TargetFile instance with information for 'target_path'.
+        """Returns ``TargetFile`` instance with information for ``target_path``.
 
         The return value can be used as an argument to
         ``download_target()`` and ``find_cached_target()``.
@@ -159,7 +159,7 @@ class Updater:
             DownloadError: Download of a metadata file failed in some way
 
         Returns:
-            A TargetFile instance or None.
+            A ``TargetFile`` instance or ``None``.
         """
 
         if self._trusted_set.targets is None:
@@ -174,9 +174,9 @@ class Updater:
         """Checks whether a local file is an up to date target
 
         Args:
-            targetinfo: TargetFile from ``get_targetinfo()``.
-            filepath: Local path to file. If None, a file path is generated
-                based on ``target_dir`` constructor argument.
+            targetinfo: ``TargetFile`` from ``get_targetinfo()``.
+            filepath: Local path to file. If ``None``, a file path is
+                generated based on ``target_dir`` constructor argument.
 
         Raises:
             ValueError: Incorrect arguments
@@ -205,13 +205,13 @@ class Updater:
         """Downloads the target file specified by ``targetinfo``.
 
         Args:
-            targetinfo: TargetFile from ``get_targetinfo()``.
-            filepath: Local path to download into. If None, the file is
+            targetinfo: ``TargetFile`` from ``get_targetinfo()``.
+            filepath: Local path to download into. If ``None``, the file is
                 downloaded into directory defined by ``target_dir`` constructor
                 argument using a generated filename. If file already exists,
                 it is overwritten.
             target_base_url: Base URL used to form the final target
-                download URL. Default is the value provided in Updater()
+                download URL. Default is the value provided in ``Updater()``
 
         Raises:
             ValueError: Invalid arguments
@@ -359,7 +359,7 @@ class Updater:
             self._persist_metadata(Snapshot.type, data)
 
     def _load_targets(self, role: str, parent_role: str) -> Metadata[Targets]:
-        """Load local (and if needed remote) metadata for 'role'."""
+        """Load local (and if needed remote) metadata for ``role``."""
 
         # Avoid loading 'role' more than once during "get_targetinfo"
         if role in self._trusted_set:

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -149,7 +149,7 @@ class Updater:
         targets) metadata it needs to return the target information.
 
         Args:
-            target_path: A `path-relative-URL string
+            target_path: `path-relative-URL string
                 <https://url.spec.whatwg.org/#path-relative-url-string>`_
                 that uniquely identifies the target within the repository.
 
@@ -159,7 +159,7 @@ class Updater:
             DownloadError: Download of a metadata file failed in some way
 
         Returns:
-            A ``TargetFile`` instance or ``None``.
+            ``TargetFile`` instance or ``None``.
         """
 
         if self._trusted_set.targets is None:


### PR DESCRIPTION
This change unifies ngclient docstrings language, including wording and quoting. No major changes included, as docs look well-formed.

Fixes #1844

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [n/a] Tests have been added for the bug fix or new feature
- [n/a] Docs have been added for the bug fix or new feature


