### PR TITLE
doc: update PyPI Development Status classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ keywords = [
   "updater",
 ]
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
   "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Since v1.0.0 python-tuf is no longer beta software.

See https://pypi.org/classifiers/ for available classifiers.
