### PR TITLE
workflows: Add a "all tests pass" check

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -77,6 +77,13 @@ jobs:
         run: |
           coveralls --service=github
 
+  all-tests-pass:
+    name: All tests passed
+    needs: [lint-test, tests]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All test jobs have completed successfully."
+
   coveralls-fin:
     # Always run when all 'tests' jobs have finished even if they failed
     # TODO: Replace always() with a 'at least one job succeeded' expression


### PR DESCRIPTION
This way we can avoid naming all the matrix tests individually in "required checks to pass before merging" in GitHub UI (which requires tweaking everytime supported Python versions change).

This copies the changes from https://github.com/secure-systems-lab/securesystemslib/pull/926.

When this is merged we can remove all the individual test checks in the _"Require status checks to pass before merging"_ list in branch protection settings and replace them with the check "tests / All tests passed"