### PR TITLE
ngclient: Increase default max_root_rotations

### DIFF
--- a/tuf/ngclient/config.py
+++ b/tuf/ngclient/config.py
@@ -44,7 +44,7 @@ class UpdaterConfig:
             prefixed to ngclient user agent when the default fetcher is used.
     """
 
-    max_root_rotations: int = 32
+    max_root_rotations: int = 256
     max_delegations: int = 32
     root_max_length: int = 512000  # bytes
     timestamp_max_length: int = 16384  # bytes


### PR DESCRIPTION
this configuration variable controls how many root versions the client will upgrade in a single refresh(). The idea is to prevent a malicious repository from filling the disk with root versions.

We want a number that is high enough that a repository should not have made that many roots in the time that clients take to update the "embedded" root that the client shipped with.

32 is small enough that a repository could possibly reach it while clients with v1 embedded in them are still in use. Let's bump to 256: this should be plenty.

Fixes #2672 

