### PR TITLE
docs: Clean up blog header

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,5 +9,8 @@ github_username:  theupdateframework
 
 show_excerpts: true # set to false to remove excerpts on the homepage
 
+header_pages: # make sure ordinary docs are not linked from blog header
+  - index.md
+
 theme: minima
 


### PR DESCRIPTION
Minima theme for Github Pages by default adds all files in blog root (docs/) as links in
the header. This looks ridiculous in our case: let's just have a link to
blog front page.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

---

Tested this fix in https://github.com/jku/github-pages-with-jekyll / https://jku.github.io/github-pages-with-jekyll/