### PR TITLE
Port securesystemslib.hash module

### DIFF
--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -80,7 +80,7 @@ logger = logging.getLogger(__name__)
 
 SPEC_VER = ".".join(SPECIFICATION_VERSION)
 
-_DEFAULT_HASH_ALGORITHM = "sha256"
+_HASH_ALGORITHM = "sha256"
 
 
 @dataclass
@@ -294,9 +294,9 @@ class RepositorySimulator(FetcherInterface):
         self, role: str
     ) -> tuple[dict[str, str], int]:
         data = self.fetch_metadata(role)
-        digest_object = hashlib.new(_DEFAULT_HASH_ALGORITHM)
+        digest_object = hashlib.new(_HASH_ALGORITHM)
         digest_object.update(data)
-        hashes = {_DEFAULT_HASH_ALGORITHM: digest_object.hexdigest()}
+        hashes = {_HASH_ALGORITHM: digest_object.hexdigest()}
         return hashes, len(data)
 
     def update_timestamp(self) -> None:

--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -45,6 +45,7 @@ Example::
 from __future__ import annotations
 
 import datetime
+import hashlib
 import logging
 import os
 import tempfile
@@ -52,7 +53,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 from urllib import parse
 
-import securesystemslib.hash as sslib_hash
 from securesystemslib.signer import CryptoSigner, Signer
 
 from tuf.api.exceptions import DownloadHTTPError
@@ -79,6 +79,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 SPEC_VER = ".".join(SPECIFICATION_VERSION)
+
+_DEFAULT_HASH_ALGORITHM = "sha256"
 
 
 @dataclass
@@ -292,9 +294,9 @@ class RepositorySimulator(FetcherInterface):
         self, role: str
     ) -> tuple[dict[str, str], int]:
         data = self.fetch_metadata(role)
-        digest_object = sslib_hash.digest(sslib_hash.DEFAULT_HASH_ALGORITHM)
+        digest_object = hashlib.new(_DEFAULT_HASH_ALGORITHM)
         digest_object.update(data)
-        hashes = {sslib_hash.DEFAULT_HASH_ALGORITHM: digest_object.hexdigest()}
+        hashes = {_DEFAULT_HASH_ALGORITHM: digest_object.hexdigest()}
         return hashes, len(data)
 
     def update_timestamp(self) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -895,6 +895,12 @@ class TestMetadata(unittest.TestCase):
             # test with data as bytes
             snapshot_metafile.verify_length_and_hashes(data)
 
+            # test with custom blake algorithm
+            snapshot_metafile.hashes = {
+                "blake2b-256": "963a3c31aad8e2a91cfc603fdba12555e48dd0312674ac48cce2c19c243236a1"
+            }
+            snapshot_metafile.verify_length_and_hashes(data)
+
             # test exceptions
             expected_length = snapshot_metafile.length
             snapshot_metafile.length = 2345
@@ -987,6 +993,12 @@ class TestMetadata(unittest.TestCase):
         targetfile_from_data = TargetFile.from_data(target_file_path, data)
         targetfile_from_data.verify_length_and_hashes(data)
 
+        # Test with custom blake hash algorithm
+        targetfile_from_data = TargetFile.from_data(
+            target_file_path, data, ["blake2b-256"]
+        )
+        targetfile_from_data.verify_length_and_hashes(data)
+
     def test_metafile_from_data(self) -> None:
         data = b"Inline test content"
 
@@ -1009,6 +1021,10 @@ class TestMetadata(unittest.TestCase):
                 },
             ),
         )
+
+        # Test with custom blake hash algorithm
+        metafile = MetaFile.from_data(1, data, ["blake2b-256"])
+        metafile.verify_length_and_hashes(data)
 
     def test_targetfile_get_prefixed_paths(self) -> None:
         target = TargetFile(100, {"sha256": "abc", "md5": "def"}, "a/b/f.ext")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import ClassVar
 
 from securesystemslib import exceptions as sslib_exceptions
-from securesystemslib import hash as sslib_hash
 from securesystemslib.signer import (
     CryptoSigner,
     Key,
@@ -958,9 +957,7 @@ class TestMetadata(unittest.TestCase):
         # Test with a non-existing file
         file_path = os.path.join(self.repo_dir, Targets.type, "file123.txt")
         with self.assertRaises(FileNotFoundError):
-            TargetFile.from_file(
-                file_path, file_path, [sslib_hash.DEFAULT_HASH_ALGORITHM]
-            )
+            TargetFile.from_file(file_path, file_path, ["sha256"])
 
         # Test with an unsupported algorithm
         file_path = os.path.join(self.repo_dir, Targets.type, "file1.txt")

--- a/tuf/api/_payload.py
+++ b/tuf/api/_payload.py
@@ -49,28 +49,36 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T", "Root", "Timestamp", "Snapshot", "Targets")
 
 
-def _hash(algo: str) -> Any:  # noqa: ANN401
-    """Returns new hash object, supporting custom "blake2b-256" algo name."""
+def _get_digest(algo: str) -> Any:  # noqa: ANN401
+    """New digest helper to support custom "blake2b-256" algo name."""
     if algo == _BLAKE_HASH_ALGORITHM:
         return hashlib.blake2b(digest_size=32)
 
     return hashlib.new(algo)
 
 
-def _file_hash(f: IO[bytes], algo: str) -> Any:  # noqa: ANN401
-    """Returns hashed file."""
+def _hash_bytes(data: bytes, algo: str) -> str:
+    """Returns hexdigest for data using algo."""
+    digest = _get_digest(algo)
+    digest.update(data)
+
+    return digest.hexdigest()
+
+
+def _hash_file(f: IO[bytes], algo: str) -> str:
+    """Returns hexdigest for file using algo."""
     f.seek(0)
     if sys.version_info >= (3, 11):
-        digest = hashlib.file_digest(f, lambda: _hash(algo))  # type: ignore[arg-type]
+        digest = hashlib.file_digest(f, lambda: _get_digest(algo))  # type: ignore[arg-type]
 
     else:
         # Fallback for older Pythons. Chunk size is taken from the previously
         # used and now deprecated `securesystemslib.hash.digest_fileobject`.
-        digest = _hash(algo)
+        digest = _get_digest(algo)
         for chunk in iter(lambda: f.read(4096), b""):
             digest.update(chunk)
 
-    return digest
+    return digest.hexdigest()
 
 
 class Signed(metaclass=abc.ABCMeta):
@@ -695,17 +703,15 @@ class BaseFile:
         for algo, exp_hash in expected_hashes.items():
             try:
                 if isinstance(data, bytes):
-                    digest_object = _hash(algo)
-                    digest_object.update(data)
+                    observed_hash = _hash_bytes(data, algo)
                 else:
                     # if data is not bytes, assume it is a file object
-                    digest_object = _file_hash(data, algo)
+                    observed_hash = _hash_file(data, algo)
             except (ValueError, TypeError) as e:
                 raise LengthOrHashMismatchError(
                     f"Unsupported algorithm '{algo}'"
                 ) from e
 
-            observed_hash = digest_object.hexdigest()
             if observed_hash != exp_hash:
                 raise LengthOrHashMismatchError(
                     f"Observed hash {observed_hash} does not match "
@@ -760,14 +766,11 @@ class BaseFile:
         for algorithm in hash_algorithms:
             try:
                 if isinstance(data, bytes):
-                    digest_object = _hash(algorithm)
-                    digest_object.update(data)
+                    hashes[algorithm] = _hash_bytes(data, algorithm)
                 else:
-                    digest_object = _file_hash(data, algorithm)
+                    hashes[algorithm] = _hash_file(data, algorithm)
             except (ValueError, TypeError) as e:
                 raise ValueError(f"Unsupported algorithm '{algorithm}'") from e
-
-            hashes[algorithm] = digest_object.hexdigest()
 
         return (length, hashes)
 

--- a/tuf/api/_payload.py
+++ b/tuf/api/_payload.py
@@ -854,7 +854,7 @@ class MetaFile(BaseFile):
             version: Version of the metadata file.
             data: Metadata bytes that the metafile represents.
             hash_algorithms: Hash algorithms to create the hashes with. If not
-            specified, the securesystemslib default hash algorithm is used.
+            specified, "sha256" is used.
 
         Raises:
             ValueError: The hash algorithms list contains an unsupported
@@ -1564,7 +1564,7 @@ class TargetFile(BaseFile):
                 targets URL.
             local_path: Local path to target file content.
             hash_algorithms: Hash algorithms to calculate hashes with. If not
-                specified the securesystemslib default hash algorithm is used.
+                specified, "sha256" is used.
 
         Raises:
             FileNotFoundError: The file doesn't exist.
@@ -1588,7 +1588,7 @@ class TargetFile(BaseFile):
                 targets URL.
             data: Target file content.
             hash_algorithms: Hash algorithms to create the hashes with. If not
-                specified the securesystemslib default hash algorithm is used.
+                specified, "sha256" is used.
 
         Raises:
             ValueError: The hash algorithms list contains an unsupported

--- a/tuf/api/_payload.py
+++ b/tuf/api/_payload.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 import abc
 import fnmatch
+import hashlib
 import io
 import logging
+import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import (
@@ -21,7 +23,6 @@ from typing import (
 )
 
 from securesystemslib import exceptions as sslib_exceptions
-from securesystemslib import hash as sslib_hash
 from securesystemslib.signer import Key, Signature
 
 from tuf.api.exceptions import LengthOrHashMismatchError, UnsignedMetadataError
@@ -34,6 +35,9 @@ _SNAPSHOT = "snapshot"
 _TARGETS = "targets"
 _TIMESTAMP = "timestamp"
 
+_DEFAULT_HASH_ALGORITHM = "sha256"
+_BLAKE_HASH_ALGORITHM = "blake2b-256"
+
 # We aim to support SPECIFICATION_VERSION and require the input metadata
 # files to have the same major version (the first number) as ours.
 SPECIFICATION_VERSION = ["1", "0", "31"]
@@ -43,6 +47,30 @@ logger = logging.getLogger(__name__)
 
 # T is a Generic type constraint for container payloads
 T = TypeVar("T", "Root", "Timestamp", "Snapshot", "Targets")
+
+
+def _hash(algo: str) -> Any:  # noqa: ANN401
+    """Returns new hash object, supporting custom "blake2b-256" algo name."""
+    if algo == _BLAKE_HASH_ALGORITHM:
+        return hashlib.blake2b(digest_size=32)
+
+    return hashlib.new(algo)
+
+
+def _file_hash(f: IO[bytes], algo: str) -> Any:  # noqa: ANN401
+    """Returns hashed file."""
+    f.seek(0)
+    if sys.version_info >= (3, 11):
+        digest = hashlib.file_digest(f, lambda: _hash(algo))  # type: ignore[arg-type]
+
+    else:
+        # Fallback for older Pythons. Chunk size is taken from the previously
+        # used and now deprecated `securesystemslib.hash.digest_fileobject`.
+        digest = _hash(algo)
+        for chunk in iter(lambda: f.read(4096), b""):
+            digest.update(chunk)
+
+    return digest
 
 
 class Signed(metaclass=abc.ABCMeta):
@@ -664,19 +692,15 @@ class BaseFile:
         data: bytes | IO[bytes], expected_hashes: dict[str, str]
     ) -> None:
         """Verify that the hash of ``data`` matches ``expected_hashes``."""
-        is_bytes = isinstance(data, bytes)
         for algo, exp_hash in expected_hashes.items():
             try:
-                if is_bytes:
-                    digest_object = sslib_hash.digest(algo)
+                if isinstance(data, bytes):
+                    digest_object = _hash(algo)
                     digest_object.update(data)
                 else:
                     # if data is not bytes, assume it is a file object
-                    digest_object = sslib_hash.digest_fileobject(data, algo)
-            except (
-                sslib_exceptions.UnsupportedAlgorithmError,
-                sslib_exceptions.FormatError,
-            ) as e:
+                    digest_object = _file_hash(data, algo)
+            except (ValueError, TypeError) as e:
                 raise LengthOrHashMismatchError(
                     f"Unsupported algorithm '{algo}'"
                 ) from e
@@ -731,21 +755,16 @@ class BaseFile:
         hashes = {}
 
         if hash_algorithms is None:
-            hash_algorithms = [sslib_hash.DEFAULT_HASH_ALGORITHM]
+            hash_algorithms = [_DEFAULT_HASH_ALGORITHM]
 
         for algorithm in hash_algorithms:
             try:
                 if isinstance(data, bytes):
-                    digest_object = sslib_hash.digest(algorithm)
+                    digest_object = _hash(algorithm)
                     digest_object.update(data)
                 else:
-                    digest_object = sslib_hash.digest_fileobject(
-                        data, algorithm
-                    )
-            except (
-                sslib_exceptions.UnsupportedAlgorithmError,
-                sslib_exceptions.FormatError,
-            ) as e:
+                    digest_object = _file_hash(data, algorithm)
+            except (ValueError, TypeError) as e:
                 raise ValueError(f"Unsupported algorithm '{algorithm}'") from e
 
             hashes[algorithm] = digest_object.hexdigest()
@@ -1150,7 +1169,7 @@ class DelegatedRole(Role):
         if self.path_hash_prefixes is not None:
             # Calculate the hash of the filepath
             # to determine in which bin to find the target.
-            digest_object = sslib_hash.digest(algorithm="sha256")
+            digest_object = hashlib.new(name="sha256")
             digest_object.update(target_filepath.encode("utf-8"))
             target_filepath_hash = digest_object.hexdigest()
 
@@ -1269,7 +1288,7 @@ class SuccinctRoles(Role):
             target_filepath: URL path to a target file, relative to a base
                 targets URL.
         """
-        hasher = sslib_hash.digest(algorithm="sha256")
+        hasher = hashlib.new(name="sha256")
         hasher.update(target_filepath.encode("utf-8"))
 
         # We can't ever need more than 4 bytes (32 bits).


### PR DESCRIPTION
securesystemslib.hash is a small wrapper around hashlib, which serves two main purposes:
* provide helper function to hash a file
* translate custom hash algorithm name "blake2b-256" to "blake2b" with (digest_size=32).

In preparation for the removal of securesystemslib.hash, this patch ports above behavior to tuf and uses the builtin hashlib directly where possible.

related secure-systems-lab/securesystemslib#943