### PR TITLE
tuf: move INFO logs to DEBUG or WARNING

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -443,7 +443,7 @@ class Metadata(Generic[T]):
                 key.verify_signature(delegated_metadata, signed_serializer)
                 signing_keys.add(key.keyid)
             except exceptions.UnsignedMetadataError:
-                logger.info("Key %s failed to verify %s", keyid, delegated_role)
+                logger.warning("Key %s failed to verify %s", keyid, delegated_role)
 
         if len(signing_keys) < role.threshold:
             raise exceptions.UnsignedMetadataError(
@@ -776,7 +776,7 @@ class Key:
             SerializationError,
         ) as e:
             # Log unexpected failure, but continue as if there was no signature
-            logger.info("Key %s failed to verify sig: %s", self.keyid, str(e))
+            logger.warning("Key %s failed to verify sig: %s", self.keyid, str(e))
             raise exceptions.UnsignedMetadataError(
                 f"Failed to verify {self.keyid} signature"
             ) from e

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -443,7 +443,9 @@ class Metadata(Generic[T]):
                 key.verify_signature(delegated_metadata, signed_serializer)
                 signing_keys.add(key.keyid)
             except exceptions.UnsignedMetadataError:
-                logger.warning("Key %s failed to verify %s", keyid, delegated_role)
+                logger.warning(
+                    "Key %s failed to verify %s", keyid, delegated_role
+                )
 
         if len(signing_keys) < role.threshold:
             raise exceptions.UnsignedMetadataError(
@@ -776,7 +778,9 @@ class Key:
             SerializationError,
         ) as e:
             # Log unexpected failure, but continue as if there was no signature
-            logger.warning("Key %s failed to verify sig: %s", self.keyid, str(e))
+            logger.warning(
+                "Key %s failed to verify sig: %s", self.keyid, str(e)
+            )
             raise exceptions.UnsignedMetadataError(
                 f"Failed to verify {self.keyid} signature"
             ) from e

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -443,7 +443,7 @@ class Metadata(Generic[T]):
                 key.verify_signature(delegated_metadata, signed_serializer)
                 signing_keys.add(key.keyid)
             except exceptions.UnsignedMetadataError:
-                logger.warning(
+                logger.debug(
                     "Key %s failed to verify %s", keyid, delegated_role
                 )
 
@@ -778,7 +778,9 @@ class Key:
             SerializationError,
         ) as e:
             # Log unexpected failure, but continue as if there was no signature
-            logger.debug("Key %s failed to verify sig: %s", self.keyid, str(e))
+            logger.warning(
+                "Key %s failed to verify sig: %s", self.keyid, str(e)
+            )
             raise exceptions.UnsignedMetadataError(
                 f"Failed to verify {self.keyid} signature"
             ) from e

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -778,9 +778,7 @@ class Key:
             SerializationError,
         ) as e:
             # Log unexpected failure, but continue as if there was no signature
-            logger.warning(
-                "Key %s failed to verify sig: %s", self.keyid, str(e)
-            )
+            logger.debug("Key %s failed to verify sig: %s", self.keyid, str(e))
             raise exceptions.UnsignedMetadataError(
                 f"Failed to verify {self.keyid} signature"
             ) from e

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -173,7 +173,7 @@ class TrustedMetadataSet(abc.Mapping):
         new_root.verify_delegate(Root.type, new_root)
 
         self._trusted_set[Root.type] = new_root
-        logger.info("Updated root v%d", new_root.signed.version)
+        logger.debug("Updated root v%d", new_root.signed.version)
 
         return new_root
 
@@ -243,7 +243,7 @@ class TrustedMetadataSet(abc.Mapping):
         # protection of new timestamp: expiry is checked in update_snapshot()
 
         self._trusted_set[Timestamp.type] = new_timestamp
-        logger.info("Updated timestamp v%d", new_timestamp.signed.version)
+        logger.debug("Updated timestamp v%d", new_timestamp.signed.version)
 
         # timestamp is loaded: raise if it is not valid _final_ timestamp
         self._check_final_timestamp()
@@ -338,7 +338,7 @@ class TrustedMetadataSet(abc.Mapping):
         # protection of new snapshot: it is checked when targets is updated
 
         self._trusted_set[Snapshot.type] = new_snapshot
-        logger.info("Updated snapshot v%d", new_snapshot.signed.version)
+        logger.debug("Updated snapshot v%d", new_snapshot.signed.version)
 
         # snapshot is loaded, but we raise if it's not valid _final_ snapshot
         self._check_final_snapshot()
@@ -433,7 +433,7 @@ class TrustedMetadataSet(abc.Mapping):
             raise exceptions.ExpiredMetadataError(f"New {role_name} is expired")
 
         self._trusted_set[role_name] = new_delegate
-        logger.info("Updated %s v%d", role_name, version)
+        logger.debug("Updated %s v%d", role_name, version)
 
         return new_delegate
 
@@ -453,4 +453,4 @@ class TrustedMetadataSet(abc.Mapping):
         new_root.verify_delegate(Root.type, new_root)
 
         self._trusted_set[Root.type] = new_root
-        logger.info("Loaded trusted root v%d", new_root.signed.version)
+        logger.debug("Loaded trusted root v%d", new_root.signed.version)

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -260,7 +260,7 @@ class Updater:
             with open(filepath, "wb") as destination_file:
                 shutil.copyfileobj(target_file, destination_file)
 
-        logger.info("Downloaded target %s", targetinfo.path)
+        logger.debug("Downloaded target %s", targetinfo.path)
         return filepath
 
     def _download_metadata(


### PR DESCRIPTION
This should reduce some default logging noise when TUF's ngclient is used as a library in other applications (in particular, `sigstore-python`).

See: https://github.com/sigstore/sigstore-python/pull/351

cc @jku 

Signed-off-by: William Woodruff <william@trailofbits.com>


