### PR TITLE
made variable public

### DIFF
--- a/tuf/api/dsse.py
+++ b/tuf/api/dsse.py
@@ -52,7 +52,7 @@ class SimpleEnvelope(Generic[T], BaseSimpleEnvelope):
 
     """
 
-    _DEFAULT_PAYLOAD_TYPE = "application/vnd.tuf+json"
+    DEFAULT_PAYLOAD_TYPE = "application/vnd.tuf+json"
 
     @classmethod
     def from_bytes(cls, data: bytes) -> "SimpleEnvelope[T]":
@@ -119,7 +119,7 @@ class SimpleEnvelope(Generic[T], BaseSimpleEnvelope):
         except Exception as e:
             raise SerializationError from e
 
-        return cls(json_bytes, cls._DEFAULT_PAYLOAD_TYPE, {})
+        return cls(json_bytes, cls.DEFAULT_PAYLOAD_TYPE, {})
 
     def get_signed(self) -> T:
         """Extract and deserialize payload JSON bytes from envelope.

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -490,9 +490,9 @@ def _load_from_simple_envelope(
 
     envelope = SimpleEnvelope[T].from_bytes(data)
 
-    if envelope.payload_type != SimpleEnvelope._DEFAULT_PAYLOAD_TYPE:  # noqa: SLF001
+    if envelope.payload_type != SimpleEnvelope.DEFAULT_PAYLOAD_TYPE:  # noqa: SLF001
         raise exceptions.RepositoryError(
-            f"Expected '{SimpleEnvelope._DEFAULT_PAYLOAD_TYPE}', "  # noqa: SLF001
+            f"Expected '{SimpleEnvelope.DEFAULT_PAYLOAD_TYPE}', "  # noqa: SLF001
             f"got '{envelope.payload_type}'"
         )
 

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -490,9 +490,9 @@ def _load_from_simple_envelope(
 
     envelope = SimpleEnvelope[T].from_bytes(data)
 
-    if envelope.payload_type != SimpleEnvelope.DEFAULT_PAYLOAD_TYPE:  # noqa: SLF001
+    if envelope.payload_type != SimpleEnvelope.DEFAULT_PAYLOAD_TYPE:
         raise exceptions.RepositoryError(
-            f"Expected '{SimpleEnvelope.DEFAULT_PAYLOAD_TYPE}', "  # noqa: SLF001
+            f"Expected '{SimpleEnvelope.DEFAULT_PAYLOAD_TYPE}', "
             f"got '{envelope.payload_type}'"
         )
 


### PR DESCRIPTION
<!--
Before submitting a pull request:
  * Run linter and tests locally: Use "tox"
  * Ensure your commits are signed-off-by: Use "commit --signoff"
  * Make sure new code has tests and is documented
  * For more info, see docs/CONTRIBUTING.rst

Once commits are signed off and tested, describe the purpose and contents
of the pull request below.
-->

**Description of the changes being introduced by the pull request**:
It makes _DEAFULT_PAYLOAD_TYPE variable public, so that flake8 linter don't show any error.



Fixes #2598 

