### PR TITLE
Appending Fetcher docs to state the method to be implemented.

### DIFF
--- a/docs/api/tuf.ngclient.fetcher.rst
+++ b/docs/api/tuf.ngclient.fetcher.rst
@@ -3,3 +3,4 @@ Fetcher
 
 .. automodule:: tuf.ngclient.fetcher
    :undoc-members:
+   :private-members: _fetch

--- a/tuf/ngclient/fetcher.py
+++ b/tuf/ngclient/fetcher.py
@@ -23,6 +23,9 @@ class FetcherInterface:
     By providing a concrete implementation of the abstract interface,
     users of the framework can plug-in their preferred/customized
     network stack.
+
+    Implementations of FetcherInterface only need to implement ``_fetch()``.
+    The public API of the class is already implemented.
     """
 
     __metaclass__ = abc.ABCMeta


### PR DESCRIPTION
Fetcher.py: Appending class docstring

Fixes #1916

Description of the changes being introduced by the pull request:

The class docstring for `FetcherInterface` needed to clearly state that
only `_fetch()` had to be implemented in it's implementation. This is
because the public API of the interface is implemented already.

Signed-off-by: Abhisman Sarkar <abhisman.sarkar@gmail.com>

