### PR TITLE
build: remove obsolete setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-# This file exists to keep dependabot happy:
-# https://github.com/dependabot/dependabot-core/issues/4483
-from setuptools import setup
-setup()


### PR DESCRIPTION
setup.py was removed in favor of setup.cfg in #1626 and re-added
later in #1832 to work around a Dependabot issue #1828. This issue
seems to have been fixed upstream in dependabot/dependabot-core#5392.

Fixes #2089


