### PR TITLE
Metadata test full serialization cycle

### DIFF
--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -73,8 +73,15 @@ class TestSerialization(unittest.TestCase):
     @utils.run_sub_tests_with_dataset(valid_metadata)
     def test_valid_metadata_serialization(self, test_case_data: bytes) -> None:
         md = Metadata.from_bytes(test_case_data)
-        input_dict = json.loads(test_case_data)
-        self.assertDictEqual(input_dict, md.to_dict())
+
+        # Convert to a JSON and sort the keys the way we do in JSONSerializer.
+        separators = (",", ":")
+        test_json = json.loads(test_case_data)
+        test_bytes = json.dumps(
+            test_json, separators=separators, sort_keys=True
+        ).encode("utf-8")
+
+        self.assertEqual(test_bytes, md.to_bytes())
 
     invalid_signatures: utils.DataSet = {
         "missing keyid attribute in a signature": '{ "sig": "abc" }',


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Replace the usage of Metadata.to_dict inside
test_valid_metadata_serialization and instead use Metadata.to_bytes()
in order to test that the full serialization cycle is working as
expected:
Metadata.from_bytes -> Metadata.to_bytes

_Raised from Jussi's comment: https://github.com/theupdateframework/python-tuf/pull/1809#discussion_r804473334_

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


