### PR TITLE
requirements-test: Upgrade black to fix lint

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,7 @@
 
 # additional test tools for linting and coverage measurement
 coverage==6.3.2
-black==22.1.0
+black==22.3.0
 isort==5.10.1
 pylint==2.13.2
 mypy==0.942


### PR DESCRIPTION
Black uses some internal Click API which was just removed:
Upgrade black to 22.3 that fixes this.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

---

Lint is currently broken on develop, this should fix it.