### PR TITLE
Adopt upstream DSSE model change

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1233,9 +1233,7 @@ class TestSimpleEnvelope(unittest.TestCase):
             envelope.sign(signer)
             self.assertTrue(len(envelope.signatures) == 1)
 
-            root.verify_delegate(
-                role.type, envelope.pae(), envelope.signatures_dict
-            )
+            root.verify_delegate(role.type, envelope.pae(), envelope.signatures)
 
 
 # Run unit test.

--- a/tuf/api/dsse.py
+++ b/tuf/api/dsse.py
@@ -1,7 +1,7 @@
 """Low-level TUF DSSE API. (experimental!)"""
 
 import json
-from typing import Dict, Generic, Type, cast
+from typing import Generic, Type, cast
 
 from securesystemslib.dsse import Envelope as BaseSimpleEnvelope
 
@@ -42,24 +42,17 @@ class SimpleEnvelope(Generic[T], BaseSimpleEnvelope):
         delegator.verify_delegate(
             role_name,
             envelope.pae(),  # Note, how we don't pass ``envelope.payload``!
-            envelope.signatures_dict,
+            envelope.signatures,
             )
 
     Attributes:
         payload: Serialized payload bytes.
         payload_type: Payload string identifier.
-        signatures: List of ``Signature`` objects.
-        signatures_dict: Ordered dictionary of keyids to ``Signature`` objects.
+        signatures: Dictionary of keyids to ``Signature`` objects
 
     """
 
     _DEFAULT_PAYLOAD_TYPE = "application/vnd.tuf+json"
-
-    @property
-    def signatures_dict(self) -> Dict:
-        """Convenience alias for ``self.signatures`` mapped to keyids."""
-        # TODO: Propose changing ``signatures`` list to dict upstream
-        return {sig.keyid: sig for sig in self.signatures}
 
     @classmethod
     def from_bytes(cls, data: bytes) -> "SimpleEnvelope[T]":
@@ -126,7 +119,7 @@ class SimpleEnvelope(Generic[T], BaseSimpleEnvelope):
         except Exception as e:
             raise SerializationError from e
 
-        return cls(json_bytes, cls._DEFAULT_PAYLOAD_TYPE, [])
+        return cls(json_bytes, cls._DEFAULT_PAYLOAD_TYPE, {})
 
     def get_signed(self) -> T:
         """Extract and deserialize payload JSON bytes from envelope.

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -500,7 +500,7 @@ def _load_from_simple_envelope(
         if role_name is None:
             role_name = role.type
         delegator.verify_delegate(
-            role_name, envelope.pae(), envelope.signatures_dict
+            role_name, envelope.pae(), envelope.signatures
         )
 
     signed = envelope.get_signed()
@@ -509,4 +509,4 @@ def _load_from_simple_envelope(
             f"Expected '{role.type}', got '{signed.type}'"
         )
 
-    return signed, envelope.pae(), envelope.signatures_dict
+    return signed, envelope.pae(), envelope.signatures


### PR DESCRIPTION
*[blocks on next securesystemslib release]*

Adopt `securesystemslib.dsse.Envelope.signatures` type change from list to dict (secure-systems-lab/securesystemslib/pull/743) in `tuf.api.dsse.SimpleEnvelope` subclass.

fixes #2564
