### PR TITLE
Add TargetFile.get_prefixed_paths()

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -731,6 +731,36 @@ class TestMetadata(unittest.TestCase):
         )
         self.assertEqual(sorted(target.get_prefixed_paths()), ["public/path/abc.file.ext", "public/path/def.file.ext"])
 
+        target = TargetFile(
+            100, {"sha256": "abc", "md5": "def"}, ""
+        )
+        self.assertEqual(sorted(target.get_prefixed_paths()), [])
+
+        target = TargetFile(
+            100, {"sha256": "abc", "md5": "def"}, "public/path/"
+        )
+        self.assertEqual(sorted(target.get_prefixed_paths()), [])
+
+        target = TargetFile(
+            100, {"sha256": "abc", "md5": "def"}, "file.ext"
+        )
+        self.assertEqual(sorted(target.get_prefixed_paths()), ["abc.file.ext", "def.file.ext"])
+
+        target = TargetFile(
+            100, {"sha256": "abc", "md5": "def"}, "public/path/.ext"
+        )
+        self.assertEqual(sorted(target.get_prefixed_paths()), ["public/path/abc..ext", "public/path/def..ext"])
+
+        target = TargetFile(
+            100, {"sha256": "abc"}, "/root/file.ext"
+        )
+        self.assertEqual(sorted(target.get_prefixed_paths()), ["/root/abc.file.ext"])
+
+        target = TargetFile(
+            100, {"sha256": "abc"}, "/"
+        )
+        self.assertEqual(sorted(target.get_prefixed_paths()), [])
+
     def test_is_delegated_role(self) -> None:
         # test path matches
         # see more extensive tests in test_is_target_in_pathpattern()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -725,41 +725,33 @@ class TestMetadata(unittest.TestCase):
         targetfile_from_data = TargetFile.from_data(target_file_path, data)
         targetfile_from_data.verify_length_and_hashes(data)
 
-    def test_targetfile_hash_prefix_paths(self) -> None:
-        target = TargetFile(
-            100, {"sha256": "abc", "md5": "def"}, "public/path/file.ext"
+    def test_targetfile_get_prefixed_paths(self) -> None:
+        target = TargetFile(100, {"sha256": "abc", "md5": "def"}, "a/b/f.ext")
+        self.assertEqual(
+            target.get_prefixed_paths(), ["a/b/abc.f.ext", "a/b/def.f.ext"]
         )
-        self.assertEqual(sorted(target.get_prefixed_paths()), ["public/path/abc.file.ext", "public/path/def.file.ext"])
 
-        target = TargetFile(
-            100, {"sha256": "abc", "md5": "def"}, ""
-        )
-        self.assertEqual(sorted(target.get_prefixed_paths()), [])
+        target = TargetFile(100, {"sha256": "abc", "md5": "def"}, "")
+        self.assertEqual(target.get_prefixed_paths(), ["abc.", "def."])
 
-        target = TargetFile(
-            100, {"sha256": "abc", "md5": "def"}, "public/path/"
-        )
-        self.assertEqual(sorted(target.get_prefixed_paths()), [])
+        target = TargetFile(100, {"sha256": "abc", "md5": "def"}, "a/b/")
+        self.assertEqual(target.get_prefixed_paths(), ["a/b/abc.", "a/b/def."])
 
-        target = TargetFile(
-            100, {"sha256": "abc", "md5": "def"}, "file.ext"
+        target = TargetFile(100, {"sha256": "abc", "md5": "def"}, "f.ext")
+        self.assertEqual(
+            target.get_prefixed_paths(), ["abc.f.ext", "def.f.ext"]
         )
-        self.assertEqual(sorted(target.get_prefixed_paths()), ["abc.file.ext", "def.file.ext"])
 
-        target = TargetFile(
-            100, {"sha256": "abc", "md5": "def"}, "public/path/.ext"
+        target = TargetFile(100, {"sha256": "abc", "md5": "def"}, "a/b/.ext")
+        self.assertEqual(
+            target.get_prefixed_paths(), ["a/b/abc..ext", "a/b/def..ext"]
         )
-        self.assertEqual(sorted(target.get_prefixed_paths()), ["public/path/abc..ext", "public/path/def..ext"])
 
-        target = TargetFile(
-            100, {"sha256": "abc"}, "/root/file.ext"
-        )
-        self.assertEqual(sorted(target.get_prefixed_paths()), ["/root/abc.file.ext"])
+        target = TargetFile(100, {"sha256": "abc"}, "/root/file.ext")
+        self.assertEqual(target.get_prefixed_paths(), ["/root/abc.file.ext"])
 
-        target = TargetFile(
-            100, {"sha256": "abc"}, "/"
-        )
-        self.assertEqual(sorted(target.get_prefixed_paths()), [])
+        target = TargetFile(100, {"sha256": "abc"}, "/")
+        self.assertEqual(target.get_prefixed_paths(), ["/abc."])
 
     def test_is_delegated_role(self) -> None:
         # test path matches

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -725,6 +725,12 @@ class TestMetadata(unittest.TestCase):
         targetfile_from_data = TargetFile.from_data(target_file_path, data)
         targetfile_from_data.verify_length_and_hashes(data)
 
+    def test_targetfile_hash_prefix_paths(self) -> None:
+        target = TargetFile(
+            100, {"sha256": "abc", "md5": "def"}, "public/path/file.ext"
+        )
+        self.assertEqual(sorted(target.get_prefixed_paths()), ["public/path/abc.file.ext", "public/path/def.file.ext"])
+
     def test_is_delegated_role(self) -> None:
         # test path matches
         # see more extensive tests in test_is_target_in_pathpattern()

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1739,6 +1739,9 @@ class TargetFile(BaseFile):
         self._verify_hashes(data, self.hashes)
 
     def get_prefixed_paths(self) -> List[str]:
+        """
+        Returns hash-prefixed paths for the given target file path.
+        """
         paths = []
         path = pathlib.Path(self.path)
         name, parent = path.name, path.parent

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -1740,13 +1740,28 @@ class TargetFile(BaseFile):
 
     def get_prefixed_paths(self) -> List[str]:
         """
-        Returns hash-prefixed paths for the given target file path.
+        Returns hash-prefixed paths for the given target file path. Empty result in the case of an invalid path.
+
+        Expects self.path to be a URL path fragment, not a filesystem path.
         """
         paths = []
-        path = pathlib.Path(self.path)
-        name, parent = path.name, path.parent
+        try:
+            if not self.path:
+                raise ValueError
+            elif "/" not in self.path:
+                parent, name = None, self.path
+            else:
+                parent, name = self.path.rsplit("/", 1)
+                if name == "": 
+                    raise ValueError
+        except ValueError:
+            return paths
+
         for hash in self.hashes.values():
-            paths.append(str(parent.joinpath(f"{hash}.{name}")))
+            path = f"{hash}.{name}"
+            if parent is not None:
+                path = f"{parent}/{path}"
+            paths.append(path)
         return paths
 
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -33,6 +33,7 @@ import fnmatch
 import io
 import logging
 import tempfile
+import pathlib
 from datetime import datetime
 from typing import (
     IO,
@@ -1736,6 +1737,14 @@ class TargetFile(BaseFile):
         """
         self._verify_length(data, self.length)
         self._verify_hashes(data, self.hashes)
+
+    def get_prefixed_paths(self) -> List[str]:
+        paths = []
+        path = pathlib.Path(self.path)
+        name, parent = path.name, path.parent
+        for hash in self.hashes.values():
+            paths.append(str(parent.joinpath(f"{hash}.{name}")))
+        return paths
 
 
 class Targets(Signed):

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -33,7 +33,6 @@ import fnmatch
 import io
 import logging
 import tempfile
-import pathlib
 from datetime import datetime
 from typing import (
     IO,
@@ -1740,28 +1739,13 @@ class TargetFile(BaseFile):
 
     def get_prefixed_paths(self) -> List[str]:
         """
-        Returns hash-prefixed paths for the given target file path. Empty result in the case of an invalid path.
-
-        Expects self.path to be a URL path fragment, not a filesystem path.
+        Return hash-prefixed URL path fragments for the target file path.
         """
         paths = []
-        try:
-            if not self.path:
-                raise ValueError
-            elif "/" not in self.path:
-                parent, name = None, self.path
-            else:
-                parent, name = self.path.rsplit("/", 1)
-                if name == "": 
-                    raise ValueError
-        except ValueError:
-            return paths
+        parent, sep, name = self.path.rpartition("/")
+        for hash_value in self.hashes.values():
+            paths.append(f"{parent}{sep}{hash_value}.{name}")
 
-        for hash in self.hashes.values():
-            path = f"{hash}.{name}"
-            if parent is not None:
-                path = f"{parent}/{path}"
-            paths.append(path)
         return paths
 
 


### PR DESCRIPTION
Fixes #2166. 

This is the branch from #2180, with my improvements on top. It's a simple method but the edge cases are not obvious so it makes sense for python-tuf to handle this -- if applications do, then we end up with a many slightly different implementations.

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


