### PR TITLE
workflows: Simplify testing

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -9,7 +9,6 @@ jobs:
     name: Lint Test
     runs-on: ubuntu-latest
 
-
     steps:
       - name: Checkout TUF
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -19,7 +18,9 @@ jobs:
         with:
           python-version: 3.8
           cache: 'pip'
-          cache-dependency-path: 'requirements/*.txt'
+          cache-dependency-path: |
+            requirements/*.txt
+            pyproject.toml
 
       - name: Install dependencies
         run: |
@@ -33,23 +34,10 @@ jobs:
   tests:
     name: Tests
     needs: lint-test
-    continue-on-error: true
     strategy:
-      # Run regular TUF tests on each OS/Python combination, plus
-      # (sslib main) on Linux/Python3.x only.
       matrix:
-        toxenv: [py]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        include:
-          - python-version: 3.x
-            os: ubuntu-latest
-            toxenv: with-sslib-main
-            experimental: true
-
-    env:
-      # Set TOXENV env var to tell tox which testenv (see tox.ini) to use
-      TOXENV: ${{ matrix.toxenv }}
 
     runs-on: ${{ matrix.os }}
 
@@ -62,15 +50,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: 'requirements/*.txt'
+          cache-dependency-path: |
+            requirements/*.txt
+            pyproject.toml
 
       - name: Install dependencies
         run: |
           python3 -m pip install --constraint requirements/build.txt tox coveralls
 
-      - name: Run tox (${{ env.TOXENV }})
-        # See TOXENV environment variable for the testenv to be executed here
-        run: tox
+      - name: Run tox
+        run: tox -e py
 
       - name: Publish on coveralls.io
         # A failure to publish coverage results on coveralls should not
@@ -78,7 +67,7 @@ jobs:
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: ${{ runner.os }} / Python ${{ matrix.python-version }} / ${{ env.TOXENV }}
+          COVERALLS_FLAG_NAME: ${{ runner.os }} / Python ${{ matrix.python-version }}
           COVERALLS_PARALLEL: true
         # Use cp workaround to publish coverage reports with relative paths
         # FIXME: Consider refactoring the tests to not require the test

--- a/.github/workflows/_test_sslib_main.yml
+++ b/.github/workflows/_test_sslib_main.yml
@@ -1,0 +1,30 @@
+on:
+  workflow_call:
+  # Permissions inherited from caller workflow
+
+permissions: {}
+
+jobs:
+  sslib-main:
+    name: Test securesystemslib main branch (not a merge blocker)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout TUF
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Set up Python
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements/*.txt
+            pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --constraint requirements/build.txt tox
+
+      - name: Run tox
+        run: tox -e with-sslib-main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,5 @@ permissions: {}
 jobs:
   test:
     uses: ./.github/workflows/_test.yml
+  test-with-sslib-main:
+    uses: ./.github/workflows/_test_sslib_main.yml


### PR DESCRIPTION
* Don't try to handle sslib main test within the matrix
* Put it in a separate workflow
* Include the new workflow in CI but not in CD
* Bonus: Make cache-dependency-path more complete

Fixes #2604


---

