### PR TITLE
workflows: Fix the spec version check

### DIFF
--- a/.github/workflows/specification-version-check.yml
+++ b/.github/workflows/specification-version-check.yml
@@ -20,6 +20,7 @@ jobs:
           python-version: "3.x"
       - id: get-version
         run: |
+          python3 -m pip install -r requirements/pinned.txt
           script="from tuf.api.metadata import SPECIFICATION_VERSION; \
                   print(f\"v{'.'.join(SPECIFICATION_VERSION)}\")"
           ver=$(python3 -c "$script")


### PR DESCRIPTION
I removed all instances of "pip install -e ." from our scripts in 4e889e7 since installing python-tuf is no longer needed (PWD is in python import paths already).

This is a different case though since here we don't install dependencies separately and importing python-tuf still requires securesystemslib: Let's install the dependencies.
