### PR TITLE
Improve dev docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,8 @@
 <!--
 Before submitting a pull request:
-  * Please run linter and tests locally: "tox"
+  * Run linter and tests locally: Use "tox"
   * Ensure your commits are signed-off-by: Use "commit --signoff"
+  * Make sure new code has tests and is documented
   * For more info, see docs/CONTRIBUTING.rst
 
 Once commits are signed off and tested, describe the purpose and contents
@@ -14,11 +15,4 @@ of the pull request below.
 
 
 Fixes #<ISSUE NUMBER>
-
-
-<!-- Please check relevant options (you can remove the ones that do not apply) -->
-- [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
-- [ ] Tests have been added for the bug fix or new feature
-- [ ] Docs have been added for the bug fix or new feature
-
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,22 @@
-Please fill in the fields below to submit a pull request.  The more information
-that is provided, the better.
+<!--
+Before submitting a pull request:
+  * Please run linter and tests locally: "tox"
+  * Ensure your commits are signed-off-by: Use "commit --signoff"
+  * For more info, see docs/CONTRIBUTING.rst
 
-Fixes #<ISSUE NUMBER>
+Once commits are signed off and tested, describe the purpose and contents
+of the pull request below.
+-->
 
 **Description of the changes being introduced by the pull request**:
 
-**Please verify and check that the pull request fulfills the following
-requirements**:
 
+
+
+Fixes #<ISSUE NUMBER>
+
+
+<!-- Please check relevant options (you can remove the ones that do not apply) -->
 - [ ] The code follows the [Code Style Guidelines](https://github.com/secure-systems-lab/code-style-guidelines#code-style-guidelines)
 - [ ] Tests have been added for the bug fix or new feature
 - [ ] Docs have been added for the bug fix or new feature

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -72,7 +72,7 @@ Auto-formatting
 ---------------
 
 The linter in CI/CD will check that new TUF code is formatted with
-`ruff<https://docs.astral.sh/ruff/>`__. Auto-formatting can be done on the
+`ruff <https://docs.astral.sh/ruff/>`_. Auto-formatting can be done on the
 command line:
 ::
 

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -13,6 +13,14 @@ and must be `unit tested <#unit-tests>`_.
 
      Also see `development installation instructions <https://theupdateframework.readthedocs.io/en/latest/INSTALLATION.html#install-for-development>`_.
 
+DCO
+===
+
+Contributors must indicate acceptance of the `Developer Certificate of
+Origin <https://developercertificate.org/>`_ by appending a ``Signed-off-by:
+Your Name <example@domain.com>`` to each git commit message (see `git commit
+--signoff <https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff>`_).
+
 Testing
 =======
 
@@ -63,26 +71,9 @@ via PyPI).
 Auto-formatting
 ---------------
 
-CI/CD will check that new TUF code is formatted with `black
-<https://black.readthedocs.io/>`__ and `isort <https://pycqa.github.io/isort>`__.
-Auto-formatting can be done on the command line:
+The linter in CI/CD will check that new TUF code is formatted with
+`ruff<https://docs.astral.sh/ruff/>`__. Auto-formatting can be done on the
+command line:
 ::
 
-    $ black <filename>
-    $ isort <filename>
-
-or via source code editor plugin
-[`black <https://black.readthedocs.io/en/stable/editor_integration.html>`__,
-`isort <https://github.com/pycqa/isort/wiki/isort-Plugins>`__] or
-`pre-commit <https://pre-commit.com/>`__-powered git hooks
-[`black <https://black.readthedocs.io/en/stable/version_control_integration.html>`__,
-`isort <https://pycqa.github.io/isort/docs/configuration/pre-commit/>`__].
-
-
-DCO
-===
-
-Contributors must also indicate acceptance of the `Developer Certificate of
-Origin <https://developercertificate.org/>`_ by appending a ``Signed-off-by:
-Your Name <example@domain.com>`` to each git commit message (see `git commit
---signoff <https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff>`_).
+    $ ruff format .


### PR DESCRIPTION
I'm trying to improve the experience for first time contributors: I think it must be bad since our success rate is probably below 10% for the first version of the first PR...

* Mention tests and DCO in PR template
* tweak contributing doc

Other suggestions welcome.