### PR TITLE
build: Change build dependency pinning strategy

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -46,8 +46,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --upgrade tox coveralls
+          python3 -m pip install --constraint requirements-build.txt tox coveralls
 
       - name: Run tox (${{ env.TOXENV }})
         # See TOXENV environment variable for the testenv to be executed here
@@ -90,8 +89,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --upgrade coveralls
+          python3 -m pip install coveralls
 
       - name: Finalize publishing on coveralls.io
         continue-on-error: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install build dependency
-        run: python3 -m pip install --upgrade pip build
+        run: python3 -m pip install --constraint requirements-build.txt build
 
       - name: Build binary wheel and source tarball
         run: python3 -m build --sdist --wheel --outdir dist/ .

--- a/.github/workflows/specification-version-check.yml
+++ b/.github/workflows/specification-version-check.yml
@@ -20,7 +20,6 @@ jobs:
           python-version: "3.x"
       - id: get-version
         run: |
-          python3 -m pip install --upgrade pip
           python3 -m pip install -e .
           script="from tuf.api.metadata import SPECIFICATION_VERSION; \
                   print(f\"v{'.'.join(SPECIFICATION_VERSION)}\")"

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,4 @@
+# The build and tox versions specified here are also used as constraints
+# during CI and CD Github workflows
+build==0.9.0
+tox==3.27.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,7 @@
 # Install tuf in editable mode and requirements for local testing with tox,
-# and also for running test suite or individual tests manually
-build
-tox
-twine
-wheel
+# and also for running test suite or individual tests manually.
+# The build and tox versions specified here are also used as constraints
+# during CI and CD Github workflows
+-r requirements-build.txt
 -r requirements-test.txt
 -e .


### PR DESCRIPTION
* don't autoupgrade pip: let's consider pip to be part of python platform?
* pin build and tox in new requirements-build.txt: this mostly prevents tox from going to 4.x before we're ready
* use requirements-build.txt as constraint when installing tox or build during CI & CD
* use requirements-build.txt in requiremenets-dev.txt

Note that coveralls is not pinned, not sure if it should be.

Fixes #2216 maybe


