### PR TITLE
Update security policy to use new reporting

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,12 +1,7 @@
 # Security Issues and Bugs
 
-Security issues can be reported by emailing jcappos@nyu.edu.
+Security issues can be reported to maintainers [privately via GitHub](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability):
 
-At a minimum, the report must contain the following:
-
-* Description of the vulnerability.
-* Steps to reproduce the issue.
-
-Optionally, reports that are emailed can be encrypted with PGP. You should use PGP key fingerprint **E9C0 59EC 0D32 64FA B35F 94AD 465B F9F6 F8EB 475A**.
+- [**Report new vulnerability**](https://github.com/theupdateframework/python-tuf/security/advisories/new)
 
 Please do not use the GitHub issue tracker to submit vulnerability reports. The issue tracker is intended for bug reports and to make feature requests. Major feature requests, such as design changes to the specification, should be proposed via a [TUF Augmentation Proposal](https://theupdateframework.github.io/specification/latest/#tuf-augmentation-proposal-tap-support) (TAP).


### PR DESCRIPTION
- Enabled new [GitHub feature (beta) to privately report security issues](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) to all maintainers in repo settings. 

- Updated security policy document to instruct reporters to use the new reporting mechanism instead of email+pgp.
