### PR TITLE
Add GH workflow to build and release on GH and PyPI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.gh-release.outputs.id }}
     steps:
       - name: Checkout release tag
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
@@ -26,14 +28,29 @@ jobs:
       - name: Build binary wheel and source tarball
         run: python3 -m build --sdist --wheel --outdir dist/ .
 
-      - name: Store build artifacts for review and release
+      - id: gh-release
+        name: Publish GitHub release candiate
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+        with:
+          name: ${{ github.ref_name }}-rc
+          tag_name: ${{ github.ref }}
+          body: "Release waiting for review..."
+          files: dist/*
+
+      - name: Store build artifacts
+        # NOTE: The release job could download the assets from the GitHub release page,
+        # published in the previous step. But using the GitHub upload/download actions
+        # seems more robust as there is no need to compute download URLs.
+        # NOTE: (2) action-gh-release returns download URLSs as output, which could be
+        # propagated to next job along with release_id (see above)
+        # https://github.com/softprops/action-gh-release#outputs
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
         with:
           name: build-artifacts
           path: dist
 
-  release-on-pypi:
-    name: Release on PyPI
+  release:
+    name: Release
     runs-on: ubuntu-latest
     needs: build
     environment: release
@@ -49,3 +66,15 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Finalize GitHub release
+        uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e
+        with:
+          script: |
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: '${{ needs.build.outputs.release_id }}',
+              name: '${{ github.ref_name }}',
+              body: 'See [CHANGELOG.md](https://github.com/'+ context.repo.owner +'/'+ context.repo.repo +'/blob/${{ github.ref_name }}/docs/CHANGELOG.md) for details.'
+            })

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,21 +1,35 @@
 name: CD
 concurrency: cd
 
-# Trigger workflow on release tag push
+# Trigger workflow on completed CI (further checks below)
 on:
-  push:
-    # TODO: Should we restrict to vX.Y.Z tags?
-    tags: v*
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    # Skip unless CI was successful and ran on a ref starting with 'v' (release tag)
+    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v') }}
+    # NOTE: This works because we currently only trigger CI on a push to the 'develop'
+    # branch or a 'v*'-tag, but it seems rather brittle.
+    # Unfortunately, there is not much more info we get from the CI workflow
+    # ('workflow_run') than the ref name. No ref, ref_type, etc., so we don't even know
+    # if a tag or a branch was pushed. :(
+    # See https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_run
+    # NOTE: (2) An alternative solution might be to restructure workflows, so that all
+    # test logic from 'ci.yml' is moved to a separate workflow file '_test.yml', that
+    # can be included in both CI (triggered on push to 'develop'-branch) and CD
+    # (triggered on push to 'v*'-tag) workflows.
     outputs:
       release_id: ${{ steps.gh-release.outputs.id }}
     steps:
       - name: Checkout release tag
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Set up Python
         uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20
@@ -32,8 +46,8 @@ jobs:
         name: Publish GitHub release candiate
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         with:
-          name: ${{ github.ref_name }}-rc
-          tag_name: ${{ github.ref }}
+          name: ${{ github.event.workflow_run.head_branch }}-rc
+          tag_name: ${{ github.event.workflow_run.head_branch }}
           body: "Release waiting for review..."
           files: dist/*
 
@@ -75,6 +89,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: '${{ needs.build.outputs.release_id }}',
-              name: '${{ github.ref_name }}',
-              body: 'See [CHANGELOG.md](https://github.com/'+ context.repo.owner +'/'+ context.repo.repo +'/blob/${{ github.ref_name }}/docs/CHANGELOG.md) for details.'
+              name: '${{ github.event.workflow_run.head_branch }}',
+              body: 'See [CHANGELOG.md](https://github.com/'+ context.repo.owner +'/'+ context.repo.repo +'/blob/${{ github.event.workflow_run.head_branch }}/docs/CHANGELOG.md) for details.'
             })

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,7 +1,7 @@
 name: CD
 concurrency: cd
 
-# Trigger workflow on completed CI (further checks below)
+# Trigger workflow on any completed CI (see further checks below)
 on:
   workflow_run:
     workflows: [CI]
@@ -11,18 +11,11 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    # Skip unless CI was successful and ran on a ref starting with 'v' (release tag)
-    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v') }}
-    # NOTE: This works because we currently only trigger CI on a push to the 'develop'
-    # branch or a 'v*'-tag, but it seems rather brittle.
-    # Unfortunately, there is not much more info we get from the CI workflow
-    # ('workflow_run') than the ref name. No ref, ref_type, etc., so we don't even know
-    # if a tag or a branch was pushed. :(
-    # See https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_run
-    # NOTE: (2) An alternative solution might be to restructure workflows, so that all
-    # test logic from 'ci.yml' is moved to a separate workflow file '_test.yml', that
-    # can be included in both CI (triggered on push to 'develop'-branch) and CD
-    # (triggered on push to 'v*'-tag) workflows.
+    # Skip unless CI was successful and ran on release tag, a ref starting with 'v'.
+    # NOTE: We assume CI does not trigger on branches that start with 'v' (see #1961)
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
     outputs:
       release_id: ${{ steps.gh-release.outputs.id }}
     steps:
@@ -52,13 +45,10 @@ jobs:
           files: dist/*
 
       - name: Store build artifacts
-        # NOTE: The release job could download the assets from the GitHub release page,
-        # published in the previous step. But using the GitHub upload/download actions
-        # seems more robust as there is no need to compute download URLs.
-        # NOTE: (2) action-gh-release returns download URLSs as output, which could be
-        # propagated to next job along with release_id (see above)
-        # https://github.com/softprops/action-gh-release#outputs
         uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
+        # NOTE: The GitHub release page contains the release artifacts too, but using
+        # GitHub upload/download actions seems robuster: there is no need to compute
+        # download URLs and tampering with artifacts between jobs is more limited.
         with:
           name: build-artifacts
           path: dist
@@ -90,5 +80,8 @@ jobs:
               repo: context.repo.repo,
               release_id: '${{ needs.build.outputs.release_id }}',
               name: '${{ github.event.workflow_run.head_branch }}',
-              body: 'See [CHANGELOG.md](https://github.com/'+ context.repo.owner +'/'+ context.repo.repo +'/blob/${{ github.event.workflow_run.head_branch }}/docs/CHANGELOG.md) for details.'
+              body: 'See [CHANGELOG.md](https://github.com/' +
+                     context.repo.owner + '/' + context.repo.repo + '/blob/' +
+                     '${{ github.event.workflow_run.head_branch }}'+
+                     '/docs/CHANGELOG.md) for details.'
             })

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,51 @@
+name: CD
+concurrency: cd
+
+# Trigger workflow on release tag push
+on:
+  push:
+    # TODO: Should we restrict to vX.Y.Z tags?
+    tags: v*
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+
+      - name: Set up Python
+        uses: actions/setup-python@0ebf233433c08fb9061af664d501c3f3ff0e9e20
+        with:
+          python-version: '3.x'
+
+      - name: Install build dependency
+        run: python3 -m pip install --upgrade pip build
+
+      - name: Build binary wheel and source tarball
+        run: python3 -m build --sdist --wheel --outdir dist/ .
+
+      - name: Store build artifacts for review and release
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
+        with:
+          name: build-artifacts
+          path: dist
+
+  release-on-pypi:
+    name: Release on PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    environment: release
+    steps:
+      - name: Fetch build artifacts
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
+        with:
+          name: build-artifacts
+          path: dist
+
+      - name: Publish binary wheel and source tarball on PyPI
+        uses: pypa/gh-action-pypi-publish@717ba43cfbb0387f6ce311b169a825772f54d295
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 name: CI
 
 on:
+  # NOTE: CD relies on this configuration (see #1961)
   push:
     branches:
       - develop
     tags:
-      # TODO: Should we restrict to vX.Y.Z tags?
       - v*
 
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - develop
+    tags:
+      # TODO: Should we restrict to vX.Y.Z tags?
+      - v*
+
   pull_request:
   workflow_dispatch:
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,39 +1,29 @@
 # Release process
 
-* Ensure you have a backup of all working files and then remove files not tracked by git
-  `git clean -xdf`. **NOTE**: this will delete all files in the tuf tree that aren't
-  tracked by git
-* Ensure `docs/CHANGELOG.md` contains a one-line summary of each [notable
+1. Ensure `docs/CHANGELOG.md` contains a one-line summary of each [notable
   change](https://keepachangelog.com/) since the prior release
-* Update `tuf/__init__.py` to the new version number "A.B.C"
-* Test packaging, uploading to Test PyPI and installing from a virtual environment
-  (ensure commands invoking `python` below are using Python 3)
-  * Remove existing dist build dirs
-  * Create source dist and wheel `python3 -m build`
-  * Sign source dist `gpg --detach-sign -a dist/tuf-A.B.C.tar.gz`
-  * Sign wheel `gpg --detach-sign -a dist/tuf-A.B.C-py3-none-any.whl`
-  * Upload to test PyPI `twine upload --repository testpypi dist/*`
-  * Verify the uploaded package at https://test.pypi.org/project/tuf/:
-    Note that installing packages with pip using test.pypi.org is potentially
-    dangerous (as dependencies may be squatted): download the file and install
-    the local file instead.
-* Create a PR with updated `CHANGELOG.md` and version bumps
-* Once the PR is merged, pull the updated `develop` branch locally
-* Create a signed tag matching the updated version number on the merge commit
+2. Update `tuf/__init__.py` to the new version number `A.B.C`
+3. Create a PR with updated `CHANGELOG.md` and version bumps
+
+&#10132; Review PR on GitHub
+
+4. Once the PR is merged, pull the updated `develop` branch locally
+5. Create a signed tag for the version number on the merge commit
   `git tag --sign vA.B.C -m "vA.B.C"`
-  * Push the tag to GitHub `git push origin vA.B.C`
-* Create a new release on GitHub, copying the `CHANGELOG.md` entries for the
-  release
-* Create a package for the formal release
-  (ensure commands invoking `python` below are using Python 3)
-  * Remove existing dist build dirs
-  * Create source dist and wheel `python3 -m build`
-  * Sign source dist `gpg --detach-sign -a dist/tuf-A.B.C.tar.gz`
-  * Sign wheel `gpg --detach-sign -a dist/tuf-A.B.C-py3-none-any.whl`
-  * Upload to PyPI `twine upload dist/*`
-  * Verify the package at https://pypi.org/project/tuf/ and by installing with pip
-* Attach both signed dists and their detached signatures to the release on GitHub
-* `verify_release` should be used to make sure the release artifacts match the
-  git sources, preferably by another developer on a different machine.
-* Announce the release on [#tuf on CNCF Slack](https://cloud-native.slack.com/archives/C8NMD3QJ3)
-* Ensure [POUF 1](https://github.com/theupdateframework/taps/blob/master/POUFs/reference-POUF/pouf1.md), for the reference implementation, is up-to-date
+6. Push the tag to GitHub `git push origin vA.B.C`
+
+  *A push triggers the [CI workflow](.github/workfows/ci.yml), which, on success, triggers
+  the [CD worfklow](.github/workfows/cd.yml), which builds source dist and wheel,
+  creates a preliminary GitHub release under `vA.B.C-rc`, and pauses for review.*
+
+7. Run `verify_release --skip-pypi` locally to make sure a build on your machine matches
+  the preliminary release artifacts published on GitHub.
+
+&#10132; [Review *deployemnt*](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments) on GitHub
+
+  *An approval resumes the CD workflow to publish the release on PyPI, and to finalize the
+  GitHub release (removse `-rc` suffix and updates release notes).*
+
+8. `verify_release` may be used again to make sure the release artifacts PyPI.
+9. Announce the release on [#tuf on CNCF Slack](https://cloud-native.slack.com/archives/C8NMD3QJ3)
+10. Ensure [POUF 1](https://github.com/theupdateframework/taps/blob/master/POUFs/reference-POUF/pouf1.md), for the reference implementation, is up-to-date

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,5 +1,23 @@
 # Release process
 
+
+**Prerequisites (one-time setup)**
+
+
+1. Go to [PyPI management page](https://pypi.org/manage/account/#api-tokens) and create
+   an [API token](https://pypi.org/help/#apitoken) with its scope limited to the tuf project.
+1. Go to [GitHub
+   settings](https://github.com/theupdateframework/python-tuf/settings/environments),
+   create an
+   [environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#creating-an-environment)
+   called `release` and configure [review
+   protection](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#required-reviewers).
+1. In the environment create a
+   [secret](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#environment-secrets)
+   called `PYPI_API_TOKEN` and paste the token created above.
+
+## Release
+
 1. Ensure `docs/CHANGELOG.md` contains a one-line summary of each [notable
   change](https://keepachangelog.com/) since the prior release
 2. Update `tuf/__init__.py` to the new version number `A.B.C`
@@ -12,18 +30,21 @@
   `git tag --sign vA.B.C -m "vA.B.C"`
 6. Push the tag to GitHub `git push origin vA.B.C`
 
-  *A push triggers the [CI workflow](.github/workfows/ci.yml), which, on success, triggers
-  the [CD worfklow](.github/workfows/cd.yml), which builds source dist and wheel,
-  creates a preliminary GitHub release under `vA.B.C-rc`, and pauses for review.*
+  *A push triggers the [CI workflow](.github/workfows/ci.yml), which, on success,
+  triggers the [CD workflow](.github/workfows/cd.yml), which builds source dist and
+  wheel, creates a preliminary GitHub release under `vA.B.C-rc`, and pauses for review.*
 
 7. Run `verify_release --skip-pypi` locally to make sure a build on your machine matches
   the preliminary release artifacts published on GitHub.
 
-&#10132; [Review *deployemnt*](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments) on GitHub
+&#10132; [Review *deployment*](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments)
+on GitHub
 
   *An approval resumes the CD workflow to publish the release on PyPI, and to finalize the
-  GitHub release (removse `-rc` suffix and updates release notes).*
+  GitHub release (removes `-rc` suffix and updates release notes).*
 
-8. `verify_release` may be used again to make sure the release artifacts PyPI.
+8. `verify_release` may be used again to make sure the PyPI release artifacts match the
+   local build as well.
 9. Announce the release on [#tuf on CNCF Slack](https://cloud-native.slack.com/archives/C8NMD3QJ3)
-10. Ensure [POUF 1](https://github.com/theupdateframework/taps/blob/master/POUFs/reference-POUF/pouf1.md), for the reference implementation, is up-to-date
+10. Ensure [POUF 1](https://github.com/theupdateframework/taps/blob/master/POUFs/reference-POUF/pouf1.md),
+    for the reference implementation, is up-to-date

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
 
 [testenv:lint]
 changedir = {toxinidir}
-lint_dirs = tuf examples tests
+lint_dirs = tuf examples tests verify_release
 commands =
     black --check --diff {[testenv:lint]lint_dirs}
     isort --check --diff {[testenv:lint]lint_dirs}

--- a/verify_release
+++ b/verify_release
@@ -17,12 +17,12 @@ from filecmp import dircmp
 from tempfile import TemporaryDirectory
 
 try:
+    import build as _  # type: ignore
     import requests
-    import build
 except ImportError:
-    print ("Error: verify_release requires modules 'requests' and 'build':")
-    print ("    pip install requests build")
-    exit(1)
+    print("Error: verify_release requires modules 'requests' and 'build':")
+    print("    pip install requests build")
+    sys.exit(1)
 
 # Project variables
 # Note that only these project artifacts are supported:
@@ -128,7 +128,6 @@ def progress(s: str) -> None:
 def main() -> int:
     success = True
     with TemporaryDirectory() as build_dir:
-
         progress("Building release")
         build_version = build(build_dir)
         finished(f"Built release {build_version}")

--- a/verify_release
+++ b/verify_release
@@ -9,6 +9,7 @@ Builds a release from current commit and verifies that the release artifacts
 on GitHub and PyPI match the built release artifacts.
 """
 
+import argparse
 import json
 import os
 import subprocess
@@ -126,6 +127,15 @@ def progress(s: str) -> None:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--skip-pypi",
+        action="store_true",
+        dest="skip_pypi",
+        help="Skip PyPI release check.",
+    )
+    args = parser.parse_args()
+
     success = True
     with TemporaryDirectory() as build_dir:
         progress("Building release")
@@ -142,16 +152,17 @@ def main() -> int:
         if github_version != build_version:
             finished(f"WARNING: GitHub latest version is {github_version}")
 
-        progress("Checking PyPI latest version")
-        pypi_version = get_pypi_pip_version()
-        if pypi_version != build_version:
-            finished(f"WARNING: PyPI latest version is {pypi_version}")
+        if not args.skip_pypi:
+            progress("Checking PyPI latest version")
+            pypi_version = get_pypi_pip_version()
+            if pypi_version != build_version:
+                finished(f"WARNING: PyPI latest version is {pypi_version}")
 
-        progress("Downloading release from PyPI")
-        if not verify_pypi_release(build_version, build_dir):
-            # This is expected while build is not reproducible
-            finished("ERROR: PyPI artifacts do not match built release")
-            success = False
+            progress("Downloading release from PyPI")
+            if not verify_pypi_release(build_version, build_dir):
+                # This is expected while build is not reproducible
+                finished("ERROR: PyPI artifacts do not match built release")
+                success = False
 
         progress("Downloading release from GitHub")
         if not verify_github_release(build_version, build_dir):


### PR DESCRIPTION
Fixes #1550
Supersedes #1933

**Description of the changes being introduced by the pull request**:

Adds a new GitHub workflow (cd), which is triggered on a successful run of the automated tests (ci), but only if ci was triggered by a release tag push.

The new cd workflow builds wheel and sdist at the pushed tag, creates a preliminary GitHub release (X.Y.Z-rc), uploading the release artifacts as assets, and pauses for [review](https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments), which may include locally running `verify_release` (see RELEASE.md for details). 

Upon approval, the release artifacts are published on PyPI and the Github release is finalized.
 
This PR further:
- updates RELEASE.md to match the new workflow
- updates `verify_release` script to allow intermediate review, in order to approve the deployment.
- (unrelated) configures tox to also lint `verify_release`

Please see commits messages for details!

**Demo**
See instructions in https://github.com/lukpueh/tuf/commit/82b7b122a99d0b39c0ddff7239ee33fcb391018d, also note that:
- `cd.yml` needs to be on your [default branch for the workflow to trigger](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run)
- Please don't publish vX.Y.Z versions for demo purposes. Although, we can remove them, we can't reuse the version numbers for actual release testing. (see [PEP 440](https://peps.python.org/pep-0440/#developmental-releases) for development release version numbers)

**TODOs** (likely in follow-up PRs)
-  (critical) re-enable release signing -- Prior to this PR RELEASE.md instructed maintainers to sign release artifacts with GPG as part of the manual release process. The [installation docs](https://theupdateframework.readthedocs.io/en/latest/INSTALLATION.html#verify-release-signatures) still mention release signatures. Some ideas to fix this inconsistency:
   - quick-fix 1: don't require signing (update docs)
   - quick-fix 2: sign in GitHub action
   - quick-fix 3: sign locally and upload signatures to release assets manually (integrate with `verify_release` script?)
   - long-term fix: e.g. in-toto ([#529](https://github.com/theupdateframework/python-tuf/issues/529))
- replace 3rd-party actions with custom code -- This PR adds two 3rd-party actions `softprops/action-gh-release` and `pypa/gh-action-pypi-publish`, which goes against our "only allow actions created by GitHub"-policy. It does not seem like a big deal, because the former action is popular and recommended by the archived GitHub-native `action/create-release`, and the latter is hosted by the pypa, which also hosts `twine`, the tool we usually use to pubish on pypi. Still, we should at least see how hard it would be to implement the required logic for those actions ourselves (see [custom finalize release action](https://github.com/lukpueh/tuf/blob/37cb272a437c2a2455a1172d74e57055c6056ae6/.github/workflows/cd.yml#L84-L94) in cd.yml for inspiration)
- make ci/cd setup more robust (see [code comment](https://github.com/lukpueh/tuf/blob/37cb272a437c2a2455a1172d74e57055c6056ae6/.github/workflows/cd.yml#L16-L25))
- replace upload/download artifacts with downloading artifacts from GitHub release assets (see [code comment](https://github.com/lukpueh/tuf/blob/37cb272a437c2a2455a1172d74e57055c6056ae6/.github/workflows/cd.yml#L55-L60))
- (nice to have) auto-generate release notes for GitHub release page (see [GH docs](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes))
- Configure release job to not add GitHub auto-created release artifacts ([requested by Jussi](https://github.com/theupdateframework/python-tuf/pull/1946#discussion_r845774429))
- CD workflow could have a permissions section

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


