### PR TITLE
Add default args to Signed constructors

### DIFF
--- a/examples/repo_example/basic_repo.py
+++ b/examples/repo_example/basic_repo.py
@@ -36,7 +36,6 @@ from tuf.api.metadata import (
     Key,
     Metadata,
     MetaFile,
-    Role,
     Root,
     Snapshot,
     TargetFile,
@@ -96,12 +95,7 @@ keys: Dict[str, Dict[str, Any]] = {}
 # The targets role guarantees integrity for the files that TUF aims to protect,
 # i.e. target files. It does so by listing the relevant target files, along
 # with their hash and length.
-roles["targets"] = Metadata[Targets](
-    signed=Targets(
-        version=1, spec_version=SPEC_VERSION, expires=_in(7), targets={}
-    ),
-    signatures={},
-)
+roles["targets"] = Metadata(Targets(expires=_in(7)))
 
 # For the purpose of this example we use the top-level targets role to protect
 # the integrity of this very example script. The metadata entry contains the
@@ -124,15 +118,7 @@ roles["targets"].signed.targets[target_path] = target_file_info
 # by listing all available targets metadata files at their latest version. This
 # becomes relevant, when there are multiple targets metadata files in a
 # repository and we want to protect the client against mix-and-match attacks.
-roles["snapshot"] = Metadata[Snapshot](
-    Snapshot(
-        version=1,
-        spec_version=SPEC_VERSION,
-        expires=_in(7),
-        meta={"targets.json": MetaFile(version=1)},
-    ),
-    {},
-)
+roles["snapshot"] = Metadata(Snapshot(expires=_in(7)))
 
 # Timestamp (freshness)
 # ---------------------
@@ -146,15 +132,7 @@ roles["snapshot"] = Metadata[Snapshot](
 # format. But given that timestamp metadata always has only one entry in its
 # 'meta' field, i.e. for the latest snapshot file, the timestamp object
 # provides the shortcut 'snapshot_meta'.
-roles["timestamp"] = Metadata[Timestamp](
-    Timestamp(
-        version=1,
-        spec_version=SPEC_VERSION,
-        expires=_in(1),
-        snapshot_meta=MetaFile(version=1),
-    ),
-    {},
-)
+roles["timestamp"] = Metadata(Timestamp(expires=_in(1)))
 
 # Root (root of trust)
 # --------------------
@@ -168,32 +146,19 @@ roles["timestamp"] = Metadata[Timestamp](
 # 'keys' field), and a configuration parameter that describes whether a
 # repository uses consistent snapshots (see section 'Persist metadata' below
 # for more details).
-#
+
+# Create root metadata object
+roles["root"] = Metadata(Root(expires=_in(365)))
+
 # For this example, we generate one 'ed25519' key pair for each top-level role
 # using python-tuf's in-house crypto library.
 # See https://github.com/secure-systems-lab/securesystemslib for more details
 # about key handling, and don't forget to password-encrypt your private keys!
 for name in ["targets", "snapshot", "timestamp", "root"]:
     keys[name] = generate_ed25519_key()
-
-# Create root metadata object
-roles["root"] = Metadata[Root](
-    signed=Root(
-        version=1,
-        spec_version=SPEC_VERSION,
-        expires=_in(365),
-        keys={
-            key["keyid"]: Key.from_securesystemslib_key(key)
-            for key in keys.values()
-        },
-        roles={
-            role: Role([key["keyid"]], threshold=1)
-            for role, key in keys.items()
-        },
-        consistent_snapshot=True,
-    ),
-    signatures={},
-)
+    roles["root"].signed.add_key(
+        name, Key.from_securesystemslib_key(keys[name])
+    )
 
 # NOTE: We only need the public part to populate root, so it is possible to use
 # out-of-band mechanisms to generate key pairs and only expose the public part

--- a/examples/repo_example/hashed_bin_delegation.py
+++ b/examples/repo_example/hashed_bin_delegation.py
@@ -147,22 +147,11 @@ for name in ["bin-n", "bins"]:
 
 # Create preliminary delegating targets role (bins) and add public key for
 # delegated targets (bin_n) to key store. Delegation details are update below.
-roles["bins"] = Metadata[Targets](
-    signed=Targets(
-        version=1,
-        spec_version=SPEC_VERSION,
-        expires=_in(365),
-        targets={},
-        delegations=Delegations(
-            keys={
-                keys["bin-n"]["keyid"]: Key.from_securesystemslib_key(
-                    keys["bin-n"]
-                )
-            },
-            roles={},
-        ),
-    ),
-    signatures={},
+roles["bins"] = Metadata(Targets(expires=_in(365)))
+bin_n_key = Key.from_securesystemslib_key(keys["bin-n"])
+roles["bins"].signed.delegations = Delegations(
+    keys={bin_n_key.keyid: bin_n_key},
+    roles={},
 )
 
 # The hash bin generator yields an ordered list of incremental hash bin names
@@ -185,12 +174,7 @@ for bin_n_name, bin_n_hash_prefixes in generate_hash_bins():
     )
 
     # Create delegated targets roles (bin_n)
-    roles[bin_n_name] = Metadata[Targets](
-        signed=Targets(
-            version=1, spec_version=SPEC_VERSION, expires=_in(7), targets={}
-        ),
-        signatures={},
-    )
+    roles[bin_n_name] = Metadata(Targets(expires=_in(7)))
 
 # Add target file
 # ---------------

--- a/tests/generated_data/generate_md.py
+++ b/tests/generated_data/generate_md.py
@@ -16,7 +16,6 @@ from tuf.api.metadata import (
     TOP_LEVEL_ROLE_NAMES,
     Key,
     Metadata,
-    MetaFile,
     Role,
     Root,
     Snapshot,
@@ -97,23 +96,15 @@ def generate_all_files(
         verify: Whether to verify the newly generated files with the
             local staored.
     """
-    root = Root(1, SPEC_VERSION, EXPIRY, {}, ROLES, True)
-    root.add_key("root", keys["ed25519_0"])
-    root.add_key("timestamp", keys["ed25519_1"])
-    root.add_key("snapshot", keys["ed25519_2"])
-    root.add_key("targets", keys["ed25519_3"])
+    md_root = Metadata(Root(expires=EXPIRY))
+    md_timestamp = Metadata(Timestamp(expires=EXPIRY))
+    md_snapshot = Metadata(Snapshot(expires=EXPIRY))
+    md_targets = Metadata(Targets(expires=EXPIRY))
 
-    md_root: Metadata[Root] = Metadata(root, {})
-
-    timestamp = Timestamp(1, SPEC_VERSION, EXPIRY, MetaFile(1))
-    md_timestamp: Metadata[Timestamp] = Metadata(timestamp, {})
-
-    meta: Dict[str, MetaFile] = {"targets.json": MetaFile(1)}
-    snapshot = Snapshot(1, SPEC_VERSION, EXPIRY, meta)
-    md_snapshot: Metadata[Snapshot] = Metadata(snapshot, {})
-
-    targets = Targets(1, SPEC_VERSION, EXPIRY, {})
-    md_targets: Metadata[Targets] = Metadata(targets, {})
+    md_root.signed.add_key("root", keys["ed25519_0"])
+    md_root.signed.add_key("timestamp", keys["ed25519_1"])
+    md_root.signed.add_key("snapshot", keys["ed25519_2"])
+    md_root.signed.add_key("targets", keys["ed25519_3"])
 
     for i, md in enumerate([md_root, md_timestamp, md_snapshot, md_targets]):
         assert isinstance(md, Metadata)

--- a/tests/generated_data/generate_md.py
+++ b/tests/generated_data/generate_md.py
@@ -11,17 +11,7 @@ from typing import Dict, List, Optional
 from securesystemslib.signer import SSlibSigner
 
 from tests import utils
-from tuf.api.metadata import (
-    SPECIFICATION_VERSION,
-    TOP_LEVEL_ROLE_NAMES,
-    Key,
-    Metadata,
-    Role,
-    Root,
-    Snapshot,
-    Targets,
-    Timestamp,
-)
+from tuf.api.metadata import Key, Metadata, Root, Snapshot, Targets, Timestamp
 from tuf.api.serialization.json import JSONSerializer
 
 # Hardcode keys and expiry time to achieve reproducibility.
@@ -60,13 +50,11 @@ for index in range(4):
 
 expires_str = "2050-01-01T00:00:00Z"
 EXPIRY = datetime.strptime(expires_str, "%Y-%m-%dT%H:%M:%SZ")
-SPEC_VERSION = ".".join(SPECIFICATION_VERSION)
 OUT_DIR = "generated_data/ed25519_metadata"
 if not os.path.exists(OUT_DIR):
     os.mkdir(OUT_DIR)
 
 SERIALIZER = JSONSerializer()
-ROLES = {role_name: Role([], 1) for role_name in TOP_LEVEL_ROLE_NAMES}
 
 
 def verify_generation(md: Metadata, path: str) -> None:

--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -65,7 +65,6 @@ from tuf.api.metadata import (
     Key,
     Metadata,
     MetaFile,
-    Role,
     Root,
     Snapshot,
     TargetFile,
@@ -176,26 +175,16 @@ class RepositorySimulator(FetcherInterface):
     def _initialize(self) -> None:
         """Setup a minimal valid repository."""
 
-        targets = Targets(1, SPEC_VER, self.safe_expiry, {}, None)
-        self.md_targets = Metadata(targets, {})
-
-        meta = {"targets.json": MetaFile(targets.version)}
-        snapshot = Snapshot(1, SPEC_VER, self.safe_expiry, meta)
-        self.md_snapshot = Metadata(snapshot, {})
-
-        snapshot_meta = MetaFile(snapshot.version)
-        timestamp = Timestamp(1, SPEC_VER, self.safe_expiry, snapshot_meta)
-        self.md_timestamp = Metadata(timestamp, {})
-
-        roles = {role_name: Role([], 1) for role_name in TOP_LEVEL_ROLE_NAMES}
-        root = Root(1, SPEC_VER, self.safe_expiry, {}, roles, True)
+        self.md_targets = Metadata(Targets(expires=self.safe_expiry))
+        self.md_snapshot = Metadata(Snapshot(expires=self.safe_expiry))
+        self.md_timestamp = Metadata(Timestamp(expires=self.safe_expiry))
+        self.md_root = Metadata(Root(expires=self.safe_expiry))
 
         for role in TOP_LEVEL_ROLE_NAMES:
             key, signer = self.create_key()
-            root.add_key(role, key)
+            self.md_root.signed.add_key(role, key)
             self.add_signer(role, signer)
 
-        self.md_root = Metadata(root, {})
         self.publish_root()
 
     def publish_root(self) -> None:

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -32,7 +32,7 @@ import fnmatch
 import io
 import logging
 import tempfile
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import (
     IO,
     Any,
@@ -500,7 +500,7 @@ class Signed(metaclass=abc.ABCMeta):
 
         self.spec_version = spec_version
 
-        self.expires = expires or datetime.utcnow() + timedelta(days=1)
+        self.expires = expires or datetime.utcnow()
 
         if version is None:
             version = 1

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -32,7 +32,7 @@ import fnmatch
 import io
 import logging
 import tempfile
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import (
     IO,
     Any,
@@ -120,11 +120,11 @@ class Metadata(Generic[T]):
     def __init__(
         self,
         signed: T,
-        signatures: Dict[str, Signature],
+        signatures: Optional[Dict[str, Signature]] = None,
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ):
         self.signed: T = signed
-        self.signatures = signatures
+        self.signatures = signatures or {}
         self.unrecognized_fields: Mapping[str, Any] = unrecognized_fields or {}
 
     def __eq__(self, other: Any) -> bool:
@@ -480,11 +480,13 @@ class Signed(metaclass=abc.ABCMeta):
     # or "inner metadata")
     def __init__(
         self,
-        version: int,
-        spec_version: str,
-        expires: datetime,
-        unrecognized_fields: Optional[Mapping[str, Any]] = None,
+        version: Optional[int],
+        spec_version: Optional[str],
+        expires: Optional[datetime],
+        unrecognized_fields: Optional[Mapping[str, Any]],
     ):
+        if spec_version is None:
+            spec_version = ".".join(SPECIFICATION_VERSION)
         # Accept semver (X.Y.Z) but also X.Y for legacy compatibility
         spec_list = spec_version.split(".")
         if len(spec_list) not in [2, 3] or not all(
@@ -497,11 +499,15 @@ class Signed(metaclass=abc.ABCMeta):
             raise ValueError(f"Unsupported spec_version {spec_version}")
 
         self.spec_version = spec_version
-        self.expires = expires
 
-        if version <= 0:
+        self.expires = expires or datetime.utcnow() + timedelta(days=1)
+
+        if version is None:
+            version = 1
+        elif version <= 0:
             raise ValueError(f"version must be > 0, got {version}")
         self.version = version
+
         self.unrecognized_fields: Mapping[str, Any] = unrecognized_fields or {}
 
     def __eq__(self, other: Any) -> bool:
@@ -838,20 +844,22 @@ class Root(Signed):
     # pylint: disable=too-many-arguments
     def __init__(
         self,
-        version: int,
-        spec_version: str,
-        expires: datetime,
-        keys: Dict[str, Key],
-        roles: Mapping[str, Role],
-        consistent_snapshot: Optional[bool] = None,
+        version: Optional[int] = None,
+        spec_version: Optional[str] = None,
+        expires: Optional[datetime] = None,
+        keys: Optional[Dict[str, Key]] = None,
+        roles: Optional[Mapping[str, Role]] = None,
+        consistent_snapshot: Optional[bool] = True,
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ):
         super().__init__(version, spec_version, expires, unrecognized_fields)
         self.consistent_snapshot = consistent_snapshot
-        self.keys = keys
-        if set(roles) != TOP_LEVEL_ROLE_NAMES:
-            raise ValueError("Role names must be the top-level metadata roles")
+        self.keys = keys or {}
 
+        if roles is None:
+            roles = {r: Role([], 1) for r in TOP_LEVEL_ROLE_NAMES}
+        elif set(roles) != TOP_LEVEL_ROLE_NAMES:
+            raise ValueError("Role names must be the top-level metadata roles")
         self.roles = roles
 
     def __eq__(self, other: Any) -> bool:
@@ -1129,14 +1137,14 @@ class Timestamp(Signed):
 
     def __init__(
         self,
-        version: int,
-        spec_version: str,
-        expires: datetime,
-        snapshot_meta: MetaFile,
+        version: Optional[int] = None,
+        spec_version: Optional[str] = None,
+        expires: Optional[datetime] = None,
+        snapshot_meta: Optional[MetaFile] = None,
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ):
         super().__init__(version, spec_version, expires, unrecognized_fields)
-        self.snapshot_meta = snapshot_meta
+        self.snapshot_meta = snapshot_meta or MetaFile(1)
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Timestamp):
@@ -1190,14 +1198,14 @@ class Snapshot(Signed):
 
     def __init__(
         self,
-        version: int,
-        spec_version: str,
-        expires: datetime,
-        meta: Dict[str, MetaFile],
+        version: Optional[int] = None,
+        spec_version: Optional[str] = None,
+        expires: Optional[datetime] = None,
+        meta: Optional[Dict[str, MetaFile]] = None,
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ):
         super().__init__(version, spec_version, expires, unrecognized_fields)
-        self.meta = meta
+        self.meta = meta if meta is not None else {"targets.json": MetaFile(1)}
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Snapshot):
@@ -1660,15 +1668,15 @@ class Targets(Signed):
     # pylint: disable=too-many-arguments
     def __init__(
         self,
-        version: int,
-        spec_version: str,
-        expires: datetime,
-        targets: Dict[str, TargetFile],
+        version: Optional[int] = None,
+        spec_version: Optional[str] = None,
+        expires: Optional[datetime] = None,
+        targets: Optional[Dict[str, TargetFile]] = None,
         delegations: Optional[Delegations] = None,
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ) -> None:
         super().__init__(version, spec_version, expires, unrecognized_fields)
-        self.targets = targets
+        self.targets = targets or {}
         self.delegations = delegations
 
     def __eq__(self, other: Any) -> bool:

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -104,6 +104,14 @@ class Metadata(Generic[T]):
     ``[Root]`` is not validated at runtime (as pure annotations are not available
     then).
 
+    New Metadata instances can be created from scratch with::
+
+        one_day = datetime.utcnow() + timedelta(days=1)
+        timestamp = Metadata(Timestamp(expires=one_day))
+
+    Apart from ``expires`` all of the arguments to the inner constructors have
+    reasonable default values for new metadata.
+
     *All parameters named below are not just constructor arguments but also
     instance attributes.*
 
@@ -112,6 +120,7 @@ class Metadata(Generic[T]):
             ``Snapshot``, ``Timestamp`` or ``Root``.
         signatures: Ordered dictionary of keyids to ``Signature`` objects, each
             signing the canonical serialized representation of ``signed``.
+            Default is an empty dictionary.
         unrecognized_fields: Dictionary of all attributes that are not managed
             by TUF Metadata API. These fields are NOT signed and it's preferable
             if unrecognized fields are added to the Signed derivative classes.
@@ -444,9 +453,11 @@ class Signed(metaclass=abc.ABCMeta):
     instance attributes.*
 
     Args:
-        version: Metadata version number.
-        spec_version: Supported TUF specification version number.
-        expires: Metadata expiry date.
+        version: Metadata version number. If None, then 1 is assigned.
+        spec_version: Supported TUF specification version. If None, then the
+            version currently supported by the library is assigned.
+        expires: Metadata expiry date. If None, then current date and time is
+            assigned.
         unrecognized_fields: Dictionary of all attributes that are not managed
             by TUF Metadata API
 
@@ -825,13 +836,17 @@ class Root(Signed):
     Parameters listed below are also instance attributes.
 
     Args:
-        version: Metadata version number.
-        spec_version: Supported TUF specification version number.
-        expires: Metadata expiry date.
+        version: Metadata version number. Default is 1.
+        spec_version: Supported TUF specification version. Default is the
+            version currently supported by the library.
+        expires: Metadata expiry date. Default is current date and time.
         keys: Dictionary of keyids to Keys. Defines the keys used in ``roles``.
+            Default is empty dictionary.
         roles: Dictionary of role names to Roles. Defines which keys are
-            required to sign the metadata for a specific role.
+            required to sign the metadata for a specific role. Default is
+            a dictionary of top level roles without keys and threshold of 1.
         consistent_snapshot: ``True`` if repository supports consistent snapshots.
+            Default is True.
         unrecognized_fields: Dictionary of all attributes that are not managed
             by TUF Metadata API
 
@@ -1122,12 +1137,14 @@ class Timestamp(Signed):
     instance attributes.*
 
     Args:
-        version: Metadata version number.
-        spec_version: Supported TUF specification version number.
-        expires: Metadata expiry date.
+        version: Metadata version number. Default is 1.
+        spec_version: Supported TUF specification version. Default is the
+            version currently supported by the library.
+        expires: Metadata expiry date. Default is current date and time.
         unrecognized_fields: Dictionary of all attributes that are not managed
             by TUF Metadata API
-        snapshot_meta: Meta information for snapshot metadata.
+        snapshot_meta: Meta information for snapshot metadata. Default is a
+            MetaFile with version 1.
 
     Raises:
         ValueError: Invalid arguments.
@@ -1183,12 +1200,14 @@ class Snapshot(Signed):
     instance attributes.*
 
     Args:
-        version: Metadata version number.
-        spec_version: Supported TUF specification version number.
-        expires: Metadata expiry date.
+        version: Metadata version number. Default is 1.
+        spec_version: Supported TUF specification version. Default is the
+            version currently supported by the library.
+        expires: Metadata expiry date. Default is current date and time.
         unrecognized_fields: Dictionary of all attributes that are not managed
             by TUF Metadata API
-        meta: Dictionary of target metadata filenames to ``MetaFile`` objects.
+        meta: Dictionary of targets filenames to ``MetaFile`` objects. Default
+            is a dictionary with a Metafile for "snapshot.json" version 1.
 
     Raises:
         ValueError: Invalid arguments.
@@ -1650,12 +1669,14 @@ class Targets(Signed):
     instance attributes.*
 
     Args:
-        version: Metadata version number.
-        spec_version: Supported TUF specification version number.
-        expires: Metadata expiry date.
-        targets: Dictionary of target filenames to TargetFiles
+        version: Metadata version number. Default is 1.
+        spec_version: Supported TUF specification version. Default is the
+            version currently supported by the library.
+        expires: Metadata expiry date. Default is current date and time.
+        targets: Dictionary of target filenames to TargetFiles. Default is an
+            empty dictionary.
         delegations: Defines how this Targets delegates responsibility to other
-            Targets Metadata files.
+            Targets Metadata files. Default is None.
         unrecognized_fields: Dictionary of all attributes that are not managed
             by TUF Metadata API
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -124,7 +124,7 @@ class Metadata(Generic[T]):
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ):
         self.signed: T = signed
-        self.signatures = signatures or {}
+        self.signatures = signatures if signatures is not None else {}
         self.unrecognized_fields: Mapping[str, Any] = unrecognized_fields or {}
 
     def __eq__(self, other: Any) -> bool:
@@ -854,7 +854,7 @@ class Root(Signed):
     ):
         super().__init__(version, spec_version, expires, unrecognized_fields)
         self.consistent_snapshot = consistent_snapshot
-        self.keys = keys or {}
+        self.keys = keys if keys is not None else {}
 
         if roles is None:
             roles = {r: Role([], 1) for r in TOP_LEVEL_ROLE_NAMES}
@@ -1676,7 +1676,7 @@ class Targets(Signed):
         unrecognized_fields: Optional[Mapping[str, Any]] = None,
     ) -> None:
         super().__init__(version, spec_version, expires, unrecognized_fields)
-        self.targets = targets or {}
+        self.targets = targets if targets is not None else {}
         self.delegations = delegations
 
     def __eq__(self, other: Any) -> bool:


### PR DESCRIPTION
Tweak the constructor signatures to make creating brand new Metadata easier (the constructors were originally designed for deserialization purposes). Modify examples and tests to use the new constructor args.

The changes are backwards compatible. Resulting API is much easier to use for creating new Metadata. The API is still a bit unusual but not difficult to learn IMO:

    targets = Metadata(Targets())

There are some noteworthy cases:
* `expires` does not have a reasonable default value and I planned to leave it a required argument. That would have broken backwards compat however as order of arguments would have had to change. So expires now defaults to an arbitrary 1 day in future _EDIT: changed to `utcnow()` so default is expired metadata_
* `consistent_snapshot` defaults to True but None is still possible to indicate Metadata does not contain the field at all
* `spec_version` defaults to whatever is the current library supported version

Only the core metadata classes we're updated. There are other classes that would probably benefit from a better constructor, like Delegations, but those were not handled yet. 

Fixes #1459

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


