### PR TITLE
lint: Enable pycodestyle in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,8 +92,13 @@ select = [
 ignore = ["D400","D415","D213","D205","D202","D107","D407","D413","D212","D104","D406","D105","D411","D401","D200","D203", "PLR0913", "PLR2004"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["D", "E"]
-"examples/*/*" = ["D"] 
+"tests/*" = [
+    "D",   # pydocstyle: no docstrings required for tests
+    "E501" # line-too-long: embedded test data in "fmt: off" blocks is ok
+]
+"examples/*/*" = [
+    "D",   # pydocstyle: no docstrings required for examples
+]
 
 # mypy section
 # Read more here: https://mypy.readthedocs.io/en/stable/config_file.html#using-a-pyproject-toml-file


### PR DESCRIPTION
Only leave E501 (line-too-long) disabled: There is a lot of embedded test data that is not formatted according to the rules.

Fixes #2568
