### PR TITLE
dev requirements: Bring back editable install

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,4 @@
 -r build.txt
 -r test.txt
 -r lint.txt
+-e .


### PR DESCRIPTION
This partially reverts 4e889e7 and now again installs the current project as editable in requirements/dev.txt:
* the test suite does work without this
* but running the examples was now more difficult

so enabling editable install in dev requirements seems like the right compromise.

Fixes #2786