### PR TITLE
Fixes #1862, added way to see full stack trace on error situations

### DIFF
--- a/examples/client_example/client_example.py
+++ b/examples/client_example/client_example.py
@@ -9,6 +9,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
+import traceback
 
 from tuf.api.exceptions import DownloadError, RepositoryError
 from tuf.ngclient import Updater
@@ -39,7 +40,7 @@ def init() -> None:
         print(f"Found trusted root in {METADATA_DIR}")
 
 
-def download(target: str) -> bool:
+def download(target: str, error_level: int) -> bool:
     """
     Download the target file using ``ngclient`` Updater.
 
@@ -75,6 +76,8 @@ def download(target: str) -> bool:
 
     except (OSError, RepositoryError, DownloadError) as e:
         print(f"Failed to download target {target}: {e}")
+        if error_level != 0:
+            traceback.print_exc()
         return False
 
     return True
@@ -126,7 +129,7 @@ def main() -> None:
     init()
 
     if command_args.sub_command == "download":
-        download(command_args.target)
+        download(command_args.target, command_args.verbose)
 
     else:
         client_args.print_help()

--- a/examples/client_example/client_example.py
+++ b/examples/client_example/client_example.py
@@ -8,8 +8,8 @@ import argparse
 import logging
 import os
 import shutil
-from pathlib import Path
 import traceback
+from pathlib import Path
 
 from tuf.api.exceptions import DownloadError, RepositoryError
 from tuf.ngclient import Updater

--- a/examples/client_example/client_example.py
+++ b/examples/client_example/client_example.py
@@ -40,7 +40,7 @@ def init() -> None:
         print(f"Found trusted root in {METADATA_DIR}")
 
 
-def download(target: str, error_level: int) -> bool:
+def download(target: str) -> bool:
     """
     Download the target file using ``ngclient`` Updater.
 
@@ -76,7 +76,7 @@ def download(target: str, error_level: int) -> bool:
 
     except (OSError, RepositoryError, DownloadError) as e:
         print(f"Failed to download target {target}: {e}")
-        if error_level != 0:
+        if  logging.root.level != logging.ERROR:
             traceback.print_exc()
         return False
 
@@ -129,7 +129,7 @@ def main() -> None:
     init()
 
     if command_args.sub_command == "download":
-        download(command_args.target, command_args.verbose)
+        download(command_args.target)
 
     else:
         client_args.print_help()

--- a/examples/client_example/client_example.py
+++ b/examples/client_example/client_example.py
@@ -76,7 +76,7 @@ def download(target: str) -> bool:
 
     except (OSError, RepositoryError, DownloadError) as e:
         print(f"Failed to download target {target}: {e}")
-        if  logging.root.level != logging.ERROR:
+        if logging.root.level != logging.ERROR:
             traceback.print_exc()
         return False
 


### PR DESCRIPTION
Passed verbosity as a parameter to download function. If exception occurs in the exception block, the value of verbosity is checked and if it is not equal to the default value(0), we print the stack trace using the traceback library.


