### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -37,7 +37,7 @@ jobs:
       # (sslib main) on Linux/Python3.x only.
       matrix:
         toxenv: [py]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - python-version: 3.x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "tuf"
 description = "A secure updater framework for Python"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
   { email = "theupdateframework@googlegroups.com" },
 ]
@@ -33,7 +33,6 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -26,7 +26,7 @@
 # 1. Use this script to create a pinned requirements file for each Python
 #    version
 # ```
-# for v in 3.7 3.8 3.9 3.10 3.11; do
+# for v in 3.8 3.9 3.10 3.11; do
 #   mkvirtualenv tuf-env-${v} -p python${v};
 #   python3 -m pip install pip-tools;
 #   pip-compile --no-header -o requirements-${v}.txt main.txt;

--- a/tests/test_metadata_eq_.py
+++ b/tests/test_metadata_eq_.py
@@ -113,8 +113,7 @@ class TestMetadataComparisions(unittest.TestCase):
         md.signatures = {"a": Signature("a", "a"), "b": Signature("b", "b")}
         md_2 = copy.deepcopy(md)
         # Reverse signatures order in md_2.
-        # In python3.7 we need to cast to a list and then reverse.
-        md_2.signatures = dict(reversed(list(md_2.signatures.items())))
+        md_2.signatures = dict(reversed(md_2.signatures.items()))
         # Assert that both objects are not the same because of signatures order.
         self.assertNotEqual(md, md_2)
 
@@ -168,9 +167,8 @@ class TestMetadataComparisions(unittest.TestCase):
 
         # Create a second delegations obj with reversed roles order
         delegations_2 = copy.deepcopy(delegations)
-        # In python3.7 we need to cast to a list and then reverse.
         assert isinstance(delegations.roles, dict)
-        delegations_2.roles = dict(reversed(list(delegations.roles.items())))
+        delegations_2.roles = dict(reversed(delegations.roles.items()))
 
         # Both objects are not the equal because of delegated roles order.
         self.assertNotEqual(delegations, delegations_2)


### PR DESCRIPTION
* Python 3.7 is EOL.
* Our runtime dependencies are still ok with 3.7
* Testing dependencies have started requiring 3.8

Stop supporting and testing Python 3.7.

We could just stop testing Python 3.7 (while claiming to still support it) but that seems like it'll lead to trouble: we will inevitably use some 3.8 feature and then won't notice because we don't test 3.7 any more.
