### PR TITLE
Replace most linting tools with ruff 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,12 +16,10 @@ updates:
       # Python dependencies that are only pinned to ensure test reproducibility
       patterns:
         - "bandit"
-        - "black"
         - "coverage"
-        - "isort"
         - "mypy"
-        - "pydocstyle"
         - "pylint"
+        - "ruff"
         - "tox"
     dependencies:
       # Python (developer) runtime dependencies. Also any new dependencies not

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,6 @@ updates:
         - "bandit"
         - "coverage"
         - "mypy"
-        - "pylint"
         - "ruff"
         - "tox"
     dependencies:

--- a/examples/repository/_simplerepo.py
+++ b/examples/repository/_simplerepo.py
@@ -112,7 +112,9 @@ class SimpleRepository(Repository):
         )
 
     def open(self, role: str) -> Metadata:
-        """Return current Metadata for role from 'storage' (or create a new one)"""
+        """Return current Metadata for role from 'storage'
+        (or create a new one)
+        """
 
         if role not in self.role_cache:
             signed_init = _signed_init.get(role, Targets)

--- a/examples/uploader/_localrepo.py
+++ b/examples/uploader/_localrepo.py
@@ -62,7 +62,6 @@ class LocalRepository(Repository):
 
         # if there is a metadata version fetched from remote, use that
         # HACK: access Updater internals
-        # pylint: disable=protected-access
         if role in self.updater._trusted_set:
             return copy.deepcopy(self.updater._trusted_set[role])
 
@@ -105,7 +104,7 @@ class LocalRepository(Repository):
             with self.edit_targets(role) as delegated:
                 delegated.targets[targetpath] = targetfile
 
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             print(f"Failed to submit new {role} with added target: {e}")
             return False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,19 +83,16 @@ line-length=80
 [tool.ruff.lint]
 select = [
     "D",  # pydocstyle
-    "I",  # isort
+    "E",  # pycodestyle
     "F",  # pyflakes
+    "I",  # isort
     "N",  # pep8-naming
-    "E"   # pycodestyle 
 ] 
 ignore = ["D400","D415","D213","D205","D202","D107","D407","D413","D212","D104","D406","D105","D411","D401","D200","D203"]
+
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D", "E"]
 "examples/*/*" = ["D"] 
-"tuf/repository/__init__.py" = ["F401"]
-"tuf/api/exceptions.py" = ["F401"]
-"tuf/repository/_repository.py" = ["N818"]
-"verify_release" = ["F401", "D103", "E501"]
 
 # Pylint section
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,10 @@ line-length=80
 [tool.ruff.lint]
 ignore = ["D400","D415","D213","D205","D202","D107","D407","D413","D212","D104","D406","D105","D411","D401","D200","D203"]
 
+[tool.ruff.lint.per-file-ignores] 
+"tuf/repository/__init__.py" = ["F401"]
+"tuf/api/exceptions.py" = ["F401"]
+
 # Pylint section
 
 # Minimal pylint configuration file for Secure Systems Lab Python Style Guide:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,8 +87,9 @@ select = [
     "F",  # pyflakes
     "I",  # isort
     "N",  # pep8-naming
+    "PL", # pylint
 ] 
-ignore = ["D400","D415","D213","D205","D202","D107","D407","D413","D212","D104","D406","D105","D411","D401","D200","D203"]
+ignore = ["D400","D415","D213","D205","D202","D107","D407","D413","D212","D104","D406","D105","D411","D401","D200","D203", "PLR0913", "PLR2004"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D", "E"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,11 +81,21 @@ dev-mode-dirs = ["."]
 line-length=80
 
 [tool.ruff.lint]
+select = [
+    "D",  # pydocstyle
+    "I",  # isort
+    "F",  # pyflakes
+    "N",  # pep8-naming
+    "E"   # pycodestyle 
+] 
 ignore = ["D400","D415","D213","D205","D202","D107","D407","D413","D212","D104","D406","D105","D411","D401","D200","D203"]
-
-[tool.ruff.lint.per-file-ignores] 
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["D", "E"]
+"examples/*/*" = ["D"] 
 "tuf/repository/__init__.py" = ["F401"]
 "tuf/api/exceptions.py" = ["F401"]
+"tuf/repository/_repository.py" = ["N818"]
+"verify_release" = ["F401", "D103", "E501"]
 
 # Pylint section
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,56 +95,6 @@ ignore = ["D400","D415","D213","D205","D202","D107","D407","D413","D212","D104",
 "tests/*" = ["D", "E"]
 "examples/*/*" = ["D"] 
 
-# Pylint section
-
-# Minimal pylint configuration file for Secure Systems Lab Python Style Guide:
-#     https://github.com/secure-systems-lab/code-style-guidelines
-#
-# Based on Google Python Style Guide pylintrc and pylint defaults:
-#     https://google.github.io/styleguide/pylintrc
-#     http://pylint.pycqa.org/en/latest/technical_reference/features.html
-
-[tool.pylint.message_control]
-# Disable the message, report, category or checker with the given id(s).
-# NOTE: To keep this config as short as possible we only disable checks that
-# are currently in conflict with our code. If new code displeases the linter
-# (for good reasons) consider updating this config file, or disable checks with.
-disable=[
-  "fixme",
-  "too-few-public-methods",
-  "too-many-arguments",
-  "format",
-  "duplicate-code"
-]
-
-[tool.pylint.basic]
-good-names = ["i","j","k","v","e","f","fn","fp","_type","_"]
-# Regexes for allowed names are copied from the Google pylintrc
-# NOTE: Pylint captures regex name groups such as 'snake_case' or 'camel_case'.
-# If there are multiple groups it enfoces the prevalent naming style inside
-# each modules. Names in the exempt capturing group are ignored.
-function-rgx="^(?:(?P<exempt>setUp|tearDown|setUpModule|tearDownModule)|(?P<camel_case>_?[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_?[a-z][a-z0-9_]*))$"
-method-rgx="(?x)^(?:(?P<exempt>_[a-z0-9_]+__|runTest|setUp|tearDown|setUpTestCase|tearDownTestCase|setupSelf|tearDownClass|setUpClass|(test|assert)_*[A-Z0-9][a-zA-Z0-9_]*|next)|(?P<camel_case>_{0,2}[A-Z][a-zA-Z0-9_]*)|(?P<snake_case>_{0,2}[a-z][a-z0-9_]*))$"
-argument-rgx="^[a-z][a-z0-9_]*$"
-attr-rgx="^_{0,2}[a-z][a-z0-9_]*$"
-class-attribute-rgx="^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$"
-class-rgx="^_?[A-Z][a-zA-Z0-9]*$"
-const-rgx="^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$"
-inlinevar-rgx="^[a-z][a-z0-9_]*$"
-module-rgx="^(_?[a-z][a-z0-9_]*|__init__)$"
-no-docstring-rgx="(__.*__|main|test.*|.*test|.*Test)$"
-variable-rgx="^[a-z][a-z0-9_]*$"
-docstring-min-length=10
-
-[tool.pylint.logging]
-logging-format-style="old"
-
-[tool.pylint.miscellaneous]
-notes="TODO"
-
-[tool.pylint.STRING]
-check-quote-consistency="yes"
-
 # mypy section
 # Read more here: https://mypy.readthedocs.io/en/stable/config_file.html#using-a-pyproject-toml-file
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,17 +75,13 @@ include = [
 # from `tests` so the root directory must be added to Python's path for editable installations
 dev-mode-dirs = ["."]
 
-# Black section
-# Read more here: https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#configuration-via-a-file
-[tool.black]
+# Ruff section
+# Read more here: https://docs.astral.sh/ruff/linter/#rule-selection
+[tool.ruff]
 line-length=80
 
-# Isort section
-# Read more here: https://pycqa.github.io/isort/docs/configuration/config_files.html
-[tool.isort]
-profile="black"
-line_length=80
-known_first_party = ["tuf"]
+[tool.ruff.lint]
+ignore = ["D400","D415","D213","D205","D202","D107","D407","D413","D212","D104","D406","D105","D411","D401","D200","D203"]
 
 # Pylint section
 
@@ -156,7 +152,3 @@ module = [
   "securesystemslib.*",
 ]
 ignore_missing_imports = "True"
-
-[tool.pydocstyle]
-inherit = false
-ignore = "D400,D415,D213,D205,D202,D107,D407,D413,D212,D104,D406,D105,D411,D401,D200,D203"

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -6,7 +6,6 @@
 # Lint tools
 # (We are not so interested in the specific versions of the tools: the versions
 # are pinned to prevent unexpected linting failures when tools update)
-pylint==3.0.3
 ruff==0.2.1
 mypy==1.8.0
 bandit==1.7.7

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -6,9 +6,7 @@
 # Lint tools
 # (We are not so interested in the specific versions of the tools: the versions
 # are pinned to prevent unexpected linting failures when tools update)
-black==24.2.0
-isort==5.13.2
 pylint==3.0.3
+ruff==0.2.1
 mypy==1.8.0
 bandit==1.7.7
-pydocstyle==6.3.0

--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -99,7 +99,6 @@ class RepositoryTarget:
 class RepositorySimulator(FetcherInterface):
     """Simulates a repository that can be used for testing."""
 
-    # pylint: disable=too-many-instance-attributes
     def __init__(self) -> None:
         self.md_delegates: Dict[str, Metadata[Targets]] = {}
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -56,7 +56,6 @@ from tuf.api.serialization.json import JSONSerializer
 logger = logging.getLogger(__name__)
 
 
-# pylint: disable=too-many-public-methods,too-many-statements
 class TestMetadata(unittest.TestCase):
     """Tests for public API of all classes in 'tuf/api/metadata.py'."""
 
@@ -246,7 +245,7 @@ class TestMetadata(unittest.TestCase):
             os.path.join(self.repo_dir, "metadata", "snapshot.json")
         )
 
-        class FailingSigner(Signer):  # pylint: disable=missing-class-docstring
+        class FailingSigner(Signer):
             @classmethod
             def from_priv_key_uri(
                 cls,
@@ -365,7 +364,6 @@ class TestMetadata(unittest.TestCase):
             role2.verify_delegate("role1", role1)
 
     def test_signed_verify_delegate(self) -> None:
-        # pylint: disable=too-many-locals,too-many-statements
         root_path = os.path.join(self.repo_dir, "metadata", "root.json")
         root_md = Metadata[Root].from_file(root_path)
         root = root_md.signed
@@ -742,7 +740,6 @@ class TestMetadata(unittest.TestCase):
             root.signed.revoke_key(keyid, "nosuchrole")
 
     def test_is_target_in_pathpattern(self) -> None:
-        # pylint: disable=protected-access
         supported_use_cases = [
             ("foo.tgz", "foo.tgz"),
             ("foo.tgz", "*"),

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -53,7 +53,6 @@ class TestRepoExamples(unittest.TestCase):
         CWD."""
         script_path = str(self.repo_examples_dir / script_name)
         with open(script_path, "rb") as f:
-            # pylint: disable=exec-used
             exec(
                 compile(f.read(), script_path, "exec"),
                 {"__file__": script_path},

--- a/tests/test_metadata_eq_.py
+++ b/tests/test_metadata_eq_.py
@@ -89,7 +89,7 @@ class TestMetadataComparisions(unittest.TestCase):
 
     @utils.run_sub_tests_with_dataset(classes_attributes_modifications)
     def test_classes_eq_(self, test_case_data: Dict[str, Any]) -> None:
-        obj = self.objects[self.case_name]  # pylint: disable=no-member
+        obj = self.objects[self.case_name]
 
         # Assert that obj is not equal to an object from another type
         self.assertNotEqual(obj, "")

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -34,7 +34,6 @@ from tuf.api.serialization import DeserializationError
 logger = logging.getLogger(__name__)
 
 
-# pylint: disable=too-many-public-methods
 class TestSerialization(unittest.TestCase):
     """Test serialization for all classes in 'tuf/api/metadata.py'."""
 

--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -29,7 +29,6 @@ from tuf.ngclient._internal.trusted_metadata_set import TrustedMetadataSet
 logger = logging.getLogger(__name__)
 
 
-# pylint: disable=too-many-public-methods
 class TestTrustedMetadataSet(unittest.TestCase):
     """Tests for all public API of the TrustedMetadataSet class."""
 

--- a/tests/test_updater_consistent_snapshot.py
+++ b/tests/test_updater_consistent_snapshot.py
@@ -32,7 +32,6 @@ class TestConsistentSnapshot(unittest.TestCase):
     dump_dir: Optional[str] = None
 
     def setUp(self) -> None:
-        # pylint: disable=consider-using-with
         self.subtest_count = 0
         self.temp_dir = tempfile.TemporaryDirectory()
         self.metadata_dir = os.path.join(self.temp_dir.name, "metadata")

--- a/tests/test_updater_delegation_graphs.py
+++ b/tests/test_updater_delegation_graphs.py
@@ -67,7 +67,6 @@ class TestDelegations(unittest.TestCase):
     dump_dir: Optional[str] = None
 
     def setUp(self) -> None:
-        # pylint: disable=consider-using-with
         self.subtest_count = 0
         self.temp_dir = tempfile.TemporaryDirectory()
         self.metadata_dir = os.path.join(self.temp_dir.name, "metadata")

--- a/tests/test_updater_fetch_target.py
+++ b/tests/test_updater_fetch_target.py
@@ -34,7 +34,6 @@ class TestFetchTarget(unittest.TestCase):
     dump_dir: Optional[str] = None
 
     def setUp(self) -> None:
-        # pylint: disable-next=consider-using-with
         self.temp_dir = tempfile.TemporaryDirectory()
         self.metadata_dir = os.path.join(self.temp_dir.name, "metadata")
         self.targets_dir = os.path.join(self.temp_dir.name, "targets")

--- a/tests/test_updater_key_rotations.py
+++ b/tests/test_updater_key_rotations.py
@@ -41,7 +41,6 @@ class TestUpdaterKeyRotations(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        # pylint: disable-next=consider-using-with
         cls.temp_dir = tempfile.TemporaryDirectory()
 
         # Pre-create a bunch of keys and signers
@@ -58,14 +57,12 @@ class TestUpdaterKeyRotations(unittest.TestCase):
 
     def setup_subtest(self) -> None:
         # Setup repository for subtest: make sure no roots have been published
-        # pylint: disable=attribute-defined-outside-init
         self.sim = RepositorySimulator()
         self.sim.signed_roots.clear()
         self.sim.root.version = 0
 
         if self.dump_dir is not None:
             # create subtest dumpdir
-            # pylint: disable=no-member
             name = f"{self.id().split('.')[-1]}-{self.case_name}"
             self.sim.dump_dir = os.path.join(self.dump_dir, name)
             os.mkdir(self.sim.dump_dir)
@@ -76,7 +73,6 @@ class TestUpdaterKeyRotations(unittest.TestCase):
             self.sim.write()
 
         # bootstrap with initial root
-        # pylint: disable=attribute-defined-outside-init
         self.metadata_dir = tempfile.mkdtemp(dir=self.temp_dir.name)
         with open(os.path.join(self.metadata_dir, "root.json"), "bw") as f:
             f.write(self.sim.signed_roots[0])

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -36,7 +36,6 @@ logger = logging.getLogger(__name__)
 class TestUpdater(unittest.TestCase):
     """Test the Updater class from 'tuf/ngclient/updater.py'."""
 
-    # pylint: disable=too-many-instance-attributes
     server_process_handler: ClassVar[utils.TestServerProcess]
 
     @classmethod
@@ -282,7 +281,6 @@ class TestUpdater(unittest.TestCase):
             targetinfo.hashes = {"sha256": "abcd"}
             self.updater.download_target(targetinfo)
 
-    # pylint: disable=protected-access
     def test_updating_root(self) -> None:
         # Bump root version, resign and refresh
         self._modify_repository_root(lambda root: None, bump_version=True)

--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -36,7 +36,6 @@ from tuf.api.metadata import (
 from tuf.ngclient import Updater
 
 
-# pylint: disable=too-many-public-methods
 class TestRefresh(unittest.TestCase):
     """Test update of top-level metadata following
     'Detailed client workflow' in the specification."""
@@ -49,7 +48,6 @@ class TestRefresh(unittest.TestCase):
     ) - datetime.timedelta(days=5)
 
     def setUp(self) -> None:
-        # pylint: disable=consider-using-with
         self.temp_dir = tempfile.TemporaryDirectory()
         self.metadata_dir = os.path.join(self.temp_dir.name, "metadata")
         self.targets_dir = os.path.join(self.temp_dir.name, "targets")

--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -555,9 +555,9 @@ class TestRefresh(unittest.TestCase):
         # Modify targets contents without updating
         # snapshot's targets hashes
         self.sim.targets.version += 1
-        self.sim.snapshot.meta["targets.json"].version = (
-            self.sim.targets.version
-        )
+        self.sim.snapshot.meta[
+            "targets.json"
+        ].version = self.sim.targets.version
         self.sim.snapshot.version += 1
         self.sim.update_timestamp()
 

--- a/tests/test_updater_validation.py
+++ b/tests/test_updater_validation.py
@@ -20,7 +20,6 @@ class TestUpdater(unittest.TestCase):
     """Test ngclient Updater input validation."""
 
     def setUp(self) -> None:
-        # pylint: disable-next=consider-using-with
         self.temp_dir = tempfile.TemporaryDirectory()
         self.metadata_dir = os.path.join(self.temp_dir.name, "metadata")
         self.targets_dir = os.path.join(self.temp_dir.name, "targets")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,7 +36,6 @@ def can_connect(port: int) -> bool:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.connect(("localhost", port))
         return True
-    # pylint: disable=broad-except
     except Exception:
         return False
     finally:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -230,7 +230,6 @@ class TestServerProcess:
 
         # Reusing one subprocess in multiple tests, but split up the logs
         # for each.
-        # pylint: disable=consider-using-with
         self.__server_process = subprocess.Popen(
             command,
             stdout=subprocess.PIPE,
@@ -362,5 +361,4 @@ class TestServerProcess:
 
     def is_process_running(self) -> bool:
         assert isinstance(self.__server_process, subprocess.Popen)
-        # pylint: disable=simplifiable-if-expression
         return True if self.__server_process.poll() is None else False

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -57,7 +57,7 @@ def run_sub_tests_with_dataset(
     cases in dataset"""
 
     def real_decorator(
-        function: Callable[[unittest.TestCase, Any], None]
+        function: Callable[[unittest.TestCase, Any], None],
     ) -> Callable[[unittest.TestCase], None]:
         def wrapper(test_cls: unittest.TestCase) -> None:
             for case, data in dataset.items():

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,6 @@ lint_dirs = tuf examples tests verify_release
 commands =
     ruff check {[testenv:lint]lint_dirs}
     ruff format --diff {[testenv:lint]lint_dirs}
-    pylint -j 0 --rcfile=pyproject.toml {[testenv:lint]lint_dirs}
 
     mypy {[testenv:lint]lint_dirs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ deps =
 lint_dirs = tuf examples tests verify_release
 commands =
     ruff check  --diff {[testenv:lint]lint_dirs}
+    ruff format --diff {[testenv:lint]lint_dirs}
     pylint -j 0 --rcfile=pyproject.toml {[testenv:lint]lint_dirs}
 
     mypy {[testenv:lint]lint_dirs}

--- a/tox.ini
+++ b/tox.ini
@@ -47,12 +47,12 @@ deps =
     --editable {toxinidir}
 lint_dirs = tuf examples tests verify_release
 commands =
-    ruff check  --diff {[testenv:lint]lint_dirs}
+    ruff check {[testenv:lint]lint_dirs}
     ruff format --diff {[testenv:lint]lint_dirs}
     pylint -j 0 --rcfile=pyproject.toml {[testenv:lint]lint_dirs}
 
     mypy {[testenv:lint]lint_dirs}
-    
+
     bandit -r tuf
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -47,15 +47,12 @@ deps =
     --editable {toxinidir}
 lint_dirs = tuf examples tests verify_release
 commands =
-    black --check --diff {[testenv:lint]lint_dirs}
-    isort --check --diff {[testenv:lint]lint_dirs}
+    ruff  --check  --diff {[testenv:lint]lint_dirs}
     pylint -j 0 --rcfile=pyproject.toml {[testenv:lint]lint_dirs}
 
     mypy {[testenv:lint]lint_dirs}
-
+    
     bandit -r tuf
-
-    pydocstyle tuf
 
 [testenv:docs]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ deps =
     --editable {toxinidir}
 lint_dirs = tuf examples tests verify_release
 commands =
-    ruff  --check  --diff {[testenv:lint]lint_dirs}
+    ruff check  --diff {[testenv:lint]lint_dirs}
     pylint -j 0 --rcfile=pyproject.toml {[testenv:lint]lint_dirs}
 
     mypy {[testenv:lint]lint_dirs}

--- a/tuf/api/exceptions.py
+++ b/tuf/api/exceptions.py
@@ -10,7 +10,6 @@ there is a good reason not to, and provide that reason in those cases.
 
 #### Repository errors ####
 
-# pylint: disable=unused-import
 from securesystemslib.exceptions import StorageError  # noqa: F401
 
 

--- a/tuf/api/exceptions.py
+++ b/tuf/api/exceptions.py
@@ -11,6 +11,7 @@ there is a good reason not to, and provide that reason in those cases.
 #### Repository errors ####
 
 # pylint: disable=unused-import
+# ruff: disable unused-inport
 from securesystemslib.exceptions import StorageError
 
 
@@ -23,7 +24,9 @@ class RepositoryError(Exception):
 
 
 class UnsignedMetadataError(RepositoryError):
-    """An error about metadata object with insufficient threshold of signatures."""
+    """An error about metadata object with insufficient threshold of
+    signatures.
+    """
 
 
 class BadVersionNumberError(RepositoryError):

--- a/tuf/api/exceptions.py
+++ b/tuf/api/exceptions.py
@@ -11,8 +11,7 @@ there is a good reason not to, and provide that reason in those cases.
 #### Repository errors ####
 
 # pylint: disable=unused-import
-# ruff: disable unused-inport
-from securesystemslib.exceptions import StorageError
+from securesystemslib.exceptions import StorageError  # noqa: F401
 
 
 class RepositoryError(Exception):

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -19,9 +19,10 @@ attributes generally follow the JSON format used in the specification.
 
 The above principle means that a ``Metadata`` object represents a single
 metadata file, and has a ``signed`` attribute that is an instance of one of the
-four top level signed classes (``Root``, ``Timestamp``, ``Snapshot`` and ``Targets``).
-To make Python type annotations useful ``Metadata`` can be type constrained: e.g. the
-signed attribute of ``Metadata[Root]`` is known to be ``Root``.
+four top level signed classes (``Root``, ``Timestamp``, ``Snapshot`` and 
+``Targets``). To make Python type annotations useful ``Metadata`` can be 
+type constrained: e.g. the signed attribute of ``Metadata[Root]`` 
+is known to be ``Root``.
 
 Currently Metadata API supports JSON as the file format.
 
@@ -101,8 +102,8 @@ class Metadata(Generic[T]):
 
     Using a type constraint is not required but not doing so means T is not a
     specific type so static typing cannot happen. Note that the type constraint
-    ``[Root]`` is not validated at runtime (as pure annotations are not available
-    then).
+    ``[Root]`` is not validated at runtime (as pure annotations are not
+    available then).
 
     New Metadata instances can be created from scratch with::
 
@@ -227,6 +228,7 @@ class Metadata(Generic[T]):
             storage_backend: Object that implements
                 ``securesystemslib.storage.StorageBackendInterface``.
                 Default is ``FilesystemBackend`` (i.e. a local file).
+
         Raises:
             StorageError: The file cannot be read.
             tuf.api.serialization.DeserializationError:
@@ -357,9 +359,10 @@ class Metadata(Generic[T]):
         """Create signature over ``signed`` and assigns it to ``signatures``.
 
         Args:
-            signer: A ``securesystemslib.signer.Signer`` object that provides a private
-                key and signing implementation to generate the signature. A standard
-                implementation is available in ``securesystemslib.signer.SSlibSigner``.
+            signer: A ``securesystemslib.signer.Signer`` object that provides a
+            private key and signing implementation to generate the signature. A
+            standard implementation is available in
+            ``securesystemslib.signer.SSlibSigner``.
             append: ``True`` if the signature should be appended to
                 the list of signatures or replace any existing signatures. The
                 default behavior is to replace signatures.
@@ -403,7 +406,8 @@ class Metadata(Generic[T]):
         threshold of keys for ``delegated_role``.
 
         .. deprecated:: 3.1.0
-           Please use ``Root.verify_delegate()`` or ``Targets.verify_delegate()``.
+           Please use ``Root.verify_delegate()`` or
+           ``Targets.verify_delegate()``.
         """
 
         if self.signed.type not in ["root", "targets"]:
@@ -522,7 +526,9 @@ class Signed(metaclass=abc.ABCMeta):
     @classmethod
     @abc.abstractmethod
     def from_dict(cls, signed_dict: Dict[str, Any]) -> "Signed":
-        """Deserialization helper, creates object from json/dict representation."""
+        """Deserialization helper, creates object from json/dict
+        representation.
+        """
         raise NotImplementedError
 
     @classmethod
@@ -533,7 +539,8 @@ class Signed(metaclass=abc.ABCMeta):
         representation, and returns an ordered list to be passed as leading
         positional arguments to a subclass constructor.
 
-        See ``{Root, Timestamp, Snapshot, Targets}.from_dict`` methods for usage.
+        See ``{Root, Timestamp, Snapshot, Targets}.from_dict``
+        methods for usage.
 
         """
         _type = signed_dict.pop("_type")
@@ -551,7 +558,8 @@ class Signed(metaclass=abc.ABCMeta):
         return version, spec_version, expires
 
     def _common_fields_to_dict(self) -> Dict[str, Any]:
-        """Return a dict representation of common fields of ``Signed`` instances.
+        """Return a dict representation of common fields of
+        ``Signed`` instances.
 
         See ``{Root, Timestamp, Snapshot, Targets}.to_dict`` methods for usage.
 
@@ -700,19 +708,27 @@ class RootVerificationResult:
 
     @property
     def verified(self) -> bool:
-        """True if threshold of signatures is met in both underlying VerificationResults."""
+        """True if threshold of signatures is met in both underlying
+        VerificationResults.
+        """
         return self.first.verified and self.second.verified
 
     @property
     def signed(self) -> Dict[str, Key]:
-        """Dictionary of all signing keys that have signed, from both VerificationResults"""
-        # return a union of all signed (in python<3.9 this requires dict unpacking)
+        """Dictionary of all signing keys that have signed, from both
+        VerificationResults.
+        return a union of all signed (in python<3.9 this requires
+        dict unpacking)
+        """
         return {**self.first.signed, **self.second.signed}
 
     @property
     def unsigned(self) -> Dict[str, Key]:
-        """Dictionary of all signing keys that have not signed, from both VerificationResults"""
-        # return a union of all unsigned (in python<3.9 this requires dict unpacking)
+        """Dictionary of all signing keys that have not signed, from both
+        VerificationResults.
+        return a union of all unsigned (in python<3.9 this requires
+        dict unpacking)
+        """
         return {**self.first.unsigned, **self.second.unsigned}
 
 
@@ -828,8 +844,8 @@ class Root(Signed, _DelegatorMixin):
         roles: Dictionary of role names to Roles. Defines which keys are
             required to sign the metadata for a specific role. Default is
             a dictionary of top level roles without keys and threshold of 1.
-        consistent_snapshot: ``True`` if repository supports consistent snapshots.
-            Default is True.
+        consistent_snapshot: ``True`` if repository supports consistent
+        snapshots. Default is True.
         unrecognized_fields: Dictionary of all attributes that are not managed
             by TUF Metadata API
 
@@ -1191,6 +1207,7 @@ class MetaFile(BaseFile):
             data: Metadata bytes that the metafile represents.
             hash_algorithms: Hash algorithms to create the hashes with. If not
             specified, the securesystemslib default hash algorithm is used.
+
         Raises:
             ValueError: The hash algorithms list contains an unsupported
             algorithm.
@@ -1234,7 +1251,8 @@ class Timestamp(Signed):
     """A container for the signed part of timestamp metadata.
 
     TUF file format uses a dictionary to contain the snapshot information:
-    this is not the case with ``Timestamp.snapshot_meta`` which is a ``MetaFile``.
+    this is not the case with ``Timestamp.snapshot_meta`` which is a
+    ``MetaFile``.
 
     *All parameters named below are not just constructor arguments but also
     instance attributes.*
@@ -1366,12 +1384,13 @@ class DelegatedRole(Role):
 
     A delegation can happen in two ways:
 
-        - ``paths`` is set: delegates targets matching any path pattern in ``paths``
-        - ``path_hash_prefixes`` is set: delegates targets whose target path hash
-          starts with any of the prefixes in ``path_hash_prefixes``
+        - ``paths`` is set: delegates targets matching any path pattern in
+          ``paths``
+        - ``path_hash_prefixes`` is set: delegates targets whose target path
+          hash starts with any of the prefixes in ``path_hash_prefixes``
 
-        ``paths`` and ``path_hash_prefixes`` are mutually exclusive: both cannot be
-        set, at least one of them must be set.
+        ``paths`` and ``path_hash_prefixes`` are mutually exclusive:
+        both cannot be set, at least one of them must be set.
 
     *All parameters named below are not just constructor arguments but also
     instance attributes.*
@@ -1491,10 +1510,10 @@ class DelegatedRole(Role):
         """Determine whether the given ``target_filepath`` is in one of
         the paths that ``DelegatedRole`` is trusted to provide.
 
-        The ``target_filepath`` and the ``DelegatedRole`` paths are expected to be
-        in their canonical forms, so e.g. "a/b" instead of "a//b" . Only "/" is
-        supported as target path separator. Leading separators are not handled
-        as special cases (see `TUF specification on targetpath
+        The ``target_filepath`` and the ``DelegatedRole`` paths are expected to
+        be in their canonical forms, so e.g. "a/b" instead of "a//b" . Only "/"
+        is supported as target path separator. Leading separators are not
+        handled as special cases (see `TUF specification on targetpath
         <https://theupdateframework.github.io/specification/latest/#targetpath>`_).
 
         Args:
@@ -1613,7 +1632,8 @@ class SuccinctRoles(Role):
         }
 
     def get_role_for_target(self, target_filepath: str) -> str:
-        """Calculate the name of the delegated role responsible for ``target_filepath``.
+        """Calculate the name of the delegated role responsible for
+        ``target_filepath``.
 
         The target at path ``target_filepath`` is assigned to a bin by casting
         the left-most ``bit_length`` of bits of the file path hash digest to
@@ -1897,6 +1917,7 @@ class TargetFile(BaseFile):
             local_path: Local path to target file content.
             hash_algorithms: Hash algorithms to calculate hashes with. If not
                 specified the securesystemslib default hash algorithm is used.
+
         Raises:
             FileNotFoundError: The file doesn't exist.
             ValueError: The hash algorithms list contains an unsupported

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -70,7 +70,6 @@ _SNAPSHOT = "snapshot"
 _TARGETS = "targets"
 _TIMESTAMP = "timestamp"
 
-# pylint: disable=too-many-lines
 
 logger = logging.getLogger(__name__)
 
@@ -157,7 +156,6 @@ class Metadata(Generic[T]):
         """Default canonical json byte representation of ``self.signed``."""
 
         # Use local scope import to avoid circular import errors
-        # pylint: disable=import-outside-toplevel
         from tuf.api.serialization.json import CanonicalJSONSerializer
 
         return CanonicalJSONSerializer().serialize(self.signed)
@@ -267,7 +265,6 @@ class Metadata(Generic[T]):
 
         if deserializer is None:
             # Use local scope import to avoid circular import errors
-            # pylint: disable=import-outside-toplevel
             from tuf.api.serialization.json import JSONDeserializer
 
             deserializer = JSONDeserializer()
@@ -297,7 +294,6 @@ class Metadata(Generic[T]):
 
         if serializer is None:
             # Use local scope import to avoid circular import errors
-            # pylint: disable=import-outside-toplevel
             from tuf.api.serialization.json import JSONSerializer
 
             serializer = JSONSerializer(compact=True)
@@ -855,7 +851,6 @@ class Root(Signed, _DelegatorMixin):
 
     type = _ROOT
 
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
         version: Optional[int] = None,
@@ -2001,7 +1996,6 @@ class Targets(Signed, _DelegatorMixin):
 
     type = _TARGETS
 
-    # pylint: disable=too-many-arguments
     def __init__(
         self,
         version: Optional[int] = None,

--- a/tuf/api/serialization/__init__.py
+++ b/tuf/api/serialization/__init__.py
@@ -20,7 +20,6 @@ from typing import TYPE_CHECKING
 from tuf.api.exceptions import RepositoryError
 
 if TYPE_CHECKING:
-    # pylint: disable=cyclic-import
     from tuf.api.metadata import Metadata, Signed
 
 

--- a/tuf/api/serialization/json.py
+++ b/tuf/api/serialization/json.py
@@ -13,7 +13,6 @@ from typing import Optional
 
 from securesystemslib.formats import encode_canonical
 
-# pylint: disable=cyclic-import
 # ... to allow de/serializing Metadata and Signed objects here, while also
 # creating default de/serializers there (see metadata local scope imports).
 # NOTE: A less desirable alternative would be to add more abstraction layers.

--- a/tuf/ngclient/__init__.py
+++ b/tuf/ngclient/__init__.py
@@ -15,7 +15,7 @@ from tuf.ngclient.config import UpdaterConfig
 from tuf.ngclient.fetcher import FetcherInterface
 from tuf.ngclient.updater import Updater
 
-__all__ = [
+__all__ = [  # noqa: PLE0604
     FetcherInterface.__name__,
     RequestsFetcher.__name__,
     TargetFile.__name__,

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -1,7 +1,8 @@
 # Copyright 2021, New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
-"""Provides an implementation of ``FetcherInterface`` using the Requests HTTP library.
+"""Provides an implementation of ``FetcherInterface`` using the Requests HTTP
+library.
 """
 
 # requests_fetcher is public but comes from _internal for now (because
@@ -117,7 +118,8 @@ class RequestsFetcher(FetcherInterface):
             response.close()
 
     def _get_session(self, url: str) -> requests.Session:
-        """Return a different customized requests.Session per schema+hostname combination.
+        """Return a different customized requests.Session per schema+hostname
+        combination.
 
         Raises:
             exceptions.DownloadError: When there is a problem parsing the url.

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -73,9 +73,10 @@ logger = logging.getLogger(__name__)
 class TrustedMetadataSet(abc.Mapping):
     """Internal class to keep track of trusted metadata in ``Updater``.
 
-    ``TrustedMetadataSet`` ensures that the collection of metadata in it is valid
-    and trusted through the whole client update workflow. It provides easy ways
-    to update the metadata with the caller making decisions on what is updated.
+    ``TrustedMetadataSet`` ensures that the collection of metadata in it is
+    valid and trusted through the whole client update workflow. It provides
+    easy ways to update the metadata with the caller making decisions on
+    what is updated.
     """
 
     def __init__(self, root_data: bytes):
@@ -107,7 +108,9 @@ class TrustedMetadataSet(abc.Mapping):
         return len(self._trusted_set)
 
     def __iter__(self) -> Iterator[Metadata]:
-        """Return iterator over ``Metadata`` objects in ``TrustedMetadataSet``."""
+        """Return iterator over ``Metadata`` objects in
+        ``TrustedMetadataSet``.
+        """
         return iter(self._trusted_set.values())
 
     # Helper properties for top level metadata

--- a/tuf/repository/__init__.py
+++ b/tuf/repository/__init__.py
@@ -10,4 +10,5 @@ well as developer and signing tools.
 The repository module is not considered part of the stable python-tuf API yet.
 """
 
+# ruff: disable unused-inport
 from tuf.repository._repository import AbortEdit, Repository

--- a/tuf/repository/__init__.py
+++ b/tuf/repository/__init__.py
@@ -10,5 +10,4 @@ well as developer and signing tools.
 The repository module is not considered part of the stable python-tuf API yet.
 """
 
-# ruff: disable unused-inport
-from tuf.repository._repository import AbortEdit, Repository
+from tuf.repository._repository import AbortEdit, Repository  # noqa: F401, I001

--- a/tuf/repository/__init__.py
+++ b/tuf/repository/__init__.py
@@ -10,4 +10,4 @@ well as developer and signing tools.
 The repository module is not considered part of the stable python-tuf API yet.
 """
 
-from tuf.repository._repository import AbortEdit, Repository  # noqa: F401, I001
+from tuf.repository._repository import AbortEdit, Repository  # noqa: F401

--- a/tuf/repository/_repository.py
+++ b/tuf/repository/_repository.py
@@ -22,6 +22,7 @@ from tuf.api.metadata import (
 logger = logging.getLogger(__name__)
 
 
+# ruff: ignore N818 `Exception name should have Error suffix`
 class AbortEdit(Exception):
     """Raise to exit the edit() contextmanager without saving changes"""
 

--- a/tuf/repository/_repository.py
+++ b/tuf/repository/_repository.py
@@ -22,8 +22,7 @@ from tuf.api.metadata import (
 logger = logging.getLogger(__name__)
 
 
-# ruff: ignore N818 `Exception name should have Error suffix`
-class AbortEdit(Exception):
+class AbortEdit(Exception):  # noqa: N818
     """Raise to exit the edit() contextmanager without saving changes"""
 
 

--- a/verify_release
+++ b/verify_release
@@ -19,7 +19,7 @@ from tempfile import TemporaryDirectory
 from typing import Optional
 
 try:
-    import build as _
+    import build as _  # type: ignore
     import requests
 except ImportError:
     print("Error: verify_release requires modules 'requests' and 'build':")

--- a/verify_release
+++ b/verify_release
@@ -19,7 +19,7 @@ from tempfile import TemporaryDirectory
 from typing import Optional
 
 try:
-    import build as _  # type: ignore
+    import build as _
     import requests
 except ImportError:
     print("Error: verify_release requires modules 'requests' and 'build':")

--- a/verify_release
+++ b/verify_release
@@ -19,7 +19,7 @@ from tempfile import TemporaryDirectory
 from typing import Optional
 
 try:
-    import build as _  # type: ignore
+    import build as _  # type: ignore # noqa: F401
     import requests
 except ImportError:
     print("Error: verify_release requires modules 'requests' and 'build':")
@@ -168,19 +168,21 @@ def sign_release_artifacts(
 
 
 def finished(s: str) -> None:
+    """Displays a finished message."""
     # clear line
     sys.stdout.write("\033[K")
     print(f"* {s}")
 
 
 def progress(s: str) -> None:
+    """Displays a progress message."""
     # clear line
     sys.stdout.write("\033[K")
     # carriage return but no newline: next print will overwrite this one
     print(f"  {s}...", end="\r", flush=True)
 
 
-def main() -> int:
+def main() -> int:  # noqa: D103
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--skip-pypi",
@@ -194,8 +196,9 @@ def main() -> int:
         const=True,
         metavar="<key id>",
         dest="sign",
-        help="Sign release artifacts with 'gpg'. If no <key id> is passed, the default "
-        "signing key is used. Resulting '*.asc' files are written to CWD.",
+        help="Sign release artifacts with 'gpg'. If no <key id> is passed,"
+        " the default signing key is used. Resulting '*.asc' files are written"
+        " to CWD.",
     )
     args = parser.parse_args()
 
@@ -237,7 +240,8 @@ def main() -> int:
         else:
             finished("GitHub artifacts match the built release")
 
-        # NOTE: 'gpg' might prompt for password or ask if it should override files...
+        # NOTE: 'gpg' might prompt for password or ask if it should
+        # override files...
         if args.sign:
             progress("Signing built release with gpg")
             if success:


### PR DESCRIPTION
…pylint

Please fill in the fields below to submit a pull request.  The more information
that is provided, the better.

Fixes #2550 

**Description of the changes being introduced by the pull request**:
Linting still takes so long in this project... I propose replacing these tools with ruff check and ruff format:

black
isort
pylint
pydocstyle

**Please verify and check that the pull request fulfills the following
requirements**:

- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
- [ ] Tests have been added for the bug fix or new feature
- [ ] Docs have been added for the bug fix or new feature


