### PR TITLE
ngclient: pick old timestamp if new.version is equal

### DIFF
--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -804,6 +804,27 @@ class TestRefresh(unittest.TestCase):
         updater = self._init_updater()
         updater.refresh()
 
+    def test_timestamp_eq_versions_check(self) -> None:
+        # Test that a modified timestamp with different content, but the same
+        # version doesn't replace the valid locally stored one.
+
+        # Make a successful update of valid metadata which stores it in cache
+        self._run_refresh()
+        initial_timestamp_meta_ver = self.sim.timestamp.snapshot_meta.version
+
+        # Change timestamp without bumping its version in order to test if a new
+        # timestamp with the same version will be persisted.
+        self.sim.timestamp.snapshot_meta.version = 100
+        self._run_refresh()
+
+        # If the local timestamp md file has the same snapshot_meta.version as
+        # the initial one, then the new modified timestamp has not been stored.
+        timestamp_path = os.path.join(self.metadata_dir, "timestamp.json")
+        timestamp: Metadata[Timestamp] = Metadata.from_file(timestamp_path)
+        self.assertEqual(
+            initial_timestamp_meta_ver, timestamp.signed.snapshot_meta.version
+        )
+
 
 if __name__ == "__main__":
     if "--dump" in sys.argv:

--- a/tuf/api/exceptions.py
+++ b/tuf/api/exceptions.py
@@ -29,6 +29,10 @@ class BadVersionNumberError(RepositoryError):
     """An error for metadata that contains an invalid version number."""
 
 
+class EqualVersionNumberError(BadVersionNumberError):
+    """An error for metadata containing a previously verified version number."""
+
+
 class ExpiredMetadataError(RepositoryError):
     """Indicate that a TUF Metadata file has expired."""
 

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -226,6 +226,10 @@ class TrustedMetadataSet(abc.Mapping):
                     f"New timestamp version {new_timestamp.signed.version} must"
                     f" be >= {self.timestamp.signed.version}"
                 )
+            # Keep using old timestamp if versions are equal.
+            if new_timestamp.signed.version == self.timestamp.signed.version:
+                raise exceptions.EqualVersionNumberError()
+
             # Prevent rolling back snapshot version
             snapshot_meta = self.timestamp.signed.snapshot_meta
             new_snapshot_meta = new_timestamp.signed.snapshot_meta

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -336,7 +336,13 @@ class Updater:
         data = self._download_metadata(
             Timestamp.type, self.config.timestamp_max_length
         )
-        self._trusted_set.update_timestamp(data)
+        try:
+            self._trusted_set.update_timestamp(data)
+        except exceptions.EqualVersionNumberError:
+            # If the new timestamp version is the same as current, discard the
+            # new timestamp. This is normal and it shouldn't raise any error.
+            return
+
         self._persist_metadata(Timestamp.type, data)
 
     def _load_snapshot(self) -> None:


### PR DESCRIPTION
Fixes #2023

**Description of the changes being introduced by the pull request**:

In the spec version `1.0.30`, a new change has been added considering what
should happen if there is a new timestamp with the same version.
It says the following:
```
In case they [versions] are equal, discard the new
timestamp metadata and abort the update cycle.
This is normal and it shouldn't raise any error.
```

In other words, if there is a new timestamp with the same version, then
stop the update process and use the old timestamp.

Those changes reflect these latest specification modifications.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


