### PR TITLE
ngclient: Prevent automatic decoding of gzip files

### DIFF
--- a/tests/simple_server.py
+++ b/tests/simple_server.py
@@ -6,13 +6,14 @@
 """Simple HTTP server for python-tuf tests"""
 
 import socketserver
-from http.server import SimpleHTTPRequestHandler
+
+from tests.utils import CustomHTTPRequestHandler
 
 # Allow re-use so you can re-run tests as often as you want even if the
 # tests re-use ports. Otherwise TCP TIME-WAIT prevents reuse for ~1 minute
 socketserver.TCPServer.allow_reuse_address = True
 
-httpd = socketserver.TCPServer(("localhost", 0), SimpleHTTPRequestHandler)
+httpd = socketserver.TCPServer(("localhost", 0), CustomHTTPRequestHandler)
 port_message = "bind succeeded, server port is: " + str(httpd.server_address[1])
 print(port_message)
 httpd.serve_forever()

--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -114,7 +114,7 @@ class TestFetcher(unittest.TestCase):
         content_encoding_header = json.dumps({"Content-Encoding": "gzip"})
         headers = {utils.REQUEST_RESPONSE_HEADERS: content_encoding_header}
         get_with_headers = partialmethod(requests.Session.get, headers=headers)
-        target = 'tuf.ngclient._internal.requests_fetcher.requests.Session.get'
+        target = "tuf.ngclient._internal.requests_fetcher.requests.Session.get"
         # The test file content does not represent a real gzip file,
         # so we can expect an error to be raised if requests/urllib3 tries to
         # decode the file (urllib3 uses zlib for this).
@@ -126,7 +126,7 @@ class TestFetcher(unittest.TestCase):
                 temp_file.seek(0)
                 fetched_data = temp_file.read()
         except requests.exceptions.ContentDecodingError as e:
-            self.fail(f'fetch() raised unexpected decoding error: {e}')
+            self.fail(f"fetch() raised unexpected decoding error: {e}")
         # If all is well, decoding has *not* been attempted, and the fetched
         # data matches the original file contents
         self.assertEqual(self.file_contents, fetched_data)

--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -6,7 +6,6 @@
 """Unit test for RequestsFetcher.
 """
 
-from functools import partialmethod
 import io
 import json
 import logging
@@ -15,6 +14,7 @@ import os
 import sys
 import tempfile
 import unittest
+from functools import partialmethod
 from typing import Any, ClassVar, Iterator
 from unittest.mock import Mock, patch
 

--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -110,8 +110,6 @@ class TestFetcher(unittest.TestCase):
     # Response read timeout error
     @patch.object(requests.Session, "get")
     def test_response_read_timeout(self, mock_session_get: Any) -> None:
-        # from urllib3.connectionpool import ConnectionPool
-        # dummy_pool = ConnectionPool("dummy")
         mock_response = Mock(raw=Mock())
         attr = {
             "read.side_effect": ReadTimeoutError(

--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -112,7 +112,7 @@ class TestFetcher(unittest.TestCase):
         """
         # Serve dummy file with "Content-Encoding: gzip" header
         content_encoding_header = json.dumps({"Content-Encoding": "gzip"})
-        headers = {utils.REQUEST_RESPONSE_HEADERS: content_encoding_header}
+        headers = {utils.DESIRED_RESPONSE_HEADERS: content_encoding_header}
         get_with_headers = partialmethod(requests.Session.get, headers=headers)
         target = "tuf.ngclient._internal.requests_fetcher.requests.Session.get"
         # The test file content does not represent a real gzip file,

--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -17,7 +17,7 @@ from typing import Any, ClassVar, Iterator
 from unittest.mock import Mock, patch
 
 import requests
-from requests.models import ReadTimeoutError  # actually from urllib3
+from requests.adapters import ReadTimeoutError  # this is a urllib3 exception
 
 from tests import utils
 from tuf.api import exceptions

--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -19,7 +19,7 @@ from typing import Any, ClassVar, Iterator
 from unittest.mock import Mock, patch
 
 import requests
-from requests.adapters import ReadTimeoutError  # this is a urllib3 exception
+from urllib3.exceptions import ReadTimeoutError
 
 from tests import utils
 from tuf.api import exceptions

--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -98,7 +98,7 @@ class TestFetcher(unittest.TestCase):
             self.assertEqual(chunks_count, expected_chunks_count)
 
     # Fetch data with Content-Encoding gzip (or deflate)
-    def test_fetch_content_encoding(self):
+    def test_fetch_content_encoding(self) -> None:
         """
         Regression test for issue #2047
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,10 +20,13 @@
   Provide tests for some of the functions in utils.py module.
 """
 
+import io
+import json
 import logging
 import socket
 import sys
 import unittest
+from unittest import mock
 
 from tests import utils
 
@@ -74,6 +77,43 @@ class TestServerProcess(unittest.TestCase):
         # Test starting a server which immediately exits."
         with self.assertRaises(utils.TestServerProcessError):
             utils.TestServerProcess(logger, server="fast_server_exit.py")
+
+
+class CustomHTTPRequestHandlerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Based on cpython tests SocketlessRequestHandler:
+        # https://github.com/python/cpython/blob/main/Lib/test/test_httpservers.py#L921
+        request = mock.Mock()
+        request.makefile.return_value = io.BytesIO()
+        self.handler = utils.CustomHTTPRequestHandler(
+            request, None, None, directory=None
+        )
+        self.handler.get_called = False
+        self.handler.protocol_version = "HTTP/1.1"
+        self.handler.client_address = ('localhost', 0)
+
+    def send_request(self, message):
+        # Based on cpython tests BaseHTTPRequestHandlerTestCase:
+        # https://github.com/python/cpython/blob/main/Lib/test/test_httpservers.py#L973
+        self.handler.rfile = io.BytesIO(message)
+        self.handler.wfile = io.BytesIO()
+        self.handler.handle_one_request()
+        self.handler.wfile.seek(0)
+        return self.handler.wfile.readlines()
+
+    def test_custom_response_headers(self):
+        header_name = 'Some-Header'
+        header_value = 'some value'
+        req_header = utils.REQUEST_RESPONSE_HEADERS
+        resp_headers = json.dumps({header_name: header_value})
+        raw_header = f'{req_header}: {resp_headers}\r\n'.encode('utf-8')
+        raw_request = b'GET / HTTP/1.1\r\n'
+        raw_request += raw_header
+        raw_request += b'\r\n'
+        raw_response = b''.join(self.send_request(message=raw_request))
+        print(raw_response)
+        self.assertIn(header_name.encode('utf-8'), raw_response)
+        self.assertIn(header_value.encode('utf-8'), raw_response)
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -111,7 +111,6 @@ class CustomHTTPRequestHandlerTests(unittest.TestCase):
         raw_request += raw_header
         raw_request += b'\r\n'
         raw_response = b''.join(self.send_request(message=raw_request))
-        print(raw_response)
         self.assertIn(header_name.encode('utf-8'), raw_response)
         self.assertIn(header_value.encode('utf-8'), raw_response)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,6 +82,7 @@ class TestServerProcess(unittest.TestCase):
 
 class CustomHTTPRequestHandlerTests(unittest.TestCase):
     """Test functionality provided by CustomHTTPRequestHandler"""
+
     def setUp(self) -> None:
         # Based on cpython tests SocketlessRequestHandler:
         # https://github.com/python/cpython/blob/main/Lib/test/test_httpservers.py#L921

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,7 @@ import logging
 import socket
 import sys
 import unittest
+from typing import List
 from unittest import mock
 
 from tests import utils
@@ -80,19 +81,20 @@ class TestServerProcess(unittest.TestCase):
 
 
 class CustomHTTPRequestHandlerTests(unittest.TestCase):
+    """Test functionality provided by CustomHTTPRequestHandler"""
     def setUp(self) -> None:
         # Based on cpython tests SocketlessRequestHandler:
         # https://github.com/python/cpython/blob/main/Lib/test/test_httpservers.py#L921
         request = mock.Mock()
         request.makefile.return_value = io.BytesIO()
         self.handler = utils.CustomHTTPRequestHandler(
-            request, None, None, directory=None
+            request, None, None, directory=None  # type: ignore
         )
         self.handler.get_called = False
         self.handler.protocol_version = "HTTP/1.1"
         self.handler.client_address = ("localhost", 0)
 
-    def send_request(self, message):
+    def send_request(self, message: bytes) -> List[bytes]:
         # Based on cpython tests BaseHTTPRequestHandlerTestCase:
         # https://github.com/python/cpython/blob/main/Lib/test/test_httpservers.py#L973
         self.handler.rfile = io.BytesIO(message)
@@ -101,7 +103,7 @@ class CustomHTTPRequestHandlerTests(unittest.TestCase):
         self.handler.wfile.seek(0)
         return self.handler.wfile.readlines()
 
-    def test_custom_response_headers(self):
+    def test_custom_response_headers(self) -> None:
         header_name = "Some-Header"
         header_value = "some value"
         req_header = utils.DESIRED_RESPONSE_HEADERS

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,7 +90,7 @@ class CustomHTTPRequestHandlerTests(unittest.TestCase):
         )
         self.handler.get_called = False
         self.handler.protocol_version = "HTTP/1.1"
-        self.handler.client_address = ('localhost', 0)
+        self.handler.client_address = ("localhost", 0)
 
     def send_request(self, message):
         # Based on cpython tests BaseHTTPRequestHandlerTestCase:
@@ -102,17 +102,17 @@ class CustomHTTPRequestHandlerTests(unittest.TestCase):
         return self.handler.wfile.readlines()
 
     def test_custom_response_headers(self):
-        header_name = 'Some-Header'
-        header_value = 'some value'
+        header_name = "Some-Header"
+        header_value = "some value"
         req_header = utils.REQUEST_RESPONSE_HEADERS
         resp_headers = json.dumps({header_name: header_value})
-        raw_header = f'{req_header}: {resp_headers}\r\n'.encode('utf-8')
-        raw_request = b'GET / HTTP/1.1\r\n'
+        raw_header = f"{req_header}: {resp_headers}\r\n".encode("utf-8")
+        raw_request = b"GET / HTTP/1.1\r\n"
         raw_request += raw_header
-        raw_request += b'\r\n'
-        raw_response = b''.join(self.send_request(message=raw_request))
-        self.assertIn(header_name.encode('utf-8'), raw_response)
-        self.assertIn(header_value.encode('utf-8'), raw_response)
+        raw_request += b"\r\n"
+        raw_response = b"".join(self.send_request(message=raw_request))
+        self.assertIn(header_name.encode("utf-8"), raw_response)
+        self.assertIn(header_value.encode("utf-8"), raw_response)
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,7 +104,7 @@ class CustomHTTPRequestHandlerTests(unittest.TestCase):
     def test_custom_response_headers(self):
         header_name = "Some-Header"
         header_value = "some value"
-        req_header = utils.REQUEST_RESPONSE_HEADERS
+        req_header = utils.DESIRED_RESPONSE_HEADERS
         resp_headers = json.dumps({header_name: header_value})
         raw_header = f"{req_header}: {resp_headers}\r\n".encode("utf-8")
         raw_request = b"GET / HTTP/1.1\r\n"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -48,9 +48,10 @@ TEST_HOST_ADDRESS = "127.0.0.1"
 # DataSet is only here so type hints can be used.
 DataSet = Dict[str, Any]
 
-# May be used in a request to add headers to the response that is returned by
-# the customized http request handler.
-REQUEST_RESPONSE_HEADERS = "Request-Response-Headers"
+# If the test-server receives an HTTP-request with this custom header,
+# it will add the specified headers to the HTTP-response. The corresponding
+# value must be a JSON object with header name/value pairs.
+DESIRED_RESPONSE_HEADERS = "Desired-Response-Headers"
 
 
 # Test runner decorator: Runs the test as a set of N SubTests,
@@ -375,11 +376,11 @@ class TestServerProcess:
 
 class CustomHTTPRequestHandler(SimpleHTTPRequestHandler):
     def end_headers(self) -> None:
-        # If REQUEST_RESPONSE_HEADERS is found in the request headers, add the
+        # If DESIRED_RESPONSE_HEADERS is found in the request headers, add the
         # specified headers to the response.
-        requested_headers = self.headers.get(REQUEST_RESPONSE_HEADERS)
-        if requested_headers:
-            headers = json.loads(requested_headers)
+        desired_headers = self.headers.get(DESIRED_RESPONSE_HEADERS)
+        if desired_headers:
+            headers = json.loads(desired_headers)
             for key, value in headers.items():
                 self.send_header(keyword=key, value=value)
         super().end_headers()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,7 +22,6 @@
 
 import argparse
 import errno
-from http.server import SimpleHTTPRequestHandler
 import json
 import logging
 import os
@@ -35,6 +34,7 @@ import time
 import unittest
 import warnings
 from contextlib import contextmanager
+from http.server import SimpleHTTPRequestHandler
 from typing import IO, Any, Callable, Dict, Iterator, List, Optional
 
 logger = logging.getLogger(__name__)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -375,7 +375,7 @@ class TestServerProcess:
 
 class CustomHTTPRequestHandler(SimpleHTTPRequestHandler):
     def end_headers(self) -> None:
-        # If Custom-Response-Headers is found in the request headers, add the
+        # If REQUEST_RESPONSE_HEADERS is found in the request headers, add the
         # specified headers to the response.
         requested_headers = self.headers.get(REQUEST_RESPONSE_HEADERS)
         if requested_headers:

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -11,7 +11,7 @@ from urllib import parse
 
 # Imports
 import requests
-from requests.adapters import ReadTimeoutError  # this is a urllib3 exception
+from urllib3.exceptions import ReadTimeoutError
 
 import tuf
 from tuf.api import exceptions

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -11,7 +11,7 @@ from urllib import parse
 
 # Imports
 import requests
-from requests.models import ReadTimeoutError  # todo: import directly from urllib3?
+from requests.adapters import ReadTimeoutError  # this is a urllib3 exception
 
 import tuf
 from tuf.api import exceptions
@@ -107,12 +107,7 @@ class RequestsFetcher(FetcherInterface):
                 if not data:
                     break
                 yield data
-        except (
-            # Catch urllib3 exceptions instead of requests exceptions.
-            ReadTimeoutError,
-            # todo: Is this sufficient? Do we need to catch IncompleteRead too?
-            #  https://github.com/urllib3/urllib3/blob/43c372f6eb9f9f94848c7b7645ad19ebf6c047c5/src/urllib3/response.py#L734
-        ) as e:
+        except ReadTimeoutError as e:
             raise exceptions.SlowRetrievalError from e
 
         finally:


### PR DESCRIPTION

Fixes #2047

**Description of the changes being introduced by the pull request**:

- Replace `response.iter_content` by `response.raw` in `RequestsFetcher._chunks()`. This prevents requests/urllib3 from automatically decoding files with `Content-Encoding` headers (`gzip` or `deflate`).
- Add a `CustomHTTPRequestHandler` to `tests.utils`, and use this in `simple_server.py` (instead of `SimpleHTTPRequestHandler`). The custom request handler adds the ability to specify additional headers in an HTTP request, which are then added to the corresponding HTTP response. This is used to test the "Content-Encoding" issue.
- Add a regression test for issue 2047 which verifies that files served with a "Content-Encoding: gzip" header are not decoded.

Some open questions:

- Is it sufficient to catch `ReadTimeoutError` in `_chunks()`, or should we catch e.g. [IncompleteRead][1] too?

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature

[1]: https://github.com/urllib3/urllib3/blob/43c372f6eb9f9f94848c7b7645ad19ebf6c047c5/src/urllib3/response.py#L734

