### PR TITLE
CI: Run lint on oldest supported Python version

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout TUF
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Set up Python 3.x
+      - name: Set up Python (oldest supported version)
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: 3.x
+          python-version: 3.8
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
 


### PR DESCRIPTION
* This was suggested as best practice by a pylint developer
* Seems better than CI randomly breaking when GitHub updates Python version (and pylint starts applying new rules that we can't follow because that would break old Python versions)

--- 

In the long run I'd like to drop pylint and move to ruff (even if it's not as extensive), but this is just a quick fix to get the CI green again.
