### PR TITLE
tox: Silence docs build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,4 +54,4 @@ deps =
     -r{toxinidir}/requirements/docs.txt
 
 commands =
-    sphinx-build -b html docs docs/build/html -W
+    sphinx-build --fail-on-warning --quiet --builder html docs docs/build/html


### PR DESCRIPTION
* Add "--quiet" to the docs build: otherwise it drowns out everything else when running "tox"
* switch other short arguments to long ones as well for clarity
