### PR TITLE
workflows: Stop pinning actions that are not security relevant

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,18 +16,19 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
+      # NOTE: If you add security critical permissions, start pinning used actions
       actions: read
       contents: read
-      security-events: write
+      security-events: write # for uploading to code-scanning dashboard
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@6a28655e3dcb49cb0840ea372fd6d17733edd8a4 # v2.21.8
+      uses: github/codeql-action/init@v2 # unpinned since this is not security critical
       with:
         languages: 'python'
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@6a28655e3dcb49cb0840ea372fd6d17733edd8a4 # v2.21.8
+      uses: github/codeql-action/analyze@v2 # unpinned since this is not security critical

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -8,6 +8,7 @@ name: 'Dependency Review'
 on: [pull_request]
 
 permissions:
+  # NOTE: If you add security critical permissions, start pinning used actions
   contents: read
 
 jobs:
@@ -17,4 +18,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@6c5ccdad469c9f8a2996bfecaec55a631a347034 # v3.1.0
+        uses: actions/dependency-review-action@v3 # unpinned since this is not security critical

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -14,8 +14,9 @@ jobs:
     name: Scorecards analysis
     runs-on: ubuntu-latest
     permissions:
+      # NOTE: If you add security critical permissions, start pinning used actions
       security-events: write # for uploading to code-scanning dashboard
-      id-token: write # for signing results
+      id-token: write # for publishing results in scorecard public dataset
       actions: read
       contents: read
 
@@ -24,7 +25,7 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@08b4669551908b1024bb425080c797723083c031 # v2.2.0
+        uses: ossf/scorecard-action@v2 # unpinned since this is not security critical
         with:
           results_file: results.sarif
           # sarif format required by upload-sarif action
@@ -34,6 +35,6 @@ jobs:
           publish_results: true
 
       - name: "Upload to code-scanning dashboard"
-        uses: github/codeql-action/upload-sarif@6a28655e3dcb49cb0840ea372fd6d17733edd8a4 # v2.21.8
+        uses: github/codeql-action/upload-sarif@v2  # unpinned since this is not security critical
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
These workflows have no real security relevance (runtime, build or test) in the sense that a compromise in the dependencies could not compromise python-tuf security:
* scorecards
* dependency-review
* codeql-analysis

There is also no significant reproducibility issue as these are not part of the test suite. These are all "tier 3" dependencies as documented in https://github.com/theupdateframework/python-tuf/issues/2014#issuecomment-1303524280

Stop pinning the actions used in these workflows (except the common actions that are used everywhere like actions/checkout: use the same version of those everywhere). The benefit here is fewer Dependabot PRs: If we had done this from the start we'd have skipped ~70 PRs by now.

The interesting permissions used in these workflows are
 * `security-events: write` This can add things onto the "Security" tab in GitHub
 * `id-token: write` This allows OIDC authentication, but only as this specific workflow

These permissions look completely acceptable to me.