### PR TITLE
build: pin test requirements for deterministic CI

### DIFF
--- a/requirements-test-pinned.txt
+++ b/requirements-test-pinned.txt
@@ -1,0 +1,41 @@
+astroid==2.9.3            # via pylint
+bandit==1.7.2             # via -r requirements-test.txt
+black==22.1.0             # via -r requirements-test.txt
+certifi==2021.10.8        # via -r requirements-pinned.txt, requests
+cffi==1.15.0              # via -r requirements-pinned.txt, cryptography, pynacl
+charset-normalizer==2.0.12  # via -r requirements-pinned.txt, requests
+click==8.0.3              # via black
+coverage==6.3.1           # via -r requirements-test.txt
+cryptography==36.0.1      # via -r requirements-pinned.txt, securesystemslib
+gitdb==4.0.9              # via gitpython
+gitpython==3.1.26         # via bandit
+idna==3.3                 # via -r requirements-pinned.txt, requests
+importlib-metadata==4.11.1; python_version < '3.8'  # via click, stevedore
+isort==5.10.1             # via -r requirements-test.txt, pylint
+lazy-object-proxy==1.7.1  # via astroid
+mccabe==0.6.1             # via pylint
+mypy==0.931               # via -r requirements-test.txt
+mypy-extensions==0.4.3    # via black, mypy
+pathspec==0.9.0           # via black
+pbr==5.8.1                # via stevedore
+platformdirs==2.5.0       # via black, pylint
+pycparser==2.21           # via -r requirements-pinned.txt, cffi
+pylint==2.12.2            # via -r requirements-test.txt
+pynacl==1.5.0             # via -r requirements-pinned.txt, securesystemslib
+pyyaml==6.0               # via bandit
+requests==2.27.1          # via -r requirements-pinned.txt
+securesystemslib[crypto,pynacl]==0.22.0  # via -r requirements-pinned.txt
+smmap==5.0.0              # via gitdb
+stevedore==3.5.0          # via bandit
+toml==0.10.2              # via pylint
+tomli==2.0.1              # via black, mypy
+typed-ast==1.5.2; python_version < '3.8'  # via astroid, black, mypy
+types-requests==2.27.9    # via -r requirements-test.txt
+types-urllib3==1.26.9     # via types-requests
+typing-extensions==4.1.1  # via astroid, black, gitpython, importlib-metadata, mypy, pylint
+urllib3==1.26.8           # via -r requirements-pinned.txt, requests
+wrapt==1.13.3             # via astroid
+zipp==3.7.0; python_version < '3.8'  # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
     python3 -m coverage report -m --fail-under 97
 
 deps =
-    -r{toxinidir}/requirements-test.txt
+    -r{toxinidir}/requirements-test-pinned.txt
     # Install TUF in editable mode, instead of tox default virtual environment
     # installation (see `skipsdist`), to get relative paths in coverage reports
     --editable {toxinidir}


### PR DESCRIPTION
Fixes #1813 (?, see discussion in issue)

**Description of the changes being introduced by the pull request**:
Configures tox to use a pinned requirements file for deterministic
CI builds, i.e. our CI shouldn't start failing because of an
incompatible upstream release of any of our testing tools:

NOTE: pinned tuf runtime requirements were already were already
used for test builds before (included via `-r
requirements-pinned.txt` in 'requirements-test.txt'). Now they are
explicitly listed in 'requirements-test-pinnned.txt'.

'requirements-test-pinnned.txt' was generated semi-automatically by
running pip-compile over 'requirements-test.txt' for each
supported/tested Python version (see snippet below) and manually
merging the resulting per-Python version requirements files into
one, adding environment markers as needed.

```
for ver in 3.7.12 3.8.12 3.9.9 3.10.0; do
  pyenv virtualenv ${ver} tuf-env-${ver}
  pyenv activate tuf-env-${ver}
  python3 -m pip install -U pip pip-tools
  pip-compile --no-header --annotation-style line \
      -o requirements-test-pinned-${ver}.txt \
      requirements-test.txt
  pyenv deactivate
  pyenv uninstall -f tuf-env-${ver}
done
```

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


