### PR TITLE
verify_release: Warn about missing requirements

### DIFF
--- a/verify_release
+++ b/verify_release
@@ -16,7 +16,13 @@ import sys
 from filecmp import dircmp
 from tempfile import TemporaryDirectory
 
-import requests
+try:
+    import requests
+    import build
+except ImportError:
+    print ("Error: verify_release requires modules 'requests' and 'build':")
+    print ("    pip install requests build")
+    exit(1)
 
 # Project variables
 # Note that only these project artifacts are supported:


### PR DESCRIPTION
This is mostly useful for build module as it's not imported otherwise:
we explicitly call "python -m build" so everything works like in a
real release build.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

---

Forgot this from the initial PR: it's not critical but I think makes sense. verify_release should be something that's easy to run for anyone, not just core developers who have requirements-dev.txt installed.