### PR TITLE
Add support for unrecognized fields in Metadata

### DIFF
--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -68,6 +68,13 @@ class TestSerialization(unittest.TestCase):
                 "meta": {"snapshot.json": {"hashes": {"sha256" : "abc"}, "version": 1}}}, \
             "signatures": [] \
         }',
+        "unrecognized fields": b'{ \
+            "signed": \
+                { "_type": "timestamp", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
+                "meta": {"snapshot.json": {"hashes": {"sha256" : "abc"}, "version": 1}}}, \
+            "signatures": [{"keyid": "id", "sig": "b"}], \
+            "foo": "bar" \
+        }',
     }
 
     @utils.run_sub_tests_with_dataset(valid_metadata)


### PR DESCRIPTION
Fixes #1852

**Description of the changes being introduced by the pull request**:

The [Document formats](https://theupdateframework.github.io/specification/latest/#document-formats) section of the specification says the following:
```
All of the formats described below include the ability to add more attribute-value fields
to objects for backward-compatible format changes.
Implementers who encounter undefined attribute-value pairs in the format must include
the data when calculating hashes or verifying signatures and
must preserve the data when re-serializing.
```

I initially thought it's applicable only to the **SIGNED** fields as `undefined attribute-value pairs in the format must include the data when calculating hashes or verifying signatures`.
This doesn't mean that the sentence before that excludes `Metadata` as a possible place for additional fields.
The other maintainers agreed with me and we are going to add support for `unrecognized_fields` inside `Metadata`.

For context read: 
- https://github.com/theupdateframework/python-tuf/issues/1802
- https://github.com/theupdateframework/specification/issues/203

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


