### PR TITLE
feature: ngclient: Lazy refresh

### DIFF
--- a/tests/test_updater_consistent_snapshot.py
+++ b/tests/test_updater_consistent_snapshot.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, Iterable, List, Optional
 from tests import utils
 from tests.repository_simulator import RepositorySimulator
 from tuf.api.metadata import (
-    SPECIFICATION_VERSION,
     TOP_LEVEL_ROLE_NAMES,
     DelegatedRole,
     TargetFile,
@@ -170,12 +169,9 @@ class TestConsistentSnapshot(unittest.TestCase):
 
             self.setup_subtest(consistent_snapshot)
             # Add new delegated targets
-            spec_version = ".".join(SPECIFICATION_VERSION)
             for role in rolenames:
                 delegated_role = DelegatedRole(role, [], 1, False, ["*"], None)
-                targets = Targets(
-                    1, spec_version, self.sim.safe_expiry, {}, None
-                )
+                targets = Targets(expires=self.sim.safe_expiry)
                 self.sim.add_delegation("targets", delegated_role, targets)
             self.sim.update_snapshot()
             updater = self._init_updater()

--- a/tests/test_updater_delegation_graphs.py
+++ b/tests/test_updater_delegation_graphs.py
@@ -16,12 +16,7 @@ from typing import Iterable, List, Optional
 from tests import utils
 from tests.repository_simulator import RepositorySimulator
 from tuf.api.exceptions import UnsignedMetadataError
-from tuf.api.metadata import (
-    SPECIFICATION_VERSION,
-    TOP_LEVEL_ROLE_NAMES,
-    DelegatedRole,
-    Targets,
-)
+from tuf.api.metadata import TOP_LEVEL_ROLE_NAMES, DelegatedRole, Targets
 from tuf.ngclient import Updater
 
 
@@ -97,14 +92,11 @@ class TestDelegations(unittest.TestCase):
         populate it with delegations and target files"""
 
         self.sim = RepositorySimulator()
-        spec_version = ".".join(SPECIFICATION_VERSION)
         for d in test_case.delegations:
             if d.rolename in self.sim.md_delegates:
                 targets = self.sim.md_delegates[d.rolename].signed
             else:
-                targets = Targets(
-                    1, spec_version, self.sim.safe_expiry, {}, None
-                )
+                targets = Targets(expires=self.sim.safe_expiry)
             # unpack 'd' but skip "delegator"
             role = DelegatedRole(*astuple(d)[1:])
             self.sim.add_delegation(d.delegator, role, targets)

--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -24,7 +24,6 @@ from tuf.api.exceptions import (
     UnsignedMetadataError,
 )
 from tuf.api.metadata import (
-    SPECIFICATION_VERSION,
     TOP_LEVEL_ROLE_NAMES,
     DelegatedRole,
     Metadata,
@@ -645,8 +644,7 @@ class TestRefresh(unittest.TestCase):
         # the delegations tree
 
         # Add new delegated targets, update the snapshot
-        spec_version = ".".join(SPECIFICATION_VERSION)
-        targets = Targets(1, spec_version, self.sim.safe_expiry, {}, None)
+        targets = Targets(expires=self.sim.safe_expiry)
         role = DelegatedRole("role1", [], 1, False, ["*"], None)
         self.sim.add_delegation("targets", role, targets)
         self.sim.update_snapshot()
@@ -700,8 +698,7 @@ class TestRefresh(unittest.TestCase):
     def test_load_metadata_from_cache(self, wrapped_open: MagicMock) -> None:
 
         # Add new delegated targets
-        spec_version = ".".join(SPECIFICATION_VERSION)
-        targets = Targets(1, spec_version, self.sim.safe_expiry, {}, None)
+        targets = Targets(expires=self.sim.safe_expiry)
         role = DelegatedRole("role1", [], 1, False, ["*"], None)
         self.sim.add_delegation("targets", role, targets)
         self.sim.update_snapshot()

--- a/tuf/ngclient/config.py
+++ b/tuf/ngclient/config.py
@@ -23,7 +23,15 @@ class UpdaterConfig:
             are used, target download URLs are formed by prefixing the filename
             with a hash digest of file content by default. This can be
             overridden by setting ``prefix_targets_with_hash`` to ``False``.
-
+        lazy_refresh: Do not fetch metadata from remote if the local metadata
+            is still valid. Setting lazy_refresh to True means refresh() no
+            longer implements the full client workflow that is described in the
+            specification, and should only be used with repositories that
+            suggest using it:
+             * The client may stay unaware of metadata updates for the
+               expiry periods (typically timestamp expiry period).
+             * Repository maintenance has some additional requirements as the
+               clients may operate with older metadata.
     """
 
     max_root_rotations: int = 32
@@ -33,3 +41,4 @@ class UpdaterConfig:
     snapshot_max_length: int = 2000000  # bytes
     targets_max_length: int = 5000000  # bytes
     prefix_targets_with_hash: bool = True
+    lazy_refresh = False


### PR DESCRIPTION
Fixes #2225. This is an experiment that I would like comments on.

Implement a "lazy refresh" feature for ngclient: When configuration `lazy_refresh=True` is set, the Updater will try to only load local top-level metadata. The objective is to not have the two mandatory requests (root N+1 and timestamp) in situations where a single client typically does many refreshes while the repository does not change and where the client is content with a delay of _"timestamp expiry period"_ in getting new updates.

Notes:
* Use case comes from sigstore-python where expectation is that the same binary might be called thousands of times during a time when the repository has not changed: this results in thousands of unneeded requests and makes each call just a bit slower.
* It can be argued that this is not compatible with TUF specification -- on the other hand it can be argued that we are not trying to do a "client update" as described in spec, we are trying to use metadata that has been previously updated already: situation is comparable to a client that just stays running longer and uses the same metadata it has in memory
* If a repository suggests using lazy_refresh, it must be more careful than usual as clients may be using metadata that is _"timestamp expiry period"_ older than normal.
  * delegated metadata expiry bumps must happen earlier than normal
  * old delegated metadata versions must be available for longer
  * old target files must be available for longer

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


