### PR TITLE
Add option to sign release artifacts with verify_release

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -43,8 +43,10 @@ on GitHub
   *An approval resumes the CD workflow to publish the release on PyPI, and to finalize the
   GitHub release (removes `-rc` suffix and updates release notes).*
 
-8. `verify_release` may be used again to make sure the PyPI release artifacts match the
-   local build as well.
+8. Run `verify_release` to make sure the PyPI release artifacts match the local build as
+   well. When called as `verify_release --sign [<key id>]` the script additionally
+   creates gpg release signatures. These signature files should be made available on the
+   GitHub release page under Assets.
 9. Announce the release on [#tuf on CNCF Slack](https://cloud-native.slack.com/archives/C8NMD3QJ3)
 10. Ensure [POUF 1](https://github.com/theupdateframework/taps/blob/master/POUFs/reference-POUF/pouf1.md),
     for the reference implementation, is up-to-date

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -45,8 +45,9 @@ on GitHub
 
 8. Run `verify_release` to make sure the PyPI release artifacts match the local build as
    well. When called as `verify_release --sign [<key id>]` the script additionally
-   creates gpg release signatures. These signature files should be made available on the
-   GitHub release page under Assets.
+   creates gpg release signatures. When signed by maintainers with a corresponding GPG
+   fingerprint in the MAINTAINERS.md file, these signature files should be made available on
+   the GitHub release page under Assets.
 9. Announce the release on [#tuf on CNCF Slack](https://cloud-native.slack.com/archives/C8NMD3QJ3)
 10. Ensure [POUF 1](https://github.com/theupdateframework/taps/blob/master/POUFs/reference-POUF/pouf1.md),
     for the reference implementation, is up-to-date

--- a/verify_release
+++ b/verify_release
@@ -122,6 +122,26 @@ def verify_pypi_release(version: str, compare_dir: str) -> bool:
         return sorted(same) == [wheel, tar]
 
 
+def sign_release_artifacts(
+    version: str, build_dir: str, key_id: str = None
+) -> None:
+    """Sign built release artifacts with gpg and write signature files to cwd"""
+    tar = f"{PYPI_PROJECT}-{version}.tar.gz"
+    wheel = f"{PYPI_PROJECT}-{version}-py3-none-any.whl"
+    cmd = ["gpg", "--detach-sign", "--armor"]
+
+    if key_id is not None:
+        cmd += ["--local-user", key_id]
+
+    for filename in [tar, wheel]:
+        artifact_path = os.path.join(build_dir, filename)
+        signature_path = f"{filename}.asc"
+        subprocess.run(
+            cmd + ["--output", signature_path, artifact_path], check=True
+        )
+        assert os.path.exists(signature_path)
+
+
 def finished(s: str) -> None:
     # clear line
     sys.stdout.write("\033[K")
@@ -142,6 +162,15 @@ def main() -> int:
         action="store_true",
         dest="skip_pypi",
         help="Skip PyPI release check.",
+    )
+    parser.add_argument(
+        "--sign",
+        nargs="?",
+        const=True,
+        metavar="<key id>",
+        dest="sign",
+        help="Sign release artifacts with 'gpg'. If no <key id> is passed, the default "
+        "signing key is used. Resulting '*.asc' files are written to CWD.",
     )
     args = parser.parse_args()
 
@@ -173,7 +202,7 @@ def main() -> int:
                 finished("ERROR: PyPI artifacts do not match built release")
                 success = False
             else:
-                finished(f"PyPI artifacts match the built release")
+                finished("PyPI artifacts match the built release")
 
         progress("Downloading release from GitHub")
         if not verify_github_release(build_version, build_dir):
@@ -181,7 +210,20 @@ def main() -> int:
             finished("ERROR: GitHub artifacts do not match built release")
             success = False
         else:
-            finished(f"GitHub artifacts match the built release")
+            finished("GitHub artifacts match the built release")
+
+        # NOTE: 'gpg' might prompt for password or ask if it should override files...
+        if args.sign:
+            progress("Signing built release with gpg")
+            if success:
+                key_id = None
+                if args.sign is not True:
+                    key_id = args.sign
+
+                sign_release_artifacts(build_version, build_dir, key_id)
+                finished("Created signatures in cwd (see '*.asc' files)")
+            else:
+                finished("WARNING: Skip signing of non-matching artifacts")
 
     return 0 if success else 1
 

--- a/verify_release
+++ b/verify_release
@@ -172,15 +172,16 @@ def main() -> int:
                 # This is expected while build is not reproducible
                 finished("ERROR: PyPI artifacts do not match built release")
                 success = False
+            else:
+                finished(f"PyPI artifacts match the built release")
 
         progress("Downloading release from GitHub")
         if not verify_github_release(build_version, build_dir):
             # This is expected while build is not reproducible
             finished("ERROR: GitHub artifacts do not match built release")
             success = False
-
-        if success:
-            finished("Github and PyPI artifacts match the built release")
+        else:
+            finished(f"GitHub artifacts match the built release")
 
     return 0 if success else 1
 

--- a/verify_release
+++ b/verify_release
@@ -126,14 +126,14 @@ def sign_release_artifacts(
     version: str, build_dir: str, key_id: str = None
 ) -> None:
     """Sign built release artifacts with gpg and write signature files to cwd"""
-    tar = f"{PYPI_PROJECT}-{version}.tar.gz"
+    sdist = f"{PYPI_PROJECT}-{version}.tar.gz"
     wheel = f"{PYPI_PROJECT}-{version}-py3-none-any.whl"
     cmd = ["gpg", "--detach-sign", "--armor"]
 
     if key_id is not None:
         cmd += ["--local-user", key_id]
 
-    for filename in [tar, wheel]:
+    for filename in [sdist, wheel]:
         artifact_path = os.path.join(build_dir, filename)
         signature_path = f"{filename}.asc"
         subprocess.run(
@@ -216,14 +216,12 @@ def main() -> int:
         if args.sign:
             progress("Signing built release with gpg")
             if success:
-                key_id = None
-                if args.sign is not True:
-                    key_id = args.sign
+                key_id = args.sign if args.sign is not True else None
 
                 sign_release_artifacts(build_version, build_dir, key_id)
                 finished("Created signatures in cwd (see '*.asc' files)")
             else:
-                finished("WARNING: Skip signing of non-matching artifacts")
+                finished("WARNING: Skipped signing of non-matching artifacts")
 
     return 0 if success else 1
 


### PR DESCRIPTION
Quickfix 2 for #1966 (I suggest to leave the issue open or create a new one for a long-term fix)

**Description of the changes being introduced by the pull request**:

- Add option to sign locally built release artifacts with gpg, if they match the downloaded artifacts (from GitHub, PyPI). 
- Update RELEASE.md to describe usage of new option
- [Unrelated] Fix success message. (Happy to create a separate PR, if desired)


**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


