### PR TITLE
Dependabot: Use groups, update weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,36 @@ updates:
 - package-ecosystem: "pip"
   directory: "/"
   schedule:
-    interval: "daily"
-    time: "10:00"
+    interval: "weekly"
   open-pull-requests-limit: 10
+  groups:
+    build-and-release-dependencies:
+      # Python dependencies known to be critical to our build/release security
+      patterns:
+        - "build"
+    test-and-lint-dependencies:
+      # Python dependencies that are only pinned to ensure test reproducibility
+      patterns:
+        - "bandit"
+        - "black"
+        - "isort"
+        - "mypy"
+        - "pydocstyle"
+        - "pylint"
+        - "tox"
+    dependencies:
+      # Python (developer) runtime dependencies. Also any new dependencies not
+      # caught by earlier groups
+      patterns:
+        - "*"
+
 
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: "daily"
-    time: "10:00"
+    interval: "weekly"
   open-pull-requests-limit: 10
+  groups:
+    action-dependencies:
+      patterns:
+        - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
       # Python dependencies known to be critical to our build/release security
       patterns:
         - "build"
+        - "hatchling"
     test-and-lint-dependencies:
       # Python dependencies that are only pinned to ensure test reproducibility
       patterns:


### PR DESCRIPTION
All dependencies are now checked weekly and those weekly updates are grouped into 4 groups:
  * critical python build/release deps
  * python test and lint deps (only pinned for test repro)
  * all other python dependencies
  * All github action dependencies

This is not quite the division that was hashed out in #2014, mostly for practical reasons:
* GitHub actions are already practically split by pinning strategy so they don't really need further groups:
  * Non-security-relevant actions are pinned by tags
  * Other actions are pinned by hash
* The dependency grouping is quite limited
