### PR TITLE
Fixes #1862, added way to see full stack trace on error situations

### DIFF
--- a/examples/client_example/client_example.py
+++ b/examples/client_example/client_example.py
@@ -8,6 +8,7 @@ import argparse
 import logging
 import os
 import shutil
+import traceback
 from pathlib import Path
 
 from tuf.api.exceptions import DownloadError, RepositoryError
@@ -75,6 +76,8 @@ def download(target: str) -> bool:
 
     except (OSError, RepositoryError, DownloadError) as e:
         print(f"Failed to download target {target}: {e}")
+        if logging.root.level < logging.ERROR:
+            traceback.print_exc()
         return False
 
     return True


### PR DESCRIPTION
Passed verbosity as a parameter to download function. If exception occurs in the exception block, the value of verbosity is checked and if it is not equal to the default value(0), we print the stack trace using the traceback library.

