### PR TITLE
Lint use GitHub output format

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -26,6 +26,8 @@ jobs:
           python3 -m pip install --constraint requirements/build.txt tox coveralls
 
       - name: Run tox
+        env:
+          RUFF_OUTPUT_FORMAT: github
         run: tox -e lint
 
   tests:

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ deps =
     -r{toxinidir}/requirements/lint.txt
     --editable {toxinidir}
 lint_dirs = tuf examples tests verify_release
+passenv = RUFF_OUTPUT_FORMAT
 commands =
     ruff check {[testenv:lint]lint_dirs}
     ruff format --diff {[testenv:lint]lint_dirs}


### PR DESCRIPTION
Use `RUFF_OUTPUT_FORMAT=github` when on GitHub: this gives inline linter annotations