### PR TITLE
feat(ngclient): require explicit bootstrap argument

### DIFF
--- a/.github/scripts/conformance-client.py
+++ b/.github/scripts/conformance-client.py
@@ -27,6 +27,7 @@ def refresh(metadata_url: str, metadata_dir: str) -> None:
     updater = Updater(
         metadata_dir,
         metadata_url,
+        bootstrap=None,
     )
     updater.refresh()
     print(f"python-tuf test client: Refreshed metadata in {metadata_dir}")
@@ -46,6 +47,7 @@ def download_target(
         metadata_url,
         download_dir,
         target_base_url,
+        bootstrap=None,
     )
     target_info = updater.get_targetinfo(target_name)
     if not target_info:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Changed
+
+* ngclient: `Updater()` now requires an explicit `bootstrap` argument
+  * This is a breaking change: callers must pass `bootstrap=<root_bytes>` or `bootstrap=None`
+  * `bootstrap=None` explicitly opts into using cached `root.json` as trust anchor
+
 ## v6.0.0
 
 This release is not strictly speaking an API break from 5.1 but it does contain some

--- a/docs/INSTALLATION.rst
+++ b/docs/INSTALLATION.rst
@@ -53,6 +53,39 @@ from GitHub, change into the project root directory, and install with pip
    python3 -m pip install -r requirements/dev.txt
 
 
+Bootstrap root metadata
+-----------------------
+
+The initial trusted root metadata (``root.json``) is the trust anchor for all
+subsequent metadata verification. Applications should deploy a trusted root
+with the application and provide it to :class:`tuf.ngclient.Updater`.
+
+Recommended storage locations for bootstrap root metadata include:
+
+* a system-wide read-only path (e.g. ``/usr/share/your-app/root.json``)
+* an application bundle with appropriate permissions
+* a read-only mounted volume in containerized deployments
+
+Not recommended:
+
+* ``metadata_dir`` (the metadata cache) since it is writable by design
+* user-writable install paths (e.g. a user site-packages directory)
+* any location writable by the account running the updater
+
+Example::
+
+   from tuf.ngclient import Updater
+
+   with open("/usr/share/your-app/root.json", "rb") as f:
+       bootstrap = f.read()
+
+   updater = Updater(
+       metadata_dir="/var/lib/your-app/tuf/metadata",
+       metadata_base_url="https://example.com/metadata/",
+       bootstrap=bootstrap,
+   )
+
+
 Verify release signatures
 -------------------------
 

--- a/docs/INSTALLATION.rst
+++ b/docs/INSTALLATION.rst
@@ -53,8 +53,8 @@ from GitHub, change into the project root directory, and install with pip
    python3 -m pip install -r requirements/dev.txt
 
 
-Bootstrap root metadata
------------------------
+Application deployment
+----------------------
 
 The initial trusted root metadata (``root.json``) is the trust anchor for all
 subsequent metadata verification. Applications should deploy a trusted root

--- a/examples/client/client
+++ b/examples/client/client
@@ -79,14 +79,15 @@ def download(base_url: str, target: str) -> bool:
     print(f"Using trusted root in {metadata_dir}")
 
     try:
-        # NOTE: initial root should be provided with ``bootstrap``  argument:
-        # This examples uses unsafe Trust-On-First-Use initialization so it is
-        # not possible here.
+        # NOTE: production deployments should provide embedded root metadata
+        # bytes via the ``bootstrap`` argument. This example uses Trust-On-First-Use
+        # initialization, so it explicitly opts into using cached root.json.
         updater = Updater(
             metadata_dir=metadata_dir,
             metadata_base_url=f"{base_url}/metadata/",
             target_base_url=f"{base_url}/targets/",
             target_dir=DOWNLOAD_DIR,
+            bootstrap=None,
         )
         updater.refresh()
 

--- a/examples/uploader/_localrepo.py
+++ b/examples/uploader/_localrepo.py
@@ -47,6 +47,7 @@ class LocalRepository(Repository):
         self.updater = Updater(
             metadata_dir=metadata_dir,
             metadata_base_url=f"{base_url}/metadata/",
+            bootstrap=None,
         )
         self.updater.refresh()
 

--- a/tests/repository_simulator.py
+++ b/tests/repository_simulator.py
@@ -36,8 +36,10 @@ Example::
     updater = Updater(
         dir,
         "https://example.com/metadata/",
+        dir,
         "https://example.com/targets/",
-        sim
+        sim,
+        bootstrap=sim.signed_roots[0],
     )
     updater.refresh()
 """

--- a/tests/test_updater_consistent_snapshot.py
+++ b/tests/test_updater_consistent_snapshot.py
@@ -74,10 +74,6 @@ class TestConsistentSnapshot(unittest.TestCase):
         sim.publish_root()
         sim.prefix_targets_with_hash = prefix_targets
 
-        # Init trusted root with the latest consistent_snapshot
-        with open(os.path.join(self.metadata_dir, "root.json"), "bw") as f:
-            f.write(sim.signed_roots[-1])
-
         return sim
 
     def _init_updater(self) -> Updater:

--- a/tests/test_updater_consistent_snapshot.py
+++ b/tests/test_updater_consistent_snapshot.py
@@ -88,6 +88,7 @@ class TestConsistentSnapshot(unittest.TestCase):
             self.targets_dir,
             "https://example.com/targets/",
             self.sim,
+            bootstrap=self.sim.signed_roots[-1],
         )
 
     def _assert_metadata_files_exist(self, roles: Iterable[str]) -> None:

--- a/tests/test_updater_delegation_graphs.py
+++ b/tests/test_updater_delegation_graphs.py
@@ -120,10 +120,6 @@ class TestDelegations(unittest.TestCase):
 
     def _init_updater(self) -> Updater:
         """Create a new Updater instance"""
-        # Init trusted root for Updater
-        with open(os.path.join(self.metadata_dir, "root.json"), "bw") as f:
-            f.write(self.sim.signed_roots[0])
-
         return Updater(
             self.metadata_dir,
             "https://example.com/metadata/",

--- a/tests/test_updater_delegation_graphs.py
+++ b/tests/test_updater_delegation_graphs.py
@@ -130,6 +130,7 @@ class TestDelegations(unittest.TestCase):
             self.targets_dir,
             "https://example.com/targets/",
             self.sim,
+            bootstrap=self.sim.signed_roots[0],
         )
 
     def _assert_files_exist(self, roles: Iterable[str]) -> None:

--- a/tests/test_updater_fetch_target.py
+++ b/tests/test_updater_fetch_target.py
@@ -65,6 +65,7 @@ class TestFetchTarget(unittest.TestCase):
             self.targets_dir,
             "https://example.com/targets/",
             self.sim,
+            bootstrap=self.sim.signed_roots[0],
         )
 
     targets = {

--- a/tests/test_updater_fetch_target.py
+++ b/tests/test_updater_fetch_target.py
@@ -40,10 +40,8 @@ class TestFetchTarget(unittest.TestCase):
         os.mkdir(self.metadata_dir)
         os.mkdir(self.targets_dir)
 
-        # Setup the repository, bootstrap client root.json
+        # Setup the repository
         self.sim = RepositorySimulator()
-        with open(os.path.join(self.metadata_dir, "root.json"), "bw") as f:
-            f.write(self.sim.signed_roots[0])
 
         if self.dump_dir is not None:
             # create test specific dump directory

--- a/tests/test_updater_key_rotations.py
+++ b/tests/test_updater_key_rotations.py
@@ -72,8 +72,6 @@ class TestUpdaterKeyRotations(unittest.TestCase):
 
         # bootstrap with initial root
         self.metadata_dir = tempfile.mkdtemp(dir=self.temp_dir.name)
-        with open(os.path.join(self.metadata_dir, "root.json"), "bw") as f:
-            f.write(self.sim.signed_roots[0])
 
         updater = Updater(
             self.metadata_dir,

--- a/tests/test_updater_key_rotations.py
+++ b/tests/test_updater_key_rotations.py
@@ -79,6 +79,7 @@ class TestUpdaterKeyRotations(unittest.TestCase):
             self.metadata_dir,
             "https://example.com/metadata/",
             fetcher=self.sim,
+            bootstrap=self.sim.signed_roots[0],
         )
         updater.refresh()
 

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -115,6 +115,7 @@ class TestUpdater(unittest.TestCase):
             metadata_base_url=self.metadata_url,
             target_dir=self.dl_dir,
             target_base_url=self.targets_url,
+            bootstrap=None,
         )
 
     def tearDown(self) -> None:
@@ -247,14 +248,16 @@ class TestUpdater(unittest.TestCase):
 
     def test_both_target_urls_not_set(self) -> None:
         # target_base_url = None and Updater._target_base_url = None
-        updater = Updater(self.client_directory, self.metadata_url, self.dl_dir)
+        updater = Updater(
+            self.client_directory, self.metadata_url, self.dl_dir, bootstrap=None
+        )
         info = TargetFile(1, {"sha256": ""}, "targetpath")
         with self.assertRaises(ValueError):
             updater.download_target(info)
 
     def test_no_target_dir_no_filepath(self) -> None:
         # filepath = None and Updater.target_dir = None
-        updater = Updater(self.client_directory, self.metadata_url)
+        updater = Updater(self.client_directory, self.metadata_url, bootstrap=None)
         info = TargetFile(1, {"sha256": ""}, "targetpath")
         with self.assertRaises(ValueError):
             updater.find_cached_target(info)
@@ -344,6 +347,7 @@ class TestUpdater(unittest.TestCase):
             self.dl_dir,
             self.targets_url,
             config=UpdaterConfig(app_user_agent="MyApp/1.2.3"),
+            bootstrap=None,
         )
         updater.refresh()
         poolmgr = updater._fetcher._proxy_env.get_pool_manager(

--- a/tests/test_updater_ng.py
+++ b/tests/test_updater_ng.py
@@ -249,7 +249,10 @@ class TestUpdater(unittest.TestCase):
     def test_both_target_urls_not_set(self) -> None:
         # target_base_url = None and Updater._target_base_url = None
         updater = Updater(
-            self.client_directory, self.metadata_url, self.dl_dir, bootstrap=None
+            self.client_directory,
+            self.metadata_url,
+            self.dl_dir,
+            bootstrap=None,
         )
         info = TargetFile(1, {"sha256": ""}, "targetpath")
         with self.assertRaises(ValueError):
@@ -257,7 +260,9 @@ class TestUpdater(unittest.TestCase):
 
     def test_no_target_dir_no_filepath(self) -> None:
         # filepath = None and Updater.target_dir = None
-        updater = Updater(self.client_directory, self.metadata_url, bootstrap=None)
+        updater = Updater(
+            self.client_directory, self.metadata_url, bootstrap=None
+        )
         info = TargetFile(1, {"sha256": ""}, "targetpath")
         with self.assertRaises(ValueError):
             updater.find_cached_target(info)

--- a/tests/test_updater_validation.py
+++ b/tests/test_updater_validation.py
@@ -38,7 +38,17 @@ class TestUpdater(unittest.TestCase):
             self.targets_dir,
             "https://example.com/targets/",
             fetcher=self.sim,
+            bootstrap=self.sim.signed_roots[0],
         )
+
+    def test_bootstrap_argument_required(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+            Updater(
+                self.metadata_dir,
+                "https://example.com/metadata/",
+                fetcher=self.sim,
+            )
+        self.assertIn("bootstrap", str(ctx.exception))
 
     def test_local_target_storage_fail(self) -> None:
         self.sim.add_target("targets", b"content", "targetpath")
@@ -52,12 +62,14 @@ class TestUpdater(unittest.TestCase):
             updater.download_target(target_info, filepath="")
 
     def test_non_existing_metadata_dir(self) -> None:
+        non_existing_dir = os.path.join(self.temp_dir.name, "non-existing-dir")
         with self.assertRaises(FileNotFoundError):
             # Initialize Updater with non-existing metadata_dir
             Updater(
-                "non_existing_metadata_dir",
+                non_existing_dir,
                 "https://example.com/metadata/",
                 fetcher=self.sim,
+                bootstrap=None,
             )
 
 

--- a/tests/test_updater_validation.py
+++ b/tests/test_updater_validation.py
@@ -23,10 +23,8 @@ class TestUpdater(unittest.TestCase):
         os.mkdir(self.metadata_dir)
         os.mkdir(self.targets_dir)
 
-        # Setup the repository, bootstrap client root.json
+        # Setup the repository
         self.sim = RepositorySimulator()
-        with open(os.path.join(self.metadata_dir, "root.json"), "bw") as f:
-            f.write(self.sim.signed_roots[0])
 
     def tearDown(self) -> None:
         self.temp_dir.cleanup()
@@ -47,7 +45,7 @@ class TestUpdater(unittest.TestCase):
                 self.metadata_dir,
                 "https://example.com/metadata/",
                 fetcher=self.sim,
-            )
+            )  # type: ignore[call-arg]
         self.assertIn("bootstrap", str(ctx.exception))
 
     def test_local_target_storage_fail(self) -> None:

--- a/tuf/ngclient/updater.py
+++ b/tuf/ngclient/updater.py
@@ -13,7 +13,8 @@ High-level description of ``Updater`` functionality:
   * Initializing an ``Updater`` loads and validates the trusted local root
     metadata: This root metadata is used as the source of trust for all other
     metadata. Updater should always be initialized with the ``bootstrap``
-    argument: if this is not possible, it can be initialized from cache only.
+    argument: pass ``bootstrap=None`` only to explicitly opt into using the
+    cached root.json as the trust anchor.
   * ``refresh()`` can optionally be called to update and load all top-level
     metadata as described in the specification, using both locally cached
     metadata and metadata downloaded from the remote repository. If refresh is
@@ -79,7 +80,8 @@ class Updater:
 
     Args:
         metadata_dir: Local metadata directory. Directory must be
-            writable and it must contain a trusted root.json file
+            writable. If ``bootstrap`` is ``None``, this directory must contain
+            a trusted root.json file.
         metadata_base_url: Base URL for all remote metadata downloads
         target_dir: Local targets directory. Directory must be writable. It
             will be used as the default target download directory by
@@ -90,9 +92,11 @@ class Updater:
             download both metadata and targets. Default is ``Urllib3Fetcher``
         config: ``Optional``; ``UpdaterConfig`` could be used to setup common
             configuration options.
-        bootstrap: ``Optional``; initial root metadata. A bootstrap root should
-            always be provided. If it is not, the current root.json in the
-            metadata cache is used as the initial root.
+        bootstrap: Initial root metadata bytes. This argument is required.
+            Pass the embedded root metadata bytes for secure initialization.
+            Pass ``None`` only if you explicitly want to use the cached
+            root.json as the trust anchor (not recommended for most
+            deployments).
 
     Raises:
         OSError: Local root.json cannot be read
@@ -107,7 +111,8 @@ class Updater:
         target_base_url: str | None = None,
         fetcher: FetcherInterface | None = None,
         config: UpdaterConfig | None = None,
-        bootstrap: bytes | None = None,
+        *,
+        bootstrap: bytes | None,
     ):
         self._dir = metadata_dir
         self._metadata_base_url = _ensure_trailing_slash(metadata_base_url)
@@ -131,7 +136,7 @@ class Updater:
                 f"got '{self.config.envelope_type}'"
             )
 
-        if not bootstrap:
+        if bootstrap is None:
             # if no root was provided, use the cached non-versioned root.json
             bootstrap = self._load_local_metadata(Root.type)
 


### PR DESCRIPTION
# Description of the changes being introduced by the pull request:

This PR makes the trust anchor choice explicit in tuf.ngclient.Updater().

  - bootstrap is now a required keyword-only argument (no default)
  - Callers must choose:
      - bootstrap=<root_bytes> (recommended: embedded/deployed trusted root)
      - bootstrap=None (explicit opt-in to using cached metadata_dir/root.json as the trust anchor)
  - The fallback now triggers only on bootstrap is None (not on falsy bytes)
  - Tests and examples are updated to pass bootstrap explicitly
  - Adds documentation guidance on secure bootstrap root storage

Migration:

  - Old implicit behavior: Updater(...)
  - Preserve old behavior explicitly: Updater(..., bootstrap=None)
  - Recommended: Updater(..., bootstrap=<embedded root bytes>)

Tests:

  - python -m pytest -c pyproject.toml -q

  Ref: GHSA-9pfj-pjv5-22gj