### PR TITLE
Checking for None instead of falsyness

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -134,10 +134,10 @@ class Metadata(Generic[T]):
     ):
         self.signed: T = signed
         self.signatures = signatures if signatures is not None else {}
-        if unrecognized_fields is not None:
-            self.unrecognized_fields = unrecognized_fields
-        else:
-            self.unrecognized_fields = {}
+        if unrecognized_fields is None:
+            unrecognized_fields = {}
+
+        self.unrecognized_fields = unrecognized_fields
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Metadata):
@@ -522,10 +522,10 @@ class Signed(metaclass=abc.ABCMeta):
             raise ValueError(f"version must be > 0, got {version}")
         self.version = version
 
-        if unrecognized_fields is not None:
-            self.unrecognized_fields = unrecognized_fields
-        else:
-            self.unrecognized_fields = {}
+        if unrecognized_fields is None:
+            unrecognized_fields = {}
+
+        self.unrecognized_fields = unrecognized_fields
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Signed):
@@ -645,10 +645,10 @@ class Key:
         self.keytype = keytype
         self.scheme = scheme
         self.keyval = keyval
-        if unrecognized_fields is not None:
-            self.unrecognized_fields = unrecognized_fields
-        else:
-            self.unrecognized_fields = {}
+        if unrecognized_fields is None:
+            unrecognized_fields = {}
+
+        self.unrecognized_fields = unrecognized_fields
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Key):
@@ -806,10 +806,10 @@ class Role:
             raise ValueError("threshold should be at least 1!")
         self.keyids = keyids
         self.threshold = threshold
-        if unrecognized_fields is not None:
-            self.unrecognized_fields = unrecognized_fields
-        else:
-            self.unrecognized_fields = {}
+        if unrecognized_fields is None:
+            unrecognized_fields = {}
+
+        self.unrecognized_fields = unrecognized_fields
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Role):
@@ -1080,10 +1080,10 @@ class MetaFile(BaseFile):
         self.version = version
         self.length = length
         self.hashes = hashes
-        if unrecognized_fields is not None:
-            self.unrecognized_fields = unrecognized_fields
-        else:
-            self.unrecognized_fields = {}
+        if unrecognized_fields is None:
+            unrecognized_fields = {}
+
+        self.unrecognized_fields = unrecognized_fields
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, MetaFile):
@@ -1469,10 +1469,10 @@ class Delegations:
                 )
 
         self.roles = roles
-        if unrecognized_fields is not None:
-            self.unrecognized_fields = unrecognized_fields
-        else:
-            self.unrecognized_fields = {}
+        if unrecognized_fields is None:
+            unrecognized_fields = {}
+
+        self.unrecognized_fields = unrecognized_fields
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Delegations):
@@ -1550,11 +1550,10 @@ class TargetFile(BaseFile):
         self.length = length
         self.hashes = hashes
         self.path = path
-        if unrecognized_fields is not None:
-            self.unrecognized_fields = unrecognized_fields
-        else:
-            self.unrecognized_fields = {}
+        if unrecognized_fields is None:
+            unrecognized_fields = {}
 
+        self.unrecognized_fields = unrecognized_fields
     @property
     def custom(self) -> Any:
         """Can be used to provide implementation specific data related to the

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -134,7 +134,10 @@ class Metadata(Generic[T]):
     ):
         self.signed: T = signed
         self.signatures = signatures if signatures is not None else {}
-        self.unrecognized_fields: Dict[str, Any] = unrecognized_fields or {}
+        if unrecognized_fields is not None:
+            self.unrecognized_fields = unrecognized_fields
+        else:
+            self.unrecognized_fields = {}
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Metadata):
@@ -519,7 +522,10 @@ class Signed(metaclass=abc.ABCMeta):
             raise ValueError(f"version must be > 0, got {version}")
         self.version = version
 
-        self.unrecognized_fields: Dict[str, Any] = unrecognized_fields or {}
+        if unrecognized_fields is not None:
+            self.unrecognized_fields = unrecognized_fields
+        else:
+            self.unrecognized_fields = {}
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Signed):
@@ -639,7 +645,10 @@ class Key:
         self.keytype = keytype
         self.scheme = scheme
         self.keyval = keyval
-        self.unrecognized_fields: Dict[str, Any] = unrecognized_fields or {}
+        if unrecognized_fields is not None:
+            self.unrecognized_fields = unrecognized_fields
+        else:
+            self.unrecognized_fields = {}
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Key):
@@ -797,7 +806,10 @@ class Role:
             raise ValueError("threshold should be at least 1!")
         self.keyids = keyids
         self.threshold = threshold
-        self.unrecognized_fields: Dict[str, Any] = unrecognized_fields or {}
+        if unrecognized_fields is not None:
+            self.unrecognized_fields = unrecognized_fields
+        else:
+            self.unrecognized_fields = {}
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Role):
@@ -1068,7 +1080,10 @@ class MetaFile(BaseFile):
         self.version = version
         self.length = length
         self.hashes = hashes
-        self.unrecognized_fields: Dict[str, Any] = unrecognized_fields or {}
+        if unrecognized_fields is not None:
+            self.unrecognized_fields = unrecognized_fields
+        else:
+            self.unrecognized_fields = {}
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, MetaFile):
@@ -1454,7 +1469,10 @@ class Delegations:
                 )
 
         self.roles = roles
-        self.unrecognized_fields = unrecognized_fields or {}
+        if unrecognized_fields is not None:
+            self.unrecognized_fields = unrecognized_fields
+        else:
+            self.unrecognized_fields = {}
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Delegations):
@@ -1532,7 +1550,10 @@ class TargetFile(BaseFile):
         self.length = length
         self.hashes = hashes
         self.path = path
-        self.unrecognized_fields = unrecognized_fields or {}
+        if unrecognized_fields is not None:
+            self.unrecognized_fields = unrecognized_fields
+        else:
+            self.unrecognized_fields = {}
 
     @property
     def custom(self) -> Any:

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1554,6 +1554,7 @@ class TargetFile(BaseFile):
             unrecognized_fields = {}
 
         self.unrecognized_fields = unrecognized_fields
+
     @property
     def custom(self) -> Any:
         """Can be used to provide implementation specific data related to the


### PR DESCRIPTION
Metadata API: Checking for None instead of falsyness for unrecognized_fields

Fixes #1937

Description of the changes being introduced by the pull request:

Initialization of unrecognized_fields acts surprisingly when the input
container is empty. Hence, We're checking for None instead of falsyness.

Signed-off-by: Abhisman Sarkar <abhisman.sarkar@gmail.com>