### PR TITLE
Use future annotations

### DIFF
--- a/examples/manual_repo/basic_repo.py
+++ b/examples/manual_repo/basic_repo.py
@@ -21,6 +21,8 @@ NOTE: Metadata files will be written to a 'tmp*'-directory in CWD.
 
 """
 
+from __future__ import annotations
+
 import os
 import tempfile
 from datetime import datetime, timedelta, timezone

--- a/examples/manual_repo/hashed_bin_delegation.py
+++ b/examples/manual_repo/hashed_bin_delegation.py
@@ -16,12 +16,14 @@ NOTE: Metadata files will be written to a 'tmp*'-directory in CWD.
 
 """
 
+from __future__ import annotations
+
 import hashlib
 import os
 import tempfile
-from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from securesystemslib.signer import CryptoSigner, Signer
 
@@ -33,6 +35,9 @@ from tuf.api.metadata import (
     Targets,
 )
 from tuf.api.serialization.json import JSONSerializer
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 def _in(days: float) -> datetime:

--- a/examples/manual_repo/succinct_hash_bin_delegations.py
+++ b/examples/manual_repo/succinct_hash_bin_delegations.py
@@ -18,6 +18,8 @@ https://github.com/theupdateframework/taps/blob/master/tap15.md
 NOTE: Metadata files will be written to a 'tmp*'-directory in CWD.
 """
 
+from __future__ import annotations
+
 import math
 import os
 import tempfile

--- a/examples/repository/_simplerepo.py
+++ b/examples/repository/_simplerepo.py
@@ -3,12 +3,13 @@
 
 """Simple example of using the repository library to build a repository"""
 
+from __future__ import annotations
+
 import copy
 import json
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
-from typing import Union
 
 from securesystemslib.signer import CryptoSigner, Key, Signer
 
@@ -93,7 +94,7 @@ class SimpleRepository(Repository):
 
     def _get_verification_result(
         self, role: str, md: Metadata
-    ) -> Union[VerificationResult, RootVerificationResult]:
+    ) -> VerificationResult | RootVerificationResult:
         """Verify roles metadata using the existing repository metadata"""
         if role == Root.type:
             assert isinstance(md.signed, Root)

--- a/examples/uploader/_localrepo.py
+++ b/examples/uploader/_localrepo.py
@@ -3,6 +3,8 @@
 
 """A Repository implementation for maintainer and developer tools"""
 
+from __future__ import annotations
+
 import contextlib
 import copy
 import json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "tuf"
 description = "A secure updater framework for Python"
 readme = "README.md"
 license = { text = "MIT OR Apache-2.0" }
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 authors = [
   { email = "theupdateframework@googlegroups.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ ignore = [
     "TRY",
 
     # Individual rules that have been disabled
-    "ANN101", "ANN102", # nonsense, deprecated in ruff
     "D400", "D415", "D213", "D205", "D202", "D107", "D407", "D413", "D212", "D104", "D406", "D105", "D411", "D401", "D200", "D203",
     "ISC001", # incompatible with ruff formatter
     "PLR0913", "PLR2004",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,3 +149,13 @@ module = [
   "securesystemslib.*",
 ]
 ignore_missing_imports = "True"
+
+[tool.coverage.report]
+exclude_also = [
+    # abstract class method definition
+    "raise NotImplementedError",
+    # defensive programming: these cannot happen
+    "raise AssertionError",
+    # imports for mypy only
+    "if TYPE_CHECKING",
+]

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,5 +4,5 @@
 -r pinned.txt
 
 # coverage measurement
-coverage==7.6.8
+coverage[toml]==7.6.8
 freezegun==1.5.1

--- a/tests/generated_data/generate_md.py
+++ b/tests/generated_data/generate_md.py
@@ -3,10 +3,11 @@
 # Copyright New York University and the TUF contributors
 # SPDX-License-Identifier: MIT OR Apache-2.0
 
+from __future__ import annotations
+
 import os
 import sys
 from datetime import datetime, timezone
-from typing import Optional
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from securesystemslib.signer import CryptoSigner, Signer, SSlibKey
@@ -80,7 +81,7 @@ def verify_generation(md: Metadata, path: str) -> None:
 
 
 def generate_all_files(
-    dump: Optional[bool] = False, verify: Optional[bool] = False
+    dump: bool | None = False, verify: bool | None = False
 ) -> None:
     """Generate a new repository and optionally verify it.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 """Unit tests for api/metadata.py"""
 
+from __future__ import annotations
+
 import json
 import logging
 import os
@@ -12,7 +14,7 @@ import unittest
 from copy import copy, deepcopy
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 from securesystemslib import exceptions as sslib_exceptions
 from securesystemslib import hash as sslib_hash
@@ -245,8 +247,8 @@ class TestMetadata(unittest.TestCase):
                 cls,
                 priv_key_uri: str,
                 public_key: Key,
-                secrets_handler: Optional[SecretsHandler] = None,
-            ) -> "Signer":
+                secrets_handler: SecretsHandler | None = None,
+            ) -> Signer:
                 pass
 
             @property

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT OR Apache-2.0
 """Unit tests for 'examples' scripts."""
 
+from __future__ import annotations
+
 import glob
 import os
 import shutil

--- a/tests/test_metadata_eq_.py
+++ b/tests/test_metadata_eq_.py
@@ -3,6 +3,8 @@
 
 """Test __eq__ implementations of classes inside tuf/api/metadata.py."""
 
+from __future__ import annotations
+
 import copy
 import os
 import sys
@@ -63,7 +65,7 @@ class TestMetadataComparisions(unittest.TestCase):
 
     # Keys are class names.
     # Values are dictionaries containing attribute names and their new values.
-    classes_attributes_modifications: utils.DataSet = {
+    classes_attributes_modifications = {
         "Metadata": {"signed": None, "signatures": None},
         "Signed": {"version": -1, "spec_version": "0.0.0"},
         "Key": {"keyid": "a", "keytype": "foo", "scheme": "b", "keyval": "b"},

--- a/tests/test_metadata_serialization.py
+++ b/tests/test_metadata_serialization.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 class TestSerialization(unittest.TestCase):
     """Test serialization for all classes in 'tuf/api/metadata.py'."""
 
-    invalid_metadata: utils.DataSet = {
+    invalid_metadata = {
         "no signatures field": b'{"signed": \
             { "_type": "timestamp", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
             "meta": {"snapshot.json": {"hashes": {"sha256" : "abc"}, "version": 1}}} \
@@ -55,7 +55,7 @@ class TestSerialization(unittest.TestCase):
         with self.assertRaises(DeserializationError):
             Metadata.from_bytes(test_data)
 
-    valid_metadata: utils.DataSet = {
+    valid_metadata = {
         "multiple signatures": b'{ \
             "signed": \
                 { "_type": "timestamp", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
@@ -90,7 +90,7 @@ class TestSerialization(unittest.TestCase):
 
         self.assertEqual(test_bytes, md.to_bytes())
 
-    invalid_signatures: utils.DataSet = {
+    invalid_signatures = {
         "missing keyid attribute in a signature": '{ "sig": "abc" }',
         "missing sig attribute in a signature": '{ "keyid": "id" }',
     }
@@ -101,7 +101,7 @@ class TestSerialization(unittest.TestCase):
         with self.assertRaises(KeyError):
             Signature.from_dict(case_dict)
 
-    valid_signatures: utils.DataSet = {
+    valid_signatures = {
         "all": '{ "keyid": "id", "sig": "b"}',
         "unrecognized fields": '{ "keyid": "id", "sig": "b", "foo": "bar"}',
     }
@@ -114,7 +114,7 @@ class TestSerialization(unittest.TestCase):
 
     # Snapshot instances with meta = {} are valid, but for a full valid
     # repository it's required that meta has at least one element inside it.
-    invalid_signed: utils.DataSet = {
+    invalid_signed = {
         "no _type": '{"spec_version": "1.0.0", "expires": "2030-01-01T00:00:00Z", "meta": {}}',
         "no spec_version": '{"_type": "snapshot", "version": 1, "expires": "2030-01-01T00:00:00Z", "meta": {}}',
         "no version": '{"_type": "snapshot", "spec_version": "1.0.0", "expires": "2030-01-01T00:00:00Z", "meta": {}}',
@@ -138,7 +138,7 @@ class TestSerialization(unittest.TestCase):
         with self.assertRaises((KeyError, ValueError, TypeError)):
             Snapshot.from_dict(case_dict)
 
-    valid_keys: utils.DataSet = {
+    valid_keys = {
         "all": '{"keytype": "rsa", "scheme": "rsassa-pss-sha256", \
             "keyval": {"public": "foo"}}',
         "unrecognized field": '{"keytype": "rsa", "scheme": "rsassa-pss-sha256", \
@@ -153,7 +153,7 @@ class TestSerialization(unittest.TestCase):
         key = Key.from_dict("id", copy.copy(case_dict))
         self.assertDictEqual(case_dict, key.to_dict())
 
-    invalid_keys: utils.DataSet = {
+    invalid_keys = {
         "no keyid": '{"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "abc"}}',
         "no keytype": '{"keyid": "id", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}',
         "no scheme": '{"keyid": "id", "keytype": "rsa", "keyval": {"public": "foo"}}',
@@ -171,7 +171,7 @@ class TestSerialization(unittest.TestCase):
             keyid = case_dict.pop("keyid")
             Key.from_dict(keyid, case_dict)
 
-    invalid_roles: utils.DataSet = {
+    invalid_roles = {
         "no threshold": '{"keyids": ["keyid"]}',
         "no keyids": '{"threshold": 3}',
         "wrong threshold type": '{"keyids": ["keyid"], "threshold": "a"}',
@@ -186,7 +186,7 @@ class TestSerialization(unittest.TestCase):
         with self.assertRaises((KeyError, TypeError, ValueError)):
             Role.from_dict(case_dict)
 
-    valid_roles: utils.DataSet = {
+    valid_roles = {
         "all": '{"keyids": ["keyid"], "threshold": 3}',
         "many keyids": '{"keyids": ["a", "b", "c", "d", "e"], "threshold": 1}',
         "ordered keyids": '{"keyids": ["c", "b", "a"], "threshold": 1}',
@@ -200,7 +200,7 @@ class TestSerialization(unittest.TestCase):
         role = Role.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, role.to_dict())
 
-    valid_roots: utils.DataSet = {
+    valid_roots = {
         "all": '{"_type": "root", "spec_version": "1.0.0", "version": 1, \
             "expires": "2030-01-01T00:00:00Z", "consistent_snapshot": false, \
             "keys": { \
@@ -248,7 +248,7 @@ class TestSerialization(unittest.TestCase):
         root = Root.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, root.to_dict())
 
-    invalid_roots: utils.DataSet = {
+    invalid_roots = {
         "invalid role name": '{"_type": "root", "spec_version": "1.0.0", "version": 1, \
             "expires": "2030-01-01T00:00:00Z", "consistent_snapshot": false, \
             "keys": { \
@@ -293,7 +293,7 @@ class TestSerialization(unittest.TestCase):
         with self.assertRaises(ValueError):
             Root.from_dict(case_dict)
 
-    invalid_metafiles: utils.DataSet = {
+    invalid_metafiles = {
         "wrong length type": '{"version": 1, "length": "a", "hashes": {"sha256" : "abc"}}',
         "version 0": '{"version": 0, "length": 1, "hashes": {"sha256" : "abc"}}',
         "length below 0": '{"version": 1, "length": -1, "hashes": {"sha256" : "abc"}}',
@@ -308,7 +308,7 @@ class TestSerialization(unittest.TestCase):
         with self.assertRaises((TypeError, ValueError, AttributeError)):
             MetaFile.from_dict(case_dict)
 
-    valid_metafiles: utils.DataSet = {
+    valid_metafiles = {
         "all": '{"hashes": {"sha256" : "abc"}, "length": 12, "version": 1}',
         "no length": '{"hashes": {"sha256" : "abc"}, "version": 1 }',
         "length 0": '{"version": 1, "length": 0, "hashes": {"sha256" : "abc"}}',
@@ -323,7 +323,7 @@ class TestSerialization(unittest.TestCase):
         metafile = MetaFile.from_dict(copy.copy(case_dict))
         self.assertDictEqual(case_dict, metafile.to_dict())
 
-    invalid_timestamps: utils.DataSet = {
+    invalid_timestamps = {
         "no metafile": '{ "_type": "timestamp", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z"}',
     }
 
@@ -333,7 +333,7 @@ class TestSerialization(unittest.TestCase):
         with self.assertRaises((ValueError, KeyError)):
             Timestamp.from_dict(case_dict)
 
-    valid_timestamps: utils.DataSet = {
+    valid_timestamps = {
         "all": '{ "_type": "timestamp", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
             "meta": {"snapshot.json": {"hashes": {"sha256" : "abc"}, "version": 1}}}',
         "legacy spec_version": '{ "_type": "timestamp", "spec_version": "1.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
@@ -348,7 +348,7 @@ class TestSerialization(unittest.TestCase):
         timestamp = Timestamp.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, timestamp.to_dict())
 
-    valid_snapshots: utils.DataSet = {
+    valid_snapshots = {
         "all": '{ "_type": "snapshot", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
             "meta": { \
                 "file1.txt": {"hashes": {"sha256" : "abc"}, "version": 1}, \
@@ -367,7 +367,7 @@ class TestSerialization(unittest.TestCase):
         snapshot = Snapshot.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, snapshot.to_dict())
 
-    valid_delegated_roles: utils.DataSet = {
+    valid_delegated_roles = {
         # DelegatedRole inherits Role and some use cases can be found in the valid_roles.
         "no hash prefix attribute": '{"keyids": ["keyid"], "name": "a", "paths": ["fn1", "fn2"], \
             "terminating": false, "threshold": 1}',
@@ -390,7 +390,7 @@ class TestSerialization(unittest.TestCase):
         deserialized_role = DelegatedRole.from_dict(copy.copy(case_dict))
         self.assertDictEqual(case_dict, deserialized_role.to_dict())
 
-    invalid_delegated_roles: utils.DataSet = {
+    invalid_delegated_roles = {
         # DelegatedRole inherits Role and some use cases can be found in the invalid_roles.
         "missing hash prefixes and paths": '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false}',
         "both hash prefixes and paths": '{"name": "a", "keyids": ["keyid"], "threshold": 1, "terminating": false, \
@@ -409,7 +409,7 @@ class TestSerialization(unittest.TestCase):
         with self.assertRaises(ValueError):
             DelegatedRole.from_dict(case_dict)
 
-    valid_succinct_roles: utils.DataSet = {
+    valid_succinct_roles = {
         # SuccinctRoles inherits Role and some use cases can be found in the valid_roles.
         "standard succinct_roles information": '{"keyids": ["keyid"], "threshold": 1, \
             "bit_length": 8, "name_prefix": "foo"}',
@@ -423,7 +423,7 @@ class TestSerialization(unittest.TestCase):
         succinct_roles = SuccinctRoles.from_dict(copy.copy(case_dict))
         self.assertDictEqual(case_dict, succinct_roles.to_dict())
 
-    invalid_succinct_roles: utils.DataSet = {
+    invalid_succinct_roles = {
         # SuccinctRoles inherits Role and some use cases can be found in the invalid_roles.
         "missing bit_length from succinct_roles": '{"keyids": ["keyid"], "threshold": 1, "name_prefix": "foo"}',
         "missing name_prefix from succinct_roles": '{"keyids": ["keyid"], "threshold": 1, "bit_length": 8}',
@@ -439,7 +439,7 @@ class TestSerialization(unittest.TestCase):
         with self.assertRaises((ValueError, KeyError, TypeError)):
             SuccinctRoles.from_dict(case_dict)
 
-    invalid_delegations: utils.DataSet = {
+    invalid_delegations = {
         "empty delegations": "{}",
         "missing keys": '{ "roles": [ \
                 {"keyids": ["keyid"], "name": "a", "terminating": true, "paths": ["fn1"], "threshold": 3}, \
@@ -507,7 +507,7 @@ class TestSerialization(unittest.TestCase):
         with self.assertRaises((ValueError, KeyError, AttributeError)):
             Delegations.from_dict(case_dict)
 
-    valid_delegations: utils.DataSet = {
+    valid_delegations = {
         "with roles": '{"keys": { \
                 "keyid1" : {"keytype": "rsa", "scheme": "rsassa-pss-sha256", "keyval": {"public": "foo"}}, \
                 "keyid2" : {"keytype": "ed25519", "scheme": "ed25519", "keyval": {"public": "bar"}}}, \
@@ -533,7 +533,7 @@ class TestSerialization(unittest.TestCase):
         delegation = Delegations.from_dict(copy.deepcopy(case_dict))
         self.assertDictEqual(case_dict, delegation.to_dict())
 
-    invalid_targetfiles: utils.DataSet = {
+    invalid_targetfiles = {
         "no hashes": '{"length": 1}',
         "no length": '{"hashes": {"sha256": "abc"}}',
         # The remaining cases are the same as for invalid_hashes and
@@ -548,7 +548,7 @@ class TestSerialization(unittest.TestCase):
         with self.assertRaises(KeyError):
             TargetFile.from_dict(case_dict, "file1.txt")
 
-    valid_targetfiles: utils.DataSet = {
+    valid_targetfiles = {
         "all": '{"length": 12, "hashes": {"sha256" : "abc"}, \
             "custom" : {"foo": "bar"} }',
         "no custom": '{"length": 12, "hashes": {"sha256" : "abc"}}',
@@ -562,7 +562,7 @@ class TestSerialization(unittest.TestCase):
         target_file = TargetFile.from_dict(copy.copy(case_dict), "file1.txt")
         self.assertDictEqual(case_dict, target_file.to_dict())
 
-    valid_targets: utils.DataSet = {
+    valid_targets = {
         "all attributes": '{"_type": "targets", "spec_version": "1.0.0", "version": 1, "expires": "2030-01-01T00:00:00Z", \
             "targets": { \
                 "file.txt": {"length": 12, "hashes": {"sha256" : "abc"} }, \

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -3,6 +3,8 @@
 
 """Tests for tuf.repository module"""
 
+from __future__ import annotations
+
 import copy
 import logging
 import sys

--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -1,11 +1,13 @@
 """Unit tests for 'tuf/ngclient/_internal/trusted_metadata_set.py'."""
 
+from __future__ import annotations
+
 import logging
 import os
 import sys
 import unittest
 from datetime import datetime, timezone
-from typing import Callable, ClassVar, Optional
+from typing import Callable, ClassVar
 
 from securesystemslib.signer import Signer
 
@@ -104,8 +106,8 @@ class TestTrustedMetadataSet(unittest.TestCase):
 
     def _update_all_besides_targets(
         self,
-        timestamp_bytes: Optional[bytes] = None,
-        snapshot_bytes: Optional[bytes] = None,
+        timestamp_bytes: bytes | None = None,
+        snapshot_bytes: bytes | None = None,
     ) -> None:
         """Update all metadata roles besides targets.
 

--- a/tests/test_updater_consistent_snapshot.py
+++ b/tests/test_updater_consistent_snapshot.py
@@ -3,12 +3,13 @@
 
 """Test ngclient Updater toggling consistent snapshot"""
 
+from __future__ import annotations
+
 import os
 import sys
 import tempfile
 import unittest
-from collections.abc import Iterable
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from tests import utils
 from tests.repository_simulator import RepositorySimulator
@@ -21,6 +22,9 @@ from tuf.api.metadata import (
 )
 from tuf.ngclient import Updater
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
 
 class TestConsistentSnapshot(unittest.TestCase):
     """Test different combinations of 'consistent_snapshot' and
@@ -28,7 +32,7 @@ class TestConsistentSnapshot(unittest.TestCase):
     are formed for each combination"""
 
     # set dump_dir to trigger repository state dumps
-    dump_dir: Optional[str] = None
+    dump_dir: str | None = None
 
     def setUp(self) -> None:
         self.subtest_count = 0
@@ -98,7 +102,7 @@ class TestConsistentSnapshot(unittest.TestCase):
         for filename in filenames:
             self.assertIn(filename, local_target_files)
 
-    top_level_roles_data: utils.DataSet = {
+    top_level_roles_data = {
         "consistent_snaphot disabled": {
             "consistent_snapshot": False,
             "calls": [
@@ -143,7 +147,7 @@ class TestConsistentSnapshot(unittest.TestCase):
         finally:
             self.teardown_subtest()
 
-    delegated_roles_data: utils.DataSet = {
+    delegated_roles_data = {
         "consistent_snaphot disabled": {
             "consistent_snapshot": False,
             "expected_version": None,
@@ -162,7 +166,7 @@ class TestConsistentSnapshot(unittest.TestCase):
         # the correct version prefix, depending on 'consistent_snapshot' config
         try:
             consistent_snapshot: bool = test_case_data["consistent_snapshot"]
-            exp_version: Optional[int] = test_case_data["expected_version"]
+            exp_version: int | None = test_case_data["expected_version"]
             rolenames = ["role1", "..", "."]
             exp_calls = [(role, exp_version) for role in rolenames]
 
@@ -190,7 +194,7 @@ class TestConsistentSnapshot(unittest.TestCase):
         finally:
             self.teardown_subtest()
 
-    targets_download_data: utils.DataSet = {
+    targets_download_data = {
         "consistent_snaphot disabled": {
             "consistent_snapshot": False,
             "prefix_targets": True,
@@ -219,7 +223,7 @@ class TestConsistentSnapshot(unittest.TestCase):
         try:
             consistent_snapshot: bool = test_case_data["consistent_snapshot"]
             prefix_targets_with_hash: bool = test_case_data["prefix_targets"]
-            hash_algo: Optional[str] = test_case_data["hash_algo"]
+            hash_algo: str | None = test_case_data["hash_algo"]
             targetpaths: list[str] = test_case_data["targetpaths"]
 
             self.setup_subtest(consistent_snapshot, prefix_targets_with_hash)

--- a/tests/test_updater_delegation_graphs.py
+++ b/tests/test_updater_delegation_graphs.py
@@ -4,13 +4,14 @@
 """Test updating delegated targets roles and searching for
 target files with various delegation graphs"""
 
+from __future__ import annotations
+
 import os
 import sys
 import tempfile
 import unittest
-from collections.abc import Iterable
 from dataclasses import astuple, dataclass, field
-from typing import Optional
+from typing import TYPE_CHECKING
 
 from tests import utils
 from tests.repository_simulator import RepositorySimulator
@@ -23,6 +24,9 @@ from tuf.api.metadata import (
 )
 from tuf.ngclient import Updater
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
 
 @dataclass
 class TestDelegation:
@@ -31,8 +35,8 @@ class TestDelegation:
     keyids: list[str] = field(default_factory=list)
     threshold: int = 1
     terminating: bool = False
-    paths: Optional[list[str]] = field(default_factory=lambda: ["*"])
-    path_hash_prefixes: Optional[list[str]] = None
+    paths: list[str] | None = field(default_factory=lambda: ["*"])
+    path_hash_prefixes: list[str] | None = None
 
 
 @dataclass
@@ -63,7 +67,7 @@ class TestDelegations(unittest.TestCase):
     """Base class for delegation tests"""
 
     # set dump_dir to trigger repository state dumps
-    dump_dir: Optional[str] = None
+    dump_dir: str | None = None
 
     def setUp(self) -> None:
         self.subtest_count = 0
@@ -139,7 +143,7 @@ class TestDelegationsGraphs(TestDelegations):
     """Test creating delegations graphs with different complexity
     and successfully updating the delegated roles metadata"""
 
-    graphs: utils.DataSet = {
+    graphs = {
         "basic delegation": DelegationsTestCase(
             delegations=[TestDelegation("targets", "A")],
             visited_order=["A"],
@@ -287,7 +291,7 @@ class TestDelegationsGraphs(TestDelegations):
         finally:
             self.teardown_subtest()
 
-    invalid_metadata: utils.DataSet = {
+    invalid_metadata = {
         "unsigned delegated role": DelegationsTestCase(
             delegations=[
                 TestDelegation("targets", "invalid"),
@@ -360,7 +364,7 @@ class TestDelegationsGraphs(TestDelegations):
         exp_calls = [(quoted[:-5], 1) for quoted in roles_to_filenames.values()]
         self.assertListEqual(self.sim.fetch_tracker.metadata, exp_calls)
 
-    hash_bins_graph: utils.DataSet = {
+    hash_bins_graph = {
         "delegations": DelegationsTestCase(
             delegations=[
                 TestDelegation(
@@ -432,7 +436,7 @@ class TestDelegationsGraphs(TestDelegations):
     # By setting the bit_length the total number of bins is 2^bit_length.
     # In each test case target_path is a path to a random target we want to
     # fetch and expected_target_bin is the bin we are expecting to visit.
-    succinct_bins_graph: utils.DataSet = {
+    succinct_bins_graph = {
         "bin amount = 2, taget bin index 0": SuccinctRolesTestCase(
             bit_length=1,
             target_path="boo",
@@ -544,7 +548,7 @@ class TestTargetFileSearch(TestDelegations):
         self._init_repo(self.delegations_tree)
 
     # fmt: off
-    targets: utils.DataSet = {
+    targets = {
         "no delegations":
             TargetTestCase("targetfile", True, []),
         "targetpath matches wildcard":

--- a/tests/test_updater_fetch_target.py
+++ b/tests/test_updater_fetch_target.py
@@ -66,7 +66,7 @@ class TestFetchTarget(unittest.TestCase):
             self.sim,
         )
 
-    targets: utils.DataSet = {
+    targets = {
         "standard case": TestTarget(
             path="targetpath",
             content=b"target content",

--- a/tests/test_updater_key_rotations.py
+++ b/tests/test_updater_key_rotations.py
@@ -3,12 +3,14 @@
 
 """Test ngclient Updater key rotation handling"""
 
+from __future__ import annotations
+
 import os
 import sys
 import tempfile
 import unittest
 from dataclasses import dataclass
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 from securesystemslib.signer import CryptoSigner, Signer
 
@@ -25,14 +27,14 @@ class MdVersion:
     keys: list[int]
     threshold: int
     sigs: list[int]
-    res: Optional[type[Exception]] = None
+    res: type[Exception] | None = None
 
 
 class TestUpdaterKeyRotations(unittest.TestCase):
     """Test ngclient root rotation handling"""
 
     # set dump_dir to trigger repository state dumps
-    dump_dir: Optional[str] = None
+    dump_dir: str | None = None
     temp_dir: ClassVar[tempfile.TemporaryDirectory]
     keys: ClassVar[list[Key]]
     signers: ClassVar[list[Signer]]

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -3,6 +3,8 @@
 
 """Test Updater class"""
 
+from __future__ import annotations
+
 import logging
 import os
 import shutil

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,6 +18,8 @@
   Provide common utilities for TUF tests
 """
 
+from __future__ import annotations
+
 import argparse
 import errno
 import logging
@@ -28,11 +30,13 @@ import subprocess
 import sys
 import threading
 import time
-import unittest
 import warnings
-from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import IO, Any, Callable, Optional
+from typing import IO, TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    import unittest
+    from collections.abc import Iterator
 
 logger = logging.getLogger(__name__)
 
@@ -42,15 +46,12 @@ TESTS_DIR = os.path.dirname(os.path.realpath(__file__))
 # Used when forming URLs on the client side
 TEST_HOST_ADDRESS = "127.0.0.1"
 
-# DataSet is only here so type hints can be used.
-DataSet = dict[str, Any]
-
 
 # Test runner decorator: Runs the test as a set of N SubTests,
 # (where N is number of items in dataset), feeding the actual test
 # function one test case at a time
 def run_sub_tests_with_dataset(
-    dataset: DataSet,
+    dataset: dict[str, Any],
 ) -> Callable[[Callable], Callable]:
     """Decorator starting a unittest.TestCase.subtest() for each of the
     cases in dataset"""
@@ -103,7 +104,7 @@ def wait_for_server(
     succeeded = False
     while not succeeded and remaining_timeout > 0:
         try:
-            sock: Optional[socket.socket] = socket.socket(
+            sock: socket.socket | None = socket.socket(
                 socket.AF_INET, socket.SOCK_STREAM
             )
             assert sock is not None
@@ -185,14 +186,14 @@ class TestServerProcess:
         server: str = os.path.join(TESTS_DIR, "simple_server.py"),
         timeout: int = 10,
         popen_cwd: str = ".",
-        extra_cmd_args: Optional[list[str]] = None,
+        extra_cmd_args: list[str] | None = None,
     ):
         self.server = server
         self.__logger = log
         # Stores popped messages from the queue.
         self.__logged_messages: list[str] = []
-        self.__server_process: Optional[subprocess.Popen] = None
-        self._log_queue: Optional[queue.Queue] = None
+        self.__server_process: subprocess.Popen | None = None
+        self._log_queue: queue.Queue | None = None
         self.port = -1
         if extra_cmd_args is None:
             extra_cmd_args = []

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ changedir = tests
 commands =
     python3 --version
     python3 -m coverage run aggregate_tests.py
-    python3 -m coverage report -m --fail-under 97
+    python3 -m coverage report --rcfile {toxinidir}/pyproject.toml -m --fail-under 97
 
 deps =
     -r{toxinidir}/requirements/test.txt
@@ -38,7 +38,7 @@ commands_pre =
 
 commands =
     python3 -m coverage run aggregate_tests.py
-    python3 -m coverage report -m
+    python3 -m coverage report  --rcfile {toxinidir}/pyproject.toml -m
 
 [testenv:lint]
 changedir = {toxinidir}

--- a/tuf/api/_payload.py
+++ b/tuf/api/_payload.py
@@ -346,17 +346,19 @@ class RootVerificationResult:
     def signed(self) -> dict[str, Key]:
         """Dictionary of all signing keys that have signed, from both
         VerificationResults.
-        return a union of all signed.
+        return a union of all signed (in python<3.9 this requires
+        dict unpacking)
         """
-        return self.first.signed | self.second.signed
+        return {**self.first.signed, **self.second.signed}
 
     @property
     def unsigned(self) -> dict[str, Key]:
         """Dictionary of all signing keys that have not signed, from both
         VerificationResults.
-        return a union of all unsigned.
+        return a union of all unsigned (in python<3.9 this requires
+        dict unpacking)
         """
-        return self.first.unsigned | self.second.unsigned
+        return {**self.first.unsigned, **self.second.unsigned}
 
 
 class _DelegatorMixin(metaclass=abc.ABCMeta):

--- a/tuf/api/dsse.py
+++ b/tuf/api/dsse.py
@@ -1,5 +1,7 @@
 """Low-level TUF DSSE API. (experimental!)"""
 
+from __future__ import annotations
+
 import json
 from typing import Generic, cast
 
@@ -55,7 +57,7 @@ class SimpleEnvelope(Generic[T], BaseSimpleEnvelope):
     DEFAULT_PAYLOAD_TYPE = "application/vnd.tuf+json"
 
     @classmethod
-    def from_bytes(cls, data: bytes) -> "SimpleEnvelope[T]":
+    def from_bytes(cls, data: bytes) -> SimpleEnvelope[T]:
         """Load envelope from JSON bytes.
 
         NOTE: Unlike ``tuf.api.metadata.Metadata.from_bytes``, this method
@@ -102,7 +104,7 @@ class SimpleEnvelope(Generic[T], BaseSimpleEnvelope):
         return json_bytes
 
     @classmethod
-    def from_signed(cls, signed: T) -> "SimpleEnvelope[T]":
+    def from_signed(cls, signed: T) -> SimpleEnvelope[T]:
         """Serialize payload as JSON bytes and wrap in envelope.
 
         Args:

--- a/tuf/api/metadata.py
+++ b/tuf/api/metadata.py
@@ -30,9 +30,11 @@ A basic example of repository implementation using the Metadata is available in
 `examples/repository <https://github.com/theupdateframework/python-tuf/tree/develop/examples/repository>`_.
 """
 
+from __future__ import annotations
+
 import logging
 import tempfile
-from typing import Any, Generic, Optional, cast
+from typing import TYPE_CHECKING, Any, Generic, cast
 
 from securesystemslib.signer import Signature, Signer
 from securesystemslib.storage import FilesystemBackend, StorageBackendInterface
@@ -65,11 +67,13 @@ from tuf.api._payload import (  # noqa: F401
     VerificationResult,
 )
 from tuf.api.exceptions import UnsignedMetadataError
-from tuf.api.serialization import (
-    MetadataDeserializer,
-    MetadataSerializer,
-    SignedSerializer,
-)
+
+if TYPE_CHECKING:
+    from tuf.api.serialization import (
+        MetadataDeserializer,
+        MetadataSerializer,
+        SignedSerializer,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -121,8 +125,8 @@ class Metadata(Generic[T]):
     def __init__(
         self,
         signed: T,
-        signatures: Optional[dict[str, Signature]] = None,
-        unrecognized_fields: Optional[dict[str, Any]] = None,
+        signatures: dict[str, Signature] | None = None,
+        unrecognized_fields: dict[str, Any] | None = None,
     ):
         self.signed: T = signed
         self.signatures = signatures if signatures is not None else {}
@@ -153,7 +157,7 @@ class Metadata(Generic[T]):
         return CanonicalJSONSerializer().serialize(self.signed)
 
     @classmethod
-    def from_dict(cls, metadata: dict[str, Any]) -> "Metadata[T]":
+    def from_dict(cls, metadata: dict[str, Any]) -> Metadata[T]:
         """Create ``Metadata`` object from its json/dict representation.
 
         Args:
@@ -205,9 +209,9 @@ class Metadata(Generic[T]):
     def from_file(
         cls,
         filename: str,
-        deserializer: Optional[MetadataDeserializer] = None,
-        storage_backend: Optional[StorageBackendInterface] = None,
-    ) -> "Metadata[T]":
+        deserializer: MetadataDeserializer | None = None,
+        storage_backend: StorageBackendInterface | None = None,
+    ) -> Metadata[T]:
         """Load TUF metadata from file storage.
 
         Args:
@@ -238,8 +242,8 @@ class Metadata(Generic[T]):
     def from_bytes(
         cls,
         data: bytes,
-        deserializer: Optional[MetadataDeserializer] = None,
-    ) -> "Metadata[T]":
+        deserializer: MetadataDeserializer | None = None,
+    ) -> Metadata[T]:
         """Load TUF metadata from raw data.
 
         Args:
@@ -263,9 +267,7 @@ class Metadata(Generic[T]):
 
         return deserializer.deserialize(data)
 
-    def to_bytes(
-        self, serializer: Optional[MetadataSerializer] = None
-    ) -> bytes:
+    def to_bytes(self, serializer: MetadataSerializer | None = None) -> bytes:
         """Return the serialized TUF file format as bytes.
 
         Note that if bytes are first deserialized into ``Metadata`` and then
@@ -306,8 +308,8 @@ class Metadata(Generic[T]):
     def to_file(
         self,
         filename: str,
-        serializer: Optional[MetadataSerializer] = None,
-        storage_backend: Optional[StorageBackendInterface] = None,
+        serializer: MetadataSerializer | None = None,
+        storage_backend: StorageBackendInterface | None = None,
     ) -> None:
         """Write TUF metadata to file storage.
 
@@ -345,7 +347,7 @@ class Metadata(Generic[T]):
         self,
         signer: Signer,
         append: bool = False,
-        signed_serializer: Optional[SignedSerializer] = None,
+        signed_serializer: SignedSerializer | None = None,
     ) -> Signature:
         """Create signature over ``signed`` and assigns it to ``signatures``.
 
@@ -388,8 +390,8 @@ class Metadata(Generic[T]):
     def verify_delegate(
         self,
         delegated_role: str,
-        delegated_metadata: "Metadata",
-        signed_serializer: Optional[SignedSerializer] = None,
+        delegated_metadata: Metadata,
+        signed_serializer: SignedSerializer | None = None,
     ) -> None:
         """Verify that ``delegated_metadata`` is signed with the required
         threshold of keys for ``delegated_role``.

--- a/tuf/ngclient/_internal/requests_fetcher.py
+++ b/tuf/ngclient/_internal/requests_fetcher.py
@@ -9,9 +9,10 @@ library.
 # sigstore-python 1.0 still uses the module from there). requests_fetcher
 # can be moved out of _internal once sigstore-python 1.0 is not relevant.
 
+from __future__ import annotations
+
 import logging
-from collections.abc import Iterator
-from typing import Optional
+from typing import TYPE_CHECKING
 from urllib import parse
 
 # Imports
@@ -20,6 +21,9 @@ import requests
 import tuf
 from tuf.api import exceptions
 from tuf.ngclient.fetcher import FetcherInterface
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 # Globals
 logger = logging.getLogger(__name__)
@@ -39,7 +43,7 @@ class RequestsFetcher(FetcherInterface):
         self,
         socket_timeout: int = 30,
         chunk_size: int = 400000,
-        app_user_agent: Optional[str] = None,
+        app_user_agent: str | None = None,
     ) -> None:
         # http://docs.python-requests.org/en/master/user/advanced/#session-objects:
         #
@@ -103,7 +107,7 @@ class RequestsFetcher(FetcherInterface):
 
         return self._chunks(response)
 
-    def _chunks(self, response: "requests.Response") -> Iterator[bytes]:
+    def _chunks(self, response: requests.Response) -> Iterator[bytes]:
         """A generator function to be returned by fetch.
 
         This way the caller of fetch can differentiate between connection

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -61,13 +61,12 @@ Example of loading root, timestamp and snapshot:
 >>>         trusted_set.update_snapshot(f.read())
 """
 
+from __future__ import annotations
+
 import datetime
 import logging
 from collections import abc
-from collections.abc import Iterator
-from typing import Optional, Union, cast
-
-from securesystemslib.signer import Signature
+from typing import TYPE_CHECKING, Union, cast
 
 from tuf.api import exceptions
 from tuf.api.dsse import SimpleEnvelope
@@ -81,6 +80,11 @@ from tuf.api.metadata import (
     Timestamp,
 )
 from tuf.ngclient.config import EnvelopeType
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from securesystemslib.signer import Signature
 
 logger = logging.getLogger(__name__)
 
@@ -270,7 +274,7 @@ class TrustedMetadataSet(abc.Mapping):
             raise exceptions.ExpiredMetadataError("timestamp.json is expired")
 
     def update_snapshot(
-        self, data: bytes, trusted: Optional[bool] = False
+        self, data: bytes, trusted: bool | None = False
     ) -> Snapshot:
         """Verify and load ``data`` as new snapshot metadata.
 
@@ -402,7 +406,7 @@ class TrustedMetadataSet(abc.Mapping):
         # does not match meta version in timestamp
         self._check_final_snapshot()
 
-        delegator: Optional[Delegator] = self.get(delegator_name)
+        delegator: Delegator | None = self.get(delegator_name)
         if delegator is None:
             raise RuntimeError("Cannot load targets before delegator")
 
@@ -453,8 +457,8 @@ class TrustedMetadataSet(abc.Mapping):
 def _load_from_metadata(
     role: type[T],
     data: bytes,
-    delegator: Optional[Delegator] = None,
-    role_name: Optional[str] = None,
+    delegator: Delegator | None = None,
+    role_name: str | None = None,
 ) -> tuple[T, bytes, dict[str, Signature]]:
     """Load traditional metadata bytes, and extract and verify payload.
 
@@ -480,8 +484,8 @@ def _load_from_metadata(
 def _load_from_simple_envelope(
     role: type[T],
     data: bytes,
-    delegator: Optional[Delegator] = None,
-    role_name: Optional[str] = None,
+    delegator: Delegator | None = None,
+    role_name: str | None = None,
 ) -> tuple[T, bytes, dict[str, Signature]]:
     """Load simple envelope bytes, and extract and verify payload.
 

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -37,19 +37,23 @@ downloads target files is available in `examples/client
 <https://github.com/theupdateframework/python-tuf/tree/develop/examples/client>`_.
 """
 
+from __future__ import annotations
+
 import contextlib
 import logging
 import os
 import shutil
 import tempfile
-from typing import Optional, cast
+from typing import TYPE_CHECKING, cast
 from urllib import parse
 
 from tuf.api import exceptions
 from tuf.api.metadata import Root, Snapshot, TargetFile, Targets, Timestamp
 from tuf.ngclient._internal import requests_fetcher, trusted_metadata_set
 from tuf.ngclient.config import EnvelopeType, UpdaterConfig
-from tuf.ngclient.fetcher import FetcherInterface
+
+if TYPE_CHECKING:
+    from tuf.ngclient.fetcher import FetcherInterface
 
 logger = logging.getLogger(__name__)
 
@@ -80,10 +84,10 @@ class Updater:
         self,
         metadata_dir: str,
         metadata_base_url: str,
-        target_dir: Optional[str] = None,
-        target_base_url: Optional[str] = None,
-        fetcher: Optional[FetcherInterface] = None,
-        config: Optional[UpdaterConfig] = None,
+        target_dir: str | None = None,
+        target_base_url: str | None = None,
+        fetcher: FetcherInterface | None = None,
+        config: UpdaterConfig | None = None,
     ):
         self._dir = metadata_dir
         self._metadata_base_url = _ensure_trailing_slash(metadata_base_url)
@@ -153,7 +157,7 @@ class Updater:
         filename = parse.quote(targetinfo.path, "")
         return os.path.join(self.target_dir, filename)
 
-    def get_targetinfo(self, target_path: str) -> Optional[TargetFile]:
+    def get_targetinfo(self, target_path: str) -> TargetFile | None:
         """Return ``TargetFile`` instance with information for ``target_path``.
 
         The return value can be used as an argument to
@@ -186,8 +190,8 @@ class Updater:
     def find_cached_target(
         self,
         targetinfo: TargetFile,
-        filepath: Optional[str] = None,
-    ) -> Optional[str]:
+        filepath: str | None = None,
+    ) -> str | None:
         """Check whether a local file is an up to date target.
 
         Args:
@@ -216,8 +220,8 @@ class Updater:
     def download_target(
         self,
         targetinfo: TargetFile,
-        filepath: Optional[str] = None,
-        target_base_url: Optional[str] = None,
+        filepath: str | None = None,
+        target_base_url: str | None = None,
     ) -> str:
         """Download the target file specified by ``targetinfo``.
 
@@ -275,7 +279,7 @@ class Updater:
         return filepath
 
     def _download_metadata(
-        self, rolename: str, length: int, version: Optional[int] = None
+        self, rolename: str, length: int, version: int | None = None
     ) -> bytes:
         """Download a metadata file and return it as bytes."""
         encoded_name = parse.quote(rolename, "")
@@ -292,7 +296,7 @@ class Updater:
 
     def _persist_metadata(self, rolename: str, data: bytes) -> None:
         """Write metadata to disk atomically to avoid data loss."""
-        temp_file_name: Optional[str] = None
+        temp_file_name: str | None = None
         try:
             # encode the rolename to avoid issues with e.g. path separators
             encoded_name = parse.quote(rolename, "")
@@ -420,7 +424,7 @@ class Updater:
 
     def _preorder_depth_first_walk(
         self, target_filepath: str
-    ) -> Optional[TargetFile]:
+    ) -> TargetFile | None:
         """
         Interrogates the tree of target delegations in order of appearance
         (which implicitly order trustworthiness), and returns the matching

--- a/tuf/repository/_repository.py
+++ b/tuf/repository/_repository.py
@@ -3,12 +3,13 @@
 
 """Repository Abstraction for metadata management"""
 
+from __future__ import annotations
+
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Generator
 from contextlib import contextmanager, suppress
 from copy import deepcopy
-from typing import Optional
+from typing import TYPE_CHECKING
 
 from tuf.api.exceptions import UnsignedMetadataError
 from tuf.api.metadata import (
@@ -20,6 +21,9 @@ from tuf.api.metadata import (
     Targets,
     Timestamp,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 logger = logging.getLogger(__name__)
 
@@ -229,9 +233,7 @@ class Repository(ABC):
 
         return update_version, removed
 
-    def do_timestamp(
-        self, force: bool = False
-    ) -> tuple[bool, Optional[MetaFile]]:
+    def do_timestamp(self, force: bool = False) -> tuple[bool, MetaFile | None]:
         """Update timestamp meta information
 
         Updates timestamp according to current snapshot state

--- a/tuf/repository/_repository.py
+++ b/tuf/repository/_repository.py
@@ -114,7 +114,7 @@ class Repository(ABC):
         """Context manager for editing root metadata. See edit()"""
         with self.edit(Root.type) as root:
             if not isinstance(root, Root):
-                raise RuntimeError("Unexpected root type")
+                raise AssertionError("Unexpected root type")
             yield root
 
     @contextmanager
@@ -122,7 +122,7 @@ class Repository(ABC):
         """Context manager for editing timestamp metadata. See edit()"""
         with self.edit(Timestamp.type) as timestamp:
             if not isinstance(timestamp, Timestamp):
-                raise RuntimeError("Unexpected timestamp type")
+                raise AssertionError("Unexpected timestamp type")
             yield timestamp
 
     @contextmanager
@@ -130,7 +130,7 @@ class Repository(ABC):
         """Context manager for editing snapshot metadata. See edit()"""
         with self.edit(Snapshot.type) as snapshot:
             if not isinstance(snapshot, Snapshot):
-                raise RuntimeError("Unexpected snapshot type")
+                raise AssertionError("Unexpected snapshot type")
             yield snapshot
 
     @contextmanager
@@ -140,35 +140,35 @@ class Repository(ABC):
         """Context manager for editing targets metadata. See edit()"""
         with self.edit(rolename) as targets:
             if not isinstance(targets, Targets):
-                raise RuntimeError(f"Unexpected targets ({rolename}) type")
+                raise AssertionError(f"Unexpected targets ({rolename}) type")
             yield targets
 
     def root(self) -> Root:
         """Read current root metadata"""
         root = self.open(Root.type).signed
         if not isinstance(root, Root):
-            raise RuntimeError("Unexpected root type")
+            raise AssertionError("Unexpected root type")
         return root
 
     def timestamp(self) -> Timestamp:
         """Read current timestamp metadata"""
         timestamp = self.open(Timestamp.type).signed
         if not isinstance(timestamp, Timestamp):
-            raise RuntimeError("Unexpected timestamp type")
+            raise AssertionError("Unexpected timestamp type")
         return timestamp
 
     def snapshot(self) -> Snapshot:
         """Read current snapshot metadata"""
         snapshot = self.open(Snapshot.type).signed
         if not isinstance(snapshot, Snapshot):
-            raise RuntimeError("Unexpected snapshot type")
+            raise AssertionError("Unexpected snapshot type")
         return snapshot
 
     def targets(self, rolename: str = Targets.type) -> Targets:
         """Read current targets metadata"""
         targets = self.open(rolename).signed
         if not isinstance(targets, Targets):
-            raise RuntimeError("Unexpected targets type")
+            raise AssertionError("Unexpected targets type")
         return targets
 
     def do_snapshot(


### PR DESCRIPTION
This PR achieves two things:
* Makes us compatible with Python 3.8 again  (a non-supported release by now but I figured it's nice to not be the first one to break compatibility...)
* Starts using several nice annotation features from Python 3.10, e.g.:
   * `X | Y` instead of `typing.Union[X, Y]`, 
   * `X | None` instead of `typing.Optional[X]`, 
   * No quotes around class names in factory method return values

Almost all changes come from ruff autofixes: there should be no functional changes here. There's a small revert included to avoid the one thing that was incompatible with python 3.8.

This was tested by setting "--python-version 3.8" in our mypy invocation... Ideally we should be linting using the lowest supported python version but I did not include that change in this PR