### PR TITLE
Move (most of) Key to Securesystemslib

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,8 +61,6 @@ html_favicon = "tuf-icon-32.png"
 # -- Autodoc configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
 
-autodoc_mock_imports = ["securesystemslib"]
-
 # Tone down the "tuf.api.metadata." repetition
 add_module_names = False
 python_use_unqualified_type_names = True

--- a/examples/manual_repo/basic_repo.py
+++ b/examples/manual_repo/basic_repo.py
@@ -27,13 +27,12 @@ from pathlib import Path
 from typing import Any, Dict
 
 from securesystemslib.keys import generate_ed25519_key
-from securesystemslib.signer import SSlibSigner
+from securesystemslib.signer import SSlibKey, SSlibSigner
 
 from tuf.api.metadata import (
     SPECIFICATION_VERSION,
     DelegatedRole,
     Delegations,
-    Key,
     Metadata,
     MetaFile,
     Root,
@@ -157,7 +156,7 @@ roles["root"] = Metadata(Root(expires=_in(365)))
 for name in ["targets", "snapshot", "timestamp", "root"]:
     keys[name] = generate_ed25519_key()
     roles["root"].signed.add_key(
-        Key.from_securesystemslib_key(keys[name]), name
+        SSlibKey.from_securesystemslib_key(keys[name]), name
     )
 
 # NOTE: We only need the public part to populate root, so it is possible to use
@@ -173,7 +172,7 @@ for name in ["targets", "snapshot", "timestamp", "root"]:
 # required signature threshold.
 another_root_key = generate_ed25519_key()
 roles["root"].signed.add_key(
-    Key.from_securesystemslib_key(another_root_key), "root"
+    SSlibKey.from_securesystemslib_key(another_root_key), "root"
 )
 roles["root"].signed.roles["root"].threshold = 2
 
@@ -271,7 +270,7 @@ roles[delegatee_name] = Metadata[Targets](
 # https://theupdateframework.github.io/specification/latest/#delegations
 roles["targets"].signed.delegations = Delegations(
     keys={
-        keys[delegatee_name]["keyid"]: Key.from_securesystemslib_key(
+        keys[delegatee_name]["keyid"]: SSlibKey.from_securesystemslib_key(
             keys[delegatee_name]
         )
     },
@@ -345,7 +344,7 @@ new_root_key = generate_ed25519_key()
 
 roles["root"].signed.revoke_key(keys["root"]["keyid"], "root")
 roles["root"].signed.add_key(
-    Key.from_securesystemslib_key(new_root_key), "root"
+    SSlibKey.from_securesystemslib_key(new_root_key), "root"
 )
 roles["root"].signed.version += 1
 

--- a/examples/manual_repo/hashed_bin_delegation.py
+++ b/examples/manual_repo/hashed_bin_delegation.py
@@ -23,12 +23,11 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Tuple
 
 from securesystemslib.keys import generate_ed25519_key
-from securesystemslib.signer import SSlibSigner
+from securesystemslib.signer import SSlibKey, SSlibSigner
 
 from tuf.api.metadata import (
     DelegatedRole,
     Delegations,
-    Key,
     Metadata,
     TargetFile,
     Targets,
@@ -146,7 +145,7 @@ for name in ["bin-n", "bins"]:
 # Create preliminary delegating targets role (bins) and add public key for
 # delegated targets (bin_n) to key store. Delegation details are update below.
 roles["bins"] = Metadata(Targets(expires=_in(365)))
-bin_n_key = Key.from_securesystemslib_key(keys["bin-n"])
+bin_n_key = SSlibKey.from_securesystemslib_key(keys["bin-n"])
 roles["bins"].signed.delegations = Delegations(
     keys={bin_n_key.keyid: bin_n_key},
     roles={},

--- a/examples/manual_repo/succinct_hash_bin_delegations.py
+++ b/examples/manual_repo/succinct_hash_bin_delegations.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Dict, Tuple
 
 from securesystemslib.keys import generate_ed25519_key
-from securesystemslib.signer import SSlibSigner
+from securesystemslib.signer import SSlibKey, SSlibSigner
 
 from tuf.api.metadata import (
     Delegations,
@@ -82,7 +82,7 @@ THRESHOLD = 1
 def create_key() -> Tuple[Key, SSlibSigner]:
     """Generates a new Key and Signer."""
     sslib_key = generate_ed25519_key()
-    return Key.from_securesystemslib_key(sslib_key), SSlibSigner(sslib_key)
+    return SSlibKey.from_securesystemslib_key(sslib_key), SSlibSigner(sslib_key)
 
 
 # Create one signing key for all bins, and one for the delegating targets role.

--- a/examples/repository/_simplerepo.py
+++ b/examples/repository/_simplerepo.py
@@ -10,10 +10,9 @@ from datetime import datetime, timedelta
 from typing import Dict, List
 
 from securesystemslib import keys
-from securesystemslib.signer import Signer, SSlibSigner
+from securesystemslib.signer import Signer, SSlibKey, SSlibSigner
 
 from tuf.api.metadata import (
-    Key,
     Metadata,
     MetaFile,
     Root,
@@ -72,7 +71,7 @@ class SimpleRepository(Repository):
             for role in ["root", "timestamp", "snapshot", "targets"]:
                 key = keys.generate_ed25519_key()
                 self.signer_cache[role].append(SSlibSigner(key))
-                root.add_key(Key.from_securesystemslib_key(key), role)
+                root.add_key(SSlibKey.from_securesystemslib_key(key), role)
 
         for role in ["timestamp", "snapshot", "targets"]:
             with self.edit(role):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 dependencies = [
   "requests>=2.19.1",
-  "securesystemslib>=0.22.0",
+  "securesystemslib>=0.26.0",
 ]
 dynamic = ["version"]
 

--- a/tests/generated_data/generate_md.py
+++ b/tests/generated_data/generate_md.py
@@ -8,7 +8,7 @@ import sys
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from securesystemslib.signer import SSlibSigner
+from securesystemslib.signer import SSlibKey, SSlibSigner
 
 from tests import utils
 from tuf.api.metadata import Key, Metadata, Root, Snapshot, Targets, Timestamp
@@ -36,7 +36,7 @@ keyids: List[str] = [
 
 keys: Dict[str, Key] = {}
 for index in range(4):
-    keys[f"ed25519_{index}"] = Key.from_securesystemslib_key(
+    keys[f"ed25519_{index}"] = SSlibKey.from_securesystemslib_key(
         {
             "keytype": "ed25519",
             "scheme": "ed25519",

--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -54,7 +54,7 @@ from urllib import parse
 
 import securesystemslib.hash as sslib_hash
 from securesystemslib.keys import generate_ed25519_key
-from securesystemslib.signer import SSlibSigner
+from securesystemslib.signer import SSlibKey, SSlibSigner
 
 from tuf.api.exceptions import DownloadHTTPError
 from tuf.api.metadata import (
@@ -156,8 +156,8 @@ class RepositorySimulator(FetcherInterface):
 
     @staticmethod
     def create_key() -> Tuple[Key, SSlibSigner]:
-        sslib_key = generate_ed25519_key()
-        return Key.from_securesystemslib_key(sslib_key), SSlibSigner(sslib_key)
+        key = generate_ed25519_key()
+        return SSlibKey.from_securesystemslib_key(key), SSlibSigner(key)
 
     def add_signer(self, role: str, signer: SSlibSigner) -> None:
         if role not in self.signers:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -353,6 +353,15 @@ class TestMetadata(unittest.TestCase):
             root.verify_delegate(Snapshot.type, snapshot)
         snapshot.signed.expires = expires
 
+        # verify fails if sslib verify fails with VerificationError
+        # (in this case signature is malformed)
+        keyid = next(iter(root.signed.roles[Snapshot.type].keyids))
+        good_sig = snapshot.signatures[keyid].signature
+        snapshot.signatures[keyid].signature = "foo"
+        with self.assertRaises(exceptions.UnsignedMetadataError):
+            root.verify_delegate(Snapshot.type, snapshot)
+        snapshot.signatures[keyid].signature = good_sig
+
         # verify fails if roles keys do not sign the metadata
         with self.assertRaises(exceptions.UnsignedMetadataError):
             root.verify_delegate(Timestamp.type, snapshot)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -414,7 +414,7 @@ class TestMetadata(unittest.TestCase):
 
         # Assert that add_key with old argument order will raise an error
         with self.assertRaises(ValueError):
-            root.signed.add_key(Root.type, key_metadata)  # type: ignore
+            root.signed.add_key(Root.type, key_metadata)
 
         # Add new root key
         root.signed.add_key(key_metadata, Root.type)
@@ -515,7 +515,7 @@ class TestMetadata(unittest.TestCase):
 
         # Assert that add_key with old argument order will raise an error
         with self.assertRaises(ValueError):
-            targets.add_key("role1", key)  # type: ignore
+            targets.add_key("role1", key)
 
         # Assert that delegated role "role1" does not contain the new key
         self.assertNotIn(key.keyid, targets.delegations.roles["role1"].keyids)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,7 +23,7 @@ from securesystemslib.interface import (
     import_ed25519_publickey_from_file,
 )
 from securesystemslib.keys import generate_ed25519_key
-from securesystemslib.signer import Signature, SSlibSigner
+from securesystemslib.signer import SSlibKey, SSlibSigner
 
 from tests import utils
 from tuf.api import exceptions
@@ -34,6 +34,7 @@ from tuf.api.metadata import (
     Key,
     Metadata,
     Root,
+    Signature,
     Snapshot,
     SuccinctRoles,
     TargetFile,
@@ -382,13 +383,8 @@ class TestMetadata(unittest.TestCase):
         # Test if from_securesystemslib_key removes the private key from keyval
         # of a securesystemslib key dictionary.
         sslib_key = generate_ed25519_key()
-        key = Key.from_securesystemslib_key(sslib_key)
+        key = SSlibKey.from_securesystemslib_key(sslib_key)
         self.assertFalse("private" in key.keyval.keys())
-
-        # Test raising ValueError with non-existent keytype
-        sslib_key["keytype"] = "bad keytype"
-        with self.assertRaises(ValueError):
-            Key.from_securesystemslib_key(sslib_key)
 
     def test_root_add_key_and_revoke_key(self) -> None:
         root_path = os.path.join(self.repo_dir, "metadata", "root.json")
@@ -399,7 +395,7 @@ class TestMetadata(unittest.TestCase):
             os.path.join(self.keystore_dir, "root_key2.pub")
         )
         keyid = root_key2["keyid"]
-        key_metadata = Key(
+        key_metadata = SSlibKey(
             keyid,
             root_key2["keytype"],
             root_key2["scheme"],

--- a/tests/test_metadata_eq_.py
+++ b/tests/test_metadata_eq_.py
@@ -12,17 +12,17 @@ import sys
 import unittest
 from typing import Any, ClassVar, Dict
 
-from securesystemslib.signer import Signature
+from securesystemslib.signer import SSlibKey
 
 from tests import utils
 from tuf.api.metadata import (
     TOP_LEVEL_ROLE_NAMES,
     DelegatedRole,
     Delegations,
-    Key,
     Metadata,
     MetaFile,
     Role,
+    Signature,
     SuccinctRoles,
     TargetFile,
 )
@@ -50,7 +50,7 @@ class TestMetadataComparisions(unittest.TestCase):
 
         cls.objects["Metadata"] = Metadata(cls.objects["Timestamp"], {})
         cls.objects["Signed"] = cls.objects["Timestamp"]
-        cls.objects["Key"] = Key(
+        cls.objects["Key"] = SSlibKey(
             "id", "rsa", "rsassa-pss-sha256", {"public": "foo"}
         )
         cls.objects["Role"] = Role(["keyid1", "keyid2"], 3)

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -168,7 +168,7 @@ class TestSerialization(unittest.TestCase):
     @utils.run_sub_tests_with_dataset(invalid_keys)
     def test_invalid_key_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
-        with self.assertRaises((TypeError, KeyError)):
+        with self.assertRaises((TypeError, KeyError, ValueError)):
             keyid = case_dict.pop("keyid")
             Key.from_dict(keyid, case_dict)
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ allowlist_externals = python3
 # Must to be invoked explicitly with, e.g. `tox -e with-sslib-master`
 [testenv:with-sslib-master]
 commands_pre =
-    python3 -m pip install git+https://github.com/secure-systems-lab/securesystemslib.git@master#egg=securesystemslib[crypto,pynacl]
+    python3 -m pip install --force-reinstall git+https://github.com/secure-systems-lab/securesystemslib.git@master#egg=securesystemslib[crypto,pynacl]
 
 commands =
     python3 -m coverage run aggregate_tests.py

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -52,8 +52,7 @@ from typing import (
 
 from securesystemslib import exceptions as sslib_exceptions
 from securesystemslib import hash as sslib_hash
-from securesystemslib import keys as sslib_keys
-from securesystemslib.signer import Signature, Signer
+from securesystemslib.signer import Key, Signature, Signer
 from securesystemslib.storage import FilesystemBackend, StorageBackendInterface
 from securesystemslib.util import persist_temp_file
 
@@ -61,7 +60,6 @@ from tuf.api.exceptions import LengthOrHashMismatchError, UnsignedMetadataError
 from tuf.api.serialization import (
     MetadataDeserializer,
     MetadataSerializer,
-    SerializationError,
     SignedSerializer,
 )
 
@@ -610,178 +608,6 @@ class Signed(metaclass=abc.ABCMeta):
             reference_time = datetime.utcnow()
 
         return reference_time >= self.expires
-
-
-class Key:
-    """A container class representing the public portion of a Key.
-
-    Supported key content (type, scheme and keyval) is defined in
-    `` Securesystemslib``.
-
-    *All parameters named below are not just constructor arguments but also
-    instance attributes.*
-
-    Args:
-        keyid: Key identifier that is unique within the metadata it is used in.
-            Keyid is not verified to be the hash of a specific representation
-            of the key.
-        keytype: Key type, e.g. "rsa", "ed25519" or "ecdsa-sha2-nistp256".
-        scheme: Signature scheme. For example:
-            "rsassa-pss-sha256", "ed25519", and "ecdsa-sha2-nistp256".
-        keyval: Opaque key content
-        unrecognized_fields: Dictionary of all attributes that are not managed
-            by TUF Metadata API
-
-    Raises:
-        TypeError: Invalid type for an argument.
-    """
-
-    def __init__(
-        self,
-        keyid: str,
-        keytype: str,
-        scheme: str,
-        keyval: Dict[str, str],
-        unrecognized_fields: Optional[Dict[str, Any]] = None,
-    ):
-        if not all(
-            isinstance(at, str) for at in [keyid, keytype, scheme]
-        ) or not isinstance(keyval, dict):
-            raise TypeError("Unexpected Key attributes types!")
-        self.keyid = keyid
-        self.keytype = keytype
-        self.scheme = scheme
-        self.keyval = keyval
-        if unrecognized_fields is None:
-            unrecognized_fields = {}
-
-        self.unrecognized_fields = unrecognized_fields
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, Key):
-            return False
-
-        return (
-            self.keyid == other.keyid
-            and self.keytype == other.keytype
-            and self.scheme == other.scheme
-            and self.keyval == other.keyval
-            and self.unrecognized_fields == other.unrecognized_fields
-        )
-
-    @classmethod
-    def from_dict(cls, keyid: str, key_dict: Dict[str, Any]) -> "Key":
-        """Create ``Key`` object from its json/dict representation.
-
-        Raises:
-            KeyError, TypeError: Invalid arguments.
-        """
-        keytype = key_dict.pop("keytype")
-        scheme = key_dict.pop("scheme")
-        keyval = key_dict.pop("keyval")
-        # All fields left in the key_dict are unrecognized.
-        return cls(keyid, keytype, scheme, keyval, key_dict)
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Return the dictionary representation of self."""
-        return {
-            "keytype": self.keytype,
-            "scheme": self.scheme,
-            "keyval": self.keyval,
-            **self.unrecognized_fields,
-        }
-
-    def to_securesystemslib_key(self) -> Dict[str, Any]:
-        """Return a ``Securesystemslib`` compatible representation of self."""
-        return {
-            "keyid": self.keyid,
-            "keytype": self.keytype,
-            "scheme": self.scheme,
-            "keyval": self.keyval,
-        }
-
-    @classmethod
-    def from_securesystemslib_key(cls, key_dict: Dict[str, Any]) -> "Key":
-        """Create a ``Key`` object from a securesystemlib key json/dict representation
-        removing the private key from keyval.
-
-        Args:
-            key_dict: Key in securesystemlib dict representation.
-
-        Raises:
-            ValueError: ``key_dict`` value is not following the securesystemslib
-                format.
-        """
-        try:
-            key_meta = sslib_keys.format_keyval_to_metadata(
-                key_dict["keytype"],
-                key_dict["scheme"],
-                key_dict["keyval"],
-            )
-        except sslib_exceptions.FormatError as e:
-            raise ValueError(
-                "key_dict value is not following the securesystemslib format"
-            ) from e
-
-        return cls(
-            key_dict["keyid"],
-            key_meta["keytype"],
-            key_meta["scheme"],
-            key_meta["keyval"],
-        )
-
-    def verify_signature(
-        self,
-        metadata: Metadata,
-        signed_serializer: Optional[SignedSerializer] = None,
-    ) -> None:
-        """Verify that the ``metadata.signatures`` contains a signature made
-        with this key, correctly signing ``metadata.signed``.
-
-        Args:
-            metadata: Metadata to verify
-            signed_serializer: ``SignedSerializer`` to serialize
-                ``metadata.signed`` with. Default is ``CanonicalJSONSerializer``.
-
-        Raises:
-            UnsignedMetadataError: The signature could not be verified for a
-                variety of possible reasons: see error message.
-        """
-        try:
-            signature = metadata.signatures[self.keyid]
-        except KeyError:
-            raise UnsignedMetadataError(
-                f"No signature for key {self.keyid} found"
-            ) from None
-
-        if signed_serializer is None:
-            # pylint: disable=import-outside-toplevel
-            from tuf.api.serialization.json import CanonicalJSONSerializer
-
-            signed_serializer = CanonicalJSONSerializer()
-
-        try:
-            if not sslib_keys.verify_signature(
-                self.to_securesystemslib_key(),
-                signature.to_dict(),
-                signed_serializer.serialize(metadata.signed),
-            ):
-                raise UnsignedMetadataError(
-                    f"Failed to verify {self.keyid} signature"
-                )
-        except (
-            sslib_exceptions.CryptoError,
-            sslib_exceptions.FormatError,
-            sslib_exceptions.UnsupportedAlgorithmError,
-            SerializationError,
-        ) as e:
-            # Log unexpected failure, but continue as if there was no signature
-            logger.warning(
-                "Key %s failed to verify sig: %s", self.keyid, str(e)
-            )
-            raise UnsignedMetadataError(
-                f"Failed to verify {self.keyid} signature"
-            ) from e
 
 
 class Role:

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -57,7 +57,7 @@ from securesystemslib.signer import Signature, Signer
 from securesystemslib.storage import FilesystemBackend, StorageBackendInterface
 from securesystemslib.util import persist_temp_file
 
-from tuf.api import exceptions
+from tuf.api.exceptions import LengthOrHashMismatchError, UnsignedMetadataError
 from tuf.api.serialization import (
     MetadataDeserializer,
     MetadataSerializer,
@@ -219,7 +219,7 @@ class Metadata(Generic[T]):
                 ``securesystemslib.storage.StorageBackendInterface``.
                 Default is ``FilesystemBackend`` (i.e. a local file).
         Raises:
-            exceptions.StorageError: The file cannot be read.
+            StorageError: The file cannot be read.
             tuf.api.serialization.DeserializationError:
                 The file cannot be deserialized.
 
@@ -329,7 +329,7 @@ class Metadata(Generic[T]):
         Raises:
             tuf.api.serialization.SerializationError:
                 The metadata object cannot be serialized.
-            exceptions.StorageError: The file cannot be written.
+            StorageError: The file cannot be written.
         """
 
         bytes_data = self.to_bytes(serializer)
@@ -360,7 +360,7 @@ class Metadata(Generic[T]):
         Raises:
             tuf.api.serialization.SerializationError:
                 ``signed`` cannot be serialized.
-            exceptions.UnsignedMetadataError: Signing errors.
+            UnsignedMetadataError: Signing errors.
 
         Returns:
             ``securesystemslib.signer.Signature`` object that was added into
@@ -379,9 +379,7 @@ class Metadata(Generic[T]):
         try:
             signature = signer.sign(bytes_data)
         except Exception as e:
-            raise exceptions.UnsignedMetadataError(
-                "Problem signing the metadata"
-            ) from e
+            raise UnsignedMetadataError("Problem signing the metadata") from e
 
         if not append:
             self.signatures.clear()
@@ -442,13 +440,13 @@ class Metadata(Generic[T]):
             try:
                 key.verify_signature(delegated_metadata, signed_serializer)
                 signing_keys.add(key.keyid)
-            except exceptions.UnsignedMetadataError:
+            except UnsignedMetadataError:
                 logger.debug(
                     "Key %s failed to verify %s", keyid, delegated_role
                 )
 
         if len(signing_keys) < role.threshold:
-            raise exceptions.UnsignedMetadataError(
+            raise UnsignedMetadataError(
                 f"{delegated_role} was signed by {len(signing_keys)}/"
                 f"{role.threshold} keys",
             )
@@ -752,8 +750,8 @@ class Key:
         try:
             signature = metadata.signatures[self.keyid]
         except KeyError:
-            raise exceptions.UnsignedMetadataError(
-                f"No signature for key {self.keyid} found in metadata"
+            raise UnsignedMetadataError(
+                f"No signature for key {self.keyid} found"
             ) from None
 
         if signed_serializer is None:
@@ -768,7 +766,7 @@ class Key:
                 signature.to_dict(),
                 signed_serializer.serialize(metadata.signed),
             ):
-                raise exceptions.UnsignedMetadataError(
+                raise UnsignedMetadataError(
                     f"Failed to verify {self.keyid} signature"
                 )
         except (
@@ -781,7 +779,7 @@ class Key:
             logger.warning(
                 "Key %s failed to verify sig: %s", self.keyid, str(e)
             )
-            raise exceptions.UnsignedMetadataError(
+            raise UnsignedMetadataError(
                 f"Failed to verify {self.keyid} signature"
             ) from e
 
@@ -1017,13 +1015,13 @@ class BaseFile:
                 sslib_exceptions.UnsupportedAlgorithmError,
                 sslib_exceptions.FormatError,
             ) as e:
-                raise exceptions.LengthOrHashMismatchError(
+                raise LengthOrHashMismatchError(
                     f"Unsupported algorithm '{algo}'"
                 ) from e
 
             observed_hash = digest_object.hexdigest()
             if observed_hash != exp_hash:
-                raise exceptions.LengthOrHashMismatchError(
+                raise LengthOrHashMismatchError(
                     f"Observed hash {observed_hash} does not match "
                     f"expected hash {exp_hash}"
                 )
@@ -1041,7 +1039,7 @@ class BaseFile:
             observed_length = data.tell()
 
         if observed_length != expected_length:
-            raise exceptions.LengthOrHashMismatchError(
+            raise LengthOrHashMismatchError(
                 f"Observed length {observed_length} does not match "
                 f"expected length {expected_length}"
             )


### PR DESCRIPTION
This updates python-tuf sources for latest securesystemslib signer api changes. Most of the changes are in tests (since we test Key quite extensively) but verify_delegate() is also significantly rewritten. The commits are mostly logical -- the one exception is that the original refactoring of role/key lookup in Metadata was not great: it is fixed in a later commit by moving the functionality from Metadata to Targets and Root where it makes more sense.

Changelist:
* Key moves to Securesystemslib and the Key API changes:
  * `Key.from_securesystemslib_key()` is now `SSlibKey.from_securesystemslib_key()`
  * `Key.verify_signature()` arguments and exceptions change (it used to take Metadata as arg)
*  `Metadata.verify_delegate()` has to be rewritten because of `Key.verify_signature()` changes
* Introduced some new API calls in Targets and Root: `get_delegated_role()` and `get_key()`: these simplify the role and key lookup in `Metadata.verify_delegate()`

WRT API change: 
* this is clearly an API change (as Key changes method signatures), but not something users should suffer badly from
* Key, Signer and Signature are still technically part of the metadata API so no regression there: they just come from a securesystemslib module now.
* The Key implementations (like SSlibKey and SSlibSigner) are not currently importable through Metadata API but I don't think that is a problem?
