### PR TITLE
lint: Stop using requests annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ disable_error_code = ["attr-defined"]
 
 [[tool.mypy.overrides]]
 module = [
+  "requests.*",
   "securesystemslib.*",
   "urllib3.*"
 ]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,4 +10,3 @@ isort==5.10.1
 pylint==2.13.7
 mypy==0.942
 bandit==1.7.4
-types-requests==2.27.20


### PR DESCRIPTION
requests project does not maintain annotations: typeshed project tries
to do it for them, and releases the annotations as "types-requests".

There's two main problems:
* typeshed releases constantly: this means a lot of test dependency
  updates
* typeshed releases are not tagged in git: updates are impossible to
  review

The benefit we get from types-requests is minimal as there is very
little requests-related code and it does not change often.

Remove annotations to lower the test dependency update churn.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

---

Fixes #1988 