### PR TITLE
verify_release: Tweak pip download

### DIFF
--- a/verify_release
+++ b/verify_release
@@ -76,7 +76,7 @@ def get_pypi_pip_version() -> str:
     # newest tarball and figure out the version from the filename
     with TemporaryDirectory() as pypi_dir:
         cmd = ["pip", "download", "--no-deps", "--dest", pypi_dir]
-        source_download = cmd + ["--no-binary", ":all:", PYPI_PROJECT]
+        source_download = cmd + ["--no-binary", PYPI_PROJECT, PYPI_PROJECT]
         subprocess.run(source_download, stdout=subprocess.DEVNULL, check=True)
         for filename in os.listdir(pypi_dir):
             prefix, postfix = f"{PYPI_PROJECT}-", ".tar.gz"
@@ -113,7 +113,7 @@ def verify_pypi_release(version: str, compare_dir: str) -> bool:
         cmd = ["pip", "download", "--no-deps", "--dest", pypi_dir]
         target = f"{PYPI_PROJECT}=={version}"
         binary_download = cmd + [target]
-        source_download = cmd + ["--no-binary", ":all:", target]
+        source_download = cmd + ["--no-binary", PYPI_PROJECT, target]
 
         subprocess.run(binary_download, stdout=subprocess.DEVNULL, check=True)
         subprocess.run(source_download, stdout=subprocess.DEVNULL, check=True)


### PR DESCRIPTION
It seems `--no-deps` does not work as it used to (and actually installs
all build dependencies). This is very bad because verify_release also
uses `--no-binary :all:` leading to actually _building_ all build
dependencies from source.

Use `--no-binary tuf` instead: build dependencies will still be
installed (into a working environment) but at least they won't be built
from source.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

---

Fixes #1981

We might want to try to get to the root issue as well (how to download just one artifact, not all deps) but this change is still correct and immediately makes the script work.

