### PR TITLE
workflows: Partially revert action versions

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2 # unpinned since this is not security critical
+        uses: ossf/scorecard-action@483ef80eb98fb506c348f7d62e28055e49fe2398 # v2.3.0
         with:
           results_file: results.sarif
           # sarif format required by upload-sarif action


### PR DESCRIPTION
Commit f0058259 started not pinning hashes for actions that are used in workflows that have no runtime or build security impact.

The change does not work for scorecard as scorecard does not tag "v2": so we have to pin it. Luckily scorecard does not do that many releases.
