### PR TITLE
repository: Make snapshot/timetamp helpers non-abstract

### DIFF
--- a/tuf/repository/_repository.py
+++ b/tuf/repository/_repository.py
@@ -54,11 +54,11 @@ class Repository(ABC):
         raise NotImplementedError
 
     @property
-    @abstractmethod
     def targets_infos(self) -> Dict[str, MetaFile]:
         """Returns the MetaFiles for current targets metadatas
 
-        This property is used by snapshot() to update Snapshot.meta.
+        This property is used by snapshot() to update Snapshot.meta: Repository
+        implementations should override this property to enable snapshot().
 
         Note that there is a difference between this return value and
         Snapshot.meta: This dictionary reflects the targets metadata that
@@ -68,11 +68,12 @@ class Repository(ABC):
         raise NotImplementedError
 
     @property
-    @abstractmethod
     def snapshot_info(self) -> MetaFile:
         """Returns the MetaFile for current snapshot metadata
 
-        This property is used by timestamp() to update Timestamp.meta.
+        This property is used by timestamp() to update Timestamp.meta:
+        Repository implementations should override this property to enable
+        timestamp().
         """
         raise NotImplementedError
 


### PR DESCRIPTION
targets_infos() and snapshot_info() are helpers used by snapshot and timestamp. Some Repository implementations do not need snapshot/timestamp (think e.g. a signing tool that never modifies online roles), so the helpers should not be required.

Fixes #2308

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


