### PR TITLE
fix: update client README with valid tuf-demo target

### DIFF
--- a/examples/client/README.md
+++ b/examples/client/README.md
@@ -42,5 +42,5 @@ client needs to run `tofu` every time you restart the repository application.
 ./client --url https://jku.github.io/tuf-demo tofu
 
 # Then download example files from the repository:
-./client --url https://jku.github.io/tuf-demo download demo/succinctly-delegated-1.txt
+./client --url https://jku.github.io/tuf-demo download rdimitrov/artifact-example.md
 ```


### PR DESCRIPTION
The example command in examples/client/README.md references
demo/succinctly-delegated-1.txt which no longer exists in the
tuf-demo repository. The delegation structure currently only
has jku/*, rdimitrov/*, and kommendorkapten/* paths.

Updated the example to use rdimitrov/artifact-example.md which
is currently available and working.

