### PR TITLE
SuccinctRoles.is_delegated_role() add a test case

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -750,7 +750,14 @@ class TestMetadata(unittest.TestCase):
 
     def test_is_delegated_role_in_succinct_roles(self) -> None:
         succinct_roles = SuccinctRoles([], 1, 5, "bin")
-        false_role_name_examples = ["foo", "bin-", "bin-s", "bin-20", "bin-100"]
+        false_role_name_examples = [
+            "foo",
+            "bin-",
+            "bin-s",
+            "bin-0t",
+            "bin-20",
+            "bin-100",
+        ]
         for role_name in false_role_name_examples:
             msg = f"Error for {role_name}"
             self.assertFalse(succinct_roles.is_delegated_role(role_name), msg)


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Add a test case when there is a bin name with the desired prefix, but
which cannot be cast to a hexadecimal number.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


