### PR TITLE
build: Pin hatchling version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
-# Build-system section
 [build-system]
-requires = ["hatchling>=0.21.0"]
+# hatchling pinned for reproducibility: version should be kept up-to-date
+requires = ["hatchling==0.22.0"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
Pin hatchling version. This version should be kept up-to-date: my working assumption is that Dependabot will handle it.

I think we want to do something like this: IMO our build artifacts should not change if hatchling releases a new version (which is what happened right after we released 1.1.0: now `verify_release` will say the artifacts do not match because WHEEL file includes the hatchling version number).

Whether this exact change is the correct one, I'm not sure. Does dependabot update `build-system.requires`? I'm hoping so but I don't know :shrug: 