### PR TITLE
Add support for TAP 15

### DIFF
--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -357,17 +357,22 @@ class RepositorySimulator(FetcherInterface):
         # Create delegation
         if delegator.delegations is None:
             delegator.delegations = Delegations({}, {})
+
+        role_name: str = role.name if role.name is not None else ""
+        if role.succinct_hash_info:
+            role_name = role.succinct_hash_info.get_bin_name()
+
         # put delegation last by default
-        delegator.delegations.roles[role.name] = role
+        delegator.delegations.roles[role_name] = role
 
         # By default add one new key for the role
         key, signer = self.create_key()
-        delegator.add_key(role.name, key)
-        self.add_signer(role.name, signer)
+        delegator.add_key(role_name, key)
+        self.add_signer(role_name, signer)
 
         # Add metadata for the role
-        if role.name not in self.md_delegates:
-            self.md_delegates[role.name] = Metadata(targets, {})
+        if role_name not in self.md_delegates:
+            self.md_delegates[role_name] = Metadata(targets, {})
 
     def write(self) -> None:
         """Dump current repository metadata to self.dump_dir

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -781,6 +781,35 @@ class TestMetadata(unittest.TestCase):
         result_bin = r.find_delegation(test_data.target_path)
         self.assertEqual(result_bin, test_data.expected_bin_name)
 
+    def test_is_bin_in_succinct_hash_delegations(self) -> None:
+        succinct_delegation = SuccinctHashDelegations(5, "delegated")
+        # delegated role name suffixes are in hex format.
+        false_role_name_examples = [
+            "foo",
+            "delegated-",
+            "delegated-s",
+            "delegated-20",
+            "delegated-100",
+        ]
+        for role_name in false_role_name_examples:
+            msg = f"Error for {role_name}"
+            self.assertFalse(succinct_delegation.is_bin(role_name), msg)
+
+        true_role_name_examples = ["delegated-0", "delegated-f", "delegated-1f"]
+        for role_name in true_role_name_examples:
+            msg = f"Error for {role_name}"
+            self.assertTrue(succinct_delegation.is_bin(role_name), msg)
+
+    def test_get_all_bin_names_in_succinct_hash_delegations(self) -> None:
+        succinct_delegation = SuccinctHashDelegations(3, "delegated")
+        bin_amount = 0
+        for i, role_name in enumerate(succinct_delegation.get_all_bin_names()):
+            self.assertEqual(role_name, f"delegated-{i}")
+            bin_amount = i
+
+        # Assert that the last bin is number 7 (starting to count from 0).
+        self.assertEqual(bin_amount, 7)
+
 
 # Run unit test.
 if __name__ == "__main__":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -807,6 +807,15 @@ class TestMetadata(unittest.TestCase):
                 msg,
             )
 
+    def test_zero_padding_in_succinct_hash_delegations(self) -> None:
+        hash_prefix_lens = [2, 6, 8, 10, 16, 32]
+        expected_paddings = [1, 2, 3, 3, 5, 9]
+
+        for prefix_len, expected in zip(hash_prefix_lens, expected_paddings):
+            succinct_delegation = SuccinctHashDelegations(prefix_len, "foo")
+            m = f"Error for {prefix_len} expected padding {expected}"
+            self.assertEqual(succinct_delegation.suffix_len, expected, m)
+
 
 # Run unit test.
 if __name__ == "__main__":

--- a/tests/test_metadata_eq_.py
+++ b/tests/test_metadata_eq_.py
@@ -213,6 +213,7 @@ class TestMetadataComparisions(unittest.TestCase):
             ("terminating", None),
             ("paths", [""]),
             ("path_hash_prefixes", [""]),
+            ("succinct_hash_info", ""),
         ]:
             setattr(delegated_role_2, attr, value)
             msg = f"Failed case: {attr}"

--- a/tests/test_metadata_eq_.py
+++ b/tests/test_metadata_eq_.py
@@ -25,6 +25,7 @@ from tuf.api.metadata import (
     Role,
     Root,
     Snapshot,
+    SuccinctHashDelegations,
     TargetFile,
     Targets,
     Timestamp,
@@ -193,6 +194,19 @@ class TestMetadataComparisions(unittest.TestCase):
         # Common attributes between Signed and Snapshot doesn't need testing.
         setattr(signed_copy, "meta", None)
         self.assertNotEqual(md.signed, signed_copy)
+
+    def test_hash_delegations_eq(self) -> None:
+        hash_deleg = SuccinctHashDelegations(8, "delegated")
+        hash_deleg_2: SuccinctHashDelegations = self.copy_and_simple_assert(
+            hash_deleg
+        )
+
+        for attr, value in [("prefix_bit_len", 0), ("bin_name_prefix", "")]:
+            setattr(hash_deleg_2, attr, value)
+            msg = f"Failed case: {attr}"
+            self.assertNotEqual(hash_deleg, hash_deleg_2, msg)
+            # Restore the old value of the attribute.
+            setattr(hash_deleg_2, attr, getattr(hash_deleg, attr))
 
     def test_delegated_role_eq_(self) -> None:
         delegated_role_dict = {

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -368,10 +368,14 @@ class TestSerialization(unittest.TestCase):
 
     valid_delegated_roles: utils.DataSet = {
         # DelegatedRole inherits Role and some use cases can be found in the valid_roles.
-        "no hash prefix attribute": '{"keyids": ["keyid"], "name": "a", "paths": ["fn1", "fn2"], \
+        "missing name when succinct_hash_delegations is used": '{"keyids": ["keyid"], "terminating": false, \
+            "threshold": 1, "succinct_hash_delegations": {"delegation_hash_prefix_len": 8, "bin_name_prefix": "foo"}}',
+        "no hash prefix and succinct_hash_delegations": '{"keyids": ["keyid"], "name": "a", "paths": ["fn1", "fn2"], \
             "terminating": false, "threshold": 1}',
-        "no path attribute": '{"keyids": ["keyid"], "name": "a", "terminating": false, \
+        "no path and succinct_hash_delegations": '{"keyids": ["keyid"], "name": "a", "terminating": false, \
             "path_hash_prefixes": ["h1", "h2"], "threshold": 99}',
+        "no path and path_hash_prefixes": '{"keyids": ["keyid"], "terminating": false, \
+            "threshold": 99, "succinct_hash_delegations": {"delegation_hash_prefix_len": 8, "bin_name_prefix": "foo"}}',
         "empty paths": '{"keyids": ["keyid"], "name": "a", "paths": [], \
             "terminating": false, "threshold": 1}',
         "empty path_hash_prefixes": '{"keyids": ["keyid"], "name": "a", "terminating": false, \
@@ -391,13 +395,24 @@ class TestSerialization(unittest.TestCase):
 
     invalid_delegated_roles: utils.DataSet = {
         # DelegatedRole inherits Role and some use cases can be found in the invalid_roles.
-        "missing hash prefixes and paths": '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false}',
-        "both hash prefixes and paths": '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false, \
-            "paths": ["fn1", "fn2"], "path_hash_prefixes": ["h1", "h2"]}',
+        "missing name and succinct_hash_delegations": '{"keyids": ["keyid"], "paths": ["fn1", "fn2"], \
+            "terminating": false, "threshold": 1}',
+        "missing hash prefixes, paths and succinct_hash_delegations": '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false}',
+        "hash prefixes, paths and succinct_hash_delegations set": '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false, \
+            "paths": ["fn1", "fn2"], "path_hash_prefixes": ["h1", "h2"], "succinct_hash_delegations": {}}',
+        "paths and succinct_hash_delegations set": '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false, \
+            "paths": ["fn1", "fn2"], "succinct_hash_delegations": {}}',
+        "path_hash_prefixes and succinct_hash_delegations": '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false, \
+            "path_hash_prefixes": ["h1", "h2"], "succinct_hash_delegations": {}}',
         "invalid path type": '{"keyids": ["keyid"], "name": "a", "paths": [1,2,3], \
             "terminating": false, "threshold": 1}',
         "invalid path_hash_prefixes type": '{"keyids": ["keyid"], "name": "a", "path_hash_prefixes": [1,2,3], \
             "terminating": false, "threshold": 1}',
+        "invalid succinct_hash_delegations type": '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false, "succinct_hash_delegations": ""}',
+        "missing delegation_hash_prefix_len from succinct_hash_delegations": '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false, \
+                "succinct_hash_delegations": {"bin_name_prefix" : "foo"}}',
+        "missing bin_name_prefix from succinct_hash_delegations": '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false, \
+                "succinct_hash_delegations": {"delegation_hash_prefix_len" : 8}}',
     }
 
     @utils.run_sub_tests_with_dataset(invalid_delegated_roles)

--- a/tests/test_updater_delegation_graphs.py
+++ b/tests/test_updater_delegation_graphs.py
@@ -32,7 +32,7 @@ class TestDelegation:
     keyids: List[str] = field(default_factory=list)
     threshold: int = 1
     terminating: bool = False
-    paths: List[str] = field(default_factory=lambda: ["*"])
+    paths: Optional[List[str]] = field(default_factory=lambda: ["*"])
     path_hash_prefixes: Optional[List[str]] = None
 
 

--- a/tests/test_updater_delegation_graphs.py
+++ b/tests/test_updater_delegation_graphs.py
@@ -32,7 +32,7 @@ class TestDelegation:
     keyids: List[str] = field(default_factory=list)
     threshold: int = 1
     terminating: bool = False
-    paths: Optional[List[str]] = field(default_factory=lambda: ["*"])
+    paths: List[str] = field(default_factory=lambda: ["*"])
     path_hash_prefixes: Optional[List[str]] = None
 
 
@@ -344,8 +344,8 @@ class TestDelegationsGraphs(TestDelegations):
         for rolename in roles_to_filenames:
             delegations.append(TestDelegation("targets", rolename))
 
-        delegated_rolenames = DelegationsTestCase(delegations)
-        self._init_repo(delegated_rolenames)
+        delegated_names = DelegationsTestCase(delegations)
+        self._init_repo(delegated_names)
         updater = self._init_updater()
         updater.refresh()
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1351,6 +1351,18 @@ class SuccinctHashDelegations:
             **self.unrecognized_fields,
         }
 
+    def get_bin_name(self, bin_number: int = 0) -> str:
+        """Return the name of bin with number ``bin_number``.
+        The ``bin_number`` default is 0 as that is used to uniquely identify
+        delegated roles containing succinct hash delegations from the rest.
+
+        Args:
+            bin_number: Number of the bin that we want the name for.
+        """
+        # Add zero padding if necessary and cast to hex the suffix.
+        suffix = f"{bin_number:0{self.suffix_len}x}"
+        return f"{self.bin_name_prefix}-{suffix}"
+
     def _find_bin_for_bits(self, hash_bits_representation: str) -> str:
         """Helper function for find_delegation calculating the actual rolename.
 
@@ -1653,9 +1665,13 @@ class Delegations:
         roles_res: Dict[str, DelegatedRole] = {}
         for role_dict in roles:
             new_role = DelegatedRole.from_dict(role_dict)
-            if new_role.name in roles_res:
+            role_name: str = new_role.name if new_role.name is not None else ""
+            if new_role.succinct_hash_info:
+                role_name = new_role.succinct_hash_info.get_bin_name()
+
+            if role_name in roles_res:
                 raise ValueError(f"Duplicate role {new_role.name}")
-            roles_res[new_role.name] = new_role
+            roles_res[role_name] = new_role
         # All fields left in the delegations_dict are unrecognized.
         return cls(keys_res, roles_res, delegations_dict)
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1557,7 +1557,10 @@ class DelegatedRole(Role):
         return None
 
     def is_delegated_path(self, target_filepath: str) -> bool:
-        """Determines whether the given ``target_filepath`` is in one of
+        """.. warning::
+            This method is deprecated, use ``find_delegation()`` instead.
+
+        Determines whether the given ``target_filepath`` is in one of
         the paths that ``DelegatedRole`` is trusted to provide.
 
         The ``target_filepath`` and the ``DelegatedRole`` paths are expected to be
@@ -1588,6 +1591,10 @@ class DelegatedRole(Role):
                 # pattern (Unix shell-style wildcards).
                 if self._is_target_in_pathpattern(target_filepath, pathpattern):
                     return True
+
+        elif self.succinct_hash_info is not None:
+            # All targetpaths have a bin and are considered as trusted.
+            return True
 
         return False
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -39,6 +39,7 @@ from typing import (
     ClassVar,
     Dict,
     Generic,
+    Iterator,
     List,
     Mapping,
     Optional,
@@ -1362,6 +1363,33 @@ class SuccinctHashDelegations:
         # Add zero padding if necessary and cast to hex the suffix.
         suffix = f"{bin_number:0{self.suffix_len}x}"
         return f"{self.bin_name_prefix}-{suffix}"
+
+    def get_all_bin_names(self) -> Iterator[str]:
+        """Yield the names of all different bins one by one."""
+        for i in range(0, self.number_of_bins):
+            yield self.get_bin_name(i)
+
+    def is_bin(self, role_name: str) -> bool:
+        """Determines whether the given ``role_name`` is in one of
+        the bins that ``SuccinctHashDelegations`` is trusted to provide.
+
+        Args:
+            role_name: The name of the delegated role to check against.
+        """
+        desired_prefix = self.bin_name_prefix + "-"
+
+        if role_name.startswith(desired_prefix):
+            suffix = role_name[len(desired_prefix) :]
+            try:
+                # bin name suffixes are in hex format.
+                num = int(suffix, 16)
+                if 0 <= num < self.number_of_bins:
+                    return True
+            except ValueError:
+                # suffix is not a number
+                return False
+
+        return False
 
     def find_bin(self, target_filepath: str) -> str:
         """Calculates the name of the bin responsible for ``target_filepath``.

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1305,6 +1305,14 @@ class SuccinctHashDelegations:
         self.prefix_bit_len = prefix_bit_len
         self.bin_name_prefix = bin_name_prefix
 
+        # Calculate the suffix_len value based on the total number of bins in
+        # hex. If hash_prefix_len = 8 then number_of_bins = 256 or 100 in hex
+        # and suffix_len = 3 meaning the third bin will have a suffix of "003"
+        self.number_of_bins = 2**prefix_bit_len
+        # suffix_len is calculated based on "number_of_bins - 1" as the name
+        # of the last bin contains the number "number_of_bins -1" as a suffix.
+        self.suffix_len = len(f"{self.number_of_bins-1:x}")
+
         if unrecognized_fields is None:
             unrecognized_fields = {}
 
@@ -1354,7 +1362,10 @@ class SuccinctHashDelegations:
         bit_length = self.prefix_bit_len
         # Get the first bit_length of bits and then cast them to decimal.
         bin_number = int(hash_bits_representation[:bit_length], 2)
-        return f"{self.bin_name_prefix}-{bin_number}"
+        # Add zero padding if necessary and cast to hex the suffix.
+        suffix = f"{bin_number:0{self.suffix_len}x}"
+
+        return f"{self.bin_name_prefix}-{suffix}"
 
 
 class DelegatedRole(Role):

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -423,6 +423,17 @@ class Metadata(Generic[T]):
 
             keys = self.signed.delegations.keys
             role = self.signed.delegations.roles.get(delegated_role)
+            if role is None:
+                # Find a succinct delegation role that delegates
+                # to `delegated_role`. This is not trivial when there can be
+                # other, normal, delegations and multiple succinct delegations
+                # in the same Delegations instance.
+                for r in self.signed.delegations.roles.values():
+                    if (
+                        r.succinct_hash_info is not None
+                        and r.succinct_hash_info.is_bin(delegated_role)
+                    ):
+                        role = r
         else:
             raise TypeError("Call is valid only on delegator metadata")
 

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -437,12 +437,11 @@ class Updater:
                 # NOTE: This may be a slow operation if there are many
                 # delegated roles.
                 for child_role in targets.delegations.roles.values():
-                    if child_role.is_delegated_path(target_filepath):
-                        logger.debug("Adding child role %s", child_role.name)
+                    child_name = child_role.find_delegation(target_filepath)
+                    if child_name is not None:
+                        logger.debug("Adding child role %s", child_name)
 
-                        child_roles_to_visit.append(
-                            (child_role.name, role_name)
-                        )
+                        child_roles_to_visit.append((child_name, role_name))
                         if child_role.terminating:
                             logger.debug("Not backtracking to other roles")
                             delegations_to_visit = []


### PR DESCRIPTION
Related to issue: #1909

**Description of the changes being introduced by the pull request**:

[TAP 15](https://github.com/theupdateframework/taps/blob/master/tap15.md) was created on June 23-rd 2020 and was last modified in July 6-th 2020.
Since then the TAP has been put to `draft` status meaning it needs a prototype implementation before it's accepted as a future specification change.
Given that this TAP underlines an efficient way of handling hash bin delegations, meaning it would be really useful when `python-tuf` is integrated into `Warehouse`, it's logical that we should not only create a prototype but directly work to integrate it in `python-tuf`.

The outcome of the TAP 15 implementation is
1. Support reading, updating, and saving target metadata files that are using `succinct hashed bin delegations`.
2. Support in ngclient for calculating the delegated role name on a given target path.
3. An exemplary document inside `examples/` showcasing how `succinct hashed bin delegations` can be utilized in practice.

This pr covers points 1 and 2.
**Point 3 will be done in another pr.** 

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


