### PR TITLE
pyproject: Stop disabling urllib3 import checks in mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,5 @@ disable_error_code = ["attr-defined"]
 module = [
   "requests.*",
   "securesystemslib.*",
-  "urllib3.*"
 ]
 ignore_missing_imports = "True"


### PR DESCRIPTION
Double reasoning for this one:
* urllib3 now does have annotations
* since we don't import requests annotations (to avoid depending on typeshed) urllib3 annotations are never needed: we don't use urllib3 directly

Signed-off-by: Jussi Kukkonen <jkukkonen@google.com>

