### PR TITLE
Github workflows: Permissions tweaks

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -2,6 +2,7 @@ on:
   workflow_call:
   # Permissions inherited from caller workflow
 
+permissions: {}
 
 jobs:
   tests:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -82,6 +82,8 @@ jobs:
           path: dist
 
       - name: Publish binary wheel and source tarball on PyPI
+        # Only attempt pypi upload in upstream repository
+        if: github.repository == 'theupdateframework/python-tuf'
         uses: pypa/gh-action-pypi-publish@37f50c210e3d2f9450da2cd423303d6a14a6e29f
         with:
           user: __token__

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,8 +6,7 @@ on:
     tags:
       - v*
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   test:
@@ -17,8 +16,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: test
-    outputs:
-      release_id: ${{ steps.gh-release.outputs.id }}
     steps:
       - name: Checkout release tag
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -36,15 +33,6 @@ jobs:
       - name: Build binary wheel and source tarball
         run: python3 -m build --sdist --wheel --outdir dist/ .
 
-      - id: gh-release
-        name: Publish GitHub release candidate
-        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
-        with:
-          name: ${{ github.ref_name }}-rc
-          tag_name: ${{ github.ref }}
-          body: "Release waiting for review..."
-          files: dist/*
-
       - name: Store build artifacts
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb
         # NOTE: The GitHub release page contains the release artifacts too, but using
@@ -54,11 +42,38 @@ jobs:
           name: build-artifacts
           path: dist
 
+  candidate_release:
+    name: Release candidate on Github for review
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write # to modify GitHub releases
+    outputs:
+      release_id: ${{ steps.gh-release.outputs.id }}
+    steps:
+      - name: Fetch build artifacts
+        uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7
+        with:
+          name: build-artifacts
+          path: dist
+
+      - id: gh-release
+        name: Publish GitHub release candidate
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+        with:
+          name: ${{ github.ref_name }}-rc
+          tag_name: ${{ github.ref }}
+          body: "Release waiting for review..."
+          files: dist/*
+
+
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: build
+    needs: candidate_release
     environment: release
+    permissions:
+      contents: write # to modify GitHub releases
     steps:
       - name: Fetch build artifacts
         uses: actions/download-artifact@9782bd6a9848b53b110e712e20e42d89988822b7
@@ -79,7 +94,7 @@ jobs:
             await github.rest.repos.updateRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              release_id: '${{ needs.build.outputs.release_id }}',
+              release_id: '${{ needs.candidate_release.outputs.release_id }}',
               name: '${{ github.ref_name }}',
               body: 'See [CHANGELOG.md](https://github.com/' +
                      context.repo.owner + '/' + context.repo.repo +

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,7 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   test:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,6 +7,9 @@ on:
     branches: [ develop ]
   schedule:
     - cron: '30 0 * * 2'
+  workflow_dispatch:
+
+permissions: {}
 
 jobs:
   analyze:

--- a/.github/workflows/specification-version-check.yml
+++ b/.github/workflows/specification-version-check.yml
@@ -2,7 +2,11 @@ on:
   schedule:
     - cron: "0 13 * * *"
   workflow_dispatch:
+
 name: Specification version check
+
+permissions: {}
+
 jobs:
   # Get the version of the TUF specification the project states it supports
   get-supported-tuf-version:


### PR DESCRIPTION
Fixes #2116 

Tweak workflow permissions based on OSSF scorecard suggestions
* set workflow-level permissions to none
* use job-level permissions to minimize exposure

Also:
* skip pypi-upload step on forks (this allows testing most of the CD workflow in forks). This is not really relevant to other commits and can be removed.

