### PR TITLE
gitattributes: Fix diff hunk headers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Test data should not be modified on checkout, regardless of host settings
 *.json binary
+*.py diff=python


### PR DESCRIPTION
Git is really bad at identifying the correct Python function in the diff hunk headers (example is a change in Metadata.sign()):

    @@ -384,7 +384,7 @@ class Metadata(Generic[T]):

Amazingly there is much better context detection built-in, just not enabled. The same diff hunk headers with this commit looks like:

    @@ -384,7 +384,7 @@ def sign(
