### PR TITLE
Use spec version from tuf/api/metadata in examples

### DIFF
--- a/examples/repo_example/basic_repo.py
+++ b/examples/repo_example/basic_repo.py
@@ -30,6 +30,7 @@ from securesystemslib.keys import generate_ed25519_key
 from securesystemslib.signer import SSlibSigner
 
 from tuf.api.metadata import (
+    SPECIFICATION_VERSION,
     DelegatedRole,
     Delegations,
     Key,
@@ -82,7 +83,7 @@ def _in(days: float) -> datetime:
 # expiration intervals, whereas roles that change less and might use offline
 # keys (root, delegating targets) may have longer expiration intervals.
 
-SPEC_VERSION = "1.0.19"
+SPEC_VERSION = ".".join(SPECIFICATION_VERSION)
 
 # Define containers for role objects and cryptographic keys created below. This
 # allows us to sign and write metadata in a batch more easily.

--- a/examples/repo_example/hashed_bin_delegation.py
+++ b/examples/repo_example/hashed_bin_delegation.py
@@ -26,6 +26,7 @@ from securesystemslib.keys import generate_ed25519_key
 from securesystemslib.signer import SSlibSigner
 
 from tuf.api.metadata import (
+    SPECIFICATION_VERSION,
     DelegatedRole,
     Delegations,
     Key,
@@ -41,7 +42,7 @@ def _in(days: float) -> datetime:
     return datetime.utcnow().replace(microsecond=0) + timedelta(days=days)
 
 
-SPEC_VERSION = "1.0.19"
+SPEC_VERSION = ".".join(SPECIFICATION_VERSION)
 roles: Dict[str, Metadata] = {}
 keys: Dict[str, Dict[str, Any]] = {}
 


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Replace the hardcoded specification version with the one defined inside
tuf/api/metadata.py that way we would have one source of truth about the
specification version.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


