### PR TITLE
Support DSSE in Metadata API

### DIFF
--- a/examples/repo_example/basic_repo.py
+++ b/examples/repo_example/basic_repo.py
@@ -27,13 +27,12 @@ from pathlib import Path
 from typing import Any, Dict
 
 from securesystemslib.keys import generate_ed25519_key
-from securesystemslib.signer import SSlibSigner
+from securesystemslib.signer import SSlibKey, SSlibSigner
 
 from tuf.api.metadata import (
     SPECIFICATION_VERSION,
     DelegatedRole,
     Delegations,
-    Key,
     Metadata,
     MetaFile,
     Root,
@@ -157,7 +156,7 @@ roles["root"] = Metadata(Root(expires=_in(365)))
 for name in ["targets", "snapshot", "timestamp", "root"]:
     keys[name] = generate_ed25519_key()
     roles["root"].signed.add_key(
-        Key.from_securesystemslib_key(keys[name]), name
+        SSlibKey.from_securesystemslib_key(keys[name]), name
     )
 
 # NOTE: We only need the public part to populate root, so it is possible to use
@@ -173,7 +172,7 @@ for name in ["targets", "snapshot", "timestamp", "root"]:
 # required signature threshold.
 another_root_key = generate_ed25519_key()
 roles["root"].signed.add_key(
-    Key.from_securesystemslib_key(another_root_key), "root"
+    SSlibKey.from_securesystemslib_key(another_root_key), "root"
 )
 roles["root"].signed.roles["root"].threshold = 2
 
@@ -271,7 +270,7 @@ roles[delegatee_name] = Metadata[Targets](
 # https://theupdateframework.github.io/specification/latest/#delegations
 roles["targets"].signed.delegations = Delegations(
     keys={
-        keys[delegatee_name]["keyid"]: Key.from_securesystemslib_key(
+        keys[delegatee_name]["keyid"]: SSlibKey.from_securesystemslib_key(
             keys[delegatee_name]
         )
     },
@@ -345,7 +344,7 @@ new_root_key = generate_ed25519_key()
 
 roles["root"].signed.revoke_key(keys["root"]["keyid"], "root")
 roles["root"].signed.add_key(
-    Key.from_securesystemslib_key(new_root_key), "root"
+    SSlibKey.from_securesystemslib_key(new_root_key), "root"
 )
 roles["root"].signed.version += 1
 

--- a/examples/repo_example/hashed_bin_delegation.py
+++ b/examples/repo_example/hashed_bin_delegation.py
@@ -23,12 +23,11 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Tuple
 
 from securesystemslib.keys import generate_ed25519_key
-from securesystemslib.signer import SSlibSigner
+from securesystemslib.signer import SSlibKey, SSlibSigner
 
 from tuf.api.metadata import (
     DelegatedRole,
     Delegations,
-    Key,
     Metadata,
     TargetFile,
     Targets,
@@ -146,7 +145,7 @@ for name in ["bin-n", "bins"]:
 # Create preliminary delegating targets role (bins) and add public key for
 # delegated targets (bin_n) to key store. Delegation details are update below.
 roles["bins"] = Metadata(Targets(expires=_in(365)))
-bin_n_key = Key.from_securesystemslib_key(keys["bin-n"])
+bin_n_key = SSlibKey.from_securesystemslib_key(keys["bin-n"])
 roles["bins"].signed.delegations = Delegations(
     keys={bin_n_key.keyid: bin_n_key},
     roles={},

--- a/examples/repo_example/succinct_hash_bin_delegations.py
+++ b/examples/repo_example/succinct_hash_bin_delegations.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Dict, Tuple
 
 from securesystemslib.keys import generate_ed25519_key
-from securesystemslib.signer import SSlibSigner
+from securesystemslib.signer import SSlibKey, SSlibSigner
 
 from tuf.api.metadata import (
     Delegations,
@@ -82,7 +82,7 @@ THRESHOLD = 1
 def create_key() -> Tuple[Key, SSlibSigner]:
     """Generates a new Key and Signer."""
     sslib_key = generate_ed25519_key()
-    return Key.from_securesystemslib_key(sslib_key), SSlibSigner(sslib_key)
+    return SSlibKey.from_securesystemslib_key(sslib_key), SSlibSigner(sslib_key)
 
 
 # Create one signing key for all bins, and one for the delegating targets role.

--- a/tests/generated_data/generate_md.py
+++ b/tests/generated_data/generate_md.py
@@ -8,7 +8,7 @@ import sys
 from datetime import datetime
 from typing import Dict, List, Optional
 
-from securesystemslib.signer import SSlibSigner
+from securesystemslib.signer import SSlibKey, SSlibSigner
 
 from tests import utils
 from tuf.api.metadata import Key, Metadata, Root, Snapshot, Targets, Timestamp
@@ -36,7 +36,7 @@ keyids: List[str] = [
 
 keys: Dict[str, Key] = {}
 for index in range(4):
-    keys[f"ed25519_{index}"] = Key.from_securesystemslib_key(
+    keys[f"ed25519_{index}"] = SSlibKey.from_securesystemslib_key(
         {
             "keytype": "ed25519",
             "scheme": "ed25519",

--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -54,7 +54,7 @@ from urllib import parse
 
 import securesystemslib.hash as sslib_hash
 from securesystemslib.keys import generate_ed25519_key
-from securesystemslib.signer import SSlibSigner
+from securesystemslib.signer import SSlibKey, SSlibSigner
 
 from tuf.api.exceptions import DownloadHTTPError
 from tuf.api.metadata import (
@@ -156,8 +156,8 @@ class RepositorySimulator(FetcherInterface):
 
     @staticmethod
     def create_key() -> Tuple[Key, SSlibSigner]:
-        sslib_key = generate_ed25519_key()
-        return Key.from_securesystemslib_key(sslib_key), SSlibSigner(sslib_key)
+        key = generate_ed25519_key()
+        return SSlibKey.from_securesystemslib_key(key), SSlibSigner(key)
 
     def add_signer(self, role: str, signer: SSlibSigner) -> None:
         if role not in self.signers:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -353,6 +353,15 @@ class TestMetadata(unittest.TestCase):
             root.verify_delegate(Snapshot.type, snapshot)
         snapshot.signed.expires = expires
 
+        # verify fails if sslib verify fails with VerificationError
+        # (in this case signature is malformed)
+        keyid = next(iter(root.signed.roles[Snapshot.type].keyids))
+        good_sig = snapshot.signatures[keyid].signature
+        snapshot.signatures[keyid].signature = "foo"
+        with self.assertRaises(exceptions.UnsignedMetadataError):
+            root.verify_delegate(Snapshot.type, snapshot)
+        snapshot.signatures[keyid].signature = good_sig
+
         # verify fails if roles keys do not sign the metadata
         with self.assertRaises(exceptions.UnsignedMetadataError):
             root.verify_delegate(Timestamp.type, snapshot)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -652,7 +652,7 @@ class TestMetadata(unittest.TestCase):
 
             # Test wrong algorithm format (sslib.FormatError)
             snapshot_metafile.hashes = {
-                256: "8f88e2ba48b412c3843e9bb26e1b6f8fc9e98aceb0fbaa97ba37b4c98717d7ab"  # type: ignore[dict-item]
+                256: "8f88e2ba48b412c3843e9bb26e1b6f8fc9e98aceb0fbaa97ba37b4c98717d7ab"
             }
             with self.assertRaises(exceptions.LengthOrHashMismatchError):
                 snapshot_metafile.verify_length_and_hashes(data)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -414,7 +414,7 @@ class TestMetadata(unittest.TestCase):
 
         # Assert that add_key with old argument order will raise an error
         with self.assertRaises(ValueError):
-            root.signed.add_key(Root.type, key_metadata)  # type: ignore
+            root.signed.add_key(Root.type, key_metadata)
 
         # Add new root key
         root.signed.add_key(key_metadata, Root.type)
@@ -515,7 +515,7 @@ class TestMetadata(unittest.TestCase):
 
         # Assert that add_key with old argument order will raise an error
         with self.assertRaises(ValueError):
-            targets.add_key("role1", key)  # type: ignore
+            targets.add_key("role1", key)
 
         # Assert that delegated role "role1" does not contain the new key
         self.assertNotIn(key.keyid, targets.delegations.roles["role1"].keyids)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,7 +23,7 @@ from securesystemslib.interface import (
     import_ed25519_publickey_from_file,
 )
 from securesystemslib.keys import generate_ed25519_key
-from securesystemslib.signer import Signature, SSlibSigner
+from securesystemslib.signer import SSlibKey, SSlibSigner
 
 from tests import utils
 from tuf.api import exceptions
@@ -34,6 +34,7 @@ from tuf.api.metadata import (
     Key,
     Metadata,
     Root,
+    Signature,
     Snapshot,
     SuccinctRoles,
     TargetFile,
@@ -382,13 +383,8 @@ class TestMetadata(unittest.TestCase):
         # Test if from_securesystemslib_key removes the private key from keyval
         # of a securesystemslib key dictionary.
         sslib_key = generate_ed25519_key()
-        key = Key.from_securesystemslib_key(sslib_key)
+        key = SSlibKey.from_securesystemslib_key(sslib_key)
         self.assertFalse("private" in key.keyval.keys())
-
-        # Test raising ValueError with non-existent keytype
-        sslib_key["keytype"] = "bad keytype"
-        with self.assertRaises(ValueError):
-            Key.from_securesystemslib_key(sslib_key)
 
     def test_root_add_key_and_revoke_key(self) -> None:
         root_path = os.path.join(self.repo_dir, "metadata", "root.json")
@@ -399,7 +395,7 @@ class TestMetadata(unittest.TestCase):
             os.path.join(self.keystore_dir, "root_key2.pub")
         )
         keyid = root_key2["keyid"]
-        key_metadata = Key(
+        key_metadata = SSlibKey(
             keyid,
             root_key2["keytype"],
             root_key2["scheme"],

--- a/tests/test_metadata_eq_.py
+++ b/tests/test_metadata_eq_.py
@@ -12,17 +12,17 @@ import sys
 import unittest
 from typing import Any, ClassVar, Dict
 
-from securesystemslib.signer import Signature
+from securesystemslib.signer import SSlibKey
 
 from tests import utils
 from tuf.api.metadata import (
     TOP_LEVEL_ROLE_NAMES,
     DelegatedRole,
     Delegations,
-    Key,
     Metadata,
     MetaFile,
     Role,
+    Signature,
     SuccinctRoles,
     TargetFile,
 )
@@ -50,7 +50,7 @@ class TestMetadataComparisions(unittest.TestCase):
 
         cls.objects["Metadata"] = Metadata(cls.objects["Timestamp"], {})
         cls.objects["Signed"] = cls.objects["Timestamp"]
-        cls.objects["Key"] = Key(
+        cls.objects["Key"] = SSlibKey(
             "id", "rsa", "rsassa-pss-sha256", {"public": "foo"}
         )
         cls.objects["Role"] = Role(["keyid1", "keyid2"], 3)

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -168,7 +168,7 @@ class TestSerialization(unittest.TestCase):
     @utils.run_sub_tests_with_dataset(invalid_keys)
     def test_invalid_key_serialization(self, test_case_data: str) -> None:
         case_dict = json.loads(test_case_data)
-        with self.assertRaises((TypeError, KeyError)):
+        with self.assertRaises((TypeError, KeyError, ValueError)):
             keyid = case_dict.pop("keyid")
             Key.from_dict(keyid, case_dict)
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ install_command = python3 -m pip install {opts} {packages}
 # Must to be invoked explicitly with, e.g. `tox -e with-sslib-master`
 [testenv:with-sslib-master]
 commands_pre =
-    python3 -m pip install git+https://github.com/secure-systems-lab/securesystemslib.git@master#egg=securesystemslib[crypto,pynacl]
+    python3 -m pip install --force-reinstall git+https://github.com/secure-systems-lab/securesystemslib.git@master#egg=securesystemslib[crypto,pynacl]
 
 commands =
     python3 -m coverage run aggregate_tests.py

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -386,29 +386,11 @@ class Metadata(Generic[T]):
 
         return signature
 
-    def verify_delegate(
-        self,
-        delegated_role: str,
-        delegated_metadata: "Metadata",
-        signed_serializer: Optional[SignedSerializer] = None,
-    ) -> None:
-        """Verifies that ``delegated_metadata`` is signed with the required
-        threshold of keys for the delegated role ``delegated_role``.
+    def _get_role_and_keys(
+        self, delegated_role: str
+    ) -> Tuple["Role", Dict[str, Key]]:
+        """Return the keys and role for delegated_role"""
 
-        Args:
-            delegated_role: Name of the delegated role to verify
-            delegated_metadata: ``Metadata`` object for the delegated role
-            signed_serializer: Serializer used for delegate
-                serialization. Default is ``CanonicalJSONSerializer``.
-
-        Raises:
-            UnsignedMetadataError: ``delegated_role`` was not signed with
-                required threshold of keys for ``role_name``.
-            ValueError: no delegation was found for ``delegated_role``.
-            TypeError: called this function on non-delegating metadata class.
-        """
-
-        # Find the keys and role in delegator metadata
         role: Optional[Role] = None
         if isinstance(self.signed, Root):
             keys = self.signed.keys
@@ -431,14 +413,54 @@ class Metadata(Generic[T]):
         if role is None:
             raise ValueError(f"No delegation found for {delegated_role}")
 
+        return (role, keys)
+
+    def verify_delegate(
+        self,
+        delegated_role: str,
+        delegated_metadata: "Metadata",
+        signed_serializer: Optional[SignedSerializer] = None,
+    ) -> None:
+        """Verifies that ``delegated_metadata`` is signed with the required
+        threshold of keys for the delegated role ``delegated_role``.
+
+        Args:
+            delegated_role: Name of the delegated role to verify
+            delegated_metadata: ``Metadata`` object for the delegated role
+            signed_serializer: Serializer used for delegate
+                serialization. Default is ``CanonicalJSONSerializer``.
+
+        Raises:
+            UnsignedMetadataError: ``delegated_role`` was not signed with
+                required threshold of keys for ``role_name``.
+            ValueError: no delegation was found for ``delegated_role``.
+            TypeError: called this function on non-delegating metadata class.
+        """
+
+        if signed_serializer is None:
+            # pylint: disable=import-outside-toplevel
+            from tuf.api.serialization.json import CanonicalJSONSerializer
+
+            signed_serializer = CanonicalJSONSerializer()
+
+        data = signed_serializer.serialize(delegated_metadata.signed)
+        role, keys = self._get_role_and_keys(delegated_role)
+
         # verify that delegated_metadata is signed by threshold of unique keys
         signing_keys = set()
         for keyid in role.keyids:
-            key = keys[keyid]
+            if keyid not in keys:
+                logger.info("No key for keyid %s", keyid)
+                continue
+            if keyid not in delegated_metadata.signatures:
+                logger.info("No signature for keyid %s", keyid)
+                continue
+
+            sig = delegated_metadata.signatures[keyid]
             try:
-                key.verify_signature(delegated_metadata, signed_serializer)
-                signing_keys.add(key.keyid)
-            except UnsignedMetadataError:
+                keys[keyid].verify_signature(sig, data)
+                signing_keys.add(keyid)
+            except sslib_exceptions.UnverifiedSignatureError:
                 logger.info("Key %s failed to verify %s", keyid, delegated_role)
 
         if len(signing_keys) < role.threshold:

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -31,7 +31,6 @@ import abc
 import fnmatch
 import io
 import logging
-import tempfile
 from datetime import datetime
 from typing import (
     IO,
@@ -52,14 +51,14 @@ from typing import (
 
 from securesystemslib import exceptions as sslib_exceptions
 from securesystemslib import hash as sslib_hash
+from securesystemslib.serialization import JSONSerializable
 from securesystemslib.signer import Key, Signature, Signer
-from securesystemslib.storage import FilesystemBackend, StorageBackendInterface
-from securesystemslib.util import persist_temp_file
 
 from tuf.api.exceptions import LengthOrHashMismatchError, UnsignedMetadataError
 from tuf.api.serialization import (
     MetadataDeserializer,
     MetadataSerializer,
+    SerializationMixin,
     SignedSerializer,
 )
 
@@ -81,7 +80,7 @@ TOP_LEVEL_ROLE_NAMES = {_ROOT, _TIMESTAMP, _SNAPSHOT, _TARGETS}
 T = TypeVar("T", "Root", "Timestamp", "Snapshot", "Targets")
 
 
-class Metadata(Generic[T]):
+class Metadata(Generic[T], JSONSerializable, SerializationMixin):
     """A container for signed TUF metadata.
 
     Provides methods to convert to and from dictionary, read and write to and
@@ -199,97 +198,21 @@ class Metadata(Generic[T]):
             unrecognized_fields=metadata,
         )
 
-    @classmethod
-    def from_file(
-        cls,
-        filename: str,
-        deserializer: Optional[MetadataDeserializer] = None,
-        storage_backend: Optional[StorageBackendInterface] = None,
-    ) -> "Metadata[T]":
-        """Loads TUF metadata from file storage.
+    @staticmethod
+    def _default_deserializer() -> MetadataDeserializer:
+        """Default Deserializer to be used for deserialization."""
+        # pylint: disable=import-outside-toplevel
+        from tuf.api.serialization.json import JSONDeserializer
 
-        Args:
-            filename: Path to read the file from.
-            deserializer: ``MetadataDeserializer`` subclass instance that
-                implements the desired wireline format deserialization. Per
-                default a ``JSONDeserializer`` is used.
-            storage_backend: Object that implements
-                ``securesystemslib.storage.StorageBackendInterface``.
-                Default is ``FilesystemBackend`` (i.e. a local file).
-        Raises:
-            StorageError: The file cannot be read.
-            tuf.api.serialization.DeserializationError:
-                The file cannot be deserialized.
+        return JSONDeserializer()
 
-        Returns:
-            TUF ``Metadata`` object.
-        """
+    @staticmethod
+    def _default_serializer() -> MetadataSerializer:
+        """Default Serializer to be used for serialization."""
+        # pylint: disable=import-outside-toplevel
+        from tuf.api.serialization.json import JSONSerializer
 
-        if storage_backend is None:
-            storage_backend = FilesystemBackend()
-
-        with storage_backend.get(filename) as file_obj:
-            return cls.from_bytes(file_obj.read(), deserializer)
-
-    @classmethod
-    def from_bytes(
-        cls,
-        data: bytes,
-        deserializer: Optional[MetadataDeserializer] = None,
-    ) -> "Metadata[T]":
-        """Loads TUF metadata from raw data.
-
-        Args:
-            data: Metadata content.
-            deserializer: ``MetadataDeserializer`` implementation to use.
-                Default is ``JSONDeserializer``.
-
-        Raises:
-            tuf.api.serialization.DeserializationError:
-                The file cannot be deserialized.
-
-        Returns:
-            TUF ``Metadata`` object.
-        """
-
-        if deserializer is None:
-            # Use local scope import to avoid circular import errors
-            # pylint: disable=import-outside-toplevel
-            from tuf.api.serialization.json import JSONDeserializer
-
-            deserializer = JSONDeserializer()
-
-        return deserializer.deserialize(data)
-
-    def to_bytes(
-        self, serializer: Optional[MetadataSerializer] = None
-    ) -> bytes:
-        """Return the serialized TUF file format as bytes.
-
-        Note that if bytes are first deserialized into ``Metadata`` and then
-        serialized with ``to_bytes()``, the two are not required to be
-        identical even though the signatures are guaranteed to stay valid. If
-        byte-for-byte equivalence is required (which is the case when content
-        hashes are used in other metadata), the original content should be used
-        instead of re-serializing.
-
-        Args:
-            serializer: ``MetadataSerializer`` instance that implements the
-                desired serialization format. Default is ``JSONSerializer``.
-
-        Raises:
-            tuf.api.serialization.SerializationError:
-                The metadata object cannot be serialized.
-        """
-
-        if serializer is None:
-            # Use local scope import to avoid circular import errors
-            # pylint: disable=import-outside-toplevel
-            from tuf.api.serialization.json import JSONSerializer
-
-            serializer = JSONSerializer(compact=True)
-
-        return serializer.serialize(self)
+        return JSONSerializer(compact=True)
 
     def to_dict(self) -> Dict[str, Any]:
         """Returns the dict representation of self."""
@@ -301,40 +224,6 @@ class Metadata(Generic[T]):
             "signed": self.signed.to_dict(),
             **self.unrecognized_fields,
         }
-
-    def to_file(
-        self,
-        filename: str,
-        serializer: Optional[MetadataSerializer] = None,
-        storage_backend: Optional[StorageBackendInterface] = None,
-    ) -> None:
-        """Writes TUF metadata to file storage.
-
-        Note that if a file is first deserialized into ``Metadata`` and then
-        serialized with ``to_file()``, the two files are not required to be
-        identical even though the signatures are guaranteed to stay valid. If
-        byte-for-byte equivalence is required (which is the case when file
-        hashes are used in other metadata), the original file should be used
-        instead of re-serializing.
-
-        Args:
-            filename: Path to write the file to.
-            serializer: ``MetadataSerializer`` instance that implements the
-                desired serialization format. Default is ``JSONSerializer``.
-            storage_backend: ``StorageBackendInterface`` implementation. Default
-                is ``FilesystemBackend`` (i.e. a local file).
-
-        Raises:
-            tuf.api.serialization.SerializationError:
-                The metadata object cannot be serialized.
-            StorageError: The file cannot be written.
-        """
-
-        bytes_data = self.to_bytes(serializer)
-
-        with tempfile.TemporaryFile() as temp_file:
-            temp_file.write(bytes_data)
-            persist_temp_file(temp_file, filename, storage_backend)
 
     # Signatures.
     def sign(

--- a/tuf/api/serialization/__init__.py
+++ b/tuf/api/serialization/__init__.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 MetadataSerializer: TypeAlias = BaseSerializer
 MetadataDeserializer: TypeAlias = BaseDeserializer
 SignedSerializer: TypeAlias = BaseSerializer
+SignedDeserializer: TypeAlias = BaseDeserializer
 
 
 class SerializationError(RepositoryError):

--- a/tuf/api/serialization/__init__.py
+++ b/tuf/api/serialization/__init__.py
@@ -15,13 +15,23 @@ API objects.
 """
 
 import abc
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
+
+from securesystemslib.serialization import (
+    BaseDeserializer,
+    BaseSerializer,
+    SerializationMixin,
+)
 
 from tuf.api.exceptions import RepositoryError
 
 if TYPE_CHECKING:
     # pylint: disable=cyclic-import
     from tuf.api.metadata import Metadata, Signed
+
+MetadataSerializer: TypeAlias = BaseSerializer
+MetadataDeserializer: TypeAlias = BaseDeserializer
+SignedSerializer: TypeAlias = BaseSerializer
 
 
 class SerializationError(RepositoryError):
@@ -30,30 +40,3 @@ class SerializationError(RepositoryError):
 
 class DeserializationError(RepositoryError):
     """Error during deserialization."""
-
-
-class MetadataDeserializer(metaclass=abc.ABCMeta):
-    """Abstract base class for deserialization of Metadata objects."""
-
-    @abc.abstractmethod
-    def deserialize(self, raw_data: bytes) -> "Metadata":
-        """Deserialize bytes to Metadata object."""
-        raise NotImplementedError
-
-
-class MetadataSerializer(metaclass=abc.ABCMeta):
-    """Abstract base class for serialization of Metadata objects."""
-
-    @abc.abstractmethod
-    def serialize(self, metadata_obj: "Metadata") -> bytes:
-        """Serialize Metadata object to bytes."""
-        raise NotImplementedError
-
-
-class SignedSerializer(metaclass=abc.ABCMeta):
-    """Abstract base class for serialization of Signed objects."""
-
-    @abc.abstractmethod
-    def serialize(self, signed_obj: "Signed") -> bytes:
-        """Serialize Signed object to bytes."""
-        raise NotImplementedError

--- a/tuf/api/serialization/json.py
+++ b/tuf/api/serialization/json.py
@@ -7,11 +7,13 @@ format for transportation, and to serialize the 'signed' part of TUF role
 metadata to the OLPC Canonical JSON format for signature generation and
 verification.
 """
-
-import json
 from typing import Optional
 
 from securesystemslib.formats import encode_canonical
+from securesystemslib.serialization import (
+    JSONDeserializer as BaseJSONDeserializer,
+)
+from securesystemslib.serialization import JSONSerializer as BaseJSONSerializer
 
 # pylint: disable=cyclic-import
 # ... to allow de/serializing Metadata and Signed objects here, while also
@@ -20,20 +22,19 @@ from securesystemslib.formats import encode_canonical
 from tuf.api.metadata import Metadata, Signed
 from tuf.api.serialization import (
     DeserializationError,
-    MetadataDeserializer,
-    MetadataSerializer,
     SerializationError,
     SignedSerializer,
 )
 
 
-class JSONDeserializer(MetadataDeserializer):
+class JSONDeserializer(BaseJSONDeserializer):
     """Provides JSON to Metadata deserialize method."""
 
     def deserialize(self, raw_data: bytes) -> Metadata:
         """Deserialize utf-8 encoded JSON bytes into Metadata object."""
+
         try:
-            json_dict = json.loads(raw_data.decode("utf-8"))
+            json_dict = super().deserialize(raw_data)
             metadata_obj = Metadata.from_dict(json_dict)
 
         except Exception as e:
@@ -42,7 +43,7 @@ class JSONDeserializer(MetadataDeserializer):
         return metadata_obj
 
 
-class JSONSerializer(MetadataSerializer):
+class JSONSerializer(BaseJSONSerializer):
     """Provides Metadata to JSON serialize method.
 
     Args:
@@ -55,26 +56,19 @@ class JSONSerializer(MetadataSerializer):
     """
 
     def __init__(self, compact: bool = False, validate: Optional[bool] = False):
-        self.compact = compact
+        super().__init__(compact)
         self.validate = validate
 
-    def serialize(self, metadata_obj: Metadata) -> bytes:
+    def serialize(self, obj: Metadata) -> bytes:
         """Serialize Metadata object into utf-8 encoded JSON bytes."""
 
         try:
-            indent = None if self.compact else 1
-            separators = (",", ":") if self.compact else (",", ": ")
-            json_bytes = json.dumps(
-                metadata_obj.to_dict(),
-                indent=indent,
-                separators=separators,
-                sort_keys=True,
-            ).encode("utf-8")
+            json_bytes = BaseJSONSerializer.serialize(self, obj)
 
             if self.validate:
                 try:
                     new_md_obj = JSONDeserializer().deserialize(json_bytes)
-                    if metadata_obj != new_md_obj:
+                    if obj != new_md_obj:
                         raise ValueError(
                             "Metadata changes if you serialize and deserialize."
                         )
@@ -90,12 +84,12 @@ class JSONSerializer(MetadataSerializer):
 class CanonicalJSONSerializer(SignedSerializer):
     """Provides Signed to OLPC Canonical JSON serialize method."""
 
-    def serialize(self, signed_obj: Signed) -> bytes:
+    def serialize(self, obj: Signed) -> bytes:
         """Serialize Signed object into utf-8 encoded OLPC Canonical JSON
         bytes.
         """
         try:
-            signed_dict = signed_obj.to_dict()
+            signed_dict = obj.to_dict()
             canonical_bytes = encode_canonical(signed_dict).encode("utf-8")
 
         except Exception as e:


### PR DESCRIPTION
**Notes to reviewer:**
- based on: [#2165](https://github.com/theupdateframework/python-tuf/pull/2165) and [sslib#487](https://github.com/secure-systems-lab/securesystemslib/pull/487)
  (tests should pass locally, when installing tuf and securesystemslib from these branches)
- relevant diff: https://github.com/lukpueh/tuf/compare/no-key...dsse
- leaving as draft until above PRs are merged and, in the case of securesystemslib, released
- the design is smart (h/t @PradyumnaKrishna), but adds quite some complexity to metadata API
- this needs better tests and documentation, but I wanted to get a first round of feedback before spending more time on it
- the commit messages have many details

**Description of the changes being introduced by the pull request**:

Adds a TUF-specific [DSSE](https://github.com/secure-systems-lab/dsse) (`Envelope`) implementation and defines an abstract interface (`BaseMetadata`) for common `Envelope` and `Metadata` operations. `BaseMetadata` can be used independently of the underlying metadata type to read or write from and to file or bytes, and to  create or verify signatures. 

**caveat:** Optional arguments may be different for common `Envelope` and `Metadata` methods. This is because they require de/serialization operations at different stages. Envelope must deserialize, when accessing the payload (`get_signed`), but Metadata not. Metadata, OTOH, must serialize to canonical json when signing or verifying (`sign` and `verify_delegate`), but Envelope not.

This PR also adopts the new securesystemslib de/serialization infrastructure, which, most notably, 
- separates basic JSON bytes deserialization from custom object instantiation, 
- adds a `SerializationMixin`, which provides convenience methods to read or write from and to file or bytes 

**caveat:**  users of the serialization mixin must implement methods that return default de/serializers that can be used by the mixin.
