### PR TITLE
Fix typo CD.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@ jobs:
         run: python3 -m build --sdist --wheel --outdir dist/ .
 
       - id: gh-release
-        name: Publish GitHub release candiate
+        name: Publish GitHub release candidate
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         with:
           name: ${{ github.ref_name }}-rc


### PR DESCRIPTION
Fixed typo in CD.yml: 'candidate' instead ' candidate'.

Signed-off-by: Kairo de Araujo <kdearaujo@vmware.com>

- [X] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)


