### PR TITLE
Expose default fetcher

### DIFF
--- a/docs/api/tuf.ngclient.fetcher.rst
+++ b/docs/api/tuf.ngclient.fetcher.rst
@@ -1,6 +1,9 @@
 Fetcher
 ============
 
-.. automodule:: tuf.ngclient.fetcher
+.. autoclass:: tuf.ngclient.FetcherInterface
    :undoc-members:
    :private-members: _fetch
+
+.. autoclass:: tuf.ngclient.RequestsFetcher
+   :no-inherited-members:

--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -20,7 +20,7 @@ import requests
 
 from tests import utils
 from tuf.api import exceptions
-from tuf.ngclient._internal.requests_fetcher import RequestsFetcher
+from tuf.ngclient import RequestsFetcher
 
 logger = logging.getLogger(__name__)
 

--- a/tuf/ngclient/__init__.py
+++ b/tuf/ngclient/__init__.py
@@ -4,12 +4,18 @@
 """TUF client public API
 """
 
+
+# requests_fetcher is public but comes from _internal for now (because
+# sigstore-python 1.0 still uses the module from there). requests_fetcher
+# can be moved out of _internal once sigstore-python 1.0 is not relevant.
+from tuf.ngclient._internal.requests_fetcher import RequestsFetcher
 from tuf.ngclient.config import UpdaterConfig
 from tuf.ngclient.fetcher import FetcherInterface
 from tuf.ngclient.updater import Updater
 
 __all__ = [
     FetcherInterface.__name__,
+    RequestsFetcher.__name__,
     Updater.__name__,
     UpdaterConfig.__name__,
 ]

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -5,6 +5,10 @@
   HTTP library.
 """
 
+# requests_fetcher is public but comes from _internal for now (because
+# sigstore-python 1.0 still uses the module from there). requests_fetcher
+# can be moved out of _internal once sigstore-python 1.0 is not relevant.
+
 import logging
 from typing import Dict, Iterator, Tuple
 from urllib import parse

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -24,8 +24,10 @@ class RequestsFetcher(FetcherInterface):
     """An implementation of ``FetcherInterface`` based on the requests library.
 
     Attributes:
-        _sessions: Dictionary of ``Requests.Session`` objects storing a separate
-            session per scheme+hostname combination.
+        socket_timeout: Timeout in seconds, used for both initial connection
+            delay and the maximum delay between bytes received. Default is
+            4 seconds.
+        chunk_size: Chunk size in bytes used when downloading.
     """
 
     def __init__(self) -> None:


### PR DESCRIPTION
This is useful for those who want to use the default fetcher but modify some attributes

The file itself could be moved to tuf/ngclient/ but this is not done yet as sigstore-python is using this internal module. Move can be done once sigstore-python 1.0 is no longer relevant.

Fixes #2268

Signed-off-by: Jussi Kukkonen <jkukkonen@google.com>

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


