### PR TITLE
tests: Fix test signer to match new securesystemslib API

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -255,6 +255,10 @@ class TestMetadata(unittest.TestCase):
             ) -> "Signer":
                 pass
 
+            @property
+            def public_key(self) -> Key:
+                raise RuntimeError("Not a real signer")
+
             def sign(self, payload: bytes) -> Signature:
                 raise RuntimeError("signing failed")
 


### PR DESCRIPTION
securesystemslib main requires Signers to have a public_key property.

This fixes test failure on current main branch.