### PR TITLE
tox: Add python3 to allow list, bump tox to 4.x

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,4 +1,4 @@
 # The build and tox versions specified here are also used as constraints
 # during CI and CD Github workflows
 build==0.9.0
-tox==3.28.0
+tox==4.1.2

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,9 @@ deps =
 
 install_command = python3 -m pip install {opts} {packages}
 
+# Workaround https://github.com/tox-dev/tox/issues/2801 (python3 not allowed in Windows)
+allowlist_externals = python3
+
 # Develop test env to run tests against securesystemslib's master branch
 # Must to be invoked explicitly with, e.g. `tox -e with-sslib-master`
 [testenv:with-sslib-master]


### PR DESCRIPTION
This should enable tox4 and fix #1791, #2218
