### PR TITLE
workflows: Only test old Pythons on linux

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -37,7 +37,12 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
+        include:
+          - python-version: "3.12"
+            os: macos-latest
+          - python-version: "3.12"
+            os: windows-latest
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
* This fixes current CI (new mac runners do not have old pythons)
* This is also sensible: running the complete matrix seems wasteful

-- 

I've removed the relevant tests from "required checks" in project settings already.