### PR TITLE
changed depreciated __metaclass__ to metaclass

### DIFF
--- a/tuf/ngclient/fetcher.py
+++ b/tuf/ngclient/fetcher.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 # Classes
-class FetcherInterface:
+class FetcherInterface(abc.ABC):
     """Defines an interface for abstract network download.
 
     By providing a concrete implementation of the abstract interface,
@@ -28,7 +28,7 @@ class FetcherInterface:
     The public API of the class is already implemented.
     """
 
-    __metaclass__ = abc.ABCMeta
+    metaclass = abc.ABCMeta
 
     @abc.abstractmethod
     def _fetch(self, url: str) -> Iterator[bytes]:

--- a/tuf/ngclient/fetcher.py
+++ b/tuf/ngclient/fetcher.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 # Classes
-class FetcherInterface(abc.ABC):
+class FetcherInterface(metaclass=abc.ABCMeta):
     """Defines an interface for abstract network download.
 
     By providing a concrete implementation of the abstract interface,
@@ -27,8 +27,6 @@ class FetcherInterface(abc.ABC):
     Implementations of FetcherInterface only need to implement ``_fetch()``.
     The public API of the class is already implemented.
     """
-
-    metaclass = abc.ABCMeta
 
     @abc.abstractmethod
     def _fetch(self, url: str) -> Iterator[bytes]:


### PR DESCRIPTION
Fixes #2196 

In **Python 2**, the `__metaclass__ `attribute is used to specify the `metaclass` for a class. In **Python 3**, this syntax has been _changed_, and the metaclass keyword argument is used instead.

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tox test had ran successfully.

It's a simple fix which can be verified by anyone

