### PR TITLE
Offline mode

### DIFF
--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -192,22 +192,35 @@ class TestTrustedMetadataSet(unittest.TestCase):
             self.metadata["role1"], "role1", Targets.type
         )
 
+    def test_initial_root_with_invalid_json(self) -> None:
+        # root is not json
+        with self.assertRaises(exceptions.RepositoryError):
+            TrustedMetadataSet(b"")
+
+        # root is invalid
+        root = Metadata.from_bytes(self.metadata[Root.type])
+        root.signed.version += 1
+        with self.assertRaises(exceptions.UnsignedMetadataError):
+            TrustedMetadataSet(root.to_bytes())
+
+        # metadata is of wrong type
+        with self.assertRaises(exceptions.RepositoryError):
+            TrustedMetadataSet(self.metadata[Snapshot.type])
+
     def test_root_with_invalid_json(self) -> None:
-        # Test loading initial root and root update
-        for test_func in [TrustedMetadataSet, self.trusted_set.update_root]:
-            # root is not json
-            with self.assertRaises(exceptions.RepositoryError):
-                test_func(b"")
+        # root is not json
+        with self.assertRaises(exceptions.RepositoryError):
+            self.trusted_set.update_root(b"")
 
-            # root is invalid
-            root = Metadata.from_bytes(self.metadata[Root.type])
-            root.signed.version += 1
-            with self.assertRaises(exceptions.UnsignedMetadataError):
-                test_func(root.to_bytes())
+        # root is invalid
+        root = Metadata.from_bytes(self.metadata[Root.type])
+        root.signed.version += 1
+        with self.assertRaises(exceptions.UnsignedMetadataError):
+            self.trusted_set.update_root(root.to_bytes())
 
-            # metadata is of wrong type
-            with self.assertRaises(exceptions.RepositoryError):
-                test_func(self.metadata[Snapshot.type])
+        # metadata is of wrong type
+        with self.assertRaises(exceptions.RepositoryError):
+            self.trusted_set.update_root(self.metadata[Snapshot.type])
 
     def test_top_level_md_with_invalid_json(self) -> None:
         top_level_md: List[Tuple[bytes, Callable[[bytes], Metadata]]] = [

--- a/tests/test_updater_offline.py
+++ b/tests/test_updater_offline.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+
+# Copyright 2021, New York University and the TUF contributors
+# SPDX-License-Identifier: MIT OR Apache-2.0
+
+
+"""Test ngclient Updater offline mode"""
+
+import datetime
+import os
+import sys
+import tempfile
+import unittest
+from typing import Optional
+from unittest.mock import Mock, patch
+
+from tests import utils
+from tests.repository_simulator import RepositorySimulator
+from tuf.api.exceptions import DownloadError, ExpiredMetadataError
+from tuf.api.metadata import SPECIFICATION_VERSION, DelegatedRole, Targets
+from tuf.ngclient import Updater, UpdaterConfig
+
+
+class TestOffline(unittest.TestCase):
+    """Test Updater in offline mode"""
+
+    # set dump_dir to trigger repository state dumps
+    dump_dir: Optional[str] = None
+
+    def setUp(self) -> None:
+        # pylint: disable=consider-using-with
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.metadata_dir = os.path.join(self.temp_dir.name, "metadata")
+        self.targets_dir = os.path.join(self.temp_dir.name, "targets")
+        os.mkdir(self.metadata_dir)
+        os.mkdir(self.targets_dir)
+
+        self.sim = RepositorySimulator()
+
+        # Add a delegated role and two targets to repository
+        self.sim.targets.version += 1
+        spec_version = ".".join(SPECIFICATION_VERSION)
+        targets = Targets(1, spec_version, self.sim.safe_expiry, {}, None)
+        role = DelegatedRole("delegated", [], 1, False, ["delegated/*"], None)
+        self.sim.add_delegation("targets", role, targets)
+        self.sim.add_target("targets", b"hello world", "file")
+        self.sim.add_target("delegated", b"content", "delegated/file2")
+        self.sim.update_snapshot()
+
+        # boostrap client with initial root metadata
+        with open(os.path.join(self.metadata_dir, "root.json"), "bw") as f:
+            f.write(self.sim.signed_roots[0])
+
+        if self.dump_dir is not None:
+            # create test specific dump directory
+            name = self.id().split(".")[-1]
+            self.sim.dump_dir = os.path.join(self.dump_dir, name)
+            os.mkdir(self.sim.dump_dir)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _run_refresh(self) -> Updater:
+        """Create a new Updater instance and refresh"""
+        if self.dump_dir is not None:
+            self.sim.write()
+
+        updater = Updater(
+            self.metadata_dir,
+            "https://example.com/metadata/",
+            self.targets_dir,
+            "https://example.com/targets/",
+            self.sim,
+        )
+        updater.refresh()
+        return updater
+
+    def _run_offline_refresh(self) -> Updater:
+        """Create a new Updater instance and refresh"""
+        if self.dump_dir is not None:
+            self.sim.write()
+
+        updater = Updater(
+            self.metadata_dir,
+            "https://example.com/metadata/",
+            self.targets_dir,
+            "https://example.com/targets/",
+            self.sim,
+            UpdaterConfig(offline=True),
+        )
+        updater.refresh()
+        return updater
+
+    @patch.object(datetime, "datetime", wraps=datetime.datetime)
+    def test_refresh(self, mock_time: Mock) -> None:
+        """Test metadata refresh refresh()in offline mode"""
+        # Run a "online" updater refresh to get toplevel metadata in local cache
+        self._run_refresh()
+
+        self.sim.fetch_tracker.metadata.clear()
+
+        # Refresh works in Offline mode (at this point metadata is not expired)
+        self._run_offline_refresh()
+        # Expect no download attempts
+        self.assertListEqual(self.sim.fetch_tracker.metadata, [])
+
+        # Move current time a year into the future: all metadata is now expired
+        mock_time.utcnow.return_value = (
+            datetime.datetime.utcnow() + datetime.timedelta(weeks=52)
+        )
+
+        # Refresh in default online mode fails when metadata has expired
+        with self.assertRaises(ExpiredMetadataError):
+            self._run_refresh()
+
+        self.sim.fetch_tracker.metadata.clear()
+
+        # Refresh in offline mode succeeds when local metadata has expired
+        self._run_offline_refresh()
+        # Expect no download attempts
+        self.assertListEqual(self.sim.fetch_tracker.metadata, [])
+
+    def test_refresh_with_missing_top_level_metadata(self) -> None:
+        """Test metadata refresh in offline mode when cache does not contain all top level metadata"""
+        # Run a "online" updater refresh to get toplevel metadata in local cache
+        self._run_refresh()
+
+        self.sim.fetch_tracker.metadata.clear()
+
+        for role in ["targets", "snapshot", "timestamp"]:
+            fname = os.path.join(self.metadata_dir, f"{role}.json")
+            os.remove(fname)
+
+            # Refresh in offline mode fails since top level metadata is not in cache
+            with self.assertRaises(DownloadError):
+                self._run_offline_refresh()
+            # Expect no download attempts
+            self.assertListEqual(self.sim.fetch_tracker.metadata, [])
+
+    def test_download(self) -> None:
+        """Test download in offline mode"""
+
+        # Run a "online" updater refresh to get toplevel metadata in local cache
+        self._run_refresh()
+
+        self.sim.fetch_tracker.metadata.clear()
+        self.sim.fetch_tracker.targets.clear()
+
+        # Downloading a target file while in offline mode fails
+        updater = self._run_offline_refresh()
+        info = updater.get_targetinfo("file")
+        assert info
+        with self.assertRaises(DownloadError):
+            updater.download_target(info)
+
+        # Expect no download attempts
+        self.assertListEqual(self.sim.fetch_tracker.metadata, [])
+        self.assertListEqual(self.sim.fetch_tracker.targets, [])
+
+    def test_find_cached_target(self) -> None:
+        """Test find_cached_target() in offline mode"""
+
+        # Run a "online" refresh to get metadata in local cache
+        updater = self._run_refresh()
+
+        # offline find_cached_target() returns None because target is not cached
+        updater = self._run_offline_refresh()
+        info = updater.get_targetinfo("file")
+        assert info
+        self.assertIsNone(updater.find_cached_target(info))
+
+        # Run a "online" download to get target in local cache
+        updater = self._run_refresh()
+        info = updater.get_targetinfo("file")
+        assert info
+        updater.download_target(info)
+
+        self.sim.fetch_tracker.metadata.clear()
+        self.sim.fetch_tracker.targets.clear()
+
+        # offline find_cached_target() succeeds now
+        updater = self._run_offline_refresh()
+        info = updater.get_targetinfo("file")
+        assert info
+        self.assertIsNotNone(updater.find_cached_target(info))
+        # Expect no download attempts
+        self.assertListEqual(self.sim.fetch_tracker.metadata, [])
+        self.assertListEqual(self.sim.fetch_tracker.targets, [])
+
+    def test_get_targetinfo_with_delegated_metadata(self) -> None:
+        # Run a "online" refresh to get toplevel metadata in local cache
+        updater = self._run_refresh()
+
+        # offline find_cached_target() fails because delegated metadata is not cached
+        updater = self._run_offline_refresh()
+        with self.assertRaises(DownloadError):
+            updater.get_targetinfo("delegated/file2")
+
+
+if __name__ == "__main__":
+    if "--dump" in sys.argv:
+        TestOffline.dump_dir = tempfile.mkdtemp()
+        print(f"Repository Simulator dumps in {TestOffline.dump_dir}")
+        sys.argv.remove("--dump")
+
+    utils.configure_test_logging(sys.argv)
+    unittest.main()

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -78,13 +78,14 @@ class TrustedMetadataSet(abc.Mapping):
     to update the metadata with the caller making decisions on what is updated.
     """
 
-    def __init__(self, root_data: bytes):
+    def __init__(self, root_data: bytes, is_offline: bool = False):
         """Initialize ``TrustedMetadataSet`` by loading trusted root metadata.
 
         Args:
             root_data: Trusted root metadata as bytes. Note that this metadata
                 will only be verified by itself: it is the source of trust for
                 all metadata in the ``TrustedMetadataSet``
+            is_offline: Defines whether the client wants to be offline or not.
 
         Raises:
             RepositoryError: Metadata failed to load or verify. The actual
@@ -92,6 +93,7 @@ class TrustedMetadataSet(abc.Mapping):
         """
         self._trusted_set: Dict[str, Metadata] = {}
         self.reference_time = datetime.datetime.utcnow()
+        self.offline = is_offline
 
         # Load and validate the local root metadata. Valid initial trusted root
         # metadata is required
@@ -207,7 +209,10 @@ class TrustedMetadataSet(abc.Mapping):
             raise RuntimeError("Cannot update timestamp after snapshot")
 
         # client workflow 5.3.10: Make sure final root is not expired.
-        if self.root.signed.is_expired(self.reference_time):
+        if (
+            self.root.signed.is_expired(self.reference_time)
+            and not self.offline
+        ):
             raise exceptions.ExpiredMetadataError("Final root.json is expired")
         # No need to check for 5.3.11 (fast forward attack recovery):
         # timestamp/snapshot can not yet be loaded at this point
@@ -252,7 +257,8 @@ class TrustedMetadataSet(abc.Mapping):
         logger.debug("Updated timestamp v%d", new_timestamp.signed.version)
 
         # timestamp is loaded: raise if it is not valid _final_ timestamp
-        self._check_final_timestamp()
+        if not self.offline:
+            self._check_final_timestamp()
 
         return new_timestamp
 
@@ -263,7 +269,9 @@ class TrustedMetadataSet(abc.Mapping):
             raise exceptions.ExpiredMetadataError("timestamp.json is expired")
 
     def update_snapshot(
-        self, data: bytes, trusted: Optional[bool] = False
+        self,
+        data: bytes,
+        trusted: Optional[bool] = False,
     ) -> Metadata[Snapshot]:
         """Verify and load ``data`` as new snapshot metadata.
 
@@ -300,7 +308,8 @@ class TrustedMetadataSet(abc.Mapping):
         logger.debug("Updating snapshot")
 
         # Snapshot cannot be loaded if final timestamp is expired
-        self._check_final_timestamp()
+        if not self.offline:
+            self._check_final_timestamp()
 
         snapshot_meta = self.timestamp.signed.snapshot_meta
 
@@ -355,7 +364,10 @@ class TrustedMetadataSet(abc.Mapping):
     def _check_final_snapshot(self) -> None:
         """Raise if snapshot is expired or meta version does not match."""
 
-        if self.snapshot.signed.is_expired(self.reference_time):
+        if (
+            self.snapshot.signed.is_expired(self.reference_time)
+            and not self.offline
+        ):
             raise exceptions.ExpiredMetadataError("snapshot.json is expired")
         snapshot_meta = self.timestamp.signed.snapshot_meta
         if self.snapshot.signed.version != snapshot_meta.version:
@@ -436,7 +448,10 @@ class TrustedMetadataSet(abc.Mapping):
                 f"Expected {role_name} v{meta.version}, got v{version}."
             )
 
-        if new_delegate.signed.is_expired(self.reference_time):
+        if (
+            new_delegate.signed.is_expired(self.reference_time)
+            and not self.offline
+        ):
             raise exceptions.ExpiredMetadataError(f"New {role_name} is expired")
 
         self._trusted_set[role_name] = new_delegate

--- a/tuf/ngclient/config.py
+++ b/tuf/ngclient/config.py
@@ -24,7 +24,13 @@ class UpdaterConfig:
             are used, target download URLs are formed by prefixing the filename
             with a hash digest of file content by default. This can be
             overridden by setting ``prefix_targets_with_hash`` to ``False``.
-
+        offline: When offline, Updater works normally except for two differences: First,
+            expired metadata is considered valid. Second, Updater will not
+            download metadata or targets (if a download would be needed, a DownloadError
+            is raised instead). This is useful for a client that has all required
+            metadata and targets cached locally and is willing to sacrifice timeliness of
+            metadata for offline functionality. Offline mode is not strictly compatible
+            with the TUF client workflow.
     """
 
     max_root_rotations: int = 32

--- a/tuf/ngclient/config.py
+++ b/tuf/ngclient/config.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 
 @dataclass
+# pylint: disable=too-many-instance-attributes
 class UpdaterConfig:
     """Used to store ``Updater`` configuration.
 
@@ -33,3 +34,4 @@ class UpdaterConfig:
     snapshot_max_length: int = 2000000  # bytes
     targets_max_length: int = 5000000  # bytes
     prefix_targets_with_hash: bool = True
+    offline: bool = False

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -101,9 +101,11 @@ class Updater:
 
         # Read trusted local root metadata
         data = self._load_local_metadata(Root.type)
-        self._trusted_set = trusted_metadata_set.TrustedMetadataSet(data)
         self._fetcher = fetcher or requests_fetcher.RequestsFetcher()
         self.config = config or UpdaterConfig()
+        self._trusted_set = trusted_metadata_set.TrustedMetadataSet(
+            data, self.config.offline
+        )
 
     def refresh(self) -> None:
         """Refresh top-level metadata.
@@ -129,6 +131,17 @@ class Updater:
             DownloadError: Download of a metadata file failed in some way
         """
 
+        if self._trusted_set.offline:
+            # Try loading only local data
+            data = self._load_local_metadata(Timestamp.type)
+            self._trusted_set.update_timestamp(data)
+            data = self._load_local_metadata(Snapshot.type)
+            self._trusted_set.update_snapshot(data, trusted=True)
+            data = self._load_local_metadata(Targets.type)
+            self._trusted_set.update_delegated_targets(
+                data, Targets.type, Root.type
+            )
+            return
         self._load_root()
         self._load_timestamp()
         self._load_snapshot()
@@ -224,10 +237,14 @@ class Updater:
             DownloadError: Download of the target file failed in some way
             RepositoryError: Downloaded target failed to be verified in some way
             OSError: Failed to write target to file
+            RuntimeError: Download of target file cannot occur because in offline mode
 
         Returns:
             Local path to downloaded file
         """
+
+        if self._trusted_set.offline:
+            raise RuntimeError("Cannot download when offline")
 
         if filepath is None:
             filepath = self._generate_target_file_path(targetinfo)
@@ -386,6 +403,11 @@ class Updater:
             logger.debug("Local %s is valid: not downloading new one", role)
             return delegated_targets
         except (OSError, exceptions.RepositoryError) as e:
+            # fail if local data is unavailable and in offline mode
+            if self._trusted_set.offline:
+                raise exceptions.DownloadError(
+                    "Local metadata is missing; cannot download metadata in offline mode"
+                )
             # Local 'role' does not exist or is invalid: update from remote
             logger.debug("Failed to load local %s: %s", role, e)
 


### PR DESCRIPTION
Fixes #2359, supersedes #2363

### Summary

This is based 2363 code by Emile Baez, Emerson Rounds and omartounsi7 (see first commit). I've fixed some merge issues and linting problems, added tests and finally done some refactoring.

The PR exposes a new config option `offline: bool`. When offline, Updater behaviour changes in two ways:
1. nothing is downloaded during `refresh()`,  `get_target_info()` and `find_cached_target()`: the operations are done using locally available metadata only.
1. Metadata expiry is no longer respected. All other security checks are still in operation

What this means is that an offline Updater can be used when client
* has all the required metadata and targets cached locally (either because it has used Updater in online mode before or because some other process has filled the caches out-of-band)
* is fine with the compromise in security that using potentially revoked keys means

### Implementation notes

These are mostly about changes I did on top of 2363:

* The TrustedMetadataSet argument was renamed: as the component does not know anything about downloads, `offline` seemed less useful. The argument is now `respect_expiry` which I think is accurate. The expiry checks were consolidated in one method: if metadata has expired it either raises or logs a warning based on `respect_expiry` 
* Updater exceptions were standardized: If Updater would have to download something but is offline, it now raises DownloadError
* Testing feels solid now
  * There's a new set of tests for Updater with `offline=True`: these try to ensure nothing is downloaded while offline,  basic offline cases work and that offline errors are what we expect
  * TrustedMetadataSet tests were essentially doubled with subtests to cover both possible `respect_expiry` values 
  * It would be an option to do the same subtest treatment to Updater tests to ensure that `offline=True`  does not change anything we don't expect it to change... but I feel like this is a reasonable amount of tests
* I've moved the Updater `offline` checks to the `Updater._load_*()` methods: You can check the commit-before-last if you want to see what the alternative option looks like


- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


