### PR TITLE
Made the dicts being serialized ordered.

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -138,7 +138,9 @@ class Metadata(Generic[T]):
         if unrecognized_fields is None:
             unrecognized_fields = {}
 
-        self.unrecognized_fields = unrecognized_fields
+        self.unrecognized_fields = type(unrecognized_fields)(
+            sorted(unrecognized_fields.items(), key=lambda x: x[0])
+        )
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Metadata):
@@ -930,9 +932,12 @@ class Root(Signed):
     def to_dict(self) -> Dict[str, Any]:
         """Returns the dict representation of self."""
         root_dict = self._common_fields_to_dict()
-        keys = {keyid: key.to_dict() for (keyid, key) in self.keys.items()}
+        keys = {
+            keyid: key.to_dict()
+            for (keyid, key) in sorted(self.keys.items(), key=lambda x: x[0])
+        }
         roles = {}
-        for role_name, role in self.roles.items():
+        for role_name, role in sorted(self.roles.items(), key=lambda x: x[0]):
             roles[role_name] = role.to_dict()
         if self.consistent_snapshot is not None:
             root_dict["consistent_snapshot"] = self.consistent_snapshot
@@ -1278,7 +1283,9 @@ class Snapshot(Signed):
         """Returns the dict representation of self."""
         snapshot_dict = self._common_fields_to_dict()
         meta_dict = {}
-        for meta_path, meta_info in self.meta.items():
+        for meta_path, meta_info in sorted(
+            self.meta.items(), key=lambda x: x[0]
+        ):
             meta_dict[meta_path] = meta_info.to_dict()
 
         snapshot_dict["meta"] = meta_dict
@@ -1697,7 +1704,10 @@ class Delegations:
 
     def to_dict(self) -> Dict[str, Any]:
         """Returns the dict representation of self."""
-        keys = {keyid: key.to_dict() for keyid, key in self.keys.items()}
+        keys = {
+            keyid: key.to_dict()
+            for keyid, key in sorted(self.keys.items(), key=lambda x: x[0])
+        }
         res_dict: Dict[str, Any] = {
             "keys": keys,
             **self.unrecognized_fields,
@@ -1971,7 +1981,9 @@ class Targets(Signed):
         """Returns the dict representation of self."""
         targets_dict = self._common_fields_to_dict()
         targets = {}
-        for target_path, target_file_obj in self.targets.items():
+        for target_path, target_file_obj in sorted(
+            self.targets.items(), key=lambda x: x[0]
+        ):
             targets[target_path] = target_file_obj.to_dict()
         targets_dict[_TARGETS] = targets
         if self.delegations is not None:


### PR DESCRIPTION
Fixes #2161

**Description of the changes being introduced by the pull request**:

* Sort the dicts being serialized by their keys to enforce the same ordering all the time.
* Use `OrderedDict` type. I know that just `dict` is also ordered in modern versions of Python, but `OrderedDict` is more future-proof.

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature - not needed
- [ ] Docs have been added for the bug fix or new feature - not needed


