### PR TITLE
Repository annotations

### DIFF
--- a/examples/repository/_simplerepo.py
+++ b/examples/repository/_simplerepo.py
@@ -176,15 +176,10 @@ class SimpleRepository(Repository):
                 if not targetpath.startswith(f"{role}/"):
                     raise ValueError(f"targets allowed under {role}/ only")
 
-            targets_md = self.role_cache["targets"][-1]
+            targets_md = self.open("targets")
             targets_md.verify_delegate(role, md)
-            if role in self.role_cache:
-                current_md = self.role_cache[role][-1]
-                current_ver = current_md.signed.version
-            else:
-                current_ver = 0
 
-            if md.signed.version != current_ver + 1:
+            if md.signed.version != self.targets(role).version + 1:
                 raise ValueError("Invalid version {md.signed.version}")
 
         except (RepositoryError, ValueError) as e:

--- a/examples/repository/_simplerepo.py
+++ b/examples/repository/_simplerepo.py
@@ -127,7 +127,7 @@ class SimpleRepository(Repository):
         self.target_cache[path] = data
 
         # add a target in the targets metadata
-        with self.edit_targets("targets") as targets:
+        with self.edit_targets() as targets:
             targets.targets[path] = TargetFile.from_data(path, data)
 
         logger.debug("Targets v%d", targets.version)
@@ -145,7 +145,7 @@ class SimpleRepository(Repository):
 
             # add delegation and key
             role = DelegatedRole(rolename, [], 1, True, [f"{rolename}/*"])
-            with self.edit("targets") as targets:
+            with self.edit_targets() as targets:
                 if targets.delegations is None:
                     targets.delegations = Delegations({}, {})
 

--- a/examples/repository/_simplerepo.py
+++ b/examples/repository/_simplerepo.py
@@ -133,8 +133,8 @@ class SimpleRepository(Repository):
         logger.debug("Targets v%d", targets.version)
 
         # update snapshot, timestamp
-        self.snapshot()
-        self.timestamp()
+        self.do_snapshot()
+        self.do_timestamp()
 
     def submit_delegation(self, rolename: str, data: bytes) -> bool:
         """Add a delegation to a (offline signed) delegated targets metadata"""
@@ -159,8 +159,8 @@ class SimpleRepository(Repository):
         logger.debug("Targets v%d", targets.version)
 
         # update snapshot, timestamp
-        self.snapshot()
-        self.timestamp()
+        self.do_snapshot()
+        self.do_timestamp()
 
         return True
 
@@ -201,7 +201,7 @@ class SimpleRepository(Repository):
             self.target_cache[targetpath] = bytes(f"{targetpath}", "utf-8")
 
         # update snapshot, timestamp
-        self.snapshot()
-        self.timestamp()
+        self.do_snapshot()
+        self.do_timestamp()
 
         return True

--- a/examples/repository/_simplerepo.py
+++ b/examples/repository/_simplerepo.py
@@ -71,7 +71,7 @@ class SimpleRepository(Repository):
         )
 
         # setup a basic repository, generate signing key per top-level role
-        with self.edit("root") as root:
+        with self.edit_root() as root:
             for role in ["root", "timestamp", "snapshot", "targets"]:
                 key = keys.generate_ed25519_key()
                 self.signer_cache[role].append(SSlibSigner(key))
@@ -127,7 +127,7 @@ class SimpleRepository(Repository):
         self.target_cache[path] = data
 
         # add a target in the targets metadata
-        with self.edit("targets") as targets:
+        with self.edit_targets("targets") as targets:
             targets.targets[path] = TargetFile.from_data(path, data)
 
         logger.debug("Targets v%d", targets.version)

--- a/examples/repository/_simplerepo.py
+++ b/examples/repository/_simplerepo.py
@@ -148,7 +148,8 @@ class SimpleRepository(Repository):
             with self.edit_targets() as targets:
                 if targets.delegations is None:
                     targets.delegations = Delegations({}, {})
-
+                if targets.delegations.roles is None:
+                    targets.delegations.roles = {}
                 targets.delegations.roles[rolename] = role
                 targets.add_key(key, rolename)
 

--- a/examples/uploader/_localrepo.py
+++ b/examples/uploader/_localrepo.py
@@ -102,7 +102,7 @@ class LocalRepository(Repository):
         data = bytes(targetpath, "utf-8")
         targetfile = TargetFile.from_data(targetpath, data)
         try:
-            with self.edit(role) as delegated:
+            with self.edit_targets(role) as delegated:
                 delegated.targets[targetpath] = targetfile
 
         except Exception as e:  # pylint: disable=broad-except

--- a/tuf/repository/_repository.py
+++ b/tuf/repository/_repository.py
@@ -107,7 +107,7 @@ class Repository(ABC):
         """Context manager for editing root metadata. See edit()"""
         with self.edit(Root.type) as root:
             if not isinstance(root, Root):
-                raise RuntimeError("Unexpected Root type")
+                raise RuntimeError("Unexpected root type")
             yield root
 
     @contextmanager
@@ -115,7 +115,7 @@ class Repository(ABC):
         """Context manager for editing timestamp metadata. See edit()"""
         with self.edit(Timestamp.type) as timestamp:
             if not isinstance(timestamp, Timestamp):
-                raise RuntimeError("Unexpected Timestamp type")
+                raise RuntimeError("Unexpected timestamp type")
             yield timestamp
 
     @contextmanager
@@ -123,7 +123,7 @@ class Repository(ABC):
         """Context manager for editing snapshot metadata. See edit()"""
         with self.edit(Snapshot.type) as snapshot:
             if not isinstance(snapshot, Snapshot):
-                raise RuntimeError("Unexpected Snapshot type")
+                raise RuntimeError("Unexpected snapshot type")
             yield snapshot
 
     @contextmanager
@@ -131,8 +131,36 @@ class Repository(ABC):
         """Context manager for editing targets metadata. See edit()"""
         with self.edit(rolename) as targets:
             if not isinstance(targets, Targets):
-                raise RuntimeError(f"Unexpected Targets ({rolename}) type")
+                raise RuntimeError(f"Unexpected targets ({rolename}) type")
             yield targets
+
+    def root(self) -> Root:
+        """Read current root metadata"""
+        root = self.open(Root.type).signed
+        if not isinstance(root, Root):
+            raise RuntimeError("Unexpected root type")
+        return root
+
+    def timestamp(self) -> Timestamp:
+        """Read current timestamp metadata"""
+        timestamp = self.open(Timestamp.type).signed
+        if not isinstance(timestamp, Timestamp):
+            raise RuntimeError("Unexpected timestamp type")
+        return timestamp
+
+    def snapshot(self) -> Snapshot:
+        """Read current snapshot metadata"""
+        snapshot = self.open(Snapshot.type).signed
+        if not isinstance(snapshot, Snapshot):
+            raise RuntimeError("Unexpected snapshot type")
+        return snapshot
+
+    def targets(self, rolename: str) -> Targets:
+        """Read current targets metadata"""
+        targets = self.open(rolename).signed
+        if not isinstance(targets, Targets):
+            raise RuntimeError("Unexpected targets type")
+        return targets
 
     def do_snapshot(
         self, force: bool = False

--- a/tuf/repository/_repository.py
+++ b/tuf/repository/_repository.py
@@ -9,7 +9,15 @@ from contextlib import contextmanager, suppress
 from copy import deepcopy
 from typing import Dict, Generator, Optional, Tuple
 
-from tuf.api.metadata import Metadata, MetaFile, Signed
+from tuf.api.metadata import (
+    Metadata,
+    MetaFile,
+    Root,
+    Signed,
+    Snapshot,
+    Targets,
+    Timestamp,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +101,38 @@ class Repository(ABC):
         with suppress(AbortEdit):
             yield md.signed
             self.close(role, md)
+
+    @contextmanager
+    def edit_root(self) -> Generator[Root, None, None]:
+        """Context manager for editing root metadata. See edit()"""
+        with self.edit(Root.type) as root:
+            if not isinstance(root, Root):
+                raise RuntimeError("Unexpected Root type")
+            yield root
+
+    @contextmanager
+    def edit_timestamp(self) -> Generator[Timestamp, None, None]:
+        """Context manager for editing timestamp metadata. See edit()"""
+        with self.edit(Timestamp.type) as timestamp:
+            if not isinstance(timestamp, Timestamp):
+                raise RuntimeError("Unexpected Timestamp type")
+            yield timestamp
+
+    @contextmanager
+    def edit_snapshot(self) -> Generator[Snapshot, None, None]:
+        """Context manager for editing snapshot metadata. See edit()"""
+        with self.edit(Snapshot.type) as snapshot:
+            if not isinstance(snapshot, Snapshot):
+                raise RuntimeError("Unexpected Snapshot type")
+            yield snapshot
+
+    @contextmanager
+    def edit_targets(self, rolename: str) -> Generator[Targets, None, None]:
+        """Context manager for editing targets metadata. See edit()"""
+        with self.edit(rolename) as targets:
+            if not isinstance(targets, Targets):
+                raise RuntimeError(f"Unexpected Targets ({rolename}) type")
+            yield targets
 
     def snapshot(self, force: bool = False) -> Tuple[bool, Dict[str, MetaFile]]:
         """Update snapshot meta information

--- a/tuf/repository/_repository.py
+++ b/tuf/repository/_repository.py
@@ -134,7 +134,9 @@ class Repository(ABC):
                 raise RuntimeError(f"Unexpected Targets ({rolename}) type")
             yield targets
 
-    def snapshot(self, force: bool = False) -> Tuple[bool, Dict[str, MetaFile]]:
+    def do_snapshot(
+        self, force: bool = False
+    ) -> Tuple[bool, Dict[str, MetaFile]]:
         """Update snapshot meta information
 
         Updates the snapshot meta information according to current targets
@@ -182,7 +184,9 @@ class Repository(ABC):
 
         return update_version, removed
 
-    def timestamp(self, force: bool = False) -> Tuple[bool, Optional[MetaFile]]:
+    def do_timestamp(
+        self, force: bool = False
+    ) -> Tuple[bool, Optional[MetaFile]]:
         """Update timestamp meta information
 
         Updates timestamp according to current snapshot state

--- a/tuf/repository/_repository.py
+++ b/tuf/repository/_repository.py
@@ -127,7 +127,9 @@ class Repository(ABC):
             yield snapshot
 
     @contextmanager
-    def edit_targets(self, rolename: str) -> Generator[Targets, None, None]:
+    def edit_targets(
+        self, rolename: str = Targets.type
+    ) -> Generator[Targets, None, None]:
         """Context manager for editing targets metadata. See edit()"""
         with self.edit(rolename) as targets:
             if not isinstance(targets, Targets):
@@ -155,7 +157,7 @@ class Repository(ABC):
             raise RuntimeError("Unexpected snapshot type")
         return snapshot
 
-    def targets(self, rolename: str) -> Targets:
+    def targets(self, rolename: str = Targets.type) -> Targets:
         """Read current targets metadata"""
         targets = self.open(rolename).signed
         if not isinstance(targets, Targets):


### PR DESCRIPTION
Extend Repository API with
1. Read-only accessors for correctly typed Signed objects: 
   ```python
   root() -> Root
   timestamp() -> Timestamp
   snapshot() -> Snapshot
   targets(role: Optional[str]) -> Targets
   ```
1. typed versions of the edit() context manager:
   ```python
   edit_root()
   edit_timestamp()
   edit_snapshot()
   edit_targets(role: Optional[str])
   ```
This requires renaming old `timestamp()/snapshot()` to `do_timestamp()` and `do_snapshot()`.

The advantages are:
* less magic strings ("targets", "root") in application code
* more annotation coverage in application (and python-tuf) code
* mostly more readable code

Fixes #2311

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature
