### PR TITLE
PoC: TAP 19 - Add support for Content Addressable Systems like IPFS in TUF

### DIFF
--- a/tuf/adapter/adapter.py
+++ b/tuf/adapter/adapter.py
@@ -1,0 +1,91 @@
+# Copyright 2020, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+"""Implementation of content addressable targets"""
+import os
+import sys
+import inspect
+from abc import ABC, abstractmethod
+from typing import Optional
+import requests
+
+class Adapter(ABC):
+    """Abstract class for content addressable systems"""
+
+    @staticmethod
+    @abstractmethod
+    def scheme_name() -> str:
+        """Return the scheme of the URI.
+        
+        Used to find out the correct adapter of a target file.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def fetch_target(self, target_dir: str) -> str:
+        """Download the target file and return the target directory.
+        
+        Different adapters have different methods to fetch a file from its ecosystem.
+        """
+        raise NotImplementedError
+    
+    @abstractmethod
+    def find_target_in_local_cache(self, target_dir: str) -> str:
+        """Check whether the target file exists in the local cache.
+        
+        If found, return the location of the file.
+        """
+        raise NotImplementedError
+
+class IPFS(Adapter):
+    """Implements Adapter for IPFS targets"""
+
+    ipfs_gateway_url = 'http://127.0.0.1:8081/ipfs/'
+    scheme = 'ipfs'
+
+    def __init__(self, cid: str):
+        self.cid = cid
+
+    @staticmethod
+    def scheme_name() -> str:
+        return IPFS.scheme
+
+    def fetch_target(self, target_dir: str) -> str:
+        file_url = self.ipfs_gateway_url + self.cid
+        response = requests.get(file_url, timeout=5)
+        if response.status_code == 200:
+            filepath = self._generate_target_file_path(target_dir)
+            with open(filepath, 'wb') as file:
+                file.write(response.content)
+            
+            return filepath
+
+        print('Failed to retrieve file:', response.status_code)
+        return ''
+    
+    def find_target_in_local_cache(self, target_dir: str) -> Optional[str]:
+        filepath = self._generate_target_file_path(target_dir)
+        if os.path.exists(filepath):
+            return filepath
+        
+        return None
+    
+    def _generate_target_file_path(self, target_dir: str) -> str:
+        # TODO: Add the correct extension to the file name using Content-Type response header.
+        file_name = self.cid
+        return os.path.join(target_dir, file_name)
+
+def get_adapter_class(scheme: str) -> Adapter:
+    """Return the class of the provided scheme"""
+    classType = Adapter
+    subclasses = []
+    classes = inspect.getmembers(sys.modules[__name__], inspect.isclass)
+    for name, obj in classes:
+        if (obj is not classType) and (classType in inspect.getmro(obj)):
+            subclasses.append((obj, name))
+
+    for cls, name in subclasses:
+        if cls.scheme_name() == scheme:
+            return cls
+        
+    return None

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -62,6 +62,7 @@ from tuf.api.serialization import (
     MetadataSerializer,
     SignedSerializer,
 )
+from tuf.adapter import adapter
 
 _ROOT = "root"
 _SNAPSHOT = "snapshot"
@@ -1609,6 +1610,7 @@ class TargetFile(BaseFile):
             unrecognized_fields = {}
 
         self.unrecognized_fields = unrecognized_fields
+        self.adapter: Optional[adapter.Adapter] = None
 
     @property
     def custom(self) -> Any:


### PR DESCRIPTION
Fixes #2325 

**Description of the changes being introduced by the pull request**:
This PR is a part of [GSoC'23 Project](https://summerofcode.withgoogle.com/programs/2023/projects/vT5PhNL0). It introduces support for content addressable systems like IPFS in TUF. Detailed implementation document can be found [here](https://docs.google.com/document/d/1kFlzTUniBazcke1qCs6R84fu5RklwxKrT3tgtjfA16Q/edit?usp=sharing).

In order to test with an actual content addressable system, I have created a sample [repository](https://github.com/shubham4443/tuf-ipfs) which contains metadatas with an IPFS target. Simply run the following commands to download the target file.

```console
# initialize the client with Trust-On-First-Use
./client --url https://shubham4443.github.io/tuf-ipfs tofu

# Then download example file from the IPFS:
./client --url https://shubham4443.github.io/tuf-ipfs download ipfs:QmSFEbC6Y17cdti7damkjoqESWftkyfSXjdKDQqnf4ECV7
```
The PR is in draft status. `hashes` and `length` fields in `targets.json` are redundant in case of content addressable systems and needs to be removed.

cc: @adityasaky @Ericson2314 @mnm678

**Please verify and check that the pull request fulfills the following
requirements**:

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


