### PR TITLE
dep: update pinned requirements

### DIFF
--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -7,5 +7,4 @@ pycparser==2.21           # via cffi
 pynacl==1.5.0             # via securesystemslib
 requests==2.27.1
 securesystemslib[crypto,pynacl]==0.22.0
-six==1.16.0               # via pynacl, securesystemslib
 urllib3==1.26.8           # via requests


### PR DESCRIPTION
As described in #1249 requirements-pinned.txt is automatically
updated by Dependabot on version updates, but not if transitive
dependencies are added or removed.

This patch removes the no longer required transient dependency six,
following a run of pip-compile for all supported Python versions.

No other dependency changes were detected, nor were there different
dependencies in different Python versions, requiring env markers
in the requirements file.