### PR TITLE
Single source version number

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -5,14 +5,18 @@
   tracked by git
 * Ensure `docs/CHANGELOG.md` contains a one-line summary of each [notable
   change](https://keepachangelog.com/) since the prior release
-* Update `setup.cfg` and `tuf/__init__.py` to the new version number vA.B.C
+* Update `tuf/__init__.py` to the new version number "A.B.C"
 * Test packaging, uploading to Test PyPI and installing from a virtual environment
   (ensure commands invoking `python` below are using Python 3)
   * Remove existing dist build dirs
   * Create source dist and wheel `python3 -m build`
-  * Sign the dists `gpg --detach-sign -a dist/tuf-vA.B.C.tar.gz`
+  * Sign source dist `gpg --detach-sign -a dist/tuf-A.B.C.tar.gz`
+  * Sign wheel `gpg --detach-sign -a dist/tuf-A.B.C-py3-none-any.whl`
   * Upload to test PyPI `twine upload --repository testpypi dist/*`
-  * Verify the uploaded package https://testpypi.python.org/pypi/tuf/
+  * Verify the uploaded package at https://test.pypi.org/project/tuf/:
+    Note that installing packages with pip using test.pypi.org is potentially
+    dangerous (as dependencies may be squatted): download the file and install
+    the local file instead.
 * Create a PR with updated `CHANGELOG.md` and version bumps
 * Once the PR is merged, pull the updated `develop` branch locally
 * Create a signed tag matching the updated version number on the merge commit
@@ -24,11 +28,10 @@
   (ensure commands invoking `python` below are using Python 3)
   * Remove existing dist build dirs
   * Create source dist and wheel `python3 -m build`
-  * Sign source dist `gpg --detach-sign -a dist/tuf-vA.B.C.tar.gz`
-  * Sign wheel `gpg --detach-sign -a dist/tuf-vA.B.C-py3-none-any.whl`
-  * Upload to test PyPI `twine upload --repository testpypi dist/*`
-  * Verify the uploaded package https://testpypi.python.org/pypi/tuf/
+  * Sign source dist `gpg --detach-sign -a dist/tuf-A.B.C.tar.gz`
+  * Sign wheel `gpg --detach-sign -a dist/tuf-A.B.C-py3-none-any.whl`
   * Upload to PyPI `twine upload dist/*`
+  * Verify the package at https://pypi.org/project/tuf/ and by installing with pip
 * Attach both signed dists and their detached signatures to the release on GitHub
 * Announce the release on [#tuf on CNCF Slack](https://cloud-native.slack.com/archives/C8NMD3QJ3)
 * Ensure [POUF 1](https://github.com/theupdateframework/taps/blob/master/POUFs/reference-POUF/pouf1.md), for the reference implementation, is up-to-date

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # Build-system section
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel"]
+requires = ["setuptools>=46.4.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 # Black section

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = tuf
-version = 1.0.0
+version = attr: tuf.__version__
 author = https://www.updateframework.com
 author_email = theupdateframework@googlegroups.com
 description = A secure updater framework for Python


### PR DESCRIPTION
As of setuptools 46.4.0, one can accomplish single source version number with

    version = attr: package.__version__

in setup.cfg: As long as setuptools simplified AST parser is able to
read the file, this works without actually importing the module.

---

Fix the release documentation on this aspect, and make some minor improvements to the doc.