### PR TITLE
import requests.exceptions is not necessary

### DIFF
--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -11,7 +11,6 @@ from urllib import parse
 
 # Imports
 import requests
-import requests.exceptions
 
 import tuf
 from tuf.api import exceptions


### PR DESCRIPTION
All calls use requests.* and importing requests.exceptions is not
necessary.

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>

**Description of the changes being introduced by the pull request**:
The `tuf/ngclient/_internal/requests_fetcher.py` uses `requests` and handles requests exceptions, however, all calls use the `request.* ` 

**Please verify and check that the pull request fulfills the following
requirements**:

- [X] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


