### PR TITLE
Document public API for tuf.api and tuf.ngclient

### DIFF
--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -4,5 +4,12 @@
 """TUF
 """
 
+import tuf.api
+import tuf.ngclient
+
 # This value is used in the requests user agent.
 __version__ = "2.0.0"
+__all__ = [
+    tuf.api.__name__,
+    tuf.ngclient.__name__,
+]

--- a/tuf/api/__init__.py
+++ b/tuf/api/__init__.py
@@ -1,0 +1,67 @@
+# Copyright New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""Public API for ``tuf.api``."""
+
+from .metadata import (
+    BaseFile,
+    DelegatedRole,
+    Delegations,
+    Key,
+    MetaFile,
+    Metadata,
+    Role,
+    Root,
+    SPECIFICATION_VERSION,
+    Signed,
+    Snapshot,
+    SuccinctRoles,
+    TOP_LEVEL_ROLE_NAMES,
+    TargetFile,
+    Targets,
+    Timestamp,
+)
+
+from .exceptions import (
+    BadVersionNumberError,
+    DownloadError,
+    DownloadHTTPError,
+    DownloadLengthMismatchError,
+    EqualVersionNumberError,
+    ExpiredMetadataError,
+    LengthOrHashMismatchError,
+    RepositoryError,
+    SlowRetrievalError,
+    StorageError,
+    UnsignedMetadataError,
+)
+
+__all__ = [
+    "SPECIFICATION_VERSION",
+    "TOP_LEVEL_ROLE_NAMES",
+    BadVersionNumberError.__name__,
+    BaseFile.__name__,
+    DelegatedRole.__name__,
+    Delegations.__name__,
+    DownloadError.__name__,
+    DownloadHTTPError.__name__,
+    DownloadLengthMismatchError.__name__,
+    EqualVersionNumberError.__name__,
+    ExpiredMetadataError.__name__,
+    Key.__name__,
+    LengthOrHashMismatchError.__name__,
+    MetaFile.__name__,
+    Metadata.__name__,
+    RepositoryError.__name__,
+    Role.__name__,
+    Root.__name__,
+    Signed.__name__,
+    SlowRetrievalError.__name__,
+    Snapshot.__name__,
+    StorageError.__name__,
+    SuccinctRoles.__name__,
+    TargetFile.__name__,
+    Targets.__name__,
+    Timestamp.__name__,
+    UnsignedMetadataError.__name__,
+]

--- a/tuf/api/exceptions.py
+++ b/tuf/api/exceptions.py
@@ -10,8 +10,7 @@ there is a good reason not to, and provide that reason in those cases.
 
 #### Repository errors ####
 
-# pylint: disable=unused-import
-from securesystemslib.exceptions import StorageError
+from securesystemslib.exceptions import StorageError as _SecureSystemsLibStorageError
 
 
 class RepositoryError(Exception):
@@ -39,6 +38,10 @@ class ExpiredMetadataError(RepositoryError):
 
 class LengthOrHashMismatchError(RepositoryError):
     """An error while checking the length and hash values of an object."""
+
+
+class StorageError(_SecureSystemsLibStorageError, RepositoryError):
+    """An error raised when a file cannot be read or written."""
 
 
 #### Download Errors ####

--- a/tuf/api/serialization/__init__.py
+++ b/tuf/api/serialization/__init__.py
@@ -18,6 +18,7 @@ import abc
 from typing import TYPE_CHECKING
 
 from tuf.api.exceptions import RepositoryError
+from .json import CanonicalJSONSerializer
 
 if TYPE_CHECKING:
     # pylint: disable=cyclic-import
@@ -57,3 +58,14 @@ class SignedSerializer(metaclass=abc.ABCMeta):
     def serialize(self, signed_obj: "Signed") -> bytes:
         """Serialize Signed object to bytes."""
         raise NotImplementedError
+
+
+__all__ = [
+    CanonicalJSONSerializer.__name__,
+    DeserializationError.__name__,
+    MetadataDeserializer.__name__,
+    MetadataSerializer.__name__,
+    RepositoryError.__name__,
+    SerializationError.__name__,
+    SignedSerializer.__name__,
+]

--- a/tuf/ngclient/__init__.py
+++ b/tuf/ngclient/__init__.py
@@ -7,3 +7,10 @@
 from tuf.ngclient.config import UpdaterConfig
 from tuf.ngclient.fetcher import FetcherInterface
 from tuf.ngclient.updater import Updater
+
+
+__all__ = [
+    FetcherInterface.__name__,
+    Updater.__name__,
+    UpdaterConfig.__name__,
+]


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Document public API for `tuf.api` and `tuf.ngclient` by declaring `__all__`.


