### PR TITLE
changing user-agent value

### DIFF
--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -325,7 +325,7 @@ class TestUpdater(unittest.TestCase):
         self.updater.refresh()
         session = next(iter(self.updater._fetcher._sessions.values()))
         ua = session.headers["User-Agent"]
-        self.assertEqual(ua[:4], "tuf/")
+        self.assertEqual(ua[:11], "python-tuf/")
 
         # test custom UA
         updater = Updater(
@@ -339,7 +339,7 @@ class TestUpdater(unittest.TestCase):
         session = next(iter(updater._fetcher._sessions.values()))
         ua = session.headers["User-Agent"]
 
-        self.assertEqual(ua[:16], "MyApp/1.2.3 tuf/")
+        self.assertEqual(ua[:23], "MyApp/1.2.3 python-tuf/")
 
 
 if __name__ == "__main__":

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -141,7 +141,7 @@ class RequestsFetcher(FetcherInterface):
             session = requests.Session()
             self._sessions[session_index] = session
 
-            ua = f"tuf/{tuf.__version__} {session.headers['User-Agent']}"
+            ua = f"python-tuf/{tuf.__version__} {session.headers['User-Agent']}"
             if self.app_user_agent is not None:
                 ua = f"{self.app_user_agent} {ua}"
             session.headers["User-Agent"] = ua


### PR DESCRIPTION
<!--
Before submitting a pull request:
  * Run linter and tests locally: Use "tox"
  * Ensure your commits are signed-off-by: Use "commit --signoff"
  * Make sure new code has tests and is documented
  * For more info, see docs/CONTRIBUTING.rst

Once commits are signed off and tested, describe the purpose and contents
of the pull request below.
-->

**Description of the changes being introduced by the pull request**:
It's just changing user agent string to `python-tuf/5.0.0` from `tuf/5.0.0`



Fixes #2631 

