### PR TITLE
ngclient: Fail gracefully on missing role

### DIFF
--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -389,7 +389,14 @@ class Updater:
             logger.debug("Failed to load local %s: %s", role, e)
 
             assert self._trusted_set.snapshot is not None  # nosec
-            metainfo = self._trusted_set.snapshot.signed.meta[f"{role}.json"]
+
+            snapshot = self._trusted_set.snapshot.signed
+            metainfo = snapshot.meta.get(f"{role}.json")
+            if metainfo is None:
+                raise exceptions.RepositoryError(
+                    f"Role {role} was delegated but is not part of snapshot"
+                )
+
             length = metainfo.length or self.config.targets_max_length
             version = None
             if self._trusted_set.root.signed.consistent_snapshot:


### PR DESCRIPTION
If role is delegated but missing from snapshot, we currently raise a undocumented KeyError: a generic RepositoryError seems better as callers are expected to handle it (and adding a more specific error seems useless as this is a repository software bug, not just expired metadata or something).

The same check is also done later in TrustedMetadataSet but I think keeping the check in both is clearest.

Fixes #2195

Signed-off-by: Jussi Kukkonen <jkukkonen@google.com>

---

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


