### PR TITLE
Update maintainers permission checklist

### DIFF
--- a/.github/workflows/maintainer-permissions-reminder.yml
+++ b/.github/workflows/maintainer-permissions-reminder.yml
@@ -36,7 +36,9 @@ jobs:
           ### Critical services
 
           * [ ] **PyPI**: maintainer list is visible to everyone at https://pypi.org/project/tuf/
-              * Only maintainers who do releases (+potentially org admins to prevent locking the project out)
+              * Only enough maintainers and org admins to prevent locking the project out
+          * [ ] **GitHub**: release environment reviewers listed in https://github.com/theupdateframework/python-tuf/settings/environments
+              * Maintainers who can approve releases to PyPI
           * [ ] **GitHub**: permissions visible to admins at https://github.com/theupdateframework/python-tuf/settings/access
               * "admin" permission: Only for maintainers and org admins who do project administration
               * "push/maintain" permission: Maintainers who actively approve and merge PRs (+admins)


### PR DESCRIPTION
* Release permissions are now controlled in GitHub release environment
* It is no longer required for a releasing maintainer to have PyPI
  permissions

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>
