### PR TITLE
README: Remove limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,6 @@ Security Issues and Bugs
 
 See [SECURITY.md](docs/SECURITY.md)
 
-Limitations
------------
-
-The reference implementation may behave unexpectedly when concurrently
-downloading the same target files with the same TUF client.
-
 License
 -------
 

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -28,6 +28,10 @@ High-level description of ``Updater`` functionality:
       * ``Updater.download_target()`` downloads a target file and ensures it is
         verified correct by the metadata.
 
+Note that applications using ``Updater`` should be 'single instance'
+applications: running multiple instances that use the same cache directories at
+the same time is not supported.
+
 A simple example of using the Updater to implement a Python TUF client that
 downloads target files is available in `examples/client_example
 <https://github.com/theupdateframework/python-tuf/tree/develop/examples/client_example>`_.


### PR DESCRIPTION
There may be ways to unsafely use the client library but situation should be significantly better now with ngclient:
  * metadata writing is safer, more atomic
  * non-root cached metadata is never trusted (so inconsistent cached repository is not a security issue)
  * the cache locations are now clearly application decisions (they are required Updater constructor args)

I think the current unsafe usages are not surprising or worthy of mention in top level README: it's not surprising that modifying the app cache during the apps runtime may affect the app.

Signed-off-by: Jussi Kukkonen <jkukkonen@google.com>
