### PR TITLE
Type/annotation fixes

### DIFF
--- a/tuf/api/dsse.py
+++ b/tuf/api/dsse.py
@@ -81,7 +81,7 @@ class SimpleEnvelope(Generic[T], BaseSimpleEnvelope):
         except Exception as e:
             raise DeserializationError from e
 
-        return envelope
+        return cast(SimpleEnvelope[T], envelope)
 
     def to_bytes(self) -> bytes:
         """Return envelope as JSON bytes.

--- a/tuf/api/serialization/json.py
+++ b/tuf/api/serialization/json.py
@@ -98,7 +98,10 @@ class CanonicalJSONSerializer(SignedSerializer):
         """
         try:
             signed_dict = signed_obj.to_dict()
-            canonical_bytes = encode_canonical(signed_dict).encode("utf-8")
+            canon_str = encode_canonical(signed_dict)
+            # encode_canonical cannot return None if output_function is not set
+            assert canon_str is not None  # noqa: S101
+            canonical_bytes = canon_str.encode("utf-8")
 
         except Exception as e:
             raise SerializationError from e


### PR DESCRIPTION
These annotation issues come up if the type checking is enabled for securesystemslib.
* The json serialization issue is a result of weird securesystemslib API design
* The SimpleEnvelope issue seems to point to the API being a bit wrong: I did not change API, just silenced the warning

Fixes #2775, makes it possible to potentially enable type checks in next securesystemslib release 

