### PR TITLE
Add GH workflow to build and release on PyPI (WIP)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,53 @@
+name: CD
+concurrency: cd
+
+# Trigger workflow on release tag push
+on:
+  push:
+    # TODO: Should we restrict to vX.Y.Z tags?
+    tags: v*
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+
+      - name: Set up Python
+        uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20
+        with:
+          python-version: '3.x'
+
+      - name: Install build dependency
+        run: python3 -m pip install --upgrade pip build
+
+      - name: Build binary wheel and source tarball
+        run: python3 -m build --sdist --wheel --outdir dist/ .
+
+      - name: Store build artifacts for review and release
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
+        with:
+          name: build-artifacts
+          path: dist
+
+  release-on-pypi:
+    name: Release on PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    environment: release
+    steps:
+      - name: Fetch build artifacts
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
+        with:
+          name: build-artifacts
+          path: dist
+
+      - name: Publish binary wheel and source tarball on PyPI
+        uses: pypa/gh-action-pypi-publish@717ba43cfbb0387f6ce311b169a825772f54d295
+        with:
+          user: __token__
+          # TODO: Change to PyPI and update token
+          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,8 +71,8 @@ jobs:
       - name: Finalize GitHub release
         uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e
         with:
-        script: |
-          console.log(${{needs.build.outputs.release_id}})
+          script: |
+            console.log(${{needs.build.outputs.release_id}})
 #           await github.rest.repos.updateRelease({
 
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    if: ${{ github.ref_type == 'tag' }}
     steps:
       - name: Checkout release tag
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
@@ -26,14 +27,26 @@ jobs:
       - name: Build binary wheel and source tarball
         run: python3 -m build --sdist --wheel --outdir dist/ .
 
-      - name: Store build artifacts for review and release
+      - name: Publish GitHub release candiate
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+        with:
+          name: ${{ github.ref_name }}-rc
+          tag_name: ${{ github.ref }}
+          # prerelease: true # <- verify_release script 'get_github_version' ignores pre-releases (and drafts)
+          body: "Release waiting for review..."
+          files: dist/*
+
+      - name: Store build artifacts
+        # NOTE: The release job could download the assets from the GitHub release page,
+        # published in the previous step. But using the GitHub upload/download actions
+        # seems more robust as there is no need to compute download URLs.
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
         with:
           name: build-artifacts
           path: dist
 
-  release-on-pypi:
-    name: Release on PyPI
+  release:
+    name: Release
     runs-on: ubuntu-latest
     needs: build
     environment: release
@@ -43,11 +56,18 @@ jobs:
         with:
           name: build-artifacts
           path: dist
+          
+      # - name: Publish binary wheel and source tarball on PyPI
+      #   uses: pypa/gh-action-pypi-publish@717ba43cfbb0387f6ce311b169a825772f54d295
+      #   with:
+      #     user: __token__
+      #     # TODO: Change to PyPI and update token
+      #     repository_url: https://test.pypi.org/legacy/
+      #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
 
-      - name: Publish binary wheel and source tarball on PyPI
-        uses: pypa/gh-action-pypi-publish@717ba43cfbb0387f6ce311b169a825772f54d295
+      - name: Finalize GitHub release
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         with:
-          user: __token__
-          # TODO: Change to PyPI and update token
-          repository_url: https://test.pypi.org/legacy/
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref }}
+          body: "See CHANGELOG.md for details."

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,45 +5,48 @@ concurrency: cd
 on:
   push:
     # TODO: Should we restrict to vX.Y.Z tags?
-    tags: v*
+    # tags: v*
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    if: ${{ github.ref_type == 'tag' }}
+    # if: ${{ github.ref_type == 'tag' }}
+    outputs:
+      release_id: ${{ steps.gh-release.outputs.id }}
     steps:
       - name: Checkout release tag
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
 
-      - name: Set up Python
-        uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20
-        with:
-          python-version: '3.x'
+      # - name: Set up Python
+      #   uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20
+      #   with:
+      #     python-version: '3.x'
 
-      - name: Install build dependency
-        run: python3 -m pip install --upgrade pip build
+      # - name: Install build dependency
+      #   run: python3 -m pip install --upgrade pip build
 
-      - name: Build binary wheel and source tarball
-        run: python3 -m build --sdist --wheel --outdir dist/ .
+      # - name: Build binary wheel and source tarball
+      #   run: python3 -m build --sdist --wheel --outdir dist/ .
 
-      - name: Publish GitHub release candiate
+      - id: gh-release
+        name: Publish GitHub release candiate
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         with:
           name: ${{ github.ref_name }}-rc
           tag_name: ${{ github.ref }}
           # prerelease: true # <- verify_release script 'get_github_version' ignores pre-releases (and drafts)
           body: "Release waiting for review..."
-          files: dist/*
+          # files: dist/*
 
-      - name: Store build artifacts
-        # NOTE: The release job could download the assets from the GitHub release page,
-        # published in the previous step. But using the GitHub upload/download actions
-        # seems more robust as there is no need to compute download URLs.
-        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
-        with:
-          name: build-artifacts
-          path: dist
+      # - name: Store build artifacts
+      #   # NOTE: The release job could download the assets from the GitHub release page,
+      #   # published in the previous step. But using the GitHub upload/download actions
+      #   # seems more robust as there is no need to compute download URLs.
+      #   uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
+      #   with:
+      #     name: build-artifacts
+      #     path: dist
 
   release:
     name: Release
@@ -51,12 +54,12 @@ jobs:
     needs: build
     environment: release
     steps:
-      - name: Fetch build artifacts
-        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
-        with:
-          name: build-artifacts
-          path: dist
-          
+      # - name: Fetch build artifacts
+      #   uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
+      #   with:
+      #     name: build-artifacts
+      #     path: dist
+
       # - name: Publish binary wheel and source tarball on PyPI
       #   uses: pypa/gh-action-pypi-publish@717ba43cfbb0387f6ce311b169a825772f54d295
       #   with:
@@ -66,8 +69,22 @@ jobs:
       #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
 
       - name: Finalize GitHub release
-        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+        uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e
         with:
-          name: ${{ github.ref_name }}
-          tag_name: ${{ github.ref }}
-          body: "See CHANGELOG.md for details."
+        script: |
+          console.log(${{needs.build.outputs.release_id}})
+#           await github.rest.repos.updateRelease({
+
+
+#             })
+
+# octokit.rest.repos.createRelease({
+#   owner,
+#   repo,
+#   tag_name,
+# });
+
+
+#           name: ${{ github.ref_name }}
+#           tag_name: ${{ github.ref }}
+#           body: "See CHANGELOG.md for details."

--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -5,4 +5,4 @@
 """
 
 # This value is used in the requests user agent.
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/verify_release
+++ b/verify_release
@@ -9,6 +9,7 @@ Builds a release from current commit and verifies that the release artifacts
 on GitHub and PyPI match the built release artifacts.
 """
 
+import argparse
 import json
 import os
 import subprocess
@@ -27,8 +28,8 @@ except ImportError:
 # Project variables
 # Note that only these project artifacts are supported:
 # [f"{PYPI_PROJECT}-{VER}-none-any.whl",  f"{PYPI_PROJECT}-{VER}.tar.gz"]
-GITHUB_ORG = "theupdateframework"
-GITHUB_PROJECT = "python-tuf"
+GITHUB_ORG = "lukpueh"
+GITHUB_PROJECT = "tuf"
 PYPI_PROJECT = "tuf"
 
 
@@ -126,9 +127,17 @@ def progress(s: str) -> None:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--skip-pypi",
+        action="store_true",
+        dest="skip_pypi",
+        help="Skip comparison with PyPI release.",
+    )
+    args = parser.parse_args()
+
     success = True
     with TemporaryDirectory() as build_dir:
-
         progress("Building release")
         build_version = build(build_dir)
         finished(f"Built release {build_version}")
@@ -143,16 +152,17 @@ def main() -> int:
         if github_version != build_version:
             finished(f"WARNING: GitHub latest version is {github_version}")
 
-        progress("Checking PyPI latest version")
-        pypi_version = get_pypi_pip_version()
-        if pypi_version != build_version:
-            finished(f"WARNING: PyPI latest version is {pypi_version}")
+        if not args.skip_pypi:
+            progress("Checking PyPI latest version")
+            pypi_version = get_pypi_pip_version()
+            if pypi_version != build_version:
+                finished(f"WARNING: PyPI latest version is {pypi_version}")
 
-        progress("Downloading release from PyPI")
-        if not verify_pypi_release(build_version, build_dir):
-            # This is expected while build is not reproducible
-            finished("ERROR: PyPI artifacts do not match built release")
-            success = False
+            progress("Downloading release from PyPI")
+            if not verify_pypi_release(build_version, build_dir):
+                # This is expected while build is not reproducible
+                finished("ERROR: PyPI artifacts do not match built release")
+                success = False
 
         progress("Downloading release from GitHub")
         if not verify_github_release(build_version, build_dir):


### PR DESCRIPTION
Fixes #1550 

This PR adds a workflow with two jobs to **build** and **release on PyPI**. The release job waits for the build job and uses a custom release environment, which can be configured to require review.

To share the build artifacts between the jobs and to make them available for intermediate review, we use [actions/upload-artifact](https://github.com/actions/upload-artifact) (in build) and [actions/download-artifact](https://github.com/actions/download-artifact) (in release) (also see [GitHub docs](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts)).

To upload the build artifacts to PyPI, we use [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) as [recommend by PyPA](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/).

A [demo is available in my fork](https://github.com/lukpueh/tuf/actions/runs/2065688693).

**Caveat**
The URL to grab the build artifacts created in a workflow run requires knowledge of the corresponding action ID and artifact ID, plus a login token (w/o special permissions). This makes it a bit cumbersome to fetch the artifacts with a script in order to compare them to a local build. It might be easier to instruct reviewer to download the [artifacts manually using the GitHub UI](https://docs.github.com/en/actions/managing-workflow-runs/downloading-workflow-artifacts), and tailor the [local verification script ](https://github.com/theupdateframework/python-tuf/pull/1913) accordingly.

**TODO**
- [ ] Change `repository_url` to release on PyPI instead of Test PyPI and update the token
- [ ] Require successful CI run for a pushed tag to trigger the workflow, instead of just a push (see [`workflow_run` docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow))
- [ ] Integrate workflow with [local verification](https://github.com/theupdateframework/python-tuf/pull/1913) (see caveat above)
- [ ] Add "Release on GitHub" job to workflow
   Note, this could be akin to and in parallel with the "release-on-pypi" job, waiting for the same review approval, and uploading the same build artifacts as release assets. Alternatively, we could create the release as part of the build job and upload the build artifacts as release assets right away, bypassing the download/upload caveat from above. It would be nice if we could set the release as draft at first, but that has the same caveat, i.e. it requires a token and special knowledge to download the assets.
- [ ] Update documentation
  - [ ] [RELEASE.md](https://github.com/theupdateframework/python-tuf/blob/434730fc3354574d548a9b947bdc5314ec5a2a3b/docs/RELEASE.md)
  - [ ] [INSTALLATION.html#verify-release-signatures](https://theupdateframework.readthedocs.io/en/latest/INSTALLATION.html#verify-release-signatures) 

