### PR TITLE
Move verify_delegate() to Root/Targets

### DIFF
--- a/examples/repository/_simplerepo.py
+++ b/examples/repository/_simplerepo.py
@@ -177,8 +177,7 @@ class SimpleRepository(Repository):
                 if not targetpath.startswith(f"{role}/"):
                     raise ValueError(f"targets allowed under {role}/ only")
 
-            targets_md = self.open("targets")
-            targets_md.verify_delegate(role, md)
+            self.targets().verify_delegate(role, md)
 
             if md.signed.version != self.targets(role).version + 1:
                 raise ValueError("Invalid version {md.signed.version}")

--- a/examples/repository/_simplerepo.py
+++ b/examples/repository/_simplerepo.py
@@ -177,7 +177,7 @@ class SimpleRepository(Repository):
                 if not targetpath.startswith(f"{role}/"):
                     raise ValueError(f"targets allowed under {role}/ only")
 
-            self.targets().verify_delegate(role, md)
+            self.targets().verify_delegate(role, md.signed_bytes, md.signatures)
 
             if md.signed.version != self.targets(role).version + 1:
                 raise ValueError("Invalid version {md.signed.version}")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,7 +43,7 @@ from tuf.api.metadata import (
     Timestamp,
 )
 from tuf.api.serialization import DeserializationError, SerializationError
-from tuf.api.serialization.json import CanonicalJSONSerializer, JSONSerializer
+from tuf.api.serialization.json import JSONSerializer
 
 logger = logging.getLogger(__name__)
 
@@ -202,7 +202,7 @@ class TestMetadata(unittest.TestCase):
         # Load sample metadata (targets) and assert ...
         md_obj = Metadata.from_file(os.path.join(path, "targets.json"))
         sig = md_obj.signatures[targets_keyid]
-        data = CanonicalJSONSerializer().serialize(md_obj.signed)
+        data = md_obj.signed_bytes
 
         # ... it has a single existing signature,
         self.assertEqual(len(md_obj.signatures), 1)
@@ -257,7 +257,7 @@ class TestMetadata(unittest.TestCase):
         path = os.path.join(self.repo_dir, "metadata", "timestamp.json")
         md_obj = Metadata.from_file(path)
         sig = md_obj.signatures[timestamp_keyid]
-        data = CanonicalJSONSerializer().serialize(md_obj.signed)
+        data = md_obj.signed_bytes
 
         # Test failure on unknown scheme (securesystemslib
         # UnsupportedAlgorithmError)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -345,44 +345,83 @@ class TestMetadata(unittest.TestCase):
         with self.assertRaises(ValueError):
             role2.verify_delegate("role1", role1)
 
+    # pylint: disable=too-many-locals,too-many-statements
+    def test_signed_verify_delegate(self) -> None:
+        root_path = os.path.join(self.repo_dir, "metadata", "root.json")
+        root_md = Metadata[Root].from_file(root_path)
+        root = root_md.signed
+        snapshot_path = os.path.join(self.repo_dir, "metadata", "snapshot.json")
+        snapshot_md = Metadata[Snapshot].from_file(snapshot_path)
+        snapshot = snapshot_md.signed
+        targets_path = os.path.join(self.repo_dir, "metadata", "targets.json")
+        targets_md = Metadata[Targets].from_file(targets_path)
+        targets = targets_md.signed
+        role1_path = os.path.join(self.repo_dir, "metadata", "role1.json")
+        role1_md = Metadata[Targets].from_file(role1_path)
+        role1 = role1_md.signed
+        role2_path = os.path.join(self.repo_dir, "metadata", "role2.json")
+        role2_md = Metadata[Targets].from_file(role2_path)
+        role2 = role2_md.signed
+
+        # test the expected delegation tree
+        root.verify_delegate(Root.type, root_md)
+        root.verify_delegate(Snapshot.type, snapshot_md)
+        root.verify_delegate(Targets.type, targets_md)
+        targets.verify_delegate("role1", role1_md)
+        role1.verify_delegate("role2", role2_md)
+
+        # only root and targets can verify delegates
+        with self.assertRaises(AttributeError):
+            snapshot.verify_delegate(Snapshot.type, snapshot_md)
+        # verify fails for roles that are not delegated by delegator
+        with self.assertRaises(ValueError):
+            root.verify_delegate("role1", role1_md)
+        with self.assertRaises(ValueError):
+            targets.verify_delegate(Targets.type, targets_md)
+        # verify fails when delegator has no delegations
+        with self.assertRaises(ValueError):
+            role2.verify_delegate("role1", role1_md)
+
         # verify fails when delegate content is modified
-        expires = snapshot.signed.expires
-        snapshot.signed.expires = expires + timedelta(days=1)
+        expires = snapshot.expires
+        snapshot.expires = expires + timedelta(days=1)
         with self.assertRaises(exceptions.UnsignedMetadataError):
-            root.verify_delegate(Snapshot.type, snapshot)
-        snapshot.signed.expires = expires
+            root.verify_delegate(Snapshot.type, snapshot_md)
+        snapshot.expires = expires
 
         # verify fails if sslib verify fails with VerificationError
         # (in this case signature is malformed)
-        keyid = next(iter(root.signed.roles[Snapshot.type].keyids))
-        good_sig = snapshot.signatures[keyid].signature
-        snapshot.signatures[keyid].signature = "foo"
+        keyid = next(iter(root.roles[Snapshot.type].keyids))
+        good_sig = snapshot_md.signatures[keyid].signature
+        snapshot_md.signatures[keyid].signature = "foo"
         with self.assertRaises(exceptions.UnsignedMetadataError):
-            root.verify_delegate(Snapshot.type, snapshot)
-        snapshot.signatures[keyid].signature = good_sig
+            root.verify_delegate(Snapshot.type, snapshot_md)
+        snapshot_md.signatures[keyid].signature = good_sig
 
         # verify fails if roles keys do not sign the metadata
         with self.assertRaises(exceptions.UnsignedMetadataError):
-            root.verify_delegate(Timestamp.type, snapshot)
+            root.verify_delegate(Timestamp.type, snapshot_md)
 
         # Add a key to snapshot role, make sure the new sig fails to verify
-        ts_keyid = next(iter(root.signed.roles[Timestamp.type].keyids))
-        root.signed.add_key(root.signed.keys[ts_keyid], Snapshot.type)
-        snapshot.signatures[ts_keyid] = Signature(ts_keyid, "ff" * 64)
+        ts_keyid = next(iter(root.roles[Timestamp.type].keyids))
+        root.add_key(root.keys[ts_keyid], Snapshot.type)
+        snapshot_md.signatures[ts_keyid] = Signature(ts_keyid, "ff" * 64)
 
         # verify succeeds if threshold is reached even if some signatures
         # fail to verify
-        root.verify_delegate(Snapshot.type, snapshot)
+        root.verify_delegate(Snapshot.type, snapshot_md)
 
         # verify fails if threshold of signatures is not reached
-        root.signed.roles[Snapshot.type].threshold = 2
+        root.roles[Snapshot.type].threshold = 2
         with self.assertRaises(exceptions.UnsignedMetadataError):
-            root.verify_delegate(Snapshot.type, snapshot)
+            root.verify_delegate(Snapshot.type, snapshot_md)
 
         # verify succeeds when we correct the new signature and reach the
         # threshold of 2 keys
-        snapshot.sign(SSlibSigner(self.keystore[Timestamp.type]), append=True)
-        root.verify_delegate(Snapshot.type, snapshot)
+        snapshot_md.sign(
+            SSlibSigner(self.keystore[Timestamp.type]), append=True
+        )
+        root.verify_delegate(Snapshot.type, snapshot_md)
 
     def test_key_class(self) -> None:
         # Test if from_securesystemslib_key removes the private key from keyval

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -345,8 +345,8 @@ class TestMetadata(unittest.TestCase):
         with self.assertRaises(ValueError):
             role2.verify_delegate("role1", role1)
 
-    # pylint: disable=too-many-locals,too-many-statements
     def test_signed_verify_delegate(self) -> None:
+        # pylint: disable=too-many-locals,too-many-statements
         root_path = os.path.join(self.repo_dir, "metadata", "root.json")
         root_md = Metadata[Root].from_file(root_path)
         root = root_md.signed

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -150,6 +150,16 @@ class Metadata(Generic[T]):
             and self.unrecognized_fields == other.unrecognized_fields
         )
 
+    @property
+    def signed_bytes(self) -> bytes:
+        """Default canonical json byte representation of ``self.signed``."""
+
+        # Use local scope import to avoid circular import errors
+        # pylint: disable=import-outside-toplevel
+        from tuf.api.serialization.json import CanonicalJSONSerializer
+
+        return CanonicalJSONSerializer().serialize(self.signed)
+
     @classmethod
     def from_dict(cls, metadata: Dict[str, Any]) -> "Metadata[T]":
         """Create ``Metadata`` object from its json/dict representation.
@@ -366,13 +376,9 @@ class Metadata(Generic[T]):
         """
 
         if signed_serializer is None:
-            # Use local scope import to avoid circular import errors
-            # pylint: disable=import-outside-toplevel
-            from tuf.api.serialization.json import CanonicalJSONSerializer
-
-            signed_serializer = CanonicalJSONSerializer()
-
-        bytes_data = signed_serializer.serialize(self.signed)
+            bytes_data = self.signed_bytes
+        else:
+            bytes_data = signed_serializer.serialize(self.signed)
 
         try:
             signature = signer.sign(bytes_data)

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -395,7 +395,7 @@ class Metadata(Generic[T]):
         """Verify that ``delegated_metadata`` is signed with the required
         threshold of keys for ``delegated_role``.
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 3.1.0
            Please use ``Root.verify_delegate()`` or ``Targets.verify_delegate()``.
         """
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -656,7 +656,7 @@ class _DelegatorMixin(metaclass=abc.ABCMeta):
     def verify_delegate(
         self,
         delegated_role: str,
-        delegated_metadata: "Metadata",
+        delegated_metadata: Metadata,
         signed_serializer: Optional[SignedSerializer] = None,
     ) -> None:
         """Verify that ``delegated_metadata`` is signed with the required

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -634,7 +634,7 @@ class Role:
         }
 
 
-class _Delegator(metaclass=abc.ABCMeta):
+class _DelegatorMixin(metaclass=abc.ABCMeta):
     """Class that implements verify_delegate() for Root and Targets"""
 
     @abc.abstractmethod
@@ -710,7 +710,7 @@ class _Delegator(metaclass=abc.ABCMeta):
             )
 
 
-class Root(Signed, _Delegator):
+class Root(Signed, _DelegatorMixin):
     """A container for the signed part of root metadata.
 
     Parameters listed below are also instance attributes.
@@ -1784,7 +1784,7 @@ class TargetFile(BaseFile):
         return paths
 
 
-class Targets(Signed, _Delegator):
+class Targets(Signed, _DelegatorMixin):
     """A container for the signed part of targets metadata.
 
     Targets contains verifying information about target files and also

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -393,7 +393,7 @@ class Metadata(Generic[T]):
         signed_serializer: Optional[SignedSerializer] = None,
     ) -> None:
         """Verify that ``delegated_metadata`` is signed with the required
-        threshold of keys for the delegated role ``delegated_role``.
+        threshold of keys for ``delegated_role``.
 
         .. deprecated:: 2.2.0
            Please use ``Root.verify_delegate()`` or ``Targets.verify_delegate()``.
@@ -660,7 +660,7 @@ class _DelegatorMixin(metaclass=abc.ABCMeta):
         signed_serializer: Optional[SignedSerializer] = None,
     ) -> None:
         """Verify that ``delegated_metadata`` is signed with the required
-        threshold of keys for the delegated role ``delegated_role``.
+        threshold of keys for ``delegated_role``.
 
         Args:
             delegated_role: Name of the delegated role to verify
@@ -859,11 +859,7 @@ class Root(Signed, _DelegatorMixin):
 
         return self.roles[delegated_role]
 
-    def get_key(self, keyid: str) -> Key:
-        """Return the key object for the given keyid.
-
-        Raises ValueError if key is not found.
-        """
+    def get_key(self, keyid: str) -> Key:  # noqa: D102
         if keyid not in self.keys:
             raise ValueError(f"Key {keyid} not found")
 
@@ -1958,11 +1954,7 @@ class Targets(Signed, _DelegatorMixin):
 
         return role
 
-    def get_key(self, keyid: str) -> Key:
-        """Return the key object for the given keyid.
-
-        Raises ValueError if key is not found.
-        """
+    def get_key(self, keyid: str) -> Key:  # noqa: D102
         if self.delegations is None:
             raise ValueError("No delegations found")
         if keyid not in self.delegations.keys:

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -161,7 +161,9 @@ class TrustedMetadataSet(abc.Mapping):
             )
 
         # Verify that new root is signed by trusted root
-        self.root.signed.verify_delegate(Root.type, new_root)
+        self.root.signed.verify_delegate(
+            Root.type, new_root.signed_bytes, new_root.signatures
+        )
 
         if new_root.signed.version != self.root.signed.version + 1:
             raise exceptions.BadVersionNumberError(
@@ -170,7 +172,9 @@ class TrustedMetadataSet(abc.Mapping):
             )
 
         # Verify that new root is signed by itself
-        new_root.signed.verify_delegate(Root.type, new_root)
+        new_root.signed.verify_delegate(
+            Root.type, new_root.signed_bytes, new_root.signatures
+        )
 
         self._trusted_set[Root.type] = new_root
         logger.debug("Updated root v%d", new_root.signed.version)
@@ -215,7 +219,9 @@ class TrustedMetadataSet(abc.Mapping):
                 f"Expected 'timestamp', got '{new_timestamp.signed.type}'"
             )
 
-        self.root.signed.verify_delegate(Timestamp.type, new_timestamp)
+        self.root.signed.verify_delegate(
+            Timestamp.type, new_timestamp.signed_bytes, new_timestamp.signatures
+        )
 
         # If an existing trusted timestamp is updated,
         # check for a rollback attack
@@ -310,7 +316,9 @@ class TrustedMetadataSet(abc.Mapping):
                 f"Expected 'snapshot', got '{new_snapshot.signed.type}'"
             )
 
-        self.root.signed.verify_delegate(Snapshot.type, new_snapshot)
+        self.root.signed.verify_delegate(
+            Snapshot.type, new_snapshot.signed_bytes, new_snapshot.signatures
+        )
 
         # version not checked against meta version to allow old snapshot to be
         # used in rollback protection: it is checked when targets is updated
@@ -418,7 +426,9 @@ class TrustedMetadataSet(abc.Mapping):
                 f"Expected 'targets', got '{new_delegate.signed.type}'"
             )
 
-        delegator.signed.verify_delegate(role_name, new_delegate)
+        delegator.signed.verify_delegate(
+            role_name, new_delegate.signed_bytes, new_delegate.signatures
+        )
 
         version = new_delegate.signed.version
         if version != meta.version:
@@ -447,7 +457,9 @@ class TrustedMetadataSet(abc.Mapping):
                 f"Expected 'root', got '{new_root.signed.type}'"
             )
 
-        new_root.signed.verify_delegate(Root.type, new_root)
+        new_root.signed.verify_delegate(
+            Root.type, new_root.signed_bytes, new_root.signatures
+        )
 
         self._trusted_set[Root.type] = new_root
         logger.debug("Loaded trusted root v%d", new_root.signed.version)

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -161,7 +161,7 @@ class TrustedMetadataSet(abc.Mapping):
             )
 
         # Verify that new root is signed by trusted root
-        self.root.verify_delegate(Root.type, new_root)
+        self.root.signed.verify_delegate(Root.type, new_root)
 
         if new_root.signed.version != self.root.signed.version + 1:
             raise exceptions.BadVersionNumberError(
@@ -170,7 +170,7 @@ class TrustedMetadataSet(abc.Mapping):
             )
 
         # Verify that new root is signed by itself
-        new_root.verify_delegate(Root.type, new_root)
+        new_root.signed.verify_delegate(Root.type, new_root)
 
         self._trusted_set[Root.type] = new_root
         logger.debug("Updated root v%d", new_root.signed.version)
@@ -215,7 +215,7 @@ class TrustedMetadataSet(abc.Mapping):
                 f"Expected 'timestamp', got '{new_timestamp.signed.type}'"
             )
 
-        self.root.verify_delegate(Timestamp.type, new_timestamp)
+        self.root.signed.verify_delegate(Timestamp.type, new_timestamp)
 
         # If an existing trusted timestamp is updated,
         # check for a rollback attack
@@ -310,7 +310,7 @@ class TrustedMetadataSet(abc.Mapping):
                 f"Expected 'snapshot', got '{new_snapshot.signed.type}'"
             )
 
-        self.root.verify_delegate(Snapshot.type, new_snapshot)
+        self.root.signed.verify_delegate(Snapshot.type, new_snapshot)
 
         # version not checked against meta version to allow old snapshot to be
         # used in rollback protection: it is checked when targets is updated
@@ -418,7 +418,7 @@ class TrustedMetadataSet(abc.Mapping):
                 f"Expected 'targets', got '{new_delegate.signed.type}'"
             )
 
-        delegator.verify_delegate(role_name, new_delegate)
+        delegator.signed.verify_delegate(role_name, new_delegate)
 
         version = new_delegate.signed.version
         if version != meta.version:
@@ -447,7 +447,7 @@ class TrustedMetadataSet(abc.Mapping):
                 f"Expected 'root', got '{new_root.signed.type}'"
             )
 
-        new_root.verify_delegate(Root.type, new_root)
+        new_root.signed.verify_delegate(Root.type, new_root)
 
         self._trusted_set[Root.type] = new_root
         logger.debug("Loaded trusted root v%d", new_root.signed.version)


### PR DESCRIPTION
Fixes #2361 

**Description of the changes being introduced by the pull request**:

* Add an internal `_Delegator` class that implements verify_delegate()
* Inherit that class in Root, Targets: the internal class is just an implementation detail for sharing the implementation, not something users of the library should care about
* Document Metadata.verify_delegate() as deprecated (and use the new implementation internally)
* Use the new method in tests, examples and ngclient

This will make both ngclient and external repository code slightly easier to read and write (but note that the ngclient cleanups are not included here as they touch quite a lot of lines even if they are simple).

There are several ways to add verify_delegate() to Root and Targets, I think this helper class is a decent compromise between modularity and simplicity: 
* the _Delegator class isn't intended to be part of a longer "inheritance path" (and does not have a matching element in the metadata format): it just provides an extra method for Root and Targets. If there's a naming style for this style of inheritance I'm happy to use it
* _Delegator is internal: users of the library don't need to care about it

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


