### PR TITLE
lint: Start using ruff ruleset "flake8-bandit"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
     test-and-lint-dependencies:
       # Python dependencies that are only pinned to ensure test reproducibility
       patterns:
-        - "bandit"
         - "coverage"
         - "mypy"
         - "ruff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,16 +88,22 @@ select = [
     "I",  # isort
     "N",  # pep8-naming
     "PL", # pylint
+    "S",  # flake8-bandit
 ] 
 ignore = ["D400","D415","D213","D205","D202","D107","D407","D413","D212","D104","D406","D105","D411","D401","D200","D203", "PLR0913", "PLR2004"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [
-    "D",   # pydocstyle: no docstrings required for tests
-    "E501" # line-too-long: embedded test data in "fmt: off" blocks is ok
+    "D",    # pydocstyle: no docstrings required for tests
+    "E501", # line-too-long: embedded test data in "fmt: off" blocks is ok
+    "S",    # bandit: Not running bandit on tests
 ]
 "examples/*/*" = [
-    "D",   # pydocstyle: no docstrings required for examples
+    "D", # pydocstyle: no docstrings required for examples
+    "S"  # bandit: Not running bandit on examples
+]
+"verify_release" = [
+    "S603", # bandit: this flags all uses of subprocess.run as vulnerable
 ]
 
 # mypy section

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -8,4 +8,3 @@
 # are pinned to prevent unexpected linting failures when tools update)
 ruff==0.2.2
 mypy==1.8.0
-bandit==1.7.7

--- a/tox.ini
+++ b/tox.ini
@@ -52,8 +52,6 @@ commands =
 
     mypy {[testenv:lint]lint_dirs}
 
-    bandit -r tuf
-
 [testenv:docs]
 deps =
     -r{toxinidir}/requirements/docs.txt

--- a/verify_release
+++ b/verify_release
@@ -54,21 +54,21 @@ def build(build_dir: str) -> str:
             build_cmd, stdout=subprocess.DEVNULL, check=True, env=env
         )
 
-    build_version = None
     for filename in os.listdir(build_dir):
         prefix, postfix = f"{PYPI_PROJECT}-", ".tar.gz"
         if filename.startswith(prefix) and filename.endswith(postfix):
-            build_version = filename[len(prefix) : -len(postfix)]
+            return filename[len(prefix) : -len(postfix)]
 
-    assert build_version
-    return build_version
+    raise RuntimeError("Build version not found")
 
 
 def get_git_version() -> str:
     """Return version string from git describe"""
     cmd = ["git", "describe"]
     process = subprocess.run(cmd, text=True, capture_output=True, check=True)
-    assert process.stdout.startswith("v") and process.stdout.endswith("\n")
+    if not process.stdout.startswith("v") or not process.stdout.endswith("\n"):
+        raise RuntimeError(f"Unexpected git version {process.stdout}")
+
     return process.stdout[1:-1]
 
 
@@ -93,7 +93,7 @@ def get_pypi_pip_version() -> str:
             prefix, postfix = f"{PYPI_PROJECT}-", ".tar.gz"
             if filename.startswith(prefix) and filename.endswith(postfix):
                 return filename[len(prefix) : -len(postfix)]
-        assert False
+        raise RuntimeError("PyPI version not found")
 
 
 def verify_github_release(version: str, compare_dir: str) -> bool:
@@ -164,7 +164,9 @@ def sign_release_artifacts(
         subprocess.run(
             cmd + ["--output", signature_path, artifact_path], check=True
         )
-        assert os.path.exists(signature_path)
+
+        if not os.path.exists(signature_path):
+            raise RuntimeError("Signing failed, signature not found")
 
 
 def finished(s: str) -> None:
@@ -209,7 +211,10 @@ def main() -> int:  # noqa: D103
         finished(f"Built release {build_version}")
 
         git_version = get_git_version()
-        assert git_version.startswith(build_version)
+        if not git_version.startswith(build_version):
+            raise RuntimeError(
+                f"Git version is {git_version}, expected {build_version}"
+            )
         if git_version != build_version:
             finished(f"WARNING: Git describes version as {git_version}")
 


### PR DESCRIPTION
* Remove bandit
* Add ruff ruleset "flake8-bandit"
* verify_release is now checked by bandit
  * Avoid some asserts as suggested
  * ignore a subprocess.run lint: it seems dumb
* ignore all bandit rules for tests and examples (just like before)


The ruff rules list is not 100% same as bandit itself but very close. 