### PR TITLE
workflows: Add Scorecards workflow

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,39 @@
+name: Scorecards analysis
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '21 6 * * 1'
+  push:
+    branches: [ develop ]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # for uploading to code-scanning dashboard
+      id-token: write # for signing results
+      actions: read
+      contents: read
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d
+        with:
+          results_file: results.sarif
+          # sarif format required by upload-sarif action
+          results_format: sarif
+          # "repo_token" not set because personal access tokens are dangerous.
+          # This means Branch-Protection check will not have correct results.
+          publish_results: true
+
+      - name: "Upload to code-scanning dashboard"
+        uses: github/codeql-action/upload-sarif@8aff97f12c99086bdb92ff62ae06dbbcdf07941b
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Docs](https://readthedocs.org/projects/theupdateframework/badge/)](https://theupdateframework.readthedocs.io/)
 [![CII](https://bestpractices.coreinfrastructure.org/projects/1351/badge)](https://bestpractices.coreinfrastructure.org/projects/1351)
 [![PyPI](https://img.shields.io/pypi/v/tuf)](https://pypi.org/project/tuf/)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/theupdateframework/python-tuf/badge)](https://api.securityscorecards.dev/projects/github.com/theupdateframework/python-tuf)
 
 ----------------------------
 [The Update Framework (TUF)](https://theupdateframework.io/) is a framework for


### PR DESCRIPTION
This is a modifed version of the workflow from the project itself:
* Not using personal access tokens because I believe they are a security issue (this means Branch-Protection check result will be incorrect)
* Not uploading results to actions cache: Maybe there's a point but I don't see it as the SARIF files are not very human readable

This should give us some code scanning alerts in the security tab on Github. This is not really what I'm interested in though so I've enabled the upload to https://api.securityscorecards.dev/. The results json on there is not exactly readable but it is good enough to check what the current results are -- and deps.dev should use those results after some delay I believe.

Signed-off-by: Jussi Kukkonen <jkukkonen@google.com>

--- 

Fixes #2160