### PR TITLE
Fix pydocstyle D400: first line should end with a period

### DIFF
--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -1,7 +1,7 @@
 # Copyright New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""TUF
+"""TUF.
 """
 
 # This value is used in the requests user agent.

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1,7 +1,8 @@
 # Copyright New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""
+"""The low-level Metadata API.
+
 The low-level Metadata API in ``tuf.api.metadata`` module contains:
 
 * Safe de/serialization of metadata to and from files.
@@ -550,13 +551,13 @@ class Signed(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def to_dict(self) -> Dict[str, Any]:
-        """Serialize and return a dict representation of self"""
+        """Serialize and return a dict representation of self."""
         raise NotImplementedError
 
     @classmethod
     @abc.abstractmethod
     def from_dict(cls, signed_dict: Dict[str, Any]) -> "Signed":
-        """Deserialization helper, creates object from json/dict representation"""
+        """Deserialization helper, creates object from json/dict representation."""
         raise NotImplementedError
 
     @classmethod
@@ -1003,7 +1004,7 @@ class BaseFile:
     def _verify_hashes(
         data: Union[bytes, IO[bytes]], expected_hashes: Dict[str, str]
     ) -> None:
-        """Verify that the hash of ``data`` matches ``expected_hashes``"""
+        """Verify that the hash of ``data`` matches ``expected_hashes``."""
         is_bytes = isinstance(data, bytes)
         for algo, exp_hash in expected_hashes.items():
             try:
@@ -1032,7 +1033,7 @@ class BaseFile:
     def _verify_length(
         data: Union[bytes, IO[bytes]], expected_length: int
     ) -> None:
-        """Verify that the length of ``data`` matches ``expected_length``"""
+        """Verify that the length of ``data`` matches ``expected_length``."""
         if isinstance(data, bytes):
             observed_length = len(data)
         else:
@@ -1541,8 +1542,7 @@ class SuccinctRoles(Role):
         }
 
     def get_role_for_target(self, target_filepath: str) -> str:
-        """Calculate the name of the delegated role responsible for
-        ``target_filepath``.
+        """Calculate the name of the delegated role responsible for ``target_filepath``.
 
         The target at path ``target_filepath`` is assigned to a bin by casting
         the left-most ``bit_length`` of bits of the file path hash digest to

--- a/tuf/ngclient/__init__.py
+++ b/tuf/ngclient/__init__.py
@@ -1,7 +1,7 @@
 # Copyright New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""TUF client public API
+"""TUF client public API.
 """
 
 

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -1,8 +1,7 @@
 # Copyright 2021, New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""Provides an implementation of ``FetcherInterface`` using the Requests
-  HTTP library.
+"""Provides an implementation of ``FetcherInterface`` using the Requests HTTP library.
 """
 
 # requests_fetcher is public but comes from _internal for now (because
@@ -56,7 +55,7 @@ class RequestsFetcher(FetcherInterface):
         self.chunk_size: int = 400000  # bytes
 
     def _fetch(self, url: str) -> Iterator[bytes]:
-        """Fetch the contents of HTTP/HTTPS url from a remote server
+        """Fetch the contents of HTTP/HTTPS url from a remote server.
 
         Args:
             url: URL string that represents a file location.
@@ -114,8 +113,7 @@ class RequestsFetcher(FetcherInterface):
             response.close()
 
     def _get_session(self, url: str) -> requests.Session:
-        """Return a different customized requests.Session per schema+hostname
-        combination.
+        """Return a different customized requests.Session per schema+hostname combination.
 
         Raises:
             exceptions.DownloadError: When there is a problem parsing the url.

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -1,7 +1,7 @@
 # Copyright the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""Trusted collection of client-side TUF Metadata
+"""Trusted collection of client-side TUF Metadata.
 
 ``TrustedMetadataSet`` keeps track of the current valid set of metadata for the
 client, and handles almost every step of the "Detailed client workflow" (
@@ -71,7 +71,7 @@ logger = logging.getLogger(__name__)
 
 
 class TrustedMetadataSet(abc.Mapping):
-    """Internal class to keep track of trusted metadata in ``Updater``
+    """Internal class to keep track of trusted metadata in ``Updater``.
 
     ``TrustedMetadataSet`` ensures that the collection of metadata in it is valid
     and trusted through the whole client update workflow. It provides easy ways
@@ -79,7 +79,7 @@ class TrustedMetadataSet(abc.Mapping):
     """
 
     def __init__(self, root_data: bytes):
-        """Initialize ``TrustedMetadataSet`` by loading trusted root metadata
+        """Initialize ``TrustedMetadataSet`` by loading trusted root metadata.
 
         Args:
             root_data: Trusted root metadata as bytes. Note that this metadata
@@ -99,36 +99,36 @@ class TrustedMetadataSet(abc.Mapping):
         self._load_trusted_root(root_data)
 
     def __getitem__(self, role: str) -> Metadata:
-        """Return current ``Metadata`` for ``role``"""
+        """Return current ``Metadata`` for ``role``."""
         return self._trusted_set[role]
 
     def __len__(self) -> int:
-        """Return number of ``Metadata`` objects in ``TrustedMetadataSet``"""
+        """Return number of ``Metadata`` objects in ``TrustedMetadataSet``."""
         return len(self._trusted_set)
 
     def __iter__(self) -> Iterator[Metadata]:
-        """Return iterator over ``Metadata`` objects in ``TrustedMetadataSet``"""
+        """Return iterator over ``Metadata`` objects in ``TrustedMetadataSet``."""
         return iter(self._trusted_set.values())
 
     # Helper properties for top level metadata
     @property
     def root(self) -> Metadata[Root]:
-        """Get current root ``Metadata``"""
+        """Get current root ``Metadata``."""
         return self._trusted_set[Root.type]
 
     @property
     def timestamp(self) -> Metadata[Timestamp]:
-        """Get current timestamp ``Metadata``"""
+        """Get current timestamp ``Metadata``."""
         return self._trusted_set[Timestamp.type]
 
     @property
     def snapshot(self) -> Metadata[Snapshot]:
-        """Get current snapshot ``Metadata``"""
+        """Get current snapshot ``Metadata``."""
         return self._trusted_set[Snapshot.type]
 
     @property
     def targets(self) -> Metadata[Targets]:
-        """Get current top-level targets ``Metadata``"""
+        """Get current top-level targets ``Metadata``."""
         return self._trusted_set[Targets.type]
 
     # Methods for updating metadata
@@ -251,7 +251,7 @@ class TrustedMetadataSet(abc.Mapping):
         return new_timestamp
 
     def _check_final_timestamp(self) -> None:
-        """Raise if timestamp is expired"""
+        """Raise if timestamp is expired."""
 
         if self.timestamp.signed.is_expired(self.reference_time):
             raise exceptions.ExpiredMetadataError("timestamp.json is expired")
@@ -345,7 +345,7 @@ class TrustedMetadataSet(abc.Mapping):
         return new_snapshot
 
     def _check_final_snapshot(self) -> None:
-        """Raise if snapshot is expired or meta version does not match"""
+        """Raise if snapshot is expired or meta version does not match."""
 
         if self.snapshot.signed.is_expired(self.reference_time):
             raise exceptions.ExpiredMetadataError("snapshot.json is expired")

--- a/tuf/ngclient/config.py
+++ b/tuf/ngclient/config.py
@@ -1,7 +1,7 @@
 # Copyright 2021, New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""Configuration options for ``Updater`` class
+"""Configuration options for ``Updater`` class.
 """
 
 from dataclasses import dataclass

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -1,7 +1,7 @@
 # Copyright 2020, New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""Client update workflow implementation
+"""Client update workflow implementation.
 
 The ``Updater`` class provides an implementation of the
 `TUF client workflow
@@ -177,7 +177,7 @@ class Updater:
         targetinfo: TargetFile,
         filepath: Optional[str] = None,
     ) -> Optional[str]:
-        """Check whether a local file is an up to date target
+        """Check whether a local file is an up to date target.
 
         Args:
             targetinfo: ``TargetFile`` from ``get_targetinfo()``.
@@ -266,7 +266,7 @@ class Updater:
     def _download_metadata(
         self, rolename: str, length: int, version: Optional[int] = None
     ) -> bytes:
-        """Download a metadata file and return it as bytes"""
+        """Download a metadata file and return it as bytes."""
         encoded_name = parse.quote(rolename, "")
         if version is None:
             url = f"{self._metadata_base_url}{encoded_name}.json"
@@ -330,7 +330,7 @@ class Updater:
                 break
 
     def _load_timestamp(self) -> None:
-        """Load local and remote timestamp metadata"""
+        """Load local and remote timestamp metadata."""
         try:
             data = self._load_local_metadata(Timestamp.type)
             self._trusted_set.update_timestamp(data)
@@ -352,7 +352,7 @@ class Updater:
         self._persist_metadata(Timestamp.type, data)
 
     def _load_snapshot(self) -> None:
-        """Load local (and if needed remote) snapshot metadata"""
+        """Load local (and if needed remote) snapshot metadata."""
         try:
             data = self._load_local_metadata(Snapshot.type)
             self._trusted_set.update_snapshot(data, trusted=True)
@@ -483,5 +483,5 @@ class Updater:
 
 
 def _ensure_trailing_slash(url: str) -> str:
-    """Return url guaranteed to end in a slash"""
+    """Return url guaranteed to end in a slash."""
     return url if url.endswith("/") else f"{url}/"


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Make sure the codebase is more compliant with Python's docstring convention. There are more D400 warnings by pydocstyle left. To make this change easier to review, it tries to introduce more straightforward changes to the codebase.

Rebased #2231