### PR TITLE
docs: include kairoaraujo info in MAINTAINERS.txt

### DIFF
--- a/docs/MAINTAINERS.txt
+++ b/docs/MAINTAINERS.txt
@@ -30,6 +30,11 @@ Maintainers:
     GitHub username: @jku
     PGP fingerprint: 1343 C98F AB84 859F E5EC  9E37 0527 D8A3 7F52 1A2F
 
+  Kairo de Araujo
+    Email: kairo@dearaujo.nl
+    GitHub username: @kairoaraujo
+    PGP fingerprint: FFD5 219E 49E0 06C2 1D9C  7C89 F26E 23EE 723E C8CA
+
 Emeritus Maintainers:
 
   Santiago Torres-Arias


### PR DESCRIPTION

**Description of the changes being introduced by the pull request**:

Add Kairo de Araujo information to the docs/MAINTAINERS.txt

Including my PGP fingerprint for future signing.

Related to #2700 

