### PR TITLE
Adopt recent ci/cd changes in release docs

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -30,9 +30,10 @@
   `git tag --sign vA.B.C -m "vA.B.C"`
 6. Push the tag to GitHub `git push origin vA.B.C`
 
-  *A push triggers the [CI workflow](.github/workfows/ci.yml), which, on success,
-  triggers the [CD workflow](.github/workfows/cd.yml), which builds source dist and
-  wheel, creates a preliminary GitHub release under `vA.B.C-rc`, and pauses for review.*
+  *A tag push triggers the [CD
+  workflow](https://github.com/theupdateframework/python-tuf/blob/develop/.github/workflows/cd.yml),
+  which runs the tests, builds source dist and wheel, creates a preliminary GitHub
+  release under `vA.B.C-rc`, and pauses for review.*
 
 7. Run `verify_release --skip-pypi` locally to make sure a build on your machine matches
   the preliminary release artifacts published on GitHub.


### PR DESCRIPTION
Fixes #<ISSUE NUMBER>

**Description of the changes being introduced by the pull request**:

Since #1971 ci and cd workflows run independently of each other, each of them also calling the test workflow.

- This patch updates `RELEASE.md` to match the new setup.

- It also fixes a (twice) broken link.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


