### PR TITLE
ci: migrate deprecating set-output commands

### DIFF
--- a/.github/workflows/specification-version-check.yml
+++ b/.github/workflows/specification-version-check.yml
@@ -21,7 +21,7 @@ jobs:
           script="from tuf.api.metadata import SPECIFICATION_VERSION; \
                   print(f\"v{'.'.join(SPECIFICATION_VERSION)}\")"
           ver=$(python3 -c "$script")
-          echo "::set-output name=version::$ver"
+          echo "version=$ver" >> $GITHUB_OUTPUT
   # Get the latest TUF specification release and open an issue (if needed)
   specification-bump-check:
     permissions:


### PR DESCRIPTION
Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

Closes #2144.

**Description of the changes being introduced by the pull request**:

Replace deprecating `set-output` command with `$GITHUB_OUTPUT`.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


