### PR TITLE
Start statically analyzing securesystemslib calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,6 @@ disable_error_code = ["attr-defined"]
 [[tool.mypy.overrides]]
 module = [
   "requests.*",
-  "securesystemslib.*",
 ]
 ignore_missing_imports = "True"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,12 +132,6 @@ disallow_untyped_calls = "True"
 show_error_codes = "True"
 disable_error_code = ["attr-defined"]
 
-[[tool.mypy.overrides]]
-module = [
-  "requests.*",
-]
-ignore_missing_imports = "True"
-
 [tool.coverage.report]
 exclude_also = [
     # abstract class method definition

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,6 +22,7 @@ from securesystemslib.signer import (
     Key,
     SecretsHandler,
     Signer,
+    SSlibKey,
 )
 
 from tests import utils
@@ -244,11 +245,11 @@ class TestMetadata(unittest.TestCase):
             @classmethod
             def from_priv_key_uri(
                 cls,
-                priv_key_uri: str,
-                public_key: Key,
-                secrets_handler: SecretsHandler | None = None,
+                _priv_key_uri: str,
+                _public_key: Key,
+                _secrets_handler: SecretsHandler | None = None,
             ) -> Signer:
-                pass
+                raise RuntimeError("Not a real signer")
 
             @property
             def public_key(self) -> Key:
@@ -469,43 +470,45 @@ class TestMetadata(unittest.TestCase):
         )
 
     def test_verification_result(self) -> None:
-        vr = VerificationResult(3, {"a": None}, {"b": None})
+        key = SSlibKey("", "", "", {"public": ""})
+        vr = VerificationResult(3, {"a": key}, {"b": key})
         self.assertEqual(vr.missing, 2)
         self.assertFalse(vr.verified)
         self.assertFalse(vr)
 
         # Add a signature
-        vr.signed["c"] = None
+        vr.signed["c"] = key
         self.assertEqual(vr.missing, 1)
         self.assertFalse(vr.verified)
         self.assertFalse(vr)
 
         # Add last missing signature
-        vr.signed["d"] = None
+        vr.signed["d"] = key
         self.assertEqual(vr.missing, 0)
         self.assertTrue(vr.verified)
         self.assertTrue(vr)
 
         # Add one more signature
-        vr.signed["e"] = None
+        vr.signed["e"] = key
         self.assertEqual(vr.missing, 0)
         self.assertTrue(vr.verified)
         self.assertTrue(vr)
 
     def test_root_verification_result(self) -> None:
-        vr1 = VerificationResult(3, {"a": None}, {"b": None})
-        vr2 = VerificationResult(1, {"c": None}, {"b": None})
+        key = SSlibKey("", "", "", {"public": ""})
+        vr1 = VerificationResult(3, {"a": key}, {"b": key})
+        vr2 = VerificationResult(1, {"c": key}, {"b": key})
 
         vr = RootVerificationResult(vr1, vr2)
-        self.assertEqual(vr.signed, {"a": None, "c": None})
-        self.assertEqual(vr.unsigned, {"b": None})
+        self.assertEqual(vr.signed, {"a": key, "c": key})
+        self.assertEqual(vr.unsigned, {"b": key})
         self.assertFalse(vr.verified)
         self.assertFalse(vr)
 
-        vr1.signed["c"] = None
-        vr1.signed["f"] = None
-        self.assertEqual(vr.signed, {"a": None, "c": None, "f": None})
-        self.assertEqual(vr.unsigned, {"b": None})
+        vr1.signed["c"] = key
+        vr1.signed["f"] = key
+        self.assertEqual(vr.signed, {"a": key, "c": key, "f": key})
+        self.assertEqual(vr.unsigned, {"b": key})
         self.assertTrue(vr.verified)
         self.assertTrue(vr)
 
@@ -678,7 +681,7 @@ class TestMetadata(unittest.TestCase):
 
         # Assert that add_key with old argument order will raise an error
         with self.assertRaises(ValueError):
-            root.signed.add_key(Root.type, key)
+            root.signed.add_key(Root.type, key)  # type: ignore [arg-type]
 
         # Add new root key
         root.signed.add_key(key, Root.type)
@@ -778,7 +781,7 @@ class TestMetadata(unittest.TestCase):
 
         # Assert that add_key with old argument order will raise an error
         with self.assertRaises(ValueError):
-            targets.add_key("role1", key)
+            targets.add_key(Root.type, key)  # type: ignore [arg-type]
 
         # Assert that delegated role "role1" does not contain the new key
         self.assertNotIn(key.keyid, targets.delegations.roles["role1"].keyids)
@@ -1178,7 +1181,7 @@ class TestSimpleEnvelope(unittest.TestCase):
             self.assertEqual(metadata.signed, payload)
 
     def test_fail_envelope_serialization(self) -> None:
-        envelope = SimpleEnvelope(b"foo", "bar", ["baz"])
+        envelope = SimpleEnvelope(b"foo", "bar", [])  # type: ignore[arg-type]
         with self.assertRaises(SerializationError):
             envelope.to_bytes()
 
@@ -1193,7 +1196,7 @@ class TestSimpleEnvelope(unittest.TestCase):
     def test_fail_payload_deserialization(self) -> None:
         payloads = [b"[", b'{"_type": "foo"}']
         for payload in payloads:
-            envelope = SimpleEnvelope(payload, "bar", [])
+            envelope = SimpleEnvelope(payload, "bar", {})
             with self.assertRaises(DeserializationError):
                 envelope.get_signed()
 


### PR DESCRIPTION
DRAFT: This requires a new securesystemslib release

The code changes are all in tests which is a good sign.