### PR TITLE
dependabot: Add coverage to test-and-lint group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@ updates:
       patterns:
         - "bandit"
         - "black"
+        - "coverage"
         - "isort"
         - "mypy"
         - "pydocstyle"


### PR DESCRIPTION
This seems make most sense: coverage is also  pinned mainly to get reproducible results.