### PR TITLE
ngclient: Remove "Optional" from helper props

### DIFF
--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -168,7 +168,7 @@ class Updater:
             ``TargetFile`` instance or ``None``.
         """
 
-        if self._trusted_set.targets is None:
+        if Targets.type not in self._trusted_set:
             self.refresh()
         return self._preorder_depth_first_walk(target_path)
 
@@ -361,7 +361,6 @@ class Updater:
             # Local snapshot does not exist or is invalid: update from remote
             logger.debug("Local snapshot not valid as final: %s", e)
 
-            assert self._trusted_set.timestamp is not None  # nosec
             snapshot_meta = self._trusted_set.timestamp.signed.snapshot_meta
             length = snapshot_meta.length or self.config.snapshot_max_length
             version = None
@@ -389,8 +388,6 @@ class Updater:
         except (OSError, exceptions.RepositoryError) as e:
             # Local 'role' does not exist or is invalid: update from remote
             logger.debug("Failed to load local %s: %s", role, e)
-
-            assert self._trusted_set.snapshot is not None  # nosec
 
             snapshot = self._trusted_set.snapshot.signed
             metainfo = snapshot.meta.get(f"{role}.json")


### PR DESCRIPTION
The properties in the internal TrustedMetadataSet are a bit difficult to use with static typing since they return Optional but in many cases we know the "None"-case is impossible.

Remove None from annotation: the idea is that calling the property getter too early is a programming error: it will result in KeyError which, even if not obvious, is consistent since the properties are short hand for the dictionary lookup:
 * trusted_set["timestamp"] raises KeyError if timestamp is not set
 * trusted_set.timestamp raises KeyError if timestamp is not set

Signed-off-by: Jussi Kukkonen <jkukkonen@google.com>

Fixes #2247

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)

