### PR TITLE
doc: minor updates in readme and reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ page for more details about the release and the deprecation of the legacy
 implementation, including migration instructions.*
 
 ----------------------------
-This repository is the **reference implementation** of
-[The Update Framework (TUF)](https://theupdateframework.github.io/).
-It is written in Python and intended to conform to version 1.0 of the
-[TUF specification](https://theupdateframework.github.io/specification/latest/).
+[The Update Framework (TUF)](https://theupdateframework.io/) is a framework for
+secure content delivery and updates. It protects against various types of
+supply chain attacks and provides resilience to compromise. This repository is a
+**reference implementation** written in Python. It is intended to conform to
+version 1.0 of the [TUF
+specification](https://theupdateframework.github.io/specification/latest/).
 
 Python-TUF provides two APIs:
   * [`tuf.api.metadata`](https://theupdateframework.readthedocs.io/en/latest/api/tuf.api.html),
@@ -69,10 +71,10 @@ for the reference implementation
 
 Contact
 -------
-Please contact us via our [mailing
-list](https://groups.google.com/forum/?fromgroups#!forum/theupdateframework).
-Questions, feedback, and suggestions are welcomed on this low volume mailing
-list.
+Questions, feedback, and suggestions are welcomed on our low volume [mailing
+list](https://groups.google.com/forum/?fromgroups#!forum/theupdateframework) or
+the [#tuf](https://cloud-native.slack.com/archives/C8NMD3QJ3) channel on [CNCF
+Slack](https://slack.cncf.io/).
 
 We strive to make the specification easy to implement, so if you come across
 any inconsistencies or experience any difficulty, do let us know by sending an

--- a/docs/api/api-reference.rst
+++ b/docs/api/api-reference.rst
@@ -22,12 +22,6 @@ Code `examples <https://github.com/theupdateframework/python-tuf/tree/develop/ex
 are available for client implementation using ngclient and a
 basic repository using Metadata API.
 
-.. note:: Major API changes are unlikely but these APIs are not yet
-   considered stable, and a higher-level repository operations API is not yet
-   included.
-
-   There is a legacy implementation in the source code (not covered by this
-   documentation): it is in maintenance mode and receives no feature work.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Fixes https://github.com/theupdateframework/python-tuf/issues/1795#issuecomment-1033518928

**Description of the changes being introduced by the pull request**:

- in README.md:
  - add generic opening sentence that says what TUF actually does.
  - add link to #tuf channel on CNCF slack to contact section
- in RTD/reference docs: remove note about unstable API in RTD docs (it no longer is unstable) 


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


