### PR TITLE
Advisory locking for metadata and artifacts files

### DIFF
--- a/tests/refresh_script.py
+++ b/tests/refresh_script.py
@@ -1,0 +1,15 @@
+import sys
+
+from tuf.ngclient import Updater
+
+print(f"Creating and refreshing a client {sys.argv[1]} times:")
+print(f"  metadata dir: {sys.argv[2]}")
+print(f"  metadata url: {sys.argv[3]}")
+
+
+for i in range(int(sys.argv[1])):
+    try:
+        u = Updater(metadata_dir=sys.argv[2], metadata_base_url=sys.argv[3])
+        u.refresh()
+    except OSError as e:
+        sys.exit(f"Failed on iteration {i}: {e}")

--- a/tests/refresh_script.py
+++ b/tests/refresh_script.py
@@ -1,4 +1,5 @@
 import sys
+import time
 
 from tuf.ngclient import Updater
 
@@ -6,11 +7,17 @@ print(f"Fetching metadata {sys.argv[1]} times:")
 print(f"  metadata dir: {sys.argv[2]}")
 print(f"  metadata url: {sys.argv[3]}")
 
+start = time.time()
 
 for i in range(int(sys.argv[1])):
     try:
+        refresh_start = time.time()
         u = Updater(metadata_dir=sys.argv[2], metadata_base_url=sys.argv[3])
         # file3.txt is delegated so we end up exercising all metadata load paths
         u.get_targetinfo("file3.txt")
     except OSError as e:
-        sys.exit(f"Failed on iteration {i}: {e}")
+        print(
+            f"Failed on iteration {i}, "
+            f"{time.time() - refresh_start} secs elapsed ({time.time() - start} total)"
+        )
+        raise e

--- a/tests/refresh_script.py
+++ b/tests/refresh_script.py
@@ -2,7 +2,7 @@ import sys
 
 from tuf.ngclient import Updater
 
-print(f"Creating and refreshing a client {sys.argv[1]} times:")
+print(f"Fetching metadata {sys.argv[1]} times:")
 print(f"  metadata dir: {sys.argv[2]}")
 print(f"  metadata url: {sys.argv[3]}")
 
@@ -10,6 +10,7 @@ print(f"  metadata url: {sys.argv[3]}")
 for i in range(int(sys.argv[1])):
     try:
         u = Updater(metadata_dir=sys.argv[2], metadata_base_url=sys.argv[3])
-        u.refresh()
+        # file3.txt is delegated so we end up exercising all metadata load paths
+        u.get_targetinfo("file3.txt")
     except OSError as e:
         sys.exit(f"Failed on iteration {i}: {e}")

--- a/tests/test_updater_delegation_graphs.py
+++ b/tests/test_updater_delegation_graphs.py
@@ -136,7 +136,9 @@ class TestDelegations(unittest.TestCase):
         """Assert that local metadata files match 'roles'"""
         expected_files = [f"{role}.json" for role in roles]
         found_files = [
-            e.name for e in os.scandir(self.metadata_dir) if e.is_file() and e.name != ".lock"
+            e.name
+            for e in os.scandir(self.metadata_dir)
+            if e.is_file() and e.name != ".lock"
         ]
 
         self.assertListEqual(sorted(found_files), sorted(expected_files))

--- a/tests/test_updater_delegation_graphs.py
+++ b/tests/test_updater_delegation_graphs.py
@@ -136,7 +136,7 @@ class TestDelegations(unittest.TestCase):
         """Assert that local metadata files match 'roles'"""
         expected_files = [f"{role}.json" for role in roles]
         found_files = [
-            e.name for e in os.scandir(self.metadata_dir) if e.is_file()
+            e.name for e in os.scandir(self.metadata_dir) if e.is_file() and e.name != ".lock"
         ]
 
         self.assertListEqual(sorted(found_files), sorted(expected_files))

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -356,16 +356,14 @@ class TestUpdater(unittest.TestCase):
 
         self.assertEqual(ua[:23], "MyApp/1.2.3 python-tuf/")
 
-
-class TestParallelUpdater(TestUpdater):
     def test_parallel_updaters(self) -> None:
-        # Refresh two updaters in parallel many times, using the same local metadata cache.
+        # Refresh many updaters in parallel many times, using the same local metadata cache.
         # This should reveal race conditions.
 
-        iterations = 100
+        iterations = 50
+        process_count = 10
 
-        # The project root is the parent of the tests directory
-        project_root = os.path.dirname(utils.TESTS_DIR)
+        project_root_dir = os.path.dirname(utils.TESTS_DIR)
 
         command = [
             sys.executable,
@@ -376,29 +374,26 @@ class TestParallelUpdater(TestUpdater):
             self.metadata_url,
         ]
 
-        p1 = subprocess.Popen(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd=project_root,
-        )
-        p2 = subprocess.Popen(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd=project_root,
-        )
+        procs = [
+            subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                cwd=project_root_dir,
+            )
+            for _ in range(process_count)
+        ]
 
-        stdout1, stderr1 = p1.communicate()
-        stdout2, stderr2 = p2.communicate()
-
-        if p1.returncode != 0 or p2.returncode != 0:
+        errout = ""
+        for proc in procs:
+            stdout, stderr = proc.communicate()
+            if proc.returncode != 0:
+                errout += "Parallel Refresh script failed:"
+                errout += f"\nprocess stdout: \n{stdout.decode()}"
+                errout += f"\nprocess stderr: \n{stderr.decode()}"
+        if errout:
             self.fail(
-                "Parallel refresh failed"
-                f"\nprocess 1 stdout: \n{stdout1.decode()}"
-                f"\nprocess 1 stderr: \n{stderr1.decode()}"
-                f"\nprocess 2 stdout: \n{stdout2.decode()}"
-                f"\nprocess 2 stderr: \n{stderr2.decode()}"
+                f"One or more scripts failed parallel refresh test:\n{errout}"
             )
 
 

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import sys
 import tempfile
+import subprocess
 import unittest
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Callable, ClassVar
@@ -353,6 +354,44 @@ class TestUpdater(unittest.TestCase):
 
         self.assertEqual(ua[:23], "MyApp/1.2.3 python-tuf/")
 
+
+class TestParallelUpdater(TestUpdater):
+    def test_parallel_updaters(self) -> None:
+        # Refresh two updaters in parallel many times, using the same local metadata cache.
+        # This should reveal race conditions.
+
+        iterations = 100
+
+        # The project root is the parent of the tests directory
+        project_root = os.path.dirname(utils.TESTS_DIR)
+
+        command = [
+            sys.executable,
+            "-m",
+            "tests.refresh_script",
+            str(iterations),
+            self.client_directory,
+            self.metadata_url,
+        ]
+
+        p1 = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=project_root
+        )
+        p2 = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=project_root
+        )
+
+        stdout1, stderr1 = p1.communicate()
+        stdout2, stderr2 = p2.communicate()
+
+        if p1.returncode != 0 or p2.returncode != 0:
+            self.fail(
+                "Parallel refresh failed"
+                f"\nprocess 1 stdout: \n{stdout1.decode()}"
+                f"\nprocess 1 stderr: \n{stderr1.decode()}"
+                f"\nprocess 2 stdout: \n{stdout2.decode()}"
+                f"\nprocess 2 stderr: \n{stderr2.decode()}"
+            )
 
 if __name__ == "__main__":
     utils.configure_test_logging(sys.argv)

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
-import subprocess
 import unittest
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Callable, ClassVar
@@ -158,7 +158,7 @@ class TestUpdater(unittest.TestCase):
         """Assert that local metadata files match 'roles'"""
         expected_files = [f"{role}.json" for role in roles]
         found_files = [
-            e.name for e in os.scandir(self.client_directory) if e.is_file()
+            e.name for e in os.scandir(self.client_directory) if e.is_file() and e.name != ".lock"
         ]
 
         self.assertListEqual(sorted(found_files), sorted(expected_files))

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -158,7 +158,9 @@ class TestUpdater(unittest.TestCase):
         """Assert that local metadata files match 'roles'"""
         expected_files = [f"{role}.json" for role in roles]
         found_files = [
-            e.name for e in os.scandir(self.client_directory) if e.is_file() and e.name != ".lock"
+            e.name
+            for e in os.scandir(self.client_directory)
+            if e.is_file() and e.name != ".lock"
         ]
 
         self.assertListEqual(sorted(found_files), sorted(expected_files))
@@ -375,10 +377,16 @@ class TestParallelUpdater(TestUpdater):
         ]
 
         p1 = subprocess.Popen(
-            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=project_root
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=project_root,
         )
         p2 = subprocess.Popen(
-            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=project_root
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=project_root,
         )
 
         stdout1, stderr1 = p1.communicate()
@@ -392,6 +400,7 @@ class TestParallelUpdater(TestUpdater):
                 f"\nprocess 2 stdout: \n{stdout2.decode()}"
                 f"\nprocess 2 stderr: \n{stderr2.decode()}"
             )
+
 
 if __name__ == "__main__":
     utils.configure_test_logging(sys.argv)

--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -94,7 +94,7 @@ class TestRefresh(unittest.TestCase):
         """Assert that local metadata files match 'roles'"""
         expected_files = [f"{role}.json" for role in roles]
         found_files = [
-            e.name for e in os.scandir(self.metadata_dir) if e.is_file()
+            e.name for e in os.scandir(self.metadata_dir) if e.is_file() and e.name != ".lock"
         ]
 
         self.assertListEqual(sorted(found_files), sorted(expected_files))
@@ -644,14 +644,16 @@ class TestRefresh(unittest.TestCase):
         wrapped_open.reset_mock()
 
         # First time looking for "somepath", only 'role1' must be loaded
+        # (and ".lock" for metadata locking)
         updater.get_targetinfo("somepath")
-        wrapped_open.assert_called_once_with(
+        self.assertEqual(wrapped_open.call_count, 2)
+        wrapped_open.assert_called_with(
             os.path.join(self.metadata_dir, "role1.json"), "rb"
         )
         wrapped_open.reset_mock()
         # Second call to get_targetinfo, all metadata is already loaded
         updater.get_targetinfo("somepath")
-        wrapped_open.assert_not_called()
+        self.assertEqual(wrapped_open.call_count, 1)
 
     def test_snapshot_rollback_with_local_snapshot_hash_mismatch(self) -> None:
         # Test triggering snapshot rollback check on a newly downloaded snapshot
@@ -709,6 +711,7 @@ class TestRefresh(unittest.TestCase):
         root_dir = os.path.join(self.metadata_dir, "root_history")
         wrapped_open.assert_has_calls(
             [
+                call(os.path.join(self.metadata_dir, ".lock"), "wb"),
                 call(os.path.join(root_dir, "2.root.json"), "rb"),
                 call(os.path.join(self.metadata_dir, "timestamp.json"), "rb"),
                 call(os.path.join(self.metadata_dir, "snapshot.json"), "rb"),

--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -94,7 +94,9 @@ class TestRefresh(unittest.TestCase):
         """Assert that local metadata files match 'roles'"""
         expected_files = [f"{role}.json" for role in roles]
         found_files = [
-            e.name for e in os.scandir(self.metadata_dir) if e.is_file() and e.name != ".lock"
+            e.name
+            for e in os.scandir(self.metadata_dir)
+            if e.is_file() and e.name != ".lock"
         ]
 
         self.assertListEqual(sorted(found_files), sorted(expected_files))

--- a/tests/test_updater_top_level_update.py
+++ b/tests/test_updater_top_level_update.py
@@ -135,8 +135,7 @@ class TestRefresh(unittest.TestCase):
             self._run_refresh(skip_bootstrap=True)
 
         # Metadata dir is empty
-        with self.assertRaises(FileNotFoundError):
-            os.listdir(self.metadata_dir)
+        self._assert_files_exist([])
 
     def test_trusted_root_expired(self) -> None:
         # Create an expired root version

--- a/tests/test_updater_validation.py
+++ b/tests/test_updater_validation.py
@@ -53,9 +53,9 @@ class TestUpdater(unittest.TestCase):
 
     def test_non_existing_metadata_dir(self) -> None:
         with self.assertRaises(FileNotFoundError):
-            # Initialize Updater with non-existing metadata_dir
+            # Initialize Updater with non-existing metadata_dir and no bootstrap root
             Updater(
-                "non_existing_metadata_dir",
+                f"{self.temp_dir.name}/non_existing_metadata_dir",
                 "https://example.com/metadata/",
                 fetcher=self.sim,
             )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -161,7 +161,7 @@ def cleanup_metadata_dir(path: str) -> None:
         for entry in it:
             if entry.name == "root_history":
                 cleanup_metadata_dir(entry.path)
-            elif entry.name.endswith(".json"):
+            elif entry.name.endswith(".json") or entry.name == ".lock":
                 os.remove(entry.path)
             else:
                 raise ValueError(f"Unexpected local metadata file {entry.path}")

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ skipsdist = true
 [testenv]
 commands =
     python3 --version
-    python3 -m coverage run -m unittest
-    python3 -m coverage report -m --fail-under 97
+    python3 -m coverage run -m unittest -v
+    python3 -m coverage report -m --fail-under 96
 
 deps =
     -r{toxinidir}/requirements/test.txt

--- a/tuf/ngclient/_internal/file_lock.py
+++ b/tuf/ngclient/_internal/file_lock.py
@@ -1,0 +1,56 @@
+import logging
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import IO
+
+logger = logging.getLogger(__name__)
+
+try:
+    # advisory file locking for posix
+    import fcntl
+
+    @contextmanager
+    def lock_file(path: str) -> Iterator[IO]:
+        with open(path, "wb") as f:
+            fcntl.lockf(f, fcntl.LOCK_EX)
+            yield f
+
+except ModuleNotFoundError:
+    # Windows file locking, in belt-and-suspenders-from-Temu style:
+    # Use a loop that tries to open the lockfile for 30 secs, but also
+    # use msvcrt.locking().
+    # * since open() usually just fails when another process has the file open
+    #   msvcrt.locking() almost never gets called when there is a lock. open()
+    #   sometimes succeeds for multiple processes though
+    # * msvcrt.locking() does not even block until file is available: it just
+    #   tries once per second in a non-blocking manner for 10 seconds. So if
+    #   another process keeps opening the file it's unlikely that we actually
+    #   get the lock
+    import msvcrt
+
+    @contextmanager
+    def lock_file(path: str) -> Iterator[IO]:
+        err = None
+        locked = False
+        for _ in range(100):
+            try:
+                with open(path, "wb") as f:
+                    msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
+                    locked = True
+                    yield f
+                    return
+            except FileNotFoundError:
+                # could be from yield or from open() -- either way we bail
+                raise
+            except OSError as e:
+                if locked:
+                    # yield has raised, let's not continue loop
+                    raise e
+                err = e
+                logger.warning("Unsuccessful lock attempt for %s: %s", path, e)
+                time.sleep(0.3)
+
+        # raise the last failure if we never got a lock
+        if err is not None:
+            raise err

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -92,6 +92,7 @@ except ModuleNotFoundError:
         f.write(b"\0")
         f.flush()
         f.seek(0)
+
         msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
 
 
@@ -152,15 +153,15 @@ class Updater:
                 f"got '{self.config.envelope_type}'"
             )
 
-        if not bootstrap:
-            # if no root was provided, use the cached non-versioned root.json
-            bootstrap = self._load_local_metadata(Root.type)
-
-        # Load the initial root, make sure it's cached
-        self._trusted_set = TrustedMetadataSet(
-            bootstrap, self.config.envelope_type
-        )
         with self._lock_metadata():
+            if not bootstrap:
+                # if no root was provided, use the cached non-versioned root
+                bootstrap = self._load_local_metadata(Root.type)
+
+            # Load the initial root, make sure it's cached
+            self._trusted_set = TrustedMetadataSet(
+                bootstrap, self.config.envelope_type
+            )
             self._persist_root(self._trusted_set.root.version, bootstrap)
             self._update_root_symlink()
 

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -29,10 +29,6 @@ High-level description of ``Updater`` functionality:
       * ``Updater.download_target()`` downloads a target file and ensures it is
         verified correct by the metadata.
 
-Note that applications using ``Updater`` should be 'single instance'
-applications: running multiple instances that use the same cache directories at
-the same time is not supported.
-
 A simple example of using the Updater to implement a Python TUF client that
 downloads target files is available in `examples/client
 <https://github.com/theupdateframework/python-tuf/tree/develop/examples/client>`_.

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -337,6 +337,7 @@ class Updater:
 
             target_file.seek(0)
             with open(filepath, "wb") as destination_file:
+                _lock_file(destination_file)
                 shutil.copyfileobj(target_file, destination_file)
 
         logger.debug("Downloaded target %s", targetinfo.path)

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -59,7 +59,7 @@ import os
 import shutil
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import IO, TYPE_CHECKING, cast
 from urllib import parse
 
 from tuf.api import exceptions
@@ -69,9 +69,29 @@ from tuf.ngclient.config import EnvelopeType, UpdaterConfig
 from tuf.ngclient.urllib3_fetcher import Urllib3Fetcher
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from tuf.ngclient.fetcher import FetcherInterface
 
 logger = logging.getLogger(__name__)
+
+try:
+    # advisory file locking for posix
+    import fcntl
+    def _lock_file(f: IO) -> None:
+        if f.writable():
+            fcntl.lockf(f, fcntl.LOCK_EX)
+
+except ModuleNotFoundError:
+    # Windows file locking
+    import msvcrt
+
+    def _lock_file(f: IO) -> None:
+        # On Windows we lock bytes, not the file
+        f.write(b"\0")
+        f.flush()
+        f.seek(0)
+        msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
 
 
 class Updater:
@@ -139,8 +159,23 @@ class Updater:
         self._trusted_set = TrustedMetadataSet(
             bootstrap, self.config.envelope_type
         )
-        self._persist_root(self._trusted_set.root.version, bootstrap)
-        self._update_root_symlink()
+        with self._lock_metadata():
+            self._persist_root(self._trusted_set.root.version, bootstrap)
+            self._update_root_symlink()
+
+
+    @contextlib.contextmanager
+    def _lock_metadata(self) -> Iterator[None]:
+        """Context manager for locking the metadata directory."""
+        # Ensure the whole metadata directory structure exists
+        rootdir = Path(self._dir, "root_history")
+        rootdir.mkdir(exist_ok=True, parents=True)
+
+        with open(os.path.join(self._dir, ".lock"), "wb") as f:
+            logger.debug("Getting metadata lock...")
+            _lock_file(f)
+            yield
+            logger.debug("Releasing metadata lock")
 
     def refresh(self) -> None:
         """Refresh top-level metadata.
@@ -166,10 +201,11 @@ class Updater:
             DownloadError: Download of a metadata file failed in some way
         """
 
-        self._load_root()
-        self._load_timestamp()
-        self._load_snapshot()
-        self._load_targets(Targets.type, Root.type)
+        with self._lock_metadata():
+            self._load_root()
+            self._load_timestamp()
+            self._load_snapshot()
+            self._load_targets(Targets.type, Root.type)
 
     def _generate_target_file_path(self, targetinfo: TargetFile) -> str:
         if self.target_dir is None:
@@ -205,9 +241,14 @@ class Updater:
             ``TargetFile`` instance or ``None``.
         """
 
-        if Targets.type not in self._trusted_set:
-            self.refresh()
-        return self._preorder_depth_first_walk(target_path)
+        with self._lock_metadata():
+            if Targets.type not in self._trusted_set:
+                # refresh
+                self._load_root()
+                self._load_timestamp()
+                self._load_snapshot()
+                self._load_targets(Targets.type, Root.type)
+            return self._preorder_depth_first_walk(target_path)
 
     def find_cached_target(
         self,
@@ -335,7 +376,6 @@ class Updater:
         "root_history/1.root.json").
         """
         rootdir = Path(self._dir, "root_history")
-        rootdir.mkdir(exist_ok=True, parents=True)
         self._persist_file(str(rootdir / f"{version}.root.json"), data)
 
     def _persist_file(self, filename: str, data: bytes) -> None:

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -58,13 +58,13 @@ import logging
 import os
 import shutil
 import tempfile
-import time
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, cast
 from urllib import parse
 
 from tuf.api import exceptions
 from tuf.api.metadata import Root, Snapshot, TargetFile, Targets, Timestamp
+from tuf.ngclient._internal.file_lock import lock_file
 from tuf.ngclient._internal.trusted_metadata_set import TrustedMetadataSet
 from tuf.ngclient.config import EnvelopeType, UpdaterConfig
 from tuf.ngclient.urllib3_fetcher import Urllib3Fetcher
@@ -75,55 +75,6 @@ if TYPE_CHECKING:
     from tuf.ngclient.fetcher import FetcherInterface
 
 logger = logging.getLogger(__name__)
-
-try:
-    # advisory file locking for posix
-    import fcntl
-
-    @contextlib.contextmanager
-    def _lock_file(path: str) -> Iterator[IO]:
-        with open(path, "wb") as f:
-            fcntl.lockf(f, fcntl.LOCK_EX)
-            yield f
-
-except ModuleNotFoundError:
-    # Windows file locking, in belt-and-suspenders-from-Temu style:
-    # Use a loop that tries to open the lockfile for 30 secs, but also
-    # use msvcrt.locking().
-    # * since open() usually just fails when another process has the file open
-    #   msvcrt.locking() almost never gets called when there is a lock. open()
-    #   sometimes succeeds for multiple processes though
-    # * msvcrt.locking() does not even block until file is available: it just
-    #   tries once per second in a non-blocking manner for 10 seconds. So if
-    #   another process keeps opening the file it's unlikely that we actually
-    #   get the lock
-    import msvcrt
-
-    @contextlib.contextmanager
-    def _lock_file(path: str) -> Iterator[IO]:
-        err = None
-        locked = False
-        for _ in range(100):
-            try:
-                with open(path, "wb") as f:
-                    msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
-                    locked = True
-                    yield f
-                    return
-            except FileNotFoundError:
-                # could be from yield or from open() -- either way we bail
-                raise
-            except OSError as e:
-                if locked:
-                    # yield has raised, let's not continue loop
-                    raise e
-                err = e
-                logger.warning("Unsuccessful lock attempt for %s: %s", path, e)
-                time.sleep(0.3)
-
-        # raise the last failure if we never got a lock
-        if err is not None:
-            raise err
 
 
 class Updater:
@@ -204,7 +155,7 @@ class Updater:
         """Context manager for locking the metadata directory."""
 
         logger.debug("Getting metadata lock...")
-        with _lock_file(os.path.join(self._dir, ".lock")):
+        with lock_file(os.path.join(self._dir, ".lock")):
             yield
         logger.debug("Released metadata lock")
 
@@ -274,7 +225,7 @@ class Updater:
 
         with self._lock_metadata():
             if Targets.type not in self._trusted_set:
-                # refresh
+                # implicit refresh
                 self._load_root()
                 self._load_timestamp()
                 self._load_snapshot()
@@ -367,7 +318,7 @@ class Updater:
             targetinfo.verify_length_and_hashes(target_file)
 
             target_file.seek(0)
-            with _lock_file(filepath) as destination_file:
+            with lock_file(filepath) as destination_file:
                 shutil.copyfileobj(target_file, destination_file)
 
         logger.debug("Downloaded target %s", targetinfo.path)

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -58,6 +58,7 @@ import logging
 import os
 import shutil
 import tempfile
+import time
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, cast
 from urllib import parse
@@ -79,21 +80,50 @@ try:
     # advisory file locking for posix
     import fcntl
 
-    def _lock_file(f: IO) -> None:
-        if f.writable():
+    @contextlib.contextmanager
+    def _lock_file(path: str) -> Iterator[IO]:
+        with open(path, "wb") as f:
             fcntl.lockf(f, fcntl.LOCK_EX)
+            yield f
 
 except ModuleNotFoundError:
-    # Windows file locking
+    # Windows file locking, in belt-and-suspenders-from-Temu style:
+    # Use a loop that tries to open the lockfile for 30 secs, but also
+    # use msvcrt.locking().
+    # * since open() usually just fails when another process has the file open
+    #   msvcrt.locking() almost never gets called when there is a lock. open()
+    #   sometimes succeeds for multiple processes though
+    # * msvcrt.locking() does not even block until file is available: it just
+    #   tries once per second in a non-blocking manner for 10 seconds. So if
+    #   another process keeps opening the file it's unlikely that we actually
+    #   get the lock
     import msvcrt
 
-    def _lock_file(f: IO) -> None:
-        # On Windows we lock a byte range and file must not be empty
-        f.write(b"\0")
-        f.flush()
-        f.seek(0)
+    @contextlib.contextmanager
+    def _lock_file(path: str) -> Iterator[IO]:
+        err = None
+        locked = False
+        for _ in range(100):
+            try:
+                with open(path, "wb") as f:
+                    msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
+                    locked = True
+                    yield f
+                    return
+            except FileNotFoundError:
+                # could be from yield or from open() -- either way we bail
+                raise
+            except OSError as e:
+                if locked:
+                    # yield has raised, let's not continue loop
+                    raise e
+                err = e
+                logger.warning("Unsuccessful lock attempt for %s: %s", path, e)
+                time.sleep(0.3)
 
-        msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
+        # raise the last failure if we never got a lock
+        if err is not None:
+            raise err
 
 
 class Updater:
@@ -153,6 +183,10 @@ class Updater:
                 f"got '{self.config.envelope_type}'"
             )
 
+        # Ensure the whole metadata directory structure exists
+        rootdir = Path(self._dir, "root_history")
+        rootdir.mkdir(exist_ok=True, parents=True)
+
         with self._lock_metadata():
             if not bootstrap:
                 # if no root was provided, use the cached non-versioned root
@@ -168,15 +202,11 @@ class Updater:
     @contextlib.contextmanager
     def _lock_metadata(self) -> Iterator[None]:
         """Context manager for locking the metadata directory."""
-        # Ensure the whole metadata directory structure exists
-        rootdir = Path(self._dir, "root_history")
-        rootdir.mkdir(exist_ok=True, parents=True)
 
-        with open(os.path.join(self._dir, ".lock"), "wb") as f:
-            logger.debug("Getting metadata lock...")
-            _lock_file(f)
+        logger.debug("Getting metadata lock...")
+        with _lock_file(os.path.join(self._dir, ".lock")):
             yield
-            logger.debug("Releasing metadata lock")
+        logger.debug("Released metadata lock")
 
     def refresh(self) -> None:
         """Refresh top-level metadata.
@@ -337,8 +367,7 @@ class Updater:
             targetinfo.verify_length_and_hashes(target_file)
 
             target_file.seek(0)
-            with open(filepath, "wb") as destination_file:
-                _lock_file(destination_file)
+            with _lock_file(filepath) as destination_file:
                 shutil.copyfileobj(target_file, destination_file)
 
         logger.debug("Downloaded target %s", targetinfo.path)

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -78,6 +78,7 @@ logger = logging.getLogger(__name__)
 try:
     # advisory file locking for posix
     import fcntl
+
     def _lock_file(f: IO) -> None:
         if f.writable():
             fcntl.lockf(f, fcntl.LOCK_EX)
@@ -87,7 +88,7 @@ except ModuleNotFoundError:
     import msvcrt
 
     def _lock_file(f: IO) -> None:
-        # On Windows we lock bytes, not the file
+        # On Windows we lock a byte range and file must not be empty
         f.write(b"\0")
         f.flush()
         f.seek(0)
@@ -162,7 +163,6 @@ class Updater:
         with self._lock_metadata():
             self._persist_root(self._trusted_set.root.version, bootstrap)
             self._update_root_symlink()
-
 
     @contextlib.contextmanager
     def _lock_metadata(self) -> Iterator[None]:


### PR DESCRIPTION
Add advisory file locking to make it safer to run multiple updaters (using the same metadata directory) in separate processes. This should help with #2836 

* Metadata access is protected with `<METADATA_DIR>/.lock`: this lock is used in `Updater.__init__()`, `Updater.refresh()` and `Updater.get_targetinfo()` --  lock is typically held through the whole method (in other words while the metadata is being downloaded as well)
* Artifact cache access is protected with a lock on the specific artifact file
* No dependencies (whether this is a good idea remains to be seen, see later comments about complexity and alternatives)

@stefanberger comments welcome


### Implementation notes

The implementation has just enough platform specific complexity that I'm not totally happy with it. There's clearly a chance of bugs here... Unfortunately I'm not convinced using a dependency would make that possibility go away

* The main complexity is relates to the weird file access mechanism in Windows: `mscvrt.locking()` is the recommended API but 99% of the time it's not useful because we need a file handle to call it, and we can't get one because another process already has the file open. So we need a dumb loop that keeps calling `open()` and `sleep()`. It's ugly but no-one seems to have a better solution
* the core difference between the two implementations is this: windows implementation will timeout in ~30 seconds if it does not get a lock. the posix implementation will keep waiting in `fcntl.lockf()` until the lock opens. Both have a tradeoff: On windows the updater might fail if another updater is a bit slow. On posix, if one updater hangs with a lock for some reason, all future updaters will just wait indefinitely until the original hung process is killed (or the lock file is deleted)
* There is a test that starts 10 processes that all run 50 metadata refreshes as fast as possible using the same metadata directory. Increasing those numbers significantly will trigger the mentioned failure on Windows

### TODO

* I think the posix locking probably should *maybe* timeout as well if someone is hogging the lock for long enough.
* on the other hand, someone somewhere will always see the timeout (even though it would work some time later) whatever the we set the timeout to :(

### Alternatives

https://github.com/tox-dev/filelock/ looks reasonable -- although artifact locking will be either more complicated or less parallel since you can't use filelock on the actual file you want to write.