### PR TITLE
github: Fix issue with draft releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,12 +66,9 @@ jobs:
             res = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: '${{ github.ref_name }}',
+              name: '${{ github.ref_name }}-rc',
               tag_name: '${{ github.ref }}',
-              draft: true,
-              body: 'See [CHANGELOG.md](https://github.com/' +
-                     context.repo.owner + '/' + context.repo.repo +
-                    '/blob/${{ github.ref_name }}/docs/CHANGELOG.md) for details.'
+              body: 'Release waiting for review...',
             });
 
             fs.readdirSync('dist/').forEach(file => {
@@ -113,5 +110,8 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: '${{ needs.candidate_release.outputs.release_id }}',
-              draft: false,
+              name: '${{ github.ref_name }}',
+              body: 'See [CHANGELOG.md](https://github.com/' +
+                     context.repo.owner + '/' + context.repo.repo +
+                    '/blob/${{ github.ref_name }}/docs/CHANGELOG.md) for details.'
             })


### PR DESCRIPTION
Commit 707dc49 included a change where the release candidate was marked as draft. This was a mistake as draft releases are only visible to logged in maintainers. This leads to e.g. `./verify_release` script failing while the release is a draft.

Revert those changes:
* don't use "draft" attribute
* postfix the release name with "-rc" while the release waits for approval
* Only set the real description and name after release approval

Fixes #2388
