### PR TITLE
dependabot: Add zizmor to lint dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
         - "mypy"
         - "ruff"
         - "tox"
+        - "zizmor"
     dependencies:
       # Python (developer) runtime dependencies. Also any new dependencies not
       # caught by earlier groups


### PR DESCRIPTION
This is for better dependabot grouping
