### PR TITLE
Bump minimum python version

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python (oldest supported version)
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: 'pip'
           cache-dependency-path: |
             requirements/*.txt
@@ -38,7 +38,7 @@ jobs:
     needs: lint-test
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest]
         include:
           - python-version: "3.x"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "A secure updater framework for Python"
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
 license-files = ["LICENSE", "LICENSE-MIT"]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
   { email = "theupdateframework@googlegroups.com" },
 ]
@@ -31,11 +31,11 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Security",
   "Topic :: Software Development",

--- a/tests/test_fetcher_ng.py
+++ b/tests/test_fetcher_ng.py
@@ -170,9 +170,10 @@ class TestFetcher(unittest.TestCase):
 
     # Download a file bigger than expected
     def test_download_file_length_mismatch(self) -> None:
-        with self.assertRaises(
-            exceptions.DownloadLengthMismatchError
-        ), self.fetcher.download_file(self.url, self.file_length - 4):
+        with (
+            self.assertRaises(exceptions.DownloadLengthMismatchError),
+            self.fetcher.download_file(self.url, self.file_length - 4),
+        ):
             pass  # we never get here as download_file() raises
 
 

--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -6,9 +6,8 @@ import logging
 import os
 import sys
 import unittest
-from collections.abc import Callable
 from datetime import datetime, timezone
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from securesystemslib.signer import Signer
 
@@ -30,6 +29,9 @@ from tuf.ngclient._internal.trusted_metadata_set import (
     _load_from_simple_envelope,
 )
 from tuf.ngclient.config import EnvelopeType
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_trusted_metadata_set.py
+++ b/tests/test_trusted_metadata_set.py
@@ -6,8 +6,9 @@ import logging
 import os
 import sys
 import unittest
+from collections.abc import Callable
 from datetime import datetime, timezone
-from typing import Callable, ClassVar
+from typing import ClassVar
 
 from securesystemslib.signer import Signer
 

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -11,8 +11,8 @@ import shutil
 import sys
 import tempfile
 import unittest
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, Callable, ClassVar
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, ClassVar
 from unittest.mock import MagicMock, patch
 
 from securesystemslib.signer import Signer

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -11,7 +11,7 @@ import shutil
 import sys
 import tempfile
 import unittest
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, ClassVar
 from unittest.mock import MagicMock, patch
 
@@ -30,7 +30,7 @@ from tuf.api.metadata import (
 from tuf.ngclient import Updater, UpdaterConfig
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
 logger = logging.getLogger(__name__)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,8 +31,9 @@ import sys
 import threading
 import time
 import warnings
+from collections.abc import Callable
 from contextlib import contextmanager
-from typing import IO, TYPE_CHECKING, Any, Callable
+from typing import IO, TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import unittest
@@ -111,7 +112,7 @@ def wait_for_server(
             sock.settimeout(remaining_timeout)
             sock.connect((host, port))
             succeeded = True
-        except socket.timeout:
+        except TimeoutError:
             pass
         except OSError as e:
             # ECONNREFUSED is expected while the server is not started

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,13 +31,12 @@ import sys
 import threading
 import time
 import warnings
-from collections.abc import Callable
 from contextlib import contextmanager
 from typing import IO, TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import unittest
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
 logger = logging.getLogger(__name__)
 

--- a/tuf/api/_payload.py
+++ b/tuf/api/_payload.py
@@ -1191,7 +1191,7 @@ class DelegatedRole(Role):
 
         # Every part in the pathpattern could include a glob pattern, that's why
         # each of the target and pathpattern parts should match.
-        for target, pattern in zip(target_parts, pattern_parts, strict=False):
+        for target, pattern in zip(target_parts, pattern_parts, strict=True):
             if not fnmatch.fnmatch(target, pattern):
                 return False
 

--- a/tuf/api/_payload.py
+++ b/tuf/api/_payload.py
@@ -1191,8 +1191,8 @@ class DelegatedRole(Role):
 
         # Every part in the pathpattern could include a glob pattern, that's why
         # each of the target and pathpattern parts should match.
-        for target_dir, pattern_dir in zip(target_parts, pattern_parts):
-            if not fnmatch.fnmatch(target_dir, pattern_dir):
+        for target, pattern in zip(target_parts, pattern_parts, strict=False):
+            if not fnmatch.fnmatch(target, pattern):
                 return False
 
         return True

--- a/tuf/api/_payload.py
+++ b/tuf/api/_payload.py
@@ -396,19 +396,15 @@ class RootVerificationResult:
     def signed(self) -> dict[str, Key]:
         """Dictionary of all signing keys that have signed, from both
         VerificationResults.
-        return a union of all signed (in python<3.9 this requires
-        dict unpacking)
         """
-        return {**self.first.signed, **self.second.signed}
+        return self.first.signed | self.second.signed
 
     @property
     def unsigned(self) -> dict[str, Key]:
         """Dictionary of all signing keys that have not signed, from both
         VerificationResults.
-        return a union of all unsigned (in python<3.9 this requires
-        dict unpacking)
         """
-        return {**self.first.unsigned, **self.second.unsigned}
+        return self.first.unsigned | self.second.unsigned
 
 
 class _DelegatorMixin(metaclass=abc.ABCMeta):

--- a/tuf/ngclient/_internal/trusted_metadata_set.py
+++ b/tuf/ngclient/_internal/trusted_metadata_set.py
@@ -66,7 +66,7 @@ from __future__ import annotations
 import datetime
 import logging
 from collections import abc
-from typing import TYPE_CHECKING, Union, cast
+from typing import TYPE_CHECKING, cast
 
 from tuf.api import exceptions
 from tuf.api.dsse import SimpleEnvelope
@@ -88,7 +88,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-Delegator = Union[Root, Targets]
+Delegator = Root | Targets
 
 
 class TrustedMetadataSet(abc.Mapping):


### PR DESCRIPTION
Require Python 3.10:
* 3.9 is now EOL and a lot of the development dependencies require 3.10 already in latest versions
* We could just bump the minimum tested version (like we did with 3.8 -> 3.9) but I think this time the risk of accidentally breaking 3.9 anyway is higher (since annotation improvements creep in): makes sense to just require 3.10 at this point
* Also start testing with 3.14
* All of the code changes are linter suggestions

unblocks #2895, #2894  