### PR TITLE
release: Use PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -92,6 +92,7 @@ jobs:
     environment: release
     permissions:
       contents: write # to modify GitHub releases
+      id-token: write # to authenticate as Trusted Publisher to pypi.org
     steps:
       - name: Fetch build artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
@@ -103,9 +104,6 @@ jobs:
         # Only attempt pypi upload in upstream repository
         if: github.repository == 'theupdateframework/python-tuf'
         uses: pypa/gh-action-pypi-publish@0bf742be3ebe032c25dd15117957dc15d0cfc38d
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Finalize GitHub release
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410


### PR DESCRIPTION
Instead of using the secret stored in environment secrets, allow the publish action to use the OIDC identity to authenticate to pypi.org. This repository/workflow/environment combo has been marked as a "Trusted Publisher" in pypi.org: this means PyPI should give the publish action a short lived token to use for publishing.

This enables #2370: but the secret should still be removed before closing the issue (maybe after one successful release with Trusted Publishing).
