### PR TITLE
linting: Enable all Ruff rulesets by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,55 +81,48 @@ dev-mode-dirs = ["."]
 line-length=80
 
 [tool.ruff.lint]
-select = [
-    "A",   # flake8-builtins
-    "ANN", # flake8-annotations
-    "ARG", # flake8-unused-arguments
-    "B",   # flake8-bugbear
-    "BLE", # flake8-blind-except
-    "C4",  # flake8-comprehensions
-    "D",   # pydocstyle
-    "DTZ", # flake8-datetimez
-    "E",   # pycodestyle
-    "EXE", # flake8-executable
-    "F",   # pyflakes
-    "I",   # isort
-    "ISC", # flake8-implicit-str-concat
-    "N",   # pep8-naming
-    "PL",  # pylint
-    "PGH", # pygrep-hooks
-    "PIE", # flake8-pie
-    "PYI", # flake8-pyi
-    "RET", # flake8-return
-    "RSE", # flake8-raise
-    "RUF", # ruff-specific rules
-    "S",   # flake8-bandit
-    "SIM", # flake8-simplify
-    "SLF", # flake8-self
-    "UP",  # pyupgrade
-    "W",   # pycodestyle-warning
-] 
+select = ["ALL"]
 ignore = [
+    # Rulesets we do not use at this moment
+    "COM",
+    "EM",
+    "FA",
+    "FIX",
+    "FBT",
+    "PERF",
+    "PT",
+    "PTH",
+    "TD",
+    "TRY",
+
+    # Individual rules that have been disabled
     "ANN101", "ANN102", # nonsense, deprecated in ruff
     "D400", "D415", "D213", "D205", "D202", "D107", "D407", "D413", "D212", "D104", "D406", "D105", "D411", "D401", "D200", "D203",
-    "PLR0913", "PLR2004",
     "ISC001", # incompatible with ruff formatter
+    "PLR0913", "PLR2004",
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [
     "D",      # pydocstyle: no docstrings required for tests
     "E501",   # line-too-long: embedded test data in "fmt: off" blocks is ok
+    "ERA001", # commented code is fine in tests
     "RUF012", # ruff: mutable-class-default
     "S",      # bandit: Not running bandit on tests
-    "SLF001"  # private member access is ok in tests
+    "SLF001", # private member access is ok in tests
+    "T201",   # print is ok in tests
 ]
 "examples/*/*" = [
-    "D", # pydocstyle: no docstrings required for examples
-    "S"  # bandit: Not running bandit on examples
+    "D",      # pydocstyle: no docstrings required for examples
+    "ERA001", # commented code is fine in examples
+    "INP001", # implicit package is fine in examples
+    "S",      # bandit: Not running bandit on examples
+    "T201",   # print is ok in examples
 ]
 "verify_release" = [
-    "S603", # bandit: this flags all uses of subprocess.run as vulnerable
+    "ERA001", # commented code is fine here
+    "S603",   # bandit: this flags all uses of subprocess.run as vulnerable
+    "T201",   # print is ok in verify_release
 ]
 
 [tool.ruff.lint.flake8-annotations]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -218,7 +218,7 @@ class TestServerProcess:
 
         self._wait_for_port(timeout)
 
-        self.__logger.info(self.server + " serving on " + str(self.port))
+        self.__logger.info("%s serving on %d", self.server, self.port)
 
     def _start_process(self, extra_cmd_args: List[str], popen_cwd: str) -> None:
         """Starts the process running the server."""
@@ -319,9 +319,7 @@ class TestServerProcess:
         assert isinstance(self.__server_process, subprocess.Popen)
         if self.is_process_running():
             self.__logger.info(
-                "Server process "
-                + str(self.__server_process.pid)
-                + " terminated."
+                "Server process %d terminated", self.__server_process.pid
             )
             self.__server_process.kill()
             self.__server_process.wait()


### PR DESCRIPTION
The goal here is to have ruff enable new rulesets when new releases are made without us having to do anything: we can then decide if we disable or not.

* Enable a couple more rulesets (ERA, INP, T20)
* Add a few individual ignores to tests and examples
* Default to enable all, disable the rulesets we don't want
