### PR TITLE
tests: Use freezegun for time mocking to fix pypy3 compatibility

### DIFF
--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -8,3 +8,6 @@
 # are pinned to prevent unexpected linting failures when tools update)
 ruff==0.6.7
 mypy==1.11.2
+
+# Required for type stubs
+freezegun==1.5.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,3 +5,4 @@
 
 # coverage measurement
 coverage==7.6.1
+freezegun==1.5.1


### PR DESCRIPTION
**Description of the changes being introduced by the pull request**:

Use freezegun for time mocking instead of manually patching the datetime module, as it provides a more streamlined solution that works both on CPython and on PyPy.  Unfortunately, due to differences between the C datetime extension used by CPython, and the pure Python version of datetime (used by PyPy, and as a fallback on CPython), there does not seem to be a trivial way to mock time that would work with both versions.

Fixes #2708