### PR TITLE
docs: remove a duplicated word in refresh() doc comment

### DIFF
--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -114,8 +114,8 @@ class Updater:
         that happens on demand during ``get_targetinfo()``. However, if the
         repository uses `consistent_snapshot
         <https://theupdateframework.github.io/specification/latest/#consistent-snapshots>`_,
-        then all metadata downloaded downloaded by the Updater will use the same
-        consistent repository state.
+        then all metadata downloaded by the Updater will use the same consistent
+        repository state.
 
         Raises:
             OSError: New metadata could not be written to disk


### PR DESCRIPTION
Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

**Description of the changes being introduced by the pull request**:

The following removes a duplicated word in the description of the refresh() method.

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


