### PR TITLE
Update build config to include examples dir

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ path = "tuf/__init__.py"
 [tool.hatch.build.targets.sdist]
 include = [
   "/docs",
+  "/examples",
   "/tests",
   "/tuf",
   "/requirements*.txt",


### PR DESCRIPTION
Fixes #1901

**Description of the changes being introduced by the pull request**:
Explicitly include `examples` dir in sdist.

The same would be achieved, by removing explicit includes, which
currently would also add these files/dirs:

```
/gitattributes
/github
/mypy_cache
/readthedocs.yaml
/verify_release
```

Maybe we should instead of defining includes, explicitly exclude
(some of) these files? The advantage of a blacklist approach is
that it becomes less likely to forget including files that should
be in included.

See hatch docs for:
- what files should be in sdist
https://ofek.dev/hatch/latest/plugins/builder/#source-distribution

- what files get into sdist by default:
https://ofek.dev/hatch/latest/plugins/builder/#default-file-selection_1

- how to configure what files get into sdist:
https://ofek.dev/hatch/latest/config/build/#file-selection


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


