### PR TITLE
verify_release: Build from git sources only

### DIFF
--- a/verify_release
+++ b/verify_release
@@ -34,13 +34,22 @@ PYPI_PROJECT = "tuf"
 
 def build(build_dir: str) -> str:
     """Build release locally. Return version as string"""
-    cmd = ["python3", "-m", "build", "--outdir", build_dir]
-    subprocess.run(cmd, stdout=subprocess.DEVNULL, check=True)
+    orig_dir = os.path.dirname(os.path.abspath(__file__))
+
+    with TemporaryDirectory() as src_dir:
+        # fresh git clone: this prevents uncommitted files from affecting build
+        git_cmd = ["git", "clone", "--quiet", orig_dir, src_dir]
+        subprocess.run(git_cmd, stdout=subprocess.DEVNULL, check=True)
+
+        build_cmd = ["python3", "-m", "build", "--outdir", build_dir, src_dir]
+        subprocess.run(build_cmd, stdout=subprocess.DEVNULL, check=True)
+
     build_version = None
     for filename in os.listdir(build_dir):
         prefix, postfix = f"{PYPI_PROJECT}-", ".tar.gz"
         if filename.startswith(prefix) and filename.endswith(postfix):
             build_version = filename[len(prefix) : -len(postfix)]
+
     assert build_version
     return build_version
 


### PR DESCRIPTION
Make a new (local) git clone to ensure uncommitted files do not affect
the build.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>


---

Fixes #1942

`verify_release` has the fate of every build script in history of build scripts: it ends up handling more edge cases than originally planned :grimacing: We probably should be more strict about only including only very specific files in the source release manifest... but currently extra files in the source tree may end up in the source release. This should not be a problem with #1946 as it builds from a clean git clone, but it may be a problem for `verify_release` that may be run from a dirty directory.

Avoid issue in `verify_release` by building from a clean git clone. A local clone like this will have the same checked out ref as the original repo so the build result should be 100% same.
