### PR TITLE
metadata API: Tweak exception message on sign failure

### DIFF
--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -384,7 +384,7 @@ class Metadata(Generic[T]):
         try:
             signature = signer.sign(bytes_data)
         except Exception as e:
-            raise UnsignedMetadataError("Problem signing the metadata") from e
+            raise UnsignedMetadataError(f"Failed to sign: {e}") from e
 
         if not append:
             self.signatures.clear()


### PR DESCRIPTION
I still don't know how we should handle failures in signing (maybe just let all of the weird exceptions raise instead of wrapping them) but this makes the wrapping error at least a bit more useful.

