### PR TITLE
Improve verification results

### DIFF
--- a/examples/repository/_simplerepo.py
+++ b/examples/repository/_simplerepo.py
@@ -99,11 +99,9 @@ class SimpleRepository(Repository):
         if role == Root.type:
             assert isinstance(md.signed, Root)
             root = self.root()
-            if root.version == 0:
-                # special case first root
-                root = md.signed
+            previous = root if root.version > 0 else None
             return md.signed.get_root_verification_result(
-                root, md.signed_bytes, md.signatures
+                previous, md.signed_bytes, md.signatures
             )
         if role in [Timestamp.type, Snapshot.type, Targets.type]:
             delegator: Signed = self.root()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -47,7 +47,6 @@ from tuf.api.metadata import (
     TargetFile,
     Targets,
     Timestamp,
-    VerificationResult,
 )
 from tuf.api.serialization import DeserializationError, SerializationError
 from tuf.api.serialization.json import JSONSerializer
@@ -475,91 +474,68 @@ class TestMetadata(unittest.TestCase):
         # Setup: Load test metadata and keys
         root_path = os.path.join(self.repo_dir, "metadata", "root.json")
         root = Metadata[Root].from_file(root_path)
-        initial_root_keyids = root.signed.roles[Root.type].keyids
-        self.assertEqual(len(initial_root_keyids), 1)
-        key1_id = initial_root_keyids[0]
-        key2 = self.keystore[Timestamp.type]
-        key2_id = key2["keyid"]
+
+        key1_id = root.signed.roles[Root.type].keyids[0]
+        key1 = root.signed.get_key(key1_id)
+
+        key2_id = root.signed.roles[Timestamp.type].keyids[0]
+        key2 = root.signed.get_key(key2_id)
+        priv_key2 = self.keystore[Timestamp.type]
+
         key3_id = "123456789abcdefg"
-        key4 = self.keystore[Snapshot.type]
-        key4_id = key4["keyid"]
+        priv_key4 = self.keystore[Snapshot.type]
+        key4_id = priv_key4["keyid"]
 
         # Test: 1 authorized key, 1 valid signature
         result = root.signed.get_verification_result(
             Root.type, root.signed_bytes, root.signatures
         )
-        self.assertTrue(result.verified)
-        self.assertEqual(result.signed, {key1_id})
-        self.assertEqual(result.unsigned, set())
+        self.assertTrue(result)
+        self.assertEqual(result.signed, {key1_id: key1})
+        self.assertEqual(result.unsigned, {})
 
         # Test: 2 authorized keys, 1 invalid signature
         # Adding a key, i.e. metadata change, invalidates existing signature
-        root.signed.add_key(
-            SSlibKey.from_securesystemslib_key(key2),
-            Root.type,
-        )
+        root.signed.add_key(key2, Root.type)
         result = root.signed.get_verification_result(
             Root.type, root.signed_bytes, root.signatures
         )
-        self.assertFalse(result.verified)
-        self.assertEqual(result.signed, set())
-        self.assertEqual(result.unsigned, {key1_id, key2_id})
+        self.assertFalse(result)
+        self.assertEqual(result.signed, {})
+        self.assertEqual(result.unsigned, {key1_id: key1, key2_id: key2})
 
         # Test: 3 authorized keys, 1 invalid signature, 1 key missing key data
-        # Adding a keyid w/o key, fails verification the same as no signature
-        # or an invalid signature for that key
+        # Adding a keyid w/o key, fails verification but this key is not listed
+        # in unsigned
         root.signed.roles[Root.type].keyids.append(key3_id)
         result = root.signed.get_verification_result(
             Root.type, root.signed_bytes, root.signatures
         )
-        self.assertFalse(result.verified)
-        self.assertEqual(result.signed, set())
-        self.assertEqual(result.unsigned, {key1_id, key2_id, key3_id})
+        self.assertFalse(result)
+        self.assertEqual(result.signed, {})
+        self.assertEqual(result.unsigned, {key1_id: key1, key2_id: key2})
 
         # Test: 3 authorized keys, 1 valid signature, 1 invalid signature, 1
         # key missing key data
-        root.sign(SSlibSigner(key2), append=True)
+        root.sign(SSlibSigner(priv_key2), append=True)
         result = root.signed.get_verification_result(
             Root.type, root.signed_bytes, root.signatures
         )
-        self.assertTrue(result.verified)
-        self.assertEqual(result.signed, {key2_id})
-        self.assertEqual(result.unsigned, {key1_id, key3_id})
+        self.assertTrue(result)
+        self.assertEqual(result.signed, {key2_id: key2})
+        self.assertEqual(result.unsigned, {key1_id: key1})
 
         # Test: 3 authorized keys, 1 valid signature, 1 invalid signature, 1
         # key missing key data, 1 ignored unrelated signature
-        root.sign(SSlibSigner(key4), append=True)
+        root.sign(SSlibSigner(priv_key4), append=True)
         self.assertEqual(
             set(root.signatures.keys()), {key1_id, key2_id, key4_id}
         )
-        self.assertTrue(result.verified)
-        self.assertEqual(result.signed, {key2_id})
-        self.assertEqual(result.unsigned, {key1_id, key3_id})
+        self.assertTrue(result)
+        self.assertEqual(result.signed, {key2_id: key2})
+        self.assertEqual(result.unsigned, {key1_id: key1})
 
         # See test_signed_verify_delegate for more related tests ...
-
-    def test_signed_verification_result_union(self) -> None:
-        # Test all possible "unions" (AND) of "verified" field
-        data = [
-            (True, True, True),
-            (True, False, False),
-            (False, True, False),
-            (False, False, False),
-        ]
-
-        for a_part, b_part, ab_part in data:
-            self.assertEqual(
-                VerificationResult(a_part, set(), set()).union(
-                    VerificationResult(b_part, set(), set())
-                ),
-                VerificationResult(ab_part, set(), set()),
-            )
-
-        # Test exemplary union (|) of "signed" and "unsigned" fields
-        a = VerificationResult(True, {"1"}, {"2"})
-        b = VerificationResult(True, {"3"}, {"4"})
-        ab = VerificationResult(True, {"1", "3"}, {"2", "4"})
-        self.assertEqual(a.union(b), ab)
 
     def test_key_class(self) -> None:
         # Test if from_securesystemslib_key removes the private key from keyval

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -986,11 +986,16 @@ class Root(Signed, _DelegatorMixin):
             signatures: Signatures over payload bytes
 
         Raises:
-            ValueError: no delegation was found for ``delegated_role``.
+            ValueError: no delegation was found for ``root`` or given Root
+                versions are not sequential.
         """
 
         if previous is None:
             previous = self
+        elif self.version != previous.version + 1:
+            versions = f"v{previous.version} and v{self.version}"
+            raise ValueError(
+                f"Expected sequential root versions, got {versions}.")
 
         return RootVerificationResult(
             self.get_verification_result(Root.type, payload, signatures),

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -653,8 +653,8 @@ class VerificationResult:
 
     Attributes:
         threshold: Number of required signatures.
-        signed: dict of keyid:Key containing the keys that have signed.
-        unsigned: dict of keyid:Key containing the keys that have not signed.
+        signed: dict of keyid to Key, containing keys that have signed.
+        unsigned: dict of keyid to Key, containing keys that have not signed.
     """
 
     threshold: int
@@ -675,8 +675,8 @@ class RootVerificationResult:
     """Signature verification result for root metadata.
 
     Root must be verified by itself and the previous root version. This
-    dataclass represents that combination. For the edge case of first version
-    of root, the same VerificationResult can be used twice.
+    dataclass represents both results. For the edge case of first version
+    of root, these underlying results are identical.
 
     Note that `signed` and `unsigned` correctness requires the underlying
     VerificationResult keys to not conflict (no reusing the same keyid for

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -965,30 +965,36 @@ class Root(Signed, _DelegatorMixin):
 
     def get_root_verification_result(
         self,
-        other: "Root",
+        previous: Optional["Root"],
         payload: bytes,
         signatures: Dict[str, Signature],
     ) -> RootVerificationResult:
         """Return signature threshold verification result for two root roles.
 
-        Verify root metadata with two roles (the root role from `self` and
-        `other`). If you have only one role (in the case of root v1) you can
-        provide the same Root as both `self` and `other`.
+        Verify root metadata with two roles (`self` and optionally `previous`).
+
+        If the repository has no root role versions yet, `previous` can be left
+        None. In all other cases, `previous` must be the previous version of
+        the Root.
 
         NOTE: Unlike `verify_delegate()` this method does not raise, if the
         root metadata is not fully verified.
 
         Args:
-            other: The other `Root` to verify payload with
+            previous: The previous `Root` to verify payload with, or None
             payload: Signed payload bytes for root
             signatures: Signatures over payload bytes
 
         Raises:
             ValueError: no delegation was found for ``delegated_role``.
         """
+
+        if previous is None:
+            previous = self
+
         return RootVerificationResult(
             self.get_verification_result(Root.type, payload, signatures),
-            other.get_verification_result(Root.type, payload, signatures),
+            previous.get_verification_result(Root.type, payload, signatures),
         )
 
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -701,12 +701,14 @@ class RootVerificationResult:
     @property
     def signed(self) -> Dict[str, Key]:
         """Dictionary of all signing keys that have signed, from both VerificationResults"""
-        return self.first.signed | self.second.signed
+        # return a union of all signed (in python<3.9 this requires dict unpacking)
+        return {**self.first.signed, **self.second.signed}
 
     @property
     def unsigned(self) -> Dict[str, Key]:
         """Dictionary of all signing keys that have not signed, from both VerificationResults"""
-        return self.first.unsigned | self.second.unsigned
+        # return a union of all unsigned (in python<3.9 this requires dict unpacking)
+        return {**self.first.unsigned, **self.second.unsigned}
 
 
 class _DelegatorMixin(metaclass=abc.ABCMeta):

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -802,10 +802,9 @@ class _DelegatorMixin(metaclass=abc.ABCMeta):
             delegated_role, payload, signatures
         )
         if not result:
-            role = self.get_delegated_role(delegated_role)
             raise UnsignedMetadataError(
                 f"{delegated_role} was signed by {len(result.signed)}/"
-                f"{role.threshold} keys"
+                f"{result.threshold} keys"
             )
 
 

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -669,6 +669,11 @@ class VerificationResult:
         """True if threshold of signatures is met."""
         return len(self.signed) >= self.threshold
 
+    @property
+    def missing(self) -> int:
+        """Number of additional signatures required to reach threshold."""
+        return max(0, self.threshold - len(self.signed))
+
 
 @dataclass
 class RootVerificationResult:
@@ -995,11 +1000,12 @@ class Root(Signed, _DelegatorMixin):
         elif self.version != previous.version + 1:
             versions = f"v{previous.version} and v{self.version}"
             raise ValueError(
-                f"Expected sequential root versions, got {versions}.")
+                f"Expected sequential root versions, got {versions}."
+            )
 
         return RootVerificationResult(
-            self.get_verification_result(Root.type, payload, signatures),
             previous.get_verification_result(Root.type, payload, signatures),
+            self.get_verification_result(Root.type, payload, signatures),
         )
 
 


### PR DESCRIPTION
This is an attempt at fixing the verification result handling that has been found to not work well. This API is useful mostly to repository implementations: clients should likely keep using `verify_delegate() `

**Modify VerificationResult**
* Remove `union()`: this is now handled by the new RootVerificationResult
* include threshold: This is useful and can be added now that union() does not exist
* Use `dict[str, Key]` instead of `set[str]` for signed and unsigned
* Note that the (broken metadata) case of role keyid that does not have a matching key, is now not counted as "unsigned" as it was before: it's just not counted at all 

**Add RootVerificationResult**
* Externally looks like VerificationResult (without threshold)
* It is actually two VerificationResults in a trenchcoat: `Root.get_root_verification_result()` is provided as a straightforward way to get one

Note that `RootVerificationResult.signed` and `RootVerificationResult.unsigned` assume that there are no keyid collisions between the two verifying roles (same keyid is not used for two different keys): This does **not** affect `verified` status in any way (only the `signed` and `unsigned` lists) so I think this is totally acceptable.

So far the usage looks quite nice but I think we want to try to use this in an app or two to avoid redoing the mistake of the first VerificationResult... 

Fixes #2544 

- [x] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [x] Tests have been added for the bug fix or new feature
- [x] Docs have been added for the bug fix or new feature


