### PR TITLE
Cache all root metadata versions

### DIFF
--- a/examples/client/client
+++ b/examples/client/client
@@ -30,7 +30,11 @@ def build_metadata_dir(base_url: str) -> str:
 
 def init_tofu(base_url: str) -> bool:
     """Initialize local trusted metadata (Trust-On-First-Use) and create a
-    directory for downloads"""
+    directory for downloads
+
+    NOTE: This is unsafe and for demonstration only: the bootstrap root
+    should be deployed alongside your updater application
+    """
 
     metadata_dir = build_metadata_dir(base_url)
 
@@ -81,6 +85,9 @@ def download(base_url: str, target: str) -> bool:
         os.mkdir(DOWNLOAD_DIR)
 
     try:
+        # NOTE: initial root should be provided with ``bootstrap``  argument:
+        # This examples uses unsafe Trust-On-First-Use initialization so it is
+        # not possible here.
         updater = Updater(
             metadata_dir=metadata_dir,
             metadata_base_url=f"{base_url}/metadata/",
@@ -112,7 +119,7 @@ def download(base_url: str, target: str) -> bool:
     return True
 
 
-def main() -> None:
+def main() -> str | None:
     """Main TUF Client Example function"""
 
     client_args = argparse.ArgumentParser(description="TUF Client Example")
@@ -176,6 +183,8 @@ def main() -> None:
             return f"Failed to download {command_args.target}"
     else:
         client_args.print_help()
+
+    return None
 
 
 if __name__ == "__main__":

--- a/examples/client/client
+++ b/examples/client/client
@@ -11,7 +11,8 @@ import sys
 import traceback
 from hashlib import sha256
 from pathlib import Path
-from urllib import request
+
+import urllib3
 
 from tuf.api.exceptions import DownloadError, RepositoryError
 from tuf.ngclient import Updater
@@ -30,17 +31,24 @@ def build_metadata_dir(base_url: str) -> str:
 def init_tofu(base_url: str) -> bool:
     """Initialize local trusted metadata (Trust-On-First-Use) and create a
     directory for downloads"""
+
     metadata_dir = build_metadata_dir(base_url)
 
     if not os.path.isdir(metadata_dir):
         os.makedirs(metadata_dir)
 
-    root_url = f"{base_url}/metadata/1.root.json"
-    try:
-        request.urlretrieve(root_url, f"{metadata_dir}/root.json")
-    except OSError:
-        print(f"Failed to download initial root from {root_url}")
+    response = urllib3.request("GET", f"{base_url}/metadata/1.root.json")
+    if response.status != 200:
+        print(f"Failed to download initial root {base_url}/metadata/1.root.json")
         return False
+
+    Updater(
+        metadata_dir=metadata_dir,
+        metadata_base_url=f"{base_url}/metadata/",
+        target_base_url=f"{base_url}/targets/",
+        target_dir=DOWNLOAD_DIR,
+        bootstrap=response.data,
+    )
 
     print(f"Trust-on-First-Use: Initialized new root in {metadata_dir}")
     return True

--- a/tests/test_updater_consistent_snapshot.py
+++ b/tests/test_updater_consistent_snapshot.py
@@ -62,7 +62,7 @@ class TestConsistentSnapshot(unittest.TestCase):
         if self.dump_dir is not None:
             self.sim.write()
 
-        utils.cleanup_dir(self.metadata_dir)
+        utils.cleanup_metadata_dir(self.metadata_dir)
 
     def _init_repo(
         self, consistent_snapshot: bool, prefix_targets: bool = True

--- a/tests/test_updater_delegation_graphs.py
+++ b/tests/test_updater_delegation_graphs.py
@@ -92,7 +92,7 @@ class TestDelegations(unittest.TestCase):
             self.sim.write()
 
     def teardown_subtest(self) -> None:
-        utils.cleanup_dir(self.metadata_dir)
+        utils.cleanup_metadata_dir(self.metadata_dir)
 
     def _init_repo(self, test_case: DelegationsTestCase) -> None:
         """Create a new RepositorySimulator instance and

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 import logging
 import os
 import shutil

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -5,13 +5,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 import logging
 import os
 import shutil
 import sys
 import tempfile
 import unittest
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Callable, ClassVar
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -732,6 +732,7 @@ class TestRefresh(unittest.TestCase):
         wrapped_open.assert_has_calls(
             [
                 call(os.path.join(self.metadata_dir, "root.json"), "rb"),
+                call(os.path.join(self.metadata_dir, "root_history/2.root.json"), "rb"),
                 call(os.path.join(self.metadata_dir, "timestamp.json"), "rb"),
                 call(os.path.join(self.metadata_dir, "snapshot.json"), "rb"),
                 call(os.path.join(self.metadata_dir, "targets.json"), "rb"),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -155,12 +155,16 @@ def configure_test_logging(argv: list[str]) -> None:
     logging.basicConfig(level=loglevel)
 
 
-def cleanup_dir(path: str) -> None:
-    """Delete all files inside a directory"""
-    for filepath in [
-        os.path.join(path, filename) for filename in os.listdir(path)
-    ]:
-        os.remove(filepath)
+def cleanup_metadata_dir(path: str) -> None:
+    """Delete the local metadata dir"""
+    with os.scandir(path) as it:
+        for entry in it:
+            if entry.name == "root_history":
+                cleanup_metadata_dir(entry.path)
+            elif entry.name.endswith(".json"):
+                os.remove(entry.path)
+            else:
+                raise ValueError(f"Unexpected local metadata file {entry.path}")
 
 
 class TestServerProcess:

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -12,7 +12,8 @@ secure manner: All downloaded files are verified by signed metadata.
 High-level description of ``Updater`` functionality:
   * Initializing an ``Updater`` loads and validates the trusted local root
     metadata: This root metadata is used as the source of trust for all other
-    metadata.
+    metadata. Updater should always be initialized with the ``bootstrap``
+    argument: if this is not possible, it can be initialized from cache only.
   * ``refresh()`` can optionally be called to update and load all top-level
     metadata as described in the specification, using both locally cached
     metadata and metadata downloaded from the remote repository. If refresh is
@@ -75,9 +76,9 @@ class Updater:
             download both metadata and targets. Default is ``Urllib3Fetcher``
         config: ``Optional``; ``UpdaterConfig`` could be used to setup common
             configuration options.
-        bootstrap: ``Optional``; initial root metadata. If a boostrap root is
-            not provided then the root.json in the metadata cache is used as the
-            initial root.
+        bootstrap: ``Optional``; initial root metadata. A boostrap root should
+            always be provided. If it is not, the current root.json in the
+            metadata cache is used as the initial root.
 
     Raises:
         OSError: Local root.json cannot be read


### PR DESCRIPTION
Making this _ready for review_ based on discussion in community meeting. There's no rush in getting this merged: let's make sure the review / testing is adequate.

## Problem

Currently python-tuf clients typically initialize once from the "bootstrap" root (the root metadata shipped with the client software), and subsequent startups will use the cached root as starting point. This is mostly good but there is a downside: if the bootstrap root is more secure than the cache, then we lose some security (as cache could get poisoned between the first cache initialization and the actual use). This situation can arise if the client software (and bootstrap root) is shipped in a Operating System update, container image or e.g. a Debian package: in this case the client cache is writable by user but the bootstrap root and the client software may not be.

## Solution

* Cache all root versions
* Always initialize the client starting with the secure bootstrap root
* When loading subsequent root versions, load from local cache and from remote repository

This should give us best of both worlds: 
* client always initializes from most securely stored root
* client does not download any more data than now
* client still uses local cache for roots so repository cannot serve obsolete data

The only downside is that client will now verify every root version on startup: I think this perfectly acceptable as client can and should  periodically update the bootstrap root as well -- the added computation is not an issue in practice.

## Details

The ngclient cache directory looked like this before:
```
cachedir/
    root.json
    timestamp.json
    snapshot.json
    targets.json
    somedelegatedrole.json
``` 
Now it looks like this:
```
cachedir/
    root.json        #  This is a symlink to "root_history/3.root.json" for compatibility
    timestamp.json
    snapshot.json
    targets.json
    somedelegatedrole.json
    root_history/
        1.root.json
        2.root.json
        3.root.json
``` 

* non-versioned root.json is preserved as symlink so that older python-tuf versions can coexist (and so it's easier to check current state for humans and tests)
* `root_history` directory is used to make name clashes impossible (imagine a delegated role named "1.root") : as long as the client is not susceptible to path traversal issues, this should be safe
* tests have been added to verify that roots are cached, cached roots are used and that poisoned cache is handled correctly (remote metadata is used if cache is not valid)
