### PR TITLE
Fix: allow `length` to be zero

### DIFF
--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -297,7 +297,6 @@ class TestSerialization(unittest.TestCase):
     invalid_metafiles: utils.DataSet = {
         "wrong length type": '{"version": 1, "length": "a", "hashes": {"sha256" : "abc"}}',
         "version 0": '{"version": 0, "length": 1, "hashes": {"sha256" : "abc"}}',
-        "length 0": '{"version": 1, "length": 0, "hashes": {"sha256" : "abc"}}',
         "length below 0": '{"version": 1, "length": -1, "hashes": {"sha256" : "abc"}}',
         "empty hashes dict": '{"version": 1, "length": 1, "hashes": {}}',
         "hashes wrong type": '{"version": 1, "length": 1, "hashes": 1}',
@@ -313,6 +312,7 @@ class TestSerialization(unittest.TestCase):
     valid_metafiles: utils.DataSet = {
         "all": '{"hashes": {"sha256" : "abc"}, "length": 12, "version": 1}',
         "no length": '{"hashes": {"sha256" : "abc"}, "version": 1 }',
+        "length 0": '{"version": 1, "length": 0, "hashes": {"sha256" : "abc"}}',
         "no hashes": '{"length": 12, "version": 1}',
         "unrecognized field": '{"hashes": {"sha256" : "abc"}, "length": 12, "version": 1, "foo": "bar"}',
         "many hashes": '{"hashes": {"sha256" : "abc", "sha512": "cde"}, "length": 12, "version": 1}',

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1052,8 +1052,8 @@ class BaseFile:
 
     @staticmethod
     def _validate_length(length: int) -> None:
-        if length <= 0:
-            raise ValueError(f"Length must be > 0, got {length}")
+        if length < 0:
+            raise ValueError(f"Length must be >= 0, got {length}")
 
 
 class MetaFile(BaseFile):


### PR DESCRIPTION
* As per TUF specification, length attribute is a numerical value (which can include 0) - https://theupdateframework.github.io/specification/latest/#metapath-length

fix: update tests

Fixes #2136 

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


