### PR TITLE
lint: Enable more ruff rulesets

### DIFF
--- a/examples/uploader/_localrepo.py
+++ b/examples/uploader/_localrepo.py
@@ -80,7 +80,7 @@ class LocalRepository(Repository):
         md.signed.version += 1
         md.signed.expires = datetime.now(timezone.utc) + self.expiry_period
 
-        with open(f"{self.key_dir}/{role}", "rt", encoding="utf-8") as f:
+        with open(f"{self.key_dir}/{role}", encoding="utf-8") as f:
             signer = SSlibSigner(json.loads(f.read()))
 
         md.sign(signer, append=False)
@@ -126,7 +126,7 @@ class LocalRepository(Repository):
             return False
 
         # Store the private key using rolename as filename
-        with open(f"{self.key_dir}/{role}", "wt", encoding="utf-8") as f:
+        with open(f"{self.key_dir}/{role}", "w", encoding="utf-8") as f:
             f.write(json.dumps(keydict))
 
         print(f"Uploaded new delegation, stored key in {self.key_dir}/{role}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,19 +84,26 @@ line-length=80
 select = [
     "A",   # flake8-builtins
     "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
     "D",   # pydocstyle
     "DTZ", # flake8-datetimez
     "E",   # pycodestyle
     "F",   # pyflakes
     "I",   # isort
+    "ISC", # flake8-implicit-str-concat
     "N",   # pep8-naming
     "PL",  # pylint
     "RET", # flake8-return
     "S",   # flake8-bandit
     "SIM", # flake8-simplify
+    "UP",  # pyupgrade
     "W",   # pycodestyle-warning
 ] 
-ignore = ["D400","D415","D213","D205","D202","D107","D407","D413","D212","D104","D406","D105","D411","D401","D200","D203", "PLR0913", "PLR2004"]
+ignore = [
+    "D400", "D415", "D213", "D205", "D202", "D107", "D407", "D413", "D212", "D104", "D406", "D105", "D411", "D401", "D200", "D203",
+    "PLR0913", "PLR2004",
+    "ISC001", # incompatible with ruff formatter
+]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [

--- a/tests/generated_data/generate_md.py
+++ b/tests/generated_data/generate_md.py
@@ -69,7 +69,7 @@ def verify_generation(md: Metadata, path: str) -> None:
         if static_md_bytes != md_bytes:
             raise ValueError(
                 f"Generated data != local data at {path}. Generate a new "
-                + "metadata with 'python generated_data/generate_md.py'"
+                "metadata with 'python generated_data/generate_md.py'"
             )
 
 

--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -306,7 +306,7 @@ class TestTrustedMetadataSet(unittest.TestCase):
 
         # Update timestamp with the same version.
         with self.assertRaises(exceptions.EqualVersionNumberError):
-            self.trusted_set.update_timestamp((self.metadata[Timestamp.type]))
+            self.trusted_set.update_timestamp(self.metadata[Timestamp.type])
 
         # Every object has a unique id() if they are equal, this means timestamp
         # was not updated.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -113,7 +113,7 @@ def wait_for_server(
             succeeded = True
         except socket.timeout:
             pass
-        except IOError as e:
+        except OSError as e:
             # ECONNREFUSED is expected while the server is not started
             if e.errno not in [errno.ECONNREFUSED]:
                 logger.warning(

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -106,8 +106,7 @@ class RequestsFetcher(FetcherInterface):
         """
 
         try:
-            for data in response.iter_content(self.chunk_size):
-                yield data
+            yield from response.iter_content(self.chunk_size)
         except (
             requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,


### PR DESCRIPTION
Minor fixes were needed, the only possibly interesting one is the one in RequestsFetcher (use "yield from").

This is part of #2567

I expect this to currently fail tests for unrelated reasons,  #2591 should fix it