### PR TITLE
README: Fix image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="https://cdn.rawgit.com/theupdateframework/artwork/3a649fa6/tuf-logo.svg" height="100" valign="middle" alt="TUF"/> A Framework for Securing Software Update Systems
+# <img src="https://raw.githubusercontent.com/theupdateframework/artwork/3a649fa6/tuf-logo.svg" height="100" valign="middle" alt="TUF"/> A Framework for Securing Software Update Systems
 
 [![CI badge](https://github.com/theupdateframework/python-tuf/actions/workflows/ci.yml/badge.svg)](https://github.com/theupdateframework/python-tuf/actions/workflows/ci.yml)
 [![Conformance badge](https://github.com/theupdateframework/python-tuf/actions/workflows/conformance.yml/badge.svg)](https://github.com/theupdateframework/python-tuf/actions/workflows/conformance.yml)


### PR DESCRIPTION
rawgit.com is not related to github and is deprecated, let's not use it.
