### PR TITLE
build: Remove workaround for hatchling upgrades

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build binary wheel, source tarball and changelog
         run: |
-          PIP_CONSTRAINT=requirements/build.txt python3 -m build --sdist --wheel --outdir dist/ .
+          python3 -m build --sdist --wheel --outdir dist/ .
           awk "/## $GITHUB_REF_NAME/{flag=1; next} /## v/{flag=0} flag" docs/CHANGELOG.md > changelog
 
       - name: Store build artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,5 @@
 [build-system]
-# Dependabot cannot do `build-system.requires` (dependabot/dependabot-core#8465)
-# workaround to get reproducibility and auto-updates:
-#   PIP_CONSTRAINT=requirements/build.txt python3 -m build ...
-requires = ["hatchling"]
+requires = ["hatchling==1.27.0"]
 build-backend = "hatchling.build"
 
 [project]

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,4 +2,3 @@
 # during CI and CD Github workflows
 build==1.2.2.post1
 tox==4.1.2
-hatchling==1.27.0


### PR DESCRIPTION
Apparently Dependabot now supports upgrading `build-system.requires`: we don't need the workarounds anymore.


Looks like it works:
```
updater | 2025/02/21 08:02:36 INFO <job_968450357> Checking if hatchling 1.27.0 needs updating
  proxy | 2025/02/21 08:02:36 [021] GET https://pypi.org:443/simple/hatchling/
  proxy | 2025/02/21 08:02:36 [021] 200 https://pypi.org:443/simple/hatchling/
updater | 2025/02/21 08:02:36 INFO <job_968450357> Filtered out 14 yanked versions
updater | 2025/02/21 08:02:36 INFO <job_968450357> Latest version is 1.27.0
```