### PR TITLE
Release v4.0.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## v4.0.0
+
+This release is a small API change for Metadata API users (see below).
+ngclient API is compatible but optional DSSE support has been added.
+
+### Added
+* Added optional DSSE support to Metadata API and ngclient (#2436)
+
+### Changed
+* Metadata API: Improved verification functionality for repository users (#2551):
+  * This is an API change for Metadata API users (
+    `Root.get_verification_result()` and `Targets.get_verification_result()`
+    specifically)
+  * `Root.get_root_verification_result()` has been added to handle the special
+    case of root verification
+* Started using UTC datetimes instead of naive datetimes internally (#2573)
+* Constrain securesystemslib dependency to <0.32.0 in preparation for future
+  securesystemslib API changes
+* Various build, test and lint improvements
+
+
+## v3.1.1
+
+This is a security fix release to address advisory
+GHSA-77hh-43cm-v8j6. The issue does **not** affect tuf.ngclient
+users, but could affect tuf.api.metadata users.
+
+### Changed
+* Added additional input validation to
+  `tuf.api.metadata.Targets.get_delegated_role()`
+
+
 ## v3.1.0
 
 ### Added

--- a/tuf/__init__.py
+++ b/tuf/__init__.py
@@ -4,4 +4,4 @@
 """TUF."""
 
 # This value is used in the requests user agent.
-__version__ = "3.1.0"
+__version__ = "4.0.0"


### PR DESCRIPTION
This is a major bump only because of Metadata API, ngclient remains compatible with 3.x.

---

The main motivation for doing the release right now is 
> Constrain securesystemslib dependency to <0.32.0 in preparation for future securesystemslib API changes

This allows securesystemslib to make API breaking releases without accidentally breaking python-tuf users who do not pin all of their dependencies.

Note that we had forgotten to "forward-port" the changelog and version bump from 3.1.1 branch so I did it here.