### PR TITLE
chore: fix error in spec version check workflow

### DIFF
--- a/.github/workflows/specification-version-check.yml
+++ b/.github/workflows/specification-version-check.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: "3.x"
       - id: get-version
         run: |
-          python3 -m pip install -u pip
+          python3 -m pip install --upgrade pip
           python3 -m pip install -e .
           script="from tuf.api.metadata import SPECIFICATION_VERSION; \
                   print(f\"v{'.'.join(SPECIFICATION_VERSION)}\")"


### PR DESCRIPTION
Use `--upgrade` option to upgrade pip with pip in workflow, instead of non-existing `-u` option (`-U` would also be possible).
