### PR TITLE
build: Upgrade hatchling to latest release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # hatchling pinned for reproducibility: version should be kept up-to-date
-requires = ["hatchling==1.13.0"]
+requires = ["hatchling==1.18.0"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
This is not tracked by dependabot so needs manual updates.

Manually tested by building with previous and new hatchling version and diffing unzipped/untared wheel and sdist.

There were no unexpected changes.


