### PR TITLE
Include version in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-TUF Developer Documentation
-===========================
+Python-TUF |version| Developer Documentation
+=======================================================================
 
 This documentation provides essential information for those developing software
 with the `Python reference implementation of The Update Framework (TUF)


### PR DESCRIPTION
* Without this when reading "stable" docs in readthedocs it's not clear what version the docs are for
* This still leaves "latest" a little unclear on readthedocs (since we don't set a -dev version number after release) but this is still an improvement

Fixes #1568

