### PR TITLE
github: Update github-script to 6.0.0

### DIFF
--- a/.github/workflows/maintainer-permissions-reminder.yml
+++ b/.github/workflows/maintainer-permissions-reminder.yml
@@ -13,7 +13,7 @@ jobs:
     name: File issue to review maintainer permissions
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/github-script@e3cbab99d3a9b271e1b79fc96d103a4a5534998c
+    - uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e
       with:
         script: |
           await github.rest.issues.create({

--- a/.github/workflows/specification-version.yml
+++ b/.github/workflows/specification-version.yml
@@ -25,7 +25,7 @@ jobs:
         ver=$(python3 -c "$script")
         echo "::set-output name=version::$ver"
     - name: Open issue (if needed)
-      uses: actions/github-script@e3cbab99d3a9b271e1b79fc96d103a4a5534998c
+      uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e
       with:
         script: |
           const release = await github.rest.repos.getLatestRelease({


### PR DESCRIPTION
The big change is runtime update from nodejs 12 to nodejs 16: does not
seem to affect us.

Dependabot got confused so this update is done manually to v6.0.0
release commit:
https://github.com/actions/github-script/releases/tag/v6.0.0

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

---

Dependabot tried this in #1864 but wants to update to master HEAD.