### PR TITLE
Bump supported spec version to 1.0.30

### DIFF
--- a/tests/generated_data/ed25519_metadata/root_with_ed25519.json
+++ b/tests/generated_data/ed25519_metadata/root_with_ed25519.json
@@ -2,7 +2,7 @@
  "signatures": [
   {
    "keyid": "5822582e7072996c1eef1cec24b61115d364987faa486659fe3d3dce8dae2aba",
-   "sig": "9589295d2b23b2e4747eba36e782f5f5775af975cee67ae75be7e0170556788253ca6919be9ed36e52a6023c49314a7d2b65a06541db6c3d06f84eaee585480b"
+   "sig": "9e05d02ec6e4cb9cc48592f6eca040274a1d58379d485542f8c1843c06a3fcd7ce96ab73ff345348d44ab77cf6eed5a372cfbd41fd1a202133786ce7aed9ff08"
   }
  ],
  "signed": {
@@ -65,7 +65,7 @@
     "threshold": 1
    }
   },
-  "spec_version": "1.0.29",
+  "spec_version": "1.0.30",
   "version": 1
  }
 }

--- a/tests/generated_data/ed25519_metadata/snapshot_with_ed25519.json
+++ b/tests/generated_data/ed25519_metadata/snapshot_with_ed25519.json
@@ -2,7 +2,7 @@
  "signatures": [
   {
    "keyid": "3458204ed467519c19a5316eb278b5608472a1bbf15850ebfb462d5315e4f86d",
-   "sig": "259dc96079f9b49e811b69b79253914ac5a963333eb24e5ac2d779a2d5d9d305c96c745613da59c1c48ae92d6f01a619b25066e51fc028a6ec8b56d744387006"
+   "sig": "5ee2946a5bd616b52fe381e94625a99269124a5d449db28387d814e93fe0ac78008bd9ed4cc72f84138b80cba1ce1fc91773427208b18245a0885cdaa8bf7909"
   }
  ],
  "signed": {
@@ -13,7 +13,7 @@
     "version": 1
    }
   },
-  "spec_version": "1.0.29",
+  "spec_version": "1.0.30",
   "version": 1
  }
 }

--- a/tests/generated_data/ed25519_metadata/targets_with_ed25519.json
+++ b/tests/generated_data/ed25519_metadata/targets_with_ed25519.json
@@ -2,13 +2,13 @@
  "signatures": [
   {
    "keyid": "2be5c21e3614f9f178fb49c4a34d0c18ffac30abd14ced917c60a52c8d8094b7",
-   "sig": "0a83294ac2930655def327a010be1c22f15b2b229d26792e63ff974eeb3c529f4ede60fafffabbcd5db5defae63e76067781e745164a4d00af09d5a3d4cc560c"
+   "sig": "dff8805b0620ba4f39b0d7d67adbc2e8ddffa152dded5b58958192e5caadd87b9374e1eef6870a18edda64350a48620f0d26cf56594ff98f7ea4e9d295a39207"
   }
  ],
  "signed": {
   "_type": "targets",
   "expires": "2050-01-01T00:00:00Z",
-  "spec_version": "1.0.29",
+  "spec_version": "1.0.30",
   "targets": {},
   "version": 1
  }

--- a/tests/generated_data/ed25519_metadata/timestamp_with_ed25519.json
+++ b/tests/generated_data/ed25519_metadata/timestamp_with_ed25519.json
@@ -2,7 +2,7 @@
  "signatures": [
   {
    "keyid": "09d440e3725cec247dcb8703b646a87dd2a4d75343e8095c036c32795eefe3b9",
-   "sig": "0f57e85b060f06d778c0e2bf131be3dc828beb39ffdf12776f60a9787cc5f02fdf126eb0875a5953b451bc1e88cea9b720cf180475ed0fd54615c1434de07503"
+   "sig": "e3d240f6fb94c45bcd420a3bd56b902f3a82f766948f4a6b515cf5b14fdee020a0c906505f1437b89d686031505b7b218da090a142c196eee10dd392de5a8b00"
   }
  ],
  "signed": {
@@ -13,7 +13,7 @@
     "version": 1
    }
   },
-  "spec_version": "1.0.29",
+  "spec_version": "1.0.30",
   "version": 1
  }
 }

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -76,7 +76,7 @@ logger = logging.getLogger(__name__)
 
 # We aim to support SPECIFICATION_VERSION and require the input metadata
 # files to have the same major version (the first number) as ours.
-SPECIFICATION_VERSION = ["1", "0", "29"]
+SPECIFICATION_VERSION = ["1", "0", "30"]
 TOP_LEVEL_ROLE_NAMES = {_ROOT, _TIMESTAMP, _SNAPSHOT, _TARGETS}
 
 # T is a Generic type constraint for Metadata.signed


### PR DESCRIPTION
Fixes #1992

**Description of the changes being introduced by the pull request**:

Bump the supported specification version to `1.0.30` and additionally
update the generated test metadata as it has to be up to date with the
latest changes.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


