### PR TITLE
Add support for succinct roles (TAP 15)

### DIFF
--- a/docs/api/tuf.api.metadata.supporting.rst
+++ b/docs/api/tuf.api.metadata.supporting.rst
@@ -13,6 +13,7 @@ ones (Root, Timestamp, Snapshot, Targets):
    tuf.api.metadata.MetaFile
    tuf.api.metadata.Role
    tuf.api.metadata.TargetFile
+   tuf.api.metadata.SuccinctRoles
 
 .. autoclass:: tuf.api.metadata.DelegatedRole
 
@@ -25,3 +26,5 @@ ones (Root, Timestamp, Snapshot, Targets):
 .. autoclass:: tuf.api.metadata.Role
 
 .. autoclass:: tuf.api.metadata.TargetFile
+
+.. autoclass:: tuf.api.metadata.SuccinctRoles

--- a/docs/repository-library-design.md
+++ b/docs/repository-library-design.md
@@ -63,7 +63,7 @@ are found, in the python-tuf library):
 ```python
 with repository.edit(“targets”) as targets:
     # adds a key for role1 (as an example, arbitrary edits are allowed)
-    targets.add_key(“role1”, key)
+    targets.add_key(key, “role1”)
 ```
 
 This code loads current targets metadata for editing, adds the key to a role,

--- a/examples/repo_example/basic_repo.py
+++ b/examples/repo_example/basic_repo.py
@@ -157,7 +157,7 @@ roles["root"] = Metadata(Root(expires=_in(365)))
 for name in ["targets", "snapshot", "timestamp", "root"]:
     keys[name] = generate_ed25519_key()
     roles["root"].signed.add_key(
-        name, Key.from_securesystemslib_key(keys[name])
+        Key.from_securesystemslib_key(keys[name]), name
     )
 
 # NOTE: We only need the public part to populate root, so it is possible to use
@@ -173,7 +173,7 @@ for name in ["targets", "snapshot", "timestamp", "root"]:
 # required signature threshold.
 another_root_key = generate_ed25519_key()
 roles["root"].signed.add_key(
-    "root", Key.from_securesystemslib_key(another_root_key)
+    Key.from_securesystemslib_key(another_root_key), "root"
 )
 roles["root"].signed.roles["root"].threshold = 2
 
@@ -343,9 +343,9 @@ for role_name in ["targets", "python-scripts", "snapshot", "timestamp"]:
 # remains in place, it can be used to count towards the old and new threshold.
 new_root_key = generate_ed25519_key()
 
-roles["root"].signed.remove_key("root", keys["root"]["keyid"])
+roles["root"].signed.revoke_key(keys["root"]["keyid"], "root")
 roles["root"].signed.add_key(
-    "root", Key.from_securesystemslib_key(new_root_key)
+    Key.from_securesystemslib_key(new_root_key), "root"
 )
 roles["root"].signed.version += 1
 

--- a/examples/repo_example/hashed_bin_delegation.py
+++ b/examples/repo_example/hashed_bin_delegation.py
@@ -162,6 +162,7 @@ roles["bins"].signed.delegations = Delegations(
 #              10-17                       10 11 12 13 14 15 16 17
 #              ...                         ...
 #              f8-ff                       f8 f9 fa fb fc fd fe ff
+assert roles["bins"].signed.delegations.roles is not None
 for bin_n_name, bin_n_hash_prefixes in generate_hash_bins():
     # Update delegating targets role (bins) with delegation details for each
     # delegated targets role (bin_n).

--- a/tests/generated_data/generate_md.py
+++ b/tests/generated_data/generate_md.py
@@ -89,10 +89,10 @@ def generate_all_files(
     md_snapshot = Metadata(Snapshot(expires=EXPIRY))
     md_targets = Metadata(Targets(expires=EXPIRY))
 
-    md_root.signed.add_key("root", keys["ed25519_0"])
-    md_root.signed.add_key("timestamp", keys["ed25519_1"])
-    md_root.signed.add_key("snapshot", keys["ed25519_2"])
-    md_root.signed.add_key("targets", keys["ed25519_3"])
+    md_root.signed.add_key(keys["ed25519_0"], "root")
+    md_root.signed.add_key(keys["ed25519_1"], "timestamp")
+    md_root.signed.add_key(keys["ed25519_2"], "snapshot")
+    md_root.signed.add_key(keys["ed25519_3"], "targets")
 
     for i, md in enumerate([md_root, md_timestamp, md_snapshot, md_targets]):
         assert isinstance(md, Metadata)

--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -354,9 +354,17 @@ class RepositorySimulator(FetcherInterface):
         else:
             delegator = self.md_delegates[delegator_name].signed
 
+        if (
+            delegator.delegations is not None
+            and delegator.delegations.succinct_roles is not None
+        ):
+            raise ValueError("Can't add a role when succinct_roles is used")
+
         # Create delegation
         if delegator.delegations is None:
-            delegator.delegations = Delegations({}, {})
+            delegator.delegations = Delegations({}, roles={})
+
+        assert delegator.delegations.roles is not None
         # put delegation last by default
         delegator.delegations.roles[role.name] = role
 

--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -169,7 +169,7 @@ class RepositorySimulator(FetcherInterface):
         self.signers[role].clear()
         for _ in range(0, self.root.roles[role].threshold):
             key, signer = self.create_key()
-            self.root.add_key(role, key)
+            self.root.add_key(key, role)
             self.add_signer(role, signer)
 
     def _initialize(self) -> None:
@@ -182,7 +182,7 @@ class RepositorySimulator(FetcherInterface):
 
         for role in TOP_LEVEL_ROLE_NAMES:
             key, signer = self.create_key()
-            self.md_root.signed.add_key(role, key)
+            self.md_root.signed.add_key(key, role)
             self.add_signer(role, signer)
 
         self.publish_root()
@@ -370,7 +370,7 @@ class RepositorySimulator(FetcherInterface):
 
         # By default add one new key for the role
         key, signer = self.create_key()
-        delegator.add_key(role.name, key)
+        delegator.add_key(key, role.name)
         self.add_signer(role.name, signer)
 
         # Add metadata for the role

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -495,6 +495,7 @@ class TestMetadata(unittest.TestCase):
             }
         )
         assert isinstance(targets.delegations, Delegations)
+        assert isinstance(targets.delegations.roles, Dict)
         targets.delegations.roles["role2"] = delegated_role
 
         key_dict = {

--- a/tests/test_metadata_eq_.py
+++ b/tests/test_metadata_eq_.py
@@ -23,6 +23,7 @@ from tuf.api.metadata import (
     Metadata,
     MetaFile,
     Role,
+    SuccinctRoles,
     TargetFile,
 )
 
@@ -55,6 +56,7 @@ class TestMetadataComparisions(unittest.TestCase):
         cls.objects["Role"] = Role(["keyid1", "keyid2"], 3)
         cls.objects["MetaFile"] = MetaFile(1, 12, {"sha256": "abc"})
         cls.objects["DelegatedRole"] = DelegatedRole("a", [], 1, False, ["d"])
+        cls.objects["SuccinctRoles"] = SuccinctRoles(["keyid"], 1, 8, "foo")
         cls.objects["Delegations"] = Delegations(
             {"keyid": cls.objects["Key"]}, {"a": cls.objects["DelegatedRole"]}
         )
@@ -79,6 +81,7 @@ class TestMetadataComparisions(unittest.TestCase):
             "paths": [""],
             "path_hash_prefixes": [""],
         },
+        "SuccinctRoles": {"bit_length": 0, "name_prefix": ""},
         "Delegations": {"keys": {}, "roles": {}},
         "TargetFile": {"length": 0, "hashes": {}, "path": ""},
         "Targets": {"targets": {}, "delegations": []},

--- a/tests/test_metadata_eq_.py
+++ b/tests/test_metadata_eq_.py
@@ -169,6 +169,7 @@ class TestMetadataComparisions(unittest.TestCase):
         # Create a second delegations obj with reversed roles order
         delegations_2 = copy.deepcopy(delegations)
         # In python3.7 we need to cast to a list and then reverse.
+        assert isinstance(delegations.roles, dict)
         delegations_2.roles = dict(reversed(list(delegations.roles.items())))
 
         # Both objects are not the equal because of delegated roles order.

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -491,6 +491,13 @@ class TestSerialization(unittest.TestCase):
                 {"keyids": ["keyid1"], "name": "b", "terminating": true, "paths": ["fn1"], "threshold": 3}, \
                 {"keyids": ["keyid2"], "name": "root", "terminating": true, "paths": ["fn2"], "threshold": 4} ] \
             }',
+        "roles and succinct_roles set": '{"keys": { \
+                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}, \
+                "keyid2" : {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "bar"}}}, \
+            "roles": [ \
+                {"keyids": ["keyid"], "name": "a", "terminating": true, "paths": ["fn1"], "threshold": 3}, \
+                {"keyids": ["keyid2"], "name": "b", "terminating": true, "paths": ["fn2"], "threshold": 4} ], \
+            "succinct_roles": {"keyids": ["keyid"], "threshold": 1, "bit_length": 8, "name_prefix": "foo"}}',
     }
 
     @utils.run_sub_tests_with_dataset(invalid_delegations)
@@ -502,13 +509,17 @@ class TestSerialization(unittest.TestCase):
             Delegations.from_dict(case_dict)
 
     valid_delegations: utils.DataSet = {
-        "all": '{"keys": { \
+        "with roles": '{"keys": { \
                 "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}, \
                 "keyid2" : {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "bar"}}}, \
             "roles": [ \
                 {"keyids": ["keyid"], "name": "a", "terminating": true, "paths": ["fn1"], "threshold": 3}, \
                 {"keyids": ["keyid2"], "name": "b", "terminating": true, "paths": ["fn2"], "threshold": 4} ] \
             }',
+        "with succinct_roles": '{"keys": { \
+                "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}, \
+                "keyid2" : {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "bar"}}}, \
+            "succinct_roles": {"keyids": ["keyid"], "threshold": 1, "bit_length": 8, "name_prefix": "foo"}}',
         "unrecognized field": '{"keys": {"keyid" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}}, \
             "roles": [ {"keyids": ["keyid"], "name": "a", "paths": ["fn1", "fn2"], "terminating": true, "threshold": 3} ], \
             "foo": "bar"}',

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -176,6 +176,7 @@ class TestSerialization(unittest.TestCase):
         "no threshold": '{"keyids": ["keyid"]}',
         "no keyids": '{"threshold": 3}',
         "wrong threshold type": '{"keyids": ["keyid"], "threshold": "a"}',
+        "wrong keyids type": '{"keyids": 1, "threshold": 3}',
         "threshold below 1": '{"keyids": ["keyid"], "threshold": 0}',
         "duplicate keyids": '{"keyids": ["keyid", "keyid"], "threshold": 3}',
     }

--- a/tests/test_updater_key_rotations.py
+++ b/tests/test_updater_key_rotations.py
@@ -184,7 +184,7 @@ class TestUpdaterKeyRotations(unittest.TestCase):
 
             self.sim.root.roles[Root.type].threshold = rootver.threshold
             for i in rootver.keys:
-                self.sim.root.add_key(Root.type, self.keys[i])
+                self.sim.root.add_key(self.keys[i], Root.type)
             for i in rootver.sigs:
                 self.sim.add_signer(Root.type, self.signers[i])
             self.sim.root.version += 1
@@ -254,7 +254,7 @@ class TestUpdaterKeyRotations(unittest.TestCase):
 
             self.sim.root.roles[role].threshold = md_version.threshold
             for i in md_version.keys:
-                self.sim.root.add_key(role, self.keys[i])
+                self.sim.root.add_key(self.keys[i], role)
 
             for i in md_version.sigs:
                 self.sim.add_signer(role, self.signers[i])

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -39,6 +39,7 @@ from typing import (
     ClassVar,
     Dict,
     Generic,
+    Iterator,
     List,
     Mapping,
     Optional,
@@ -1547,6 +1548,36 @@ class SuccinctRoles(Role):
         # Add zero padding if necessary and cast to hex the suffix.
         suffix = f"{bin_number:0{self.suffix_len}x}"
         return f"{self.name_prefix}-{suffix}"
+
+    def get_roles(self) -> Iterator[str]:
+        """Yield the names of all different delegated roles one by one."""
+        for i in range(0, self.number_of_bins):
+            suffix = f"{i:0{self.suffix_len}x}"
+            yield f"{self.name_prefix}-{suffix}"
+
+    def is_delegated_role(self, role_name: str) -> bool:
+        """Determines whether the given ``role_name`` is in one of
+        the delegated roles that ``SuccinctRoles`` represents.
+
+        Args:
+            role_name: The name of the role to check against.
+        """
+        desired_prefix = self.name_prefix + "-"
+
+        if not role_name.startswith(desired_prefix):
+            return False
+
+        suffix = role_name[len(desired_prefix) :]
+        if len(suffix) != self.suffix_len:
+            return False
+
+        try:
+            # make sure suffix is hex value
+            num = int(suffix, 16)
+        except ValueError:
+            return False
+
+        return 0 <= num < self.number_of_bins
 
 
 class Delegations:

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1297,7 +1297,7 @@ class DelegatedRole(Role):
         paths: Path patterns. See note above.
         path_hash_prefixes: Hash prefixes. See note above.
         unrecognized_fields: Dictionary of all attributes that are not managed
-            by TUF Metadata API
+            by TUF Metadata API.
 
     Raises:
         ValueError: Invalid arguments.
@@ -1316,11 +1316,11 @@ class DelegatedRole(Role):
         super().__init__(keyids, threshold, unrecognized_fields)
         self.name = name
         self.terminating = terminating
-        if paths is not None and path_hash_prefixes is not None:
-            raise ValueError("Either paths or path_hash_prefixes can be set")
-
-        if paths is None and path_hash_prefixes is None:
-            raise ValueError("One of paths or path_hash_prefixes must be set")
+        exclusive_vars = [paths, path_hash_prefixes]
+        if sum(1 for var in exclusive_vars if var is not None) != 1:
+            raise ValueError(
+                "Only one of (paths, path_hash_prefixes) must be set"
+            )
 
         if paths is not None and any(not isinstance(p, str) for p in paths):
             raise ValueError("Paths must be strings")
@@ -1349,7 +1349,7 @@ class DelegatedRole(Role):
         """Creates ``DelegatedRole`` object from its json/dict representation.
 
         Raises:
-            ValueError, KeyError: Invalid arguments.
+            ValueError, KeyError, TypeError: Invalid arguments.
         """
         name = role_dict.pop("name")
         keyids = role_dict.pop("keyids")

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -438,17 +438,17 @@ class Updater:
                 child_roles_to_visit = []
                 # NOTE: This may be a slow operation if there are many
                 # delegated roles.
-                for child_role in targets.delegations.roles.values():
-                    if child_role.is_delegated_path(target_filepath):
-                        logger.debug("Adding child role %s", child_role.name)
+                for (
+                    child_name,
+                    terminating,
+                ) in targets.delegations.get_roles_for_target(target_filepath):
 
-                        child_roles_to_visit.append(
-                            (child_role.name, role_name)
-                        )
-                        if child_role.terminating:
-                            logger.debug("Not backtracking to other roles")
-                            delegations_to_visit = []
-                            break
+                    logger.debug("Adding child role %s", child_name)
+                    child_roles_to_visit.append((child_name, role_name))
+                    if terminating:
+                        logger.debug("Not backtracking to other roles")
+                        delegations_to_visit = []
+                        break
                 # Push 'child_roles_to_visit' in reverse order of appearance
                 # onto 'delegations_to_visit'.  Roles are popped from the end of
                 # the list.


### PR DESCRIPTION
Related to the previous pr: https://github.com/theupdateframework/python-tuf/pull/1948 and issue #1909

**This pr includes 11 breaking changes:**

In `Delegations` class from `tuf/api/metadata.py` :
1. roles argument is made optional
2. unrecognized_fields argument becomes the 4-th rather than the 3-rd
as it used to be

In `Root` class from `tuf/api/metadata.py`:
1. The "role" and "key" arguments in "Root.add_key()" are in reverse
order - "key" becomes first and "role" second.
2. "Root.remove_key()" has been renamed to "Root.remove_key()"
3. The "role" and "keyid" arguments in "Root.revoke_key()" are in
reverse order - "keyid" becomes first and "role" second.

In `Targets` class from `tuf/api/metadata.py`:
1. The "role" and "key" arguments in "Targets.add_key()" are in reverse
order - "key" becomes first and "role" second
4. "Targets.remove_key()" has been renamed to "Targets.revoke_key()"
5. The "role" and "keyid" arguments in "Targets.revoke_key()" are in
reverse order - "keyid" becomes first and "role" second.
6.  In both methods "Targets.add_key()" and "Targets.revoke_key()" the
"role" argument becomes an optional with a default value of None

Those changes are made in an effort to make those two methods logical
for both cases when standard roles and succinct_roles are used.

**Description of the changes being introduced by the pull request**:

[TAP 15](https://github.com/theupdateframework/taps/blob/master/tap15.md) was created on June 23-rd 2020 and was last modified on July 6-th 2020.
Since then the TAP has been put to `draft` status meaning it needs a prototype implementation before it's accepted as a future specification change.
Given that this TAP underlines an efficient way of handling succinct hash bin delegations, meaning it would be really useful when `python-tuf` is integrated into `Warehouse`, it's logical that we should not only create a prototype but directly work to integrate it in `python-tuf`.

The outcome of the TAP 15 implementation is
1. Support reading, updating, and saving target metadata files that are using `succinct_roles`.
3. Support in ngclient for calculating the delegated role name on a given target path.
4. An exemplary document inside `examples/` showcasing how `succinct_roles` can be utilized in practice.

This pr covers points 1 and 2.
Point 3 will be done in another pr.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


