### PR TITLE
Metadata API: set default version for MetaFile()

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1076,7 +1076,7 @@ class MetaFile(BaseFile):
 
     def __init__(
         self,
-        version: int,
+        version: int = 1,
         length: Optional[int] = None,
         hashes: Optional[Dict[str, str]] = None,
         unrecognized_fields: Optional[Dict[str, Any]] = None,


### PR DESCRIPTION
This makes sense to me: if you create a new MetaFile, logical default
is version 1). This does not change serialization in any way.

Practical code becomes slightly nicer as

    metafiles: Dict[str, MetaFile] = defaultdict(MetaFile)

now works without lambdas.
