### PR TITLE
docs: Add CODEOWNERS file

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,1 @@
+* @theupdateframework/python-tuf-maintainers


### PR DESCRIPTION
My expectation is that this CODEOWNERS will start adding the maintainer team as suggested reviewers on every new PR (this will start happening after the change is merged to develop branch): https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

This is part of #2700 