### PR TITLE
1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,6 @@
 [![PyPI](https://img.shields.io/pypi/v/tuf)](https://pypi.org/project/tuf/)
 
 ----------------------------
-*__IMPORTANT NOTICE:__ A stable 1.0.0 release of the modern implementation only
-is scheduled for January 2022. Please see the [*1.0.0
-announcement*](https://github.com/theupdateframework/python-tuf/blob/develop/docs/1.0.0-ANNOUNCEMENT.md)
-page for more details about the release and the deprecation of the legacy
-implementation, including migration instructions.*
-
-----------------------------
 [The Update Framework (TUF)](https://theupdateframework.io/) is a framework for
 secure content delivery and updates. It protects against various types of
 supply chain attacks and provides resilience to compromise. This repository is a
@@ -30,7 +23,7 @@ Python-TUF provides two APIs:
 
 High-level support for implementing
 [repository operations](https://theupdateframework.github.io/specification/latest/#repository-operations)
-is planned but not yet provided: see [1.0.0 plans](https://github.com/theupdateframework/python-tuf/blob/develop/docs/1.0.0-ANNOUNCEMENT.md).
+is planned but not yet provided: see [ADR 10](https://github.com/theupdateframework/python-tuf/blob/develop/docs/adr/0010-repository-library-design.md).
 
 The reference implementation strives to be a readable guide and demonstration
 for those working on implementing TUF in their own languages, environments, or

--- a/docs/1.0.0-ANNOUNCEMENT.md
+++ b/docs/1.0.0-ANNOUNCEMENT.md
@@ -1,8 +1,7 @@
 # Announcing TUF 1.0.0
 
-In the past year we have made an effort to revise, redesign and rewrite this
-python-tuf reference implementation, and we are very excited to announce a
-stable 1.0.0 release scheduled for January 2022. The release *will* include:
+Python-TUF v1.0.0 is a rewritten stable reference implementation of the TUF
+specification, which *currently* includes:
 - a modern low-level [*metadata
   API*](https://theupdateframework.readthedocs.io/en/latest/api/tuf.api.html)
 - a fully specification-compliant [*updater
@@ -10,8 +9,14 @@ stable 1.0.0 release scheduled for January 2022. The release *will* include:
   serving as a more robust and yet more flexible stand-in replacement
   for the legacy client updater
 
+For the reasons outlined in [ADR 10](https://github.com/theupdateframework/python-tuf/blob/develop/docs/adr/0010-repository-library-design.md
+), this release *does not yet* include *repository tool*-like functionality.
+However, the new *metadata API* makes it easy to replicate the desired
+functionality tailored to the specific needs of any given repository (see
+*Migration* for details).
+
 As discussed in [ADR 2](https://github.com/theupdateframework/python-tuf/blob/develop/docs/adr/0002-pre-1-0-deprecation-strategy.md), this
-release *will not* include any legacy code, as its maintenance has become
+release *does not* include any legacy code, as its maintenance has become
 infeasible for the python-tuf team. The pre-1.0.0 deprecation strategy from ADR
 2 applies as follows:
 
@@ -20,13 +25,6 @@ directly by tuf’s maintainers. Pull Requests to fix bugs in the last release
 prior to 1.0.0 will be considered, and merged (subject to normal review
 processes). Note that there may be delays due to the lack of developer resources
 for reviewing such pull requests.*
-
-For the reasons outlined in [ADR 10](https://github.com/theupdateframework/python-tuf/blob/develop/docs/adr/0010-repository-library-design.md
-), this release *will not yet* include a new *repository tool*. However, the new
-*metadata API* makes it easy to replicate the desired functionality tailored to
-the specific needs of any given repository (see *Migration* for details).
-
-
 
 
 ## Migration

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## v1.0.0
+
+This release makes ngclient and the Metadata API the supported python-tuf APIs.
+It also removes the legacy implementation as documented in the
+[1.0.0 announcement](1.0.0-ANNOUNCEMENT.md): all library code is now contained
+in `tuf.api` or `tuf.ngclient`.
+
+### Added
+* tests: Extend testing (#1689, #1703, #1711, #1728, #1735, #1738,
+  #1742, #1766, #1777, #1809, #1831)
+
+### Changed
+* Metadata API: Disallow microseconds in expiry (#1712)
+* Metadata API: Preserve role keyid order (#1754)
+* Metadata API: Make exceptions more consistent (#1725, #1734, #1787, #1840,
+  #1836)
+* Metadata API: Update supported spec version to "1.0.28" (#1825)
+* Metadata API: Accept legacy spec version "1.0" (#1796)
+* Metadata API: Accept custom fields in Metadata (#1861)
+* ngclient: Remove temporary file in failure cases (#1757)
+* ngclient: Explicitly encode rolename in URL (#1759)
+* ngclient: Allow HTTP payload compression (#1774)
+* ngclient: Make exceptions more consistent (#1799, #1810)
+* docs: Improve documentation (#1744, #1749, #1750, #1755, #1771, #1776, #1772,
+  #1780, #1781, #1800, #1815, #1820, #1829, #1838, #1850, #1853, #1855, #1856
+  #1868, #1871)
+* build: Various build infrastructure improvements (#1718, #1724, #1760, #1762,
+  #1767, #1803, #1830, #1832, #1837, #1839)
+* build: Stop supporting EOL Python 3.6 (#1783)
+* build: Update dependencies (#1809, #1827, #1834, #1863, #1865, #1870)
+
+### Removed
+* Remove all legacy code including old client, repository_tool, repository_lib
+  and the scripts (#1790)
+* Metadata API: Remove modification helper methods that are no longer necessary
+  (#1736, #1740, #1743)
+* tests: Remove client tests that were replaced with better ones (#1741)
+* tests: Stop using unittest_toolbox (#1792)
+* docs: Remove deprecated documentation (#1768, #1769, #1773, #1848)
+
 
 ## v0.20.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tuf
-version = 0.20.0
+version = 1.0.0
 author = https://www.updateframework.com
 author_email = theupdateframework@googlegroups.com
 description = A secure updater framework for Python

--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -9,11 +9,3 @@
 # Currently, when the version is changed, it must be set in both locations.
 # TODO: Single-source the version number.
 __version__ = "0.20.0"
-
-# This reference implementation produces metadata intended to conform to
-# version 1.0.0 of the TUF specification, and is expected to consume metadata
-# conforming to version 1.0.0 of the TUF specification.
-# All downloaded metadata must be equal to our supported major version of 1.
-# For example, "1.4.3" and "1.0.0" are supported.  "2.0.0" is not supported.
-# See https://github.com/theupdateframework/specification
-SPECIFICATION_VERSION = "1.0.0"

--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -8,4 +8,4 @@
 # setup.cfg has it hard-coded separately.
 # Currently, when the version is changed, it must be set in both locations.
 # TODO: Single-source the version number.
-__version__ = "0.20.0"
+__version__ = "1.0.0"


### PR DESCRIPTION
This contains:
* removal of an unused constant (we could drop the commit as well, it's not too bad)
* PR #1869 as is
* PR #1851 just  with version number changes added in the same commit

I think it makes sense to do the last two here and close the other PRs without merging -- the constant removal could be dropped as I mentioned.

I'm running release tests now, but review is welcome