### PR TITLE
Constrain securesystemslib dependency to <0.32.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
 ]
 dependencies = [
   "requests>=2.19.1",
-  "securesystemslib>=0.26.0",
+  "securesystemslib>=0.26.0,<0.32.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
There are several breaking changes coming up in securesystemslib on its way to 1.0.

To not disrupt tuf users this patch constrains securesystemslib to not update the current minor version..
