### PR TITLE
feat: generate hash-prefixed path names for target

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -731,6 +731,36 @@ class TestMetadata(unittest.TestCase):
         )
         self.assertEqual(sorted(target.get_prefixed_paths()), ["public/path/abc.file.ext", "public/path/def.file.ext"])
 
+        target = TargetFile(
+            100, {"sha256": "abc", "md5": "def"}, ""
+        )
+        self.assertEqual(sorted(target.get_prefixed_paths()), [])
+
+        target = TargetFile(
+            100, {"sha256": "abc", "md5": "def"}, "public/path/"
+        )
+        self.assertEqual(sorted(target.get_prefixed_paths()), [])
+
+        target = TargetFile(
+            100, {"sha256": "abc", "md5": "def"}, "file.ext"
+        )
+        self.assertEqual(sorted(target.get_prefixed_paths()), ["abc.file.ext", "def.file.ext"])
+
+        target = TargetFile(
+            100, {"sha256": "abc", "md5": "def"}, "public/path/.ext"
+        )
+        self.assertEqual(sorted(target.get_prefixed_paths()), ["public/path/abc..ext", "public/path/def..ext"])
+
+        target = TargetFile(
+            100, {"sha256": "abc"}, "/root/file.ext"
+        )
+        self.assertEqual(sorted(target.get_prefixed_paths()), ["/root/abc.file.ext"])
+
+        target = TargetFile(
+            100, {"sha256": "abc"}, "/"
+        )
+        self.assertEqual(sorted(target.get_prefixed_paths()), [])
+
     def test_is_delegated_role(self) -> None:
         # test path matches
         # see more extensive tests in test_is_target_in_pathpattern()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -725,6 +725,12 @@ class TestMetadata(unittest.TestCase):
         targetfile_from_data = TargetFile.from_data(target_file_path, data)
         targetfile_from_data.verify_length_and_hashes(data)
 
+    def test_targetfile_hash_prefix_paths(self) -> None:
+        target = TargetFile(
+            100, {"sha256": "abc", "md5": "def"}, "public/path/file.ext"
+        )
+        self.assertEqual(sorted(target.get_prefixed_paths()), ["public/path/abc.file.ext", "public/path/def.file.ext"])
+
     def test_is_delegated_role(self) -> None:
         # test path matches
         # see more extensive tests in test_is_target_in_pathpattern()

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1894,6 +1894,9 @@ class TargetFile(BaseFile):
         self._verify_hashes(data, self.hashes)
 
     def get_prefixed_paths(self) -> List[str]:
+        """
+        Returns hash-prefixed paths for the given target file path.
+        """
         paths = []
         path = pathlib.Path(self.path)
         name, parent = path.name, path.parent

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1895,13 +1895,28 @@ class TargetFile(BaseFile):
 
     def get_prefixed_paths(self) -> List[str]:
         """
-        Returns hash-prefixed paths for the given target file path.
+        Returns hash-prefixed paths for the given target file path. Empty result in the case of an invalid path.
+
+        Expects self.path to be a URL path fragment, not a filesystem path.
         """
         paths = []
-        path = pathlib.Path(self.path)
-        name, parent = path.name, path.parent
+        try:
+            if not self.path:
+                raise ValueError
+            elif "/" not in self.path:
+                parent, name = None, self.path
+            else:
+                parent, name = self.path.rsplit("/", 1)
+                if name == "": 
+                    raise ValueError
+        except ValueError:
+            return paths
+
         for hash in self.hashes.values():
-            paths.append(str(parent.joinpath(f"{hash}.{name}")))
+            path = f"{hash}.{name}"
+            if parent is not None:
+                path = f"{parent}/{path}"
+            paths.append(path)
         return paths
 
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -32,6 +32,7 @@ import fnmatch
 import io
 import logging
 import tempfile
+import pathlib
 from datetime import datetime
 from typing import (
     IO,
@@ -1891,6 +1892,14 @@ class TargetFile(BaseFile):
         """
         self._verify_length(data, self.length)
         self._verify_hashes(data, self.hashes)
+
+    def get_prefixed_paths(self) -> List[str]:
+        paths = []
+        path = pathlib.Path(self.path)
+        name, parent = path.name, path.parent
+        for hash in self.hashes.values():
+            paths.append(str(parent.joinpath(f"{hash}.{name}")))
+        return paths
 
 
 class Targets(Signed):


### PR DESCRIPTION
Fixes #2166 

I introduced a new method `get_prefixed_paths()` for class `TargetFile`, which generates hash-prefixed paths for the given target file path. I might be missing some additional requirements, so please let me know if any other changes are needed.

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


