### PR TITLE
fixing url link

### DIFF
--- a/docs/_posts/2022-02-21-release-1-0-0.md
+++ b/docs/_posts/2022-02-21-release-1-0-0.md
@@ -34,7 +34,7 @@ easier to use APIs:
   accelerate future improvements on the project
 - Metadata API provides a solid base to build other tools on top of – as proven
   by the ngclient implementation and the [repository code
-  examples](https://github.com/theupdateframework/python-tuf/tree/develop/examples/repo_example)
+  examples](https://github.com/theupdateframework/python-tuf/tree/develop/examples/repository)
 - Both new APIs are highly extensible and allow application developers to
   include custom network stacks, file storage systems or public-key
   cryptography algorithms, while providing easy-to-use default implementations

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -27,7 +27,7 @@ is known to be ``Root``.
 Currently Metadata API supports JSON as the file format.
 
 A basic example of repository implementation using the Metadata is available in
-`examples/repo_example <https://github.com/theupdateframework/python-tuf/tree/develop/examples/repo_example>`_.
+`examples/repository <https://github.com/theupdateframework/python-tuf/tree/develop/examples/repository>`_.
 """
 
 import logging


### PR DESCRIPTION
<!--
Before submitting a pull request:
  * Run linter and tests locally: Use "tox"
  * Ensure your commits are signed-off-by: Use "commit --signoff"
  * Make sure new code has tests and is documented
  * For more info, see docs/CONTRIBUTING.rst

Once commits are signed off and tested, describe the purpose and contents
of the pull request below.
-->

**Description of the changes being introduced by the pull request**:
The files previously found at links [#1](https://github.com/theupdateframework/python-tuf/blob/develop/docs/_posts/2022-02-21-release-1-0-0.md?plain=1#L37) and [#2](https://github.com/theupdateframework/python-tuf/blob/develop/tuf/api/metadata.py#L30) have been moved to a new location.



Fixes #<ISSUE NUMBER>

