### PR TITLE
POC: Use securesystemslib base+json de/serializer and mixin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 dependencies = [
   "requests>=2.19.1",
-  "securesystemslib>=0.26.0",
+  "securesystemslib @ git+https://github.com/PradyumnaKrishna/securesystemslib@4c6be46"
 ]
 dynamic = ["version"]
 
@@ -56,6 +56,9 @@ Source = "https://github.com/theupdateframework/python-tuf"
 
 [tool.hatch.version]
 path = "tuf/__init__.py"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/requirements-pinned.txt
+++ b/requirements-pinned.txt
@@ -6,5 +6,5 @@ idna==3.4                 # via requests
 pycparser==2.21           # via cffi
 pynacl==1.5.0             # via securesystemslib
 requests==2.28.1
-securesystemslib[crypto,pynacl]==0.26.0
+git+https://github.com/PradyumnaKrishna/securesystemslib@4c6be46
 urllib3==1.26.14           # via requests

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -53,6 +53,7 @@ from typing import (
 
 from securesystemslib import exceptions as sslib_exceptions
 from securesystemslib import hash as sslib_hash
+from securesystemslib.serialization import JSONSerializable
 from securesystemslib.signer import Key, Signature, Signer
 from securesystemslib.storage import FilesystemBackend, StorageBackendInterface
 from securesystemslib.util import persist_temp_file
@@ -82,7 +83,7 @@ TOP_LEVEL_ROLE_NAMES = {_ROOT, _TIMESTAMP, _SNAPSHOT, _TARGETS}
 T = TypeVar("T", "Root", "Timestamp", "Snapshot", "Targets")
 
 
-class Metadata(Generic[T]):
+class Metadata(Generic[T], JSONSerializable):
     """A container for signed TUF metadata.
 
     Provides methods to convert to and from dictionary, read and write to and

--- a/tuf/api/serialization/__init__.py
+++ b/tuf/api/serialization/__init__.py
@@ -15,13 +15,15 @@ API objects.
 """
 
 import abc
-from typing import TYPE_CHECKING
+from typing import TypeAlias
+
+from securesystemslib.serialization import BaseDeserializer, BaseSerializer
 
 from tuf.api.exceptions import RepositoryError
 
-if TYPE_CHECKING:
-    # pylint: disable=cyclic-import
-    from tuf.api.metadata import Metadata, Signed
+MetadataSerializer: TypeAlias = BaseSerializer
+MetadataDeserializer: TypeAlias = BaseDeserializer
+SignedSerializer: TypeAlias = BaseSerializer
 
 
 class SerializationError(RepositoryError):
@@ -30,30 +32,3 @@ class SerializationError(RepositoryError):
 
 class DeserializationError(RepositoryError):
     """Error during deserialization."""
-
-
-class MetadataDeserializer(metaclass=abc.ABCMeta):
-    """Abstract base class for deserialization of Metadata objects."""
-
-    @abc.abstractmethod
-    def deserialize(self, raw_data: bytes) -> "Metadata":
-        """Deserialize bytes to Metadata object."""
-        raise NotImplementedError
-
-
-class MetadataSerializer(metaclass=abc.ABCMeta):
-    """Abstract base class for serialization of Metadata objects."""
-
-    @abc.abstractmethod
-    def serialize(self, metadata_obj: "Metadata") -> bytes:
-        """Serialize Metadata object to bytes."""
-        raise NotImplementedError
-
-
-class SignedSerializer(metaclass=abc.ABCMeta):
-    """Abstract base class for serialization of Signed objects."""
-
-    @abc.abstractmethod
-    def serialize(self, signed_obj: "Signed") -> bytes:
-        """Serialize Signed object to bytes."""
-        raise NotImplementedError

--- a/tuf/api/serialization/json.py
+++ b/tuf/api/serialization/json.py
@@ -7,11 +7,13 @@ format for transportation, and to serialize the 'signed' part of TUF role
 metadata to the OLPC Canonical JSON format for signature generation and
 verification.
 """
-
-import json
 from typing import Optional
 
 from securesystemslib.formats import encode_canonical
+from securesystemslib.serialization import (
+    JSONDeserializer as BaseJSONDeserializer,
+)
+from securesystemslib.serialization import JSONSerializer as BaseJSONSerializer
 
 # pylint: disable=cyclic-import
 # ... to allow de/serializing Metadata and Signed objects here, while also
@@ -20,20 +22,19 @@ from securesystemslib.formats import encode_canonical
 from tuf.api.metadata import Metadata, Signed
 from tuf.api.serialization import (
     DeserializationError,
-    MetadataDeserializer,
-    MetadataSerializer,
     SerializationError,
     SignedSerializer,
 )
 
 
-class JSONDeserializer(MetadataDeserializer):
+class JSONDeserializer(BaseJSONDeserializer):
     """Provides JSON to Metadata deserialize method."""
 
     def deserialize(self, raw_data: bytes) -> Metadata:
         """Deserialize utf-8 encoded JSON bytes into Metadata object."""
+
         try:
-            json_dict = json.loads(raw_data.decode("utf-8"))
+            json_dict = super().deserialize(raw_data)
             metadata_obj = Metadata.from_dict(json_dict)
 
         except Exception as e:
@@ -42,7 +43,7 @@ class JSONDeserializer(MetadataDeserializer):
         return metadata_obj
 
 
-class JSONSerializer(MetadataSerializer):
+class JSONSerializer(BaseJSONSerializer):
     """Provides Metadata to JSON serialize method.
 
     Args:
@@ -55,26 +56,19 @@ class JSONSerializer(MetadataSerializer):
     """
 
     def __init__(self, compact: bool = False, validate: Optional[bool] = False):
-        self.compact = compact
+        super().__init__(compact)
         self.validate = validate
 
-    def serialize(self, metadata_obj: Metadata) -> bytes:
+    def serialize(self, obj: Metadata) -> bytes:
         """Serialize Metadata object into utf-8 encoded JSON bytes."""
 
         try:
-            indent = None if self.compact else 1
-            separators = (",", ":") if self.compact else (",", ": ")
-            json_bytes = json.dumps(
-                metadata_obj.to_dict(),
-                indent=indent,
-                separators=separators,
-                sort_keys=True,
-            ).encode("utf-8")
+            json_bytes = BaseJSONSerializer.serialize(self, obj)
 
             if self.validate:
                 try:
                     new_md_obj = JSONDeserializer().deserialize(json_bytes)
-                    if metadata_obj != new_md_obj:
+                    if obj != new_md_obj:
                         raise ValueError(
                             "Metadata changes if you serialize and deserialize."
                         )
@@ -90,12 +84,12 @@ class JSONSerializer(MetadataSerializer):
 class CanonicalJSONSerializer(SignedSerializer):
     """Provides Signed to OLPC Canonical JSON serialize method."""
 
-    def serialize(self, signed_obj: Signed) -> bytes:
+    def serialize(self, obj: Signed) -> bytes:
         """Serialize Signed object into utf-8 encoded OLPC Canonical JSON
         bytes.
         """
         try:
-            signed_dict = signed_obj.to_dict()
+            signed_dict = obj.to_dict()
             canonical_bytes = encode_canonical(signed_dict).encode("utf-8")
 
         except Exception as e:


### PR DESCRIPTION
This PR is meant as a help for python-tuf maintainers to review the serialization-specific parts of https://github.com/secure-systems-lab/securesystemslib/pull/487, which are more tailored towards in-toto and DSSE.

Please see commit message for details.