### PR TITLE
Bump supported spec version to 1.0.31

### DIFF
--- a/tests/generated_data/ed25519_metadata/root_with_ed25519.json
+++ b/tests/generated_data/ed25519_metadata/root_with_ed25519.json
@@ -2,7 +2,7 @@
  "signatures": [
   {
    "keyid": "5822582e7072996c1eef1cec24b61115d364987faa486659fe3d3dce8dae2aba",
-   "sig": "9e05d02ec6e4cb9cc48592f6eca040274a1d58379d485542f8c1843c06a3fcd7ce96ab73ff345348d44ab77cf6eed5a372cfbd41fd1a202133786ce7aed9ff08"
+   "sig": "06fc2b26d10afae02689c96dee96ff40e702734accec6f3e69671dec0a59e0763bd7cb7d5ffa4b9e87441c4c98e798ce97cb462e7075e38ad9bc1d0d0c657309"
   }
  ],
  "signed": {
@@ -65,7 +65,7 @@
     "threshold": 1
    }
   },
-  "spec_version": "1.0.30",
+  "spec_version": "1.0.31",
   "version": 1
  }
 }

--- a/tests/generated_data/ed25519_metadata/snapshot_with_ed25519.json
+++ b/tests/generated_data/ed25519_metadata/snapshot_with_ed25519.json
@@ -2,7 +2,7 @@
  "signatures": [
   {
    "keyid": "3458204ed467519c19a5316eb278b5608472a1bbf15850ebfb462d5315e4f86d",
-   "sig": "5ee2946a5bd616b52fe381e94625a99269124a5d449db28387d814e93fe0ac78008bd9ed4cc72f84138b80cba1ce1fc91773427208b18245a0885cdaa8bf7909"
+   "sig": "bab356be0a82b85b9529aa4625cbd7b8e03b71d1a0fb5d3242f6e8377f102bcf60cc1b8c2a566fd5618c5f5ee3fc07745e84920d26e5514ad455868d7899ae03"
   }
  ],
  "signed": {
@@ -13,7 +13,7 @@
     "version": 1
    }
   },
-  "spec_version": "1.0.30",
+  "spec_version": "1.0.31",
   "version": 1
  }
 }

--- a/tests/generated_data/ed25519_metadata/targets_with_ed25519.json
+++ b/tests/generated_data/ed25519_metadata/targets_with_ed25519.json
@@ -2,13 +2,13 @@
  "signatures": [
   {
    "keyid": "2be5c21e3614f9f178fb49c4a34d0c18ffac30abd14ced917c60a52c8d8094b7",
-   "sig": "dff8805b0620ba4f39b0d7d67adbc2e8ddffa152dded5b58958192e5caadd87b9374e1eef6870a18edda64350a48620f0d26cf56594ff98f7ea4e9d295a39207"
+   "sig": "9e47f85b3edc79b7215bfee1291da46655deca0b6de99cb3968293218f3329855e57c1523120a50e3a2a8cc50aa9e886f4f74d902d28f43559f294681152f30b"
   }
  ],
  "signed": {
   "_type": "targets",
   "expires": "2050-01-01T00:00:00Z",
-  "spec_version": "1.0.30",
+  "spec_version": "1.0.31",
   "targets": {},
   "version": 1
  }

--- a/tests/generated_data/ed25519_metadata/timestamp_with_ed25519.json
+++ b/tests/generated_data/ed25519_metadata/timestamp_with_ed25519.json
@@ -2,7 +2,7 @@
  "signatures": [
   {
    "keyid": "09d440e3725cec247dcb8703b646a87dd2a4d75343e8095c036c32795eefe3b9",
-   "sig": "e3d240f6fb94c45bcd420a3bd56b902f3a82f766948f4a6b515cf5b14fdee020a0c906505f1437b89d686031505b7b218da090a142c196eee10dd392de5a8b00"
+   "sig": "f1b1921a5963485eb5f1cf83f1b44548420bdcced420a367f0c42b63c91950410287f6d062824941085361c3906bb44a365352e2971787a653443ff8df484007"
   }
  ],
  "signed": {
@@ -13,7 +13,7 @@
     "version": 1
    }
   },
-  "spec_version": "1.0.30",
+  "spec_version": "1.0.31",
   "version": 1
  }
 }

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -76,7 +76,7 @@ logger = logging.getLogger(__name__)
 
 # We aim to support SPECIFICATION_VERSION and require the input metadata
 # files to have the same major version (the first number) as ours.
-SPECIFICATION_VERSION = ["1", "0", "30"]
+SPECIFICATION_VERSION = ["1", "0", "31"]
 TOP_LEVEL_ROLE_NAMES = {_ROOT, _TIMESTAMP, _SNAPSHOT, _TARGETS}
 
 # T is a Generic type constraint for Metadata.signed


### PR DESCRIPTION
Fixes #2112

Bump the supported specification version to `1.0.31` and additionally update the generated
test metadata as it has to be up to date with the latest changes.

The new changes in the specification version `1.0.31` clarify the requirement for the new root
version as compared to the old root version in step 5.3.5:
https://theupdateframework.github.io/specification/latest/#update-root

We already do what the specification suggests in the new changes, so no other changes are required.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>

**Description of the changes being introduced by the pull request**:

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


