### PR TITLE
Fix pydocstyle D400: first line should end with a period

### DIFF
--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -1,7 +1,7 @@
 # Copyright New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""TUF
+"""TUF.
 """
 
 # This value is used in the requests user agent.

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1,7 +1,8 @@
 # Copyright New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""
+"""The low-level Metadata API.
+
 The low-level Metadata API in ``tuf.api.metadata`` module contains:
 
 * Safe de/serialization of metadata to and from files.
@@ -548,13 +549,13 @@ class Signed(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def to_dict(self) -> Dict[str, Any]:
-        """Serialization helper that returns dict representation of self"""
+        """Serialization helper that returns dict representation of self."""
         raise NotImplementedError
 
     @classmethod
     @abc.abstractmethod
     def from_dict(cls, signed_dict: Dict[str, Any]) -> "Signed":
-        """Deserialization helper, creates object from json/dict representation"""
+        """Deserialization helper, creates object from json/dict representation."""
         raise NotImplementedError
 
     @classmethod
@@ -999,7 +1000,7 @@ class BaseFile:
     def _verify_hashes(
         data: Union[bytes, IO[bytes]], expected_hashes: Dict[str, str]
     ) -> None:
-        """Verifies that the hash of ``data`` matches ``expected_hashes``"""
+        """Verifies that the hash of ``data`` matches ``expected_hashes``."""
         is_bytes = isinstance(data, bytes)
         for algo, exp_hash in expected_hashes.items():
             try:
@@ -1028,7 +1029,7 @@ class BaseFile:
     def _verify_length(
         data: Union[bytes, IO[bytes]], expected_length: int
     ) -> None:
-        """Verifies that the length of ``data`` matches ``expected_length``"""
+        """Verifies that the length of ``data`` matches ``expected_length``."""
         if isinstance(data, bytes):
             observed_length = len(data)
         else:
@@ -1537,8 +1538,7 @@ class SuccinctRoles(Role):
         }
 
     def get_role_for_target(self, target_filepath: str) -> str:
-        """Calculates the name of the delegated role responsible for
-        ``target_filepath``.
+        """Calculates the name of the delegated role responsible for ``target_filepath``.
 
         The target at path ``target_filepath`` is assigned to a bin by casting
         the left-most ``bit_length`` of bits of the file path hash digest to

--- a/tuf/ngclient/__init__.py
+++ b/tuf/ngclient/__init__.py
@@ -1,7 +1,7 @@
 # Copyright New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""TUF client public API
+"""TUF client public API.
 """
 
 from tuf.ngclient.config import UpdaterConfig

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -1,8 +1,7 @@
 # Copyright 2021, New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""Provides an implementation of ``FetcherInterface`` using the Requests
-  HTTP library.
+"""Provides an implementation of ``FetcherInterface`` using the Requests HTTP library.
 """
 
 import logging
@@ -50,7 +49,7 @@ class RequestsFetcher(FetcherInterface):
         self.chunk_size: int = 400000  # bytes
 
     def _fetch(self, url: str) -> Iterator[bytes]:
-        """Fetches the contents of HTTP/HTTPS url from a remote server
+        """Fetches the contents of HTTP/HTTPS url from a remote server.
 
         Args:
             url: URL string that represents a file location.
@@ -108,8 +107,7 @@ class RequestsFetcher(FetcherInterface):
             response.close()
 
     def _get_session(self, url: str) -> requests.Session:
-        """Returns a different customized requests.Session per schema+hostname
-        combination.
+        """Returns a different customized requests.Session per schema+hostname combination.
 
         Raises:
             exceptions.DownloadError: When there is a problem parsing the url.

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -1,7 +1,7 @@
 # Copyright the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""Trusted collection of client-side TUF Metadata
+"""Trusted collection of client-side TUF Metadata.
 
 ``TrustedMetadataSet`` keeps track of the current valid set of metadata for the
 client, and handles almost every step of the "Detailed client workflow" (
@@ -71,7 +71,7 @@ logger = logging.getLogger(__name__)
 
 
 class TrustedMetadataSet(abc.Mapping):
-    """Internal class to keep track of trusted metadata in ``Updater``
+    """Internal class to keep track of trusted metadata in ``Updater``.
 
     ``TrustedMetadataSet`` ensures that the collection of metadata in it is valid
     and trusted through the whole client update workflow. It provides easy ways
@@ -79,7 +79,7 @@ class TrustedMetadataSet(abc.Mapping):
     """
 
     def __init__(self, root_data: bytes):
-        """Initialize ``TrustedMetadataSet`` by loading trusted root metadata
+        """Initialize ``TrustedMetadataSet`` by loading trusted root metadata.
 
         Args:
             root_data: Trusted root metadata as bytes. Note that this metadata
@@ -99,36 +99,36 @@ class TrustedMetadataSet(abc.Mapping):
         self._load_trusted_root(root_data)
 
     def __getitem__(self, role: str) -> Metadata:
-        """Returns current ``Metadata`` for ``role``"""
+        """Returns current ``Metadata`` for ``role``."""
         return self._trusted_set[role]
 
     def __len__(self) -> int:
-        """Returns number of ``Metadata`` objects in ``TrustedMetadataSet``"""
+        """Returns number of ``Metadata`` objects in ``TrustedMetadataSet``."""
         return len(self._trusted_set)
 
     def __iter__(self) -> Iterator[Metadata]:
-        """Returns iterator over ``Metadata`` objects in ``TrustedMetadataSet``"""
+        """Returns iterator over ``Metadata`` objects in ``TrustedMetadataSet``."""
         return iter(self._trusted_set.values())
 
     # Helper properties for top level metadata
     @property
     def root(self) -> Metadata[Root]:
-        """Current root ``Metadata``"""
+        """Current root ``Metadata``."""
         return self._trusted_set[Root.type]
 
     @property
     def timestamp(self) -> Optional[Metadata[Timestamp]]:
-        """Current timestamp ``Metadata`` or ``None``"""
+        """Current timestamp ``Metadata`` or ``None``."""
         return self._trusted_set.get(Timestamp.type)
 
     @property
     def snapshot(self) -> Optional[Metadata[Snapshot]]:
-        """Current snapshot ``Metadata`` or ``None``"""
+        """Current snapshot ``Metadata`` or ``None``."""
         return self._trusted_set.get(Snapshot.type)
 
     @property
     def targets(self) -> Optional[Metadata[Targets]]:
-        """Current targets ``Metadata`` or ``None``"""
+        """Current targets ``Metadata`` or ``None``."""
         return self._trusted_set.get(Targets.type)
 
     # Methods for updating metadata
@@ -251,7 +251,7 @@ class TrustedMetadataSet(abc.Mapping):
         return new_timestamp
 
     def _check_final_timestamp(self) -> None:
-        """Raise if timestamp is expired"""
+        """Raise if timestamp is expired."""
 
         assert self.timestamp is not None  # nosec
         if self.timestamp.signed.is_expired(self.reference_time):
@@ -346,7 +346,7 @@ class TrustedMetadataSet(abc.Mapping):
         return new_snapshot
 
     def _check_final_snapshot(self) -> None:
-        """Raise if snapshot is expired or meta version does not match"""
+        """Raise if snapshot is expired or meta version does not match."""
 
         assert self.snapshot is not None  # nosec
         assert self.timestamp is not None  # nosec

--- a/tuf/ngclient/config.py
+++ b/tuf/ngclient/config.py
@@ -1,7 +1,7 @@
 # Copyright 2021, New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""Configuration options for ``Updater`` class
+"""Configuration options for ``Updater`` class.
 """
 
 from dataclasses import dataclass

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -1,7 +1,7 @@
 # Copyright 2020, New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""Client update workflow implementation
+"""Client update workflow implementation.
 
 The ``Updater`` class provides an implementation of the
 `TUF client workflow
@@ -177,7 +177,7 @@ class Updater:
         targetinfo: TargetFile,
         filepath: Optional[str] = None,
     ) -> Optional[str]:
-        """Checks whether a local file is an up to date target
+        """Checks whether a local file is an up to date target.
 
         Args:
             targetinfo: ``TargetFile`` from ``get_targetinfo()``.
@@ -266,7 +266,7 @@ class Updater:
     def _download_metadata(
         self, rolename: str, length: int, version: Optional[int] = None
     ) -> bytes:
-        """Download a metadata file and return it as bytes"""
+        """Download a metadata file and return it as bytes."""
         encoded_name = parse.quote(rolename, "")
         if version is None:
             url = f"{self._metadata_base_url}{encoded_name}.json"
@@ -330,7 +330,7 @@ class Updater:
                 break
 
     def _load_timestamp(self) -> None:
-        """Load local and remote timestamp metadata"""
+        """Load local and remote timestamp metadata."""
         try:
             data = self._load_local_metadata(Timestamp.type)
             self._trusted_set.update_timestamp(data)
@@ -352,7 +352,7 @@ class Updater:
         self._persist_metadata(Timestamp.type, data)
 
     def _load_snapshot(self) -> None:
-        """Load local (and if needed remote) snapshot metadata"""
+        """Load local (and if needed remote) snapshot metadata."""
         try:
             data = self._load_local_metadata(Snapshot.type)
             self._trusted_set.update_snapshot(data, trusted=True)
@@ -486,5 +486,5 @@ class Updater:
 
 
 def _ensure_trailing_slash(url: str) -> str:
-    """Return url guaranteed to end in a slash"""
+    """Return url guaranteed to end in a slash."""
     return url if url.endswith("/") else f"{url}/"


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Make sure the codebase is more compliant with Python's docstring convention. There are more D400 warnings by pydocstyle left. To make this change easier to review, it tries to introduce more straightforward changes to the codebase.

