### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -37,7 +37,7 @@ jobs:
       # (sslib main) on Linux/Python3.x only.
       matrix:
         toxenv: [py]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - python-version: 3.x
@@ -47,9 +47,6 @@ jobs:
 
     env:
       # Set TOXENV env var to tell tox which testenv (see tox.ini) to use
-      # NOTE: The Python 2.7 runner has two Python versions on the path (see
-      # setup-python below), so we tell tox explicitly to use the 'py27'
-      # testenv. For all other runners the toxenv configured above suffices.
       TOXENV: ${{ matrix.toxenv }}
 
     runs-on: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "tuf"
 description = "A secure updater framework for Python"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
   { email = "theupdateframework@googlegroups.com" },
 ]
@@ -33,7 +33,6 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -6,40 +6,5 @@
 # 'pinned.txt' is updated on GitHub with Dependabot, which
 # triggers CI/CD builds to automatically test against updated dependencies.
 #
-#
-# NOTE: 'pip-compile' only adds dependencies relevant for the Python version,
-# in which it is executed. Moreover, it does not add environment markers of
-# transitive dependencies.
-# The official recommendation for cross-environment usage of pip-compile tends
-# towards separate requirements files for each environment (see
-# jazzband/pip-tools#651), this seem like an overkill for tuf, where we only
-# have a few conditional dependencies, i.e. dependencies that are required on
-# Python < 3 only.
-#
-#
-# Below instructions can be used to re-generate 'pinned.txt', e.g.
-# if:
-# - requirements are added or removed from this file
-# - Python version support is changed
-# - CI/CD build breaks due to updates (e.g. transitive dependency conflicts)
-#
-# 1. Use this script to create a pinned requirements file for each Python
-#    version
-# ```
-# for v in 3.7 3.8 3.9 3.10 3.11; do
-#   mkvirtualenv tuf-env-${v} -p python${v};
-#   python3 -m pip install pip-tools;
-#   pip-compile --no-header -o requirements-${v}.txt main.txt;
-#   deactivate;
-#   rmvirtualenv tuf-env-${v};
-# done;
-#
-# ```
-# 2. Use this command to merge per-version files
-#    `sort -o pinned.txt -u requirements-?.?.txt`
-# 2. Manually add environment markers to pinned.txt
-# 3. Use this command to remove per-version files
-#    `rm requirements-?.?.txt`
-#
 securesystemslib[crypto, pynacl]
 requests

--- a/tests/test_metadata_eq_.py
+++ b/tests/test_metadata_eq_.py
@@ -112,10 +112,9 @@ class TestMetadataComparisions(unittest.TestCase):
         md: Metadata = self.objects["Metadata"]
         md.signatures = {"a": Signature("a", "a"), "b": Signature("b", "b")}
         md_2 = copy.deepcopy(md)
-        # Reverse signatures order in md_2.
-        # In python3.7 we need to cast to a list and then reverse.
+
+        # Reverse dict to assert unequal order
         md_2.signatures = dict(reversed(list(md_2.signatures.items())))
-        # Assert that both objects are not the same because of signatures order.
         self.assertNotEqual(md, md_2)
 
         # but if we fix the signatures order they will be equal
@@ -168,11 +167,11 @@ class TestMetadataComparisions(unittest.TestCase):
 
         # Create a second delegations obj with reversed roles order
         delegations_2 = copy.deepcopy(delegations)
-        # In python3.7 we need to cast to a list and then reverse.
-        assert isinstance(delegations.roles, dict)
-        delegations_2.roles = dict(reversed(list(delegations.roles.items())))
 
-        # Both objects are not the equal because of delegated roles order.
+        assert isinstance(delegations.roles, dict)
+
+        # Reverse dict to assert unequal order
+        delegations_2.roles = dict(reversed(list(delegations.roles.items())))
         self.assertNotEqual(delegations, delegations_2)
 
         # but if we fix the delegated roles order they will be equal


### PR DESCRIPTION
fixes #2460

- drop 3.7 build

- update pyproject.toml
  - bump min python to 3.8
  - drop 3.7 classifier

- update docs
  - reword obsolete comment in tests about dict order in 3.7
  - (unrelated) remove obsolete code snippet for per-version requirements files
  - (unrelated) remove obsolete workflow comment about 2.7
