### PR TITLE
docs: Joshua retiring as a maintainer

### DIFF
--- a/docs/MAINTAINERS.txt
+++ b/docs/MAINTAINERS.txt
@@ -19,12 +19,6 @@ Maintainers:
     GitHub username: @lukpueh
     PGP fingerprint: 8BA6 9B87 D43B E294 F23E  8120 89A2 AD3C 07D9 62E8
 
-  Joshua Lock
-    Email: joshua.lock@uk.verizon.com
-    GitHub username: @joshuagl
-    PGP fingerprint: 08F3 409F CF71 D87E 30FB D3C2 1671 F65C B748 32A4
-    Keybase username: joshuagl
-
   Jussi Kukkonen
     Email: jkukkonen@google.com
     GitHub username: @jku
@@ -37,6 +31,7 @@ Maintainers:
 
 Emeritus Maintainers:
 
+  Joshua Lock
   Santiago Torres-Arias
   Sebastien Awwad
   Teodora Sechkova


### PR DESCRIPTION
Retiring my maintainer role as I haven't been able to contribute or  review changes in some time.

Thanks so much for all the great collaboration!

Signed-off-by: Joshua Lock <joshuagloe@gmail.com>

